### PR TITLE
livepatch: display tailored warnings for new support statuses (SC-1538)

### DIFF
--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -2,9 +2,10 @@
 Feature: Livepatch
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached livepatch status shows warning when on unsupported kernel
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Then I verify that no files exist matching `/home/ubuntu/.cache/ubuntu-pro/livepatch-kernel-support-cache.json`
         When I run `pro status` as non-root
         Then I verify that files exist matching `/home/ubuntu/.cache/ubuntu-pro/livepatch-kernel-support-cache.json`
@@ -73,8 +74,8 @@ Feature: Livepatch
         Supported livepatch kernels are listed here: https://ubuntu.com/security/livepatch/docs/kernels
         """
         Examples: ubuntu release
-            | release |
-            | focal   |
+            | release | machine_type |
+            | focal   | lxd-vm       |
 
     @series.focal
     @uses.config.machine_type.any
@@ -128,9 +129,10 @@ Feature: Livepatch
 
     @series.kinetic
     @series.lunar
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Livepatch is not enabled by default and can't be enabled on interim releases
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
         """
@@ -153,6 +155,6 @@ Feature: Livepatch
         livepatch +yes +n/a +Canonical Livepatch service
         """
         Examples: ubuntu release
-            | release | pretty_name           |
-            | kinetic | 22.10 (Kinetic Kudu)  |
-            | lunar   | 23.04 (Lunar Lobster) |
+            | release | machine_type | pretty_name           |
+            | kinetic | lxd-vm       | 22.10 (Kinetic Kudu)  |
+            | lunar   | lxd-vm       | 23.04 (Lunar Lobster) |

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1202,6 +1202,19 @@ INCORRECT_ENUM_VALUE_ERROR_MESSAGE = FormattedNamedMessage(
     "Value provided was not found in {enum_class}'s allowed: value: {values}",
 )
 
+LIVEPATCH_KERNEL_UPGRADE_REQUIRED = NamedMessage(
+    name="livepatch-kernel-upgrade-required",
+    msg="""\
+The running kernel has reached the end of its active livepatch window.
+Please upgrade the kernel with apt and reboot for continued livepatch support.""",  # noqa: E501
+)
+LIVEPATCH_KERNEL_EOL = FormattedNamedMessage(
+    name="livepatch-kernel-eol",
+    msg="""\
+The current kernel ({version}, {arch}) has reached the end of its livepatch support.
+Supported kernels are listed here: https://ubuntu.com/security/livepatch/docs/kernels
+Either switch to a supported kernel or `pro disable livepatch` to dismiss this warning.""",  # noqa: E501
+)
 LIVEPATCH_KERNEL_NOT_SUPPORTED = FormattedNamedMessage(
     name="livepatch-kernel-not-supported",
     msg="""\

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -289,7 +289,8 @@ def _unattached_status(cfg: UAConfig) -> Dict[str, Any]:
         # that takes into account local information.
         if (
             ent_cls.name == "livepatch"
-            and livepatch.on_supported_kernel() is False
+            and livepatch.on_supported_kernel()
+            == livepatch.LivepatchSupport.UNSUPPORTED
         ):
             lp = ent_cls(cfg)
             descr_override = lp.status_description_override()
@@ -687,7 +688,10 @@ def format_tabular(status: Dict[str, Any], show_all: bool = False) -> str:
             content.extend(["", messages.STATUS_ALL_HINT])
 
         content.extend(["", messages.UNATTACHED.msg])
-        if livepatch.on_supported_kernel() is False:
+        if (
+            livepatch.on_supported_kernel()
+            == livepatch.LivepatchSupport.UNSUPPORTED
+        ):
             content.extend(
                 ["", messages.LIVEPATCH_KERNEL_NOT_SUPPORTED_UNATTACHED]
             )

