### PR TITLE
contract: send machine_type when getting resources

### DIFF
--- a/docs/explanations/status_columns.md
+++ b/docs/explanations/status_columns.md
@@ -19,10 +19,10 @@ livepatch        yes        Canonical Livepatch service
 
 Where:
 
-* **SERVICE**: Is the name of service being offered.
-* **AVAILABLE**: Shows if that service is available on the machine. To verify
-  if a service is available, we check the machine kernel version, architecture
-  and the Ubuntu release it is running.
+* **SERVICE**: Is the name of service being offered
+* **AVAILABLE**: Shows if that service is available on that machine. To verify
+  if a service is available, we check the machine kernel version, architecture,
+  Ubuntu release being used and the machine type (i.e lxd for LXD containers)
 * **DESCRIPTION**: A short description of the service.
 
 ## With Pro subscription attached

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -358,6 +358,7 @@ class UAContractClient(serviceclient.UAServiceClient):
             "architecture": platform["arch"],
             "series": platform["series"],
             "kernel": platform["kernel"],
+            "virt": platform["virt"],
         }
 
     def _get_activity_info(self, machine_id: Optional[str] = None):

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -116,6 +116,15 @@ def get_dpkg_arch() -> str:
 
 
 @lru_cache(maxsize=None)
+def get_virt_type() -> str:
+    try:
+        out, _ = subp(["systemd-detect-virt"])
+        return out.strip()
+    except exceptions.ProcessExecutionError:
+        return ""
+
+
+@lru_cache(maxsize=None)
 def get_machine_id(cfg) -> str:
     """
     Get system's unique machine-id or create our own in data_dir.
@@ -181,8 +190,10 @@ def get_platform_info() -> Dict[str, str]:
             "series": series.lower(),
             "kernel": get_kernel_info().uname_release,
             "arch": get_dpkg_arch(),
+            "virt": get_virt_type(),
         }
     )
+
     return platform_info
 
 

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -158,6 +158,7 @@ class TestUAContractClient:
             "arch": "arch",
             "kernel": "kernel",
             "series": "series",
+            "virt": "mtype",
         }
 
         get_machine_id.return_value = "machineId"

--- a/uaclient/tests/test_system.py
+++ b/uaclient/tests/test_system.py
@@ -620,7 +620,7 @@ class TestGetPlatformInfo:
             system.get_platform_info.__wrapped__()
 
     @pytest.mark.parametrize(
-        "os_release, arch, kernel, expected",
+        "os_release,arch,kernel,virt,expected",
         [
             (
                 {
@@ -629,6 +629,7 @@ class TestGetPlatformInfo:
                 },
                 "arm64",
                 "kernel-ver1",
+                "lxd",
                 {
                     "arch": "arm64",
                     "distribution": "Ubuntu",
@@ -637,6 +638,7 @@ class TestGetPlatformInfo:
                     "series": "xenial",
                     "type": "Linux",
                     "version": "16.04 LTS (Xenial Xerus)",
+                    "virt": "lxd",
                 },
             ),
             (
@@ -646,6 +648,7 @@ class TestGetPlatformInfo:
                 },
                 "amd64",
                 "kernel-ver2",
+                "none",
                 {
                     "arch": "amd64",
                     "distribution": "Ubuntu",
@@ -654,6 +657,7 @@ class TestGetPlatformInfo:
                     "series": "bionic",
                     "type": "Linux",
                     "version": "18.04 LTS (Bionic Beaver)",
+                    "virt": "none",
                 },
             ),
             (
@@ -663,6 +667,7 @@ class TestGetPlatformInfo:
                 },
                 "arm64",
                 "kernel-ver3",
+                "qemu",
                 {
                     "arch": "arm64",
                     "distribution": "Ubuntu",
@@ -671,6 +676,7 @@ class TestGetPlatformInfo:
                     "series": "jammy",
                     "type": "Linux",
                     "version": "22.04 LTS (Jammy Jellyfish)",
+                    "virt": "qemu",
                 },
             ),
             (
@@ -680,6 +686,7 @@ class TestGetPlatformInfo:
                 },
                 "amd64",
                 "kernel-ver4",
+                "wsl",
                 {
                     "arch": "amd64",
                     "distribution": "Ubuntu",
@@ -688,6 +695,7 @@ class TestGetPlatformInfo:
                     "series": "kinetic",
                     "type": "Linux",
                     "version": "22.10 LTS (Kinetic Kudu)",
+                    "virt": "wsl",
                 },
             ),
             (
@@ -698,6 +706,7 @@ class TestGetPlatformInfo:
                 },
                 "amd64",
                 "kernel-ver4",
+                "lxd",
                 {
                     "arch": "amd64",
                     "distribution": "Ubuntu",
@@ -706,6 +715,7 @@ class TestGetPlatformInfo:
                     "series": "jammy",
                     "type": "Linux",
                     "version": "22.04 LTS",
+                    "virt": "lxd",
                 },
             ),
             (
@@ -717,6 +727,7 @@ class TestGetPlatformInfo:
                 },
                 "amd64",
                 "kernel-ver4",
+                "lxd",
                 {
                     "arch": "amd64",
                     "distribution": "Ubuntu",
@@ -725,6 +736,7 @@ class TestGetPlatformInfo:
                     "series": "jammy",
                     "type": "Linux",
                     "version": "CORRUPTED",
+                    "virt": "lxd",
                 },
             ),
         ],
@@ -732,19 +744,23 @@ class TestGetPlatformInfo:
     @mock.patch("uaclient.system.get_kernel_info")
     @mock.patch("uaclient.system.get_dpkg_arch")
     @mock.patch("uaclient.system.parse_os_release")
+    @mock.patch("uaclient.system.get_virt_type")
     def test_get_platform_info_with_version(
         self,
+        m_get_virt_type,
         m_parse_os_release,
         m_get_dpkg_arch,
         m_get_kernel_info,
         os_release,
         arch,
         kernel,
+        virt,
         expected,
     ):
         m_parse_os_release.return_value = os_release
         m_get_dpkg_arch.return_value = arch
         m_get_kernel_info.return_value = mock.MagicMock(uname_release=kernel)
+        m_get_virt_type.return_value = virt
         assert expected == system.get_platform_info.__wrapped__()
 
 


### PR DESCRIPTION
## Proposed Commit Message
contract: send machine_type when getting resources

When unattached, we send platform information to the contract server that replies with which services are available. One gap that we have is that some services are not available on all machine types. For example, Livepatch cannot be enabled on a container. We are now sending that information to the contract server so that they can take that information in consideration when informing which services are available.

## Test Steps
Verify if the integration tests for unattached scenarios are still working as expected

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
