### PR TITLE
apt-news: deliver hook on interim releases

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -66,11 +66,7 @@ override_dh_auto_install:
 
 	# We install the conf file even on non-LTS version to avoid issues on upgrade scenarios
 	make -C apt-hook DESTDIR=$(CURDIR)/debian/ubuntu-advantage-tools install-conf
-
-# Hooks will only be delivered on LTS instances
-ifeq (LTS,$(findstring LTS,$(VERSION)))
 	make -C apt-hook DESTDIR=$(CURDIR)/debian/ubuntu-advantage-tools install
-endif
 
 	# We want to guarantee that we are not shipping any conftest files
 	find $(CURDIR)/debian/ubuntu-advantage-tools -type f -name conftest.py -delete


### PR DESCRIPTION
## Proposed Commit Message
apt-news: deliver hook on interim releases

We are now delivering the apt hook on interim releases to allow apt-news messages to appear during apt upgrade

## Test Steps
Verify if the APT news integration test is now passing for Kinetic as well as the other LTS series

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