--- a/uaclient/tests/test_livepatch.py
+++ b/uaclient/tests/test_livepatch.py
@@ -12,6 +12,7 @@ from uaclient.livepatch import (
     LivepatchPatchFixStatus,
     LivepatchPatchStatus,
     LivepatchStatusStatus,
+    LivepatchSupport,
     UALivepatchClient,
     _on_supported_kernel_api,
     _on_supported_kernel_cache,
@@ -307,19 +308,33 @@ class TestOnSupportedKernel:
                 LivepatchStatusStatus(
                     kernel=None, livepatch=None, supported="supported"
                 ),
-                True,
+                LivepatchSupport.SUPPORTED,
             ),
             (
                 LivepatchStatusStatus(
                     kernel=None, livepatch=None, supported="unsupported"
                 ),
-                False,
+                LivepatchSupport.UNSUPPORTED,
+            ),
+            (
+                LivepatchStatusStatus(
+                    kernel=None,
+                    livepatch=None,
+                    supported="kernel-upgrade-required",
+                ),
+                LivepatchSupport.KERNEL_UPGRADE_REQUIRED,
+            ),
+            (
+                LivepatchStatusStatus(
+                    kernel=None, livepatch=None, supported="kernel-end-of-life"
+                ),
+                LivepatchSupport.KERNEL_EOL,
             ),
             (
                 LivepatchStatusStatus(
                     kernel=None, livepatch=None, supported="unknown"
                 ),
-                None,
+                LivepatchSupport.UNKNOWN,
             ),
         ],
     )
@@ -554,9 +569,9 @@ class TestOnSupportedKernel:
             "expected",
         ],
         [
-            # cli result true
+            # cli result supported
             (
-                True,
+                LivepatchSupport.SUPPORTED,
                 None,
                 None,
                 None,
@@ -564,11 +579,11 @@ class TestOnSupportedKernel:
                 None,
                 [],
                 [],
-                True,
+                LivepatchSupport.SUPPORTED,
             ),
-            # cli result false
+            # cli result unsupported
             (
-                False,
+                LivepatchSupport.UNSUPPORTED,
                 None,
                 None,
                 None,
@@ -576,7 +591,43 @@ class TestOnSupportedKernel:
                 None,
                 [],
                 [],
-                False,
+                LivepatchSupport.UNSUPPORTED,
+            ),
+            # cli result upgrade-required
+            (
+                LivepatchSupport.KERNEL_UPGRADE_REQUIRED,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [],
+                [],
+                LivepatchSupport.KERNEL_UPGRADE_REQUIRED,
+            ),
+            # cli result eol
+            (
+                LivepatchSupport.KERNEL_EOL,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [],
+                [],
+                LivepatchSupport.KERNEL_EOL,
+            ),
+            # cli result definite unknown
+            (
+                LivepatchSupport.UNKNOWN,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [],
+                [],
+                LivepatchSupport.UNKNOWN,
             ),
             # insufficient kernel info
             (
@@ -597,7 +648,7 @@ class TestOnSupportedKernel:
                 None,
                 [],
                 [],
-                None,
+                LivepatchSupport.UNKNOWN,
             ),
             # cache result true
             (
@@ -618,7 +669,7 @@ class TestOnSupportedKernel:
                 None,
                 [mock.call("5.6", "generic", "amd64", "xenial")],
                 [],
-                True,
+                LivepatchSupport.SUPPORTED,
             ),
             # cache result false
             (
@@ -639,7 +690,7 @@ class TestOnSupportedKernel:
                 None,
                 [mock.call("5.6", "generic", "amd64", "xenial")],
                 [],
-                False,
+                LivepatchSupport.UNSUPPORTED,
             ),
             # cache result none
             (
@@ -660,7 +711,7 @@ class TestOnSupportedKernel:
                 None,
                 [mock.call("5.6", "generic", "amd64", "xenial")],
                 [],
-                None,
+                LivepatchSupport.UNKNOWN,
             ),
             # api result true
             (
@@ -681,7 +732,7 @@ class TestOnSupportedKernel:
                 True,
                 [mock.call("5.6", "generic", "amd64", "xenial")],
                 [mock.call("5.6", "generic", "amd64", "xenial")],
-                True,
+                LivepatchSupport.SUPPORTED,
             ),
         ],
     )


### PR DESCRIPTION
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
The new integration test should pass.
Notice that the older integration test -- the first one in livepatch.feature -- is failing with the new implementation. This is exposing a bug in livepatch where unsupported kernels are being reported as "unknown" support by the livepatch-client. So it is "correct" to be failing :/

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [x] Yes - livepatch team - done
 - [ ] No
