### PR TITLE
realtime-kernel: remove `ubuntu-realtime` package on disable

### DIFF
--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -92,8 +92,22 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I run `pro disable realtime-kernel` `with sudo` and stdin `y`
         Then stdout matches regexp:
             """
-            This will disable Ubuntu Pro updates to the Real-time kernel on this machine.
-            The Real-time kernel will remain installed.
+            This will remove the boot order preference for the Real-time kernel and
+            disable updates to the Real-time kernel.
+
+            This will NOT fully remove the kernel from your system.
+
+            After this operation is complete you must:
+            - Ensure a different kernel is installed and configured to boot
+            - Reboot into that kernel
+            - Fully remove the realtime kernel packages from your system
+                - This might look something like `apt remove linux*realtime`,
+                  but you must ensure this is correct before running it.
+            """
+        When I run `apt-cache policy ubuntu-realtime` as non-root
+        Then stdout contains substring
+            """
+            Installed: (none)
             """
 
         Examples: ubuntu release

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -47,7 +47,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     @uses.config.machine_type.lxd.vm
     Scenario Outline: Enable Real-time kernel service
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
+        When I attach `contract_token` with sudo and options `--no-auto-enable`
         Then I verify that running `pro enable realtime-kernel` `as non-root` exits `1`
         And I will see the following on stderr:
             """

--- a/features/steps/shell.py
+++ b/features/steps/shell.py
@@ -44,10 +44,6 @@ def when_i_run_command(
 ):
     command = process_template_vars(context, command)
 
-    if "<ci-proxy-ip>" in command and "proxy" in context.machines:
-        command = command.replace(
-            "<ci-proxy-ip>", context.machines["proxy"].instance.ip
-        )
     prefix = get_command_prefix_for_user_spec(user_spec)
 
     full_cmd = prefix + shlex.split(command)

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -669,3 +669,18 @@ def update_esm_caches(cfg) -> None:
     # in tests - down the rabbit hole, not worth it
     except apt.cache.FetchFailedException:
         logging.warning("Failed to fetch the ESM Apt Cache")
+
+
+def remove_packages(package_names: List[str], error_message: str):
+    run_apt_command(
+        [
+            "apt-get",
+            "remove",
+            "--assume-yes",
+            '-o Dpkg::Options::="--force-confdef"',
+            '-o Dpkg::Options::="--force-confold"',
+        ]
+        + list(package_names),
+        error_message,
+        env={"DEBIAN_FRONTEND": "noninteractive"},
+    )

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -319,17 +319,9 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         )
         remove_packages = fips_metapackage.intersection(installed_packages)
         if remove_packages:
-            env = {"DEBIAN_FRONTEND": "noninteractive"}
-            apt_options = [
-                '-o Dpkg::Options::="--force-confdef"',
-                '-o Dpkg::Options::="--force-confold"',
-            ]
-            apt.run_apt_command(
-                ["apt-get", "remove", "--assume-yes"]
-                + apt_options
-                + list(remove_packages),
+            apt.remove_packages(
+                list(fips_metapackage),
                 messages.DISABLE_FAILED_TMPL.format(title=self.title),
-                env=env,
             )
 
     def _perform_enable(self, silent: bool = False) -> bool:

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -1,6 +1,6 @@
 from typing import Optional, Tuple  # noqa: F401
 
-from uaclient import event_logger, messages, system, util
+from uaclient import apt, event_logger, messages, system, util
 from uaclient.entitlements import repo
 from uaclient.entitlements.base import IncompatibleService
 from uaclient.types import (  # noqa: F401
@@ -91,3 +91,13 @@ class RealtimeKernelEntitlement(repo.RepoEntitlement):
                 )
             ],
         }
+
+    def remove_packages(self) -> None:
+        packages = set(self.packages).intersection(
+            set(apt.get_installed_packages_names())
+        )
+        if packages:
+            apt.remove_packages(
+                list(packages),
+                messages.DISABLE_FAILED_TMPL.format(title=self.title),
+            )

--- a/uaclient/livepatch.py
+++ b/uaclient/livepatch.py
@@ -121,26 +121,31 @@ def status() -> Optional[LivepatchStatusStatus]:
     try:
         out, _ = system.subp([LIVEPATCH_CMD, "status", "--format", "json"])
     except exceptions.ProcessExecutionError:
-        logging.warning(
-            "canonical-livepatch returned error when " "checking status"
-        )
+        with util.disable_log_to_console():
+            logging.warning(
+                "canonical-livepatch returned error when checking status"
+            )
         return None
 
     try:
         status_json = json.loads(out)
     except json.JSONDecodeError:
-        logging.warning(
-            "canonical-livepatch status returned invalid json: {}".format(out)
-        )
+        with util.disable_log_to_console():
+            logging.warning(
+                "canonical-livepatch status returned invalid json: {}".format(
+                    out
+                )
+            )
         return None
 
     try:
         status_root = LivepatchStatus.from_dict(status_json)
     except IncorrectTypeError:
-        logging.warning(
-            "canonical-livepatch status returned unexpected "
-            "structure: {}".format(out)
-        )
+        with util.disable_log_to_console():
+            logging.warning(
+                "canonical-livepatch status returned unexpected "
+                "structure: {}".format(out)
+            )
         return None
 
     if status_root.status is None or len(status_root.status) < 1:

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -823,8 +823,18 @@ Do you want to continue? [ default = Yes ]: (Y/n) """.format(
     bold=TxtColor.BOLD, end_bold=TxtColor.ENDC
 )
 REALTIME_PRE_DISABLE_PROMPT = """\
-This will disable Ubuntu Pro updates to the Real-time kernel on this machine.
-The Real-time kernel will remain installed.\
+This will remove the boot order preference for the Real-time kernel and
+disable updates to the Real-time kernel.
+
+This will NOT fully remove the kernel from your system.
+
+After this operation is complete you must:
+  - Ensure a different kernel is installed and configured to boot
+  - Reboot into that kernel
+  - Fully remove the realtime kernel packages from your system
+      - This might look something like `apt remove linux*realtime`,
+        but you must ensure this is correct before running it.
+
 Are you sure? (y/N) """
 
 REALTIME_ERROR_INSTALL_ON_CONTAINER = NamedMessage(


### PR DESCRIPTION
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the existing fips_vm tests
Run the edited realtime test
Test the UX of enabling and disabling realtime in a VM

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
