### PR TITLE
readme changes - link to docs instead of a separate TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@
 </h1>
 
 ###### Clean and Consistent CLI for your Ubuntu Pro Systems
-![Latest Upstream Version](https://img.shields.io/github/v/tag/canonical/ubuntu-advantage-client.svg?label=Latest%20Upstream%20Version&logo=github&logoColor=white&color=33ce57)
-![CI](https://github.com/canonical/ubuntu-advantage-client/actions/workflows/ci-base.yaml/badge.svg?branch=main)
+[![Latest Upstream Version](https://img.shields.io/github/v/tag/canonical/ubuntu-advantage-client.svg?label=Latest%20Upstream%20Version&logo=github&logoColor=white&color=33ce57)](https://github.com/canonical/ubuntu-pro-client/tags)
+[![CI](https://github.com/canonical/ubuntu-advantage-client/actions/workflows/ci-base.yaml/badge.svg?branch=main)](https://github.com/canonical/ubuntu-pro-client/actions)
+[![Documentation Status](https://readthedocs.com/projects/canonical-ubuntu-pro-client/badge/?version=latest)](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/?badge=latest)
 <br/>
-![Released Xenial Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/xenial?label=Xenial&logo=ubuntu&logoColor=white)
-![Released Bionic Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/bionic?label=Bionic&logo=ubuntu&logoColor=white)
-![Released Focal Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/focal?label=Focal&logo=ubuntu&logoColor=white)
-![Released Jammy Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/jammy?label=Jammy&logo=ubuntu&logoColor=white)
+[![Released Xenial Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/xenial?label=Xenial&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/xenial/+source/ubuntu-advantage-tools)
+[![Released Bionic Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/bionic?label=Bionic&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/bionic/+source/ubuntu-advantage-tools)
+[![Released Focal Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/focal?label=Focal&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/focal/+source/ubuntu-advantage-tools)
+[![Released Jammy Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/jammy?label=Jammy&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/jammy/+source/ubuntu-advantage-tools)
+[![Released Kinetic Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/kinetic?label=Kinetic&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/kinetic/+source/ubuntu-advantage-tools)
+[![Released Lunar Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/lunar?label=Lunar&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/lunar/+source/ubuntu-advantage-tools)
 
 The Ubuntu Pro Client (`pro`) is the official tool to enable Canonical offerings on your
 system.
@@ -33,50 +36,7 @@ If you need any of those services for your machine, `pro` is the right tool for 
 
 `pro` is already installed on every Ubuntu system. Try it out by running `pro help`!
 
-## Documentation
-
-### Tutorials
-
-* [Getting started with Ubuntu Pro Client](./docs/tutorials/basic_commands.md)
-* [Create a FIPS compliant Ubuntu Docker image](./docs/tutorials/create_a_fips_docker_image.md)
-* [Fix vulnerabilities by CVE or USN using `pro fix`](./docs/tutorials/fix_scenarios.md)
-* [Create a Custom Ubuntu Pro Cloud Image with FIPS Updates](./docs/tutorials/create_a_fips_updates_pro_cloud_image.md)
-
-### How To Guides
-
-* [How to get an Ubuntu Pro token and attach to a subscription](./docs/howtoguides/get_token_and_attach.md)
-* [How to Configure Proxies](./docs/howtoguides/configure_proxies.md)
-* [How to Enable Ubuntu Pro Services in a Dockerfile](./docs/howtoguides/enable_in_dockerfile.md)
-* [How to Create a custom Golden Image based on Public Cloud Ubuntu Pro images](./docs/howtoguides/create_pro_golden_image.md)
-* [How to Manually update MOTD and APT messages](./docs/howtoguides/update_motd_messages.md)
-* [How to enable CIS](./docs/howtoguides/enable_cis.md)
-* [How to enable CC EAL](./docs/howtoguides/enable_cc.md)
-* [How to enable ESM Infra](./docs/howtoguides/enable_esm_infra.md)
-* [How to enable FIPS](./docs/howtoguides/enable_fips.md)
-* [How to enable Livepatch](./docs/howtoguides/enable_livepatch.md)
-* [How to configure a timer job](./docs/howtoguides/configuring_timer_jobs.md)
-* [How to attach with a configuration file](./docs/howtoguides/how_to_attach_with_config_file.md)
-* [How to collect Ubuntu Pro Client logs](./docs/howtoguides/how_to_collect_logs.md)
-* [How to simulate attach operation](./docs/howtoguides/how_to_simulate_attach.md)
-* [How to run `pro fix` in dry-run mode](./docs/howtoguides/how_to_run_fix_in_dry_run_mode.md)
-
-### Reference
-
-* [Ubuntu Release and Architecture Support Matrix](./docs/references/support_matrix.md)
-* [Network Requirements](./docs/references/network_requirements.md)
-* [API Reference Guide](./docs/references/api.md)
-* [PPAs with different versions of `pro`](./docs/references/ppas.md)
-
-### Explanation
-
-* [What is the daemon for? (And how to disable it)](./docs/explanations/what_is_the_daemon.md)
-* [What are Public Cloud Ubuntu Pro instances?](./docs/explanations/what_are_ubuntu_pro_cloud_instances.md)
-* [What is the ubuntu-advantage-pro package?](./docs/explanations/what_is_the_ubuntu_advantage_pro_package.md)
-* [What are the timer jobs?](./docs/explanations/what_are_the_timer_jobs.md)
-* [What are the Ubuntu Pro related MOTD messages?](./docs/explanations/motd_messages.md)
-* [What are the Ubuntu Pro related APT messages?](./docs/explanations/apt_messages.md)
-* [How to interpret the security-status command](./docs/explanations/how_to_interpret_the_security_status_command.md)
-* [Why Trusty (14.04) is no longer supported](./docs/explanations/why_trusty_is_no_longer_supported.md)
+Or [check out the docs](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/).
 
 ## Project and community
 

--- a/docs/_static/js/github_issue_links.js
+++ b/docs/_static/js/github_issue_links.js
@@ -4,7 +4,7 @@ window.onload = function() {
     link.classList.add("github-issue-link");
     link.text = "Have a question?";
     link.href = (
-        "https://github.com/canonical/ubuntu-advantage-client/issues/new?"
+        "https://github.com/canonical/ubuntu-pro-client/issues/new?"
         + "title=docs%3A+TYPE+YOUR+QUESTION+HERE"
         + "&body=*Please describe the question or issue you're facing with "
         + `"${document.title}"`


### PR DESCRIPTION
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Our Readme TOC of docs was getting out of date, and now that we have rtd, we don't really need it.
I also added some new badges and made our existing badges link to more interesting things than the badge itself.

LMK if this does or doesn't make sense.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
