### PR TITLE
fix: verify if package can be installed

### DIFF
--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1178,3 +1178,8 @@ MISSING_YAML_MODULE = NamedMessage(
 Couldn't import the YAML module from /usr/lib/python3/dist-packages.
 Make sure the 'python3-yaml' package is installed correctly.""",
 )
+
+FIX_CANNOT_INSTALL_PACKAGE = FormattedNamedMessage(
+    "fix-cannot-install-package",
+    "Cannot install package {package} version {version}" "",
+)


### PR DESCRIPTION
## Proposed Commit Message
fix: verify if package can be installed

When running a pro fix command, we check if the fixed package version is higher than the one currently installed. If it is, we try to update the package, but we don't check if the package can indeed be upgrade. For example, if the version that fix the error is higher than the package candidate version, we cannot install that fix. To address that, We are now checking the target package candidate version to address those potential scenarios

LP: #2006705

## Test Steps
Run the new integration test for this scenario

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
