### PR TITLE
reboot_cmds refactor (SC-1304)

### DIFF
--- a/features/reboot_cmds.feature
+++ b/features/reboot_cmds.feature
@@ -1,0 +1,48 @@
+@uses.config.contract_token
+Feature: Reboot Commands
+
+    @series.focal
+    @uses.config.machine_type.lxd.container
+    Scenario Outline: reboot-cmds removes fips package holds and updates packages
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        When I run `apt install -y strongswan` with sudo
+        When I run `pro enable fips --assume-yes` with sudo
+        When I reboot the machine
+        When I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        fips +yes +enabled
+        """
+        When I run `apt install -y --allow-downgrades strongswan=<old_version>` with sudo
+        When I run `apt-mark hold strongswan` with sudo
+        When I run `dpkg-reconfigure ubuntu-advantage-tools` with sudo
+        When I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        NOTICES
+        Reboot to FIPS kernel required
+        """
+        When I reboot the machine
+        And  I verify that running `systemctl status ua-reboot-cmds.service` `as non-root` exits `0,3`
+        Then stdout matches regexp:
+        """
+        .*status=0\/SUCCESS.*
+        """
+        When I run `pro status` with sudo
+        Then stdout does not match regexp:
+        """
+        NOTICES
+        """
+        When I run `apt-mark showholds` with sudo
+        Then I will see the following on stdout:
+        """
+        """
+        When I run `apt policy strongswan` with sudo
+        Then stdout contains substring:
+        """
+        *** <new_version> 1001
+        """
+        Examples: ubuntu release
+            | release | old_version      | new_version               |
+            | focal   | 5.8.2-1ubuntu3.5 | 5.8.2-1ubuntu3.fips.3.1.2 |

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -18,12 +18,18 @@ import logging
 import os
 import sys
 
-from uaclient import config, contract, defaults, exceptions, lock, messages
+from uaclient import (
+    config,
+    contract,
+    defaults,
+    exceptions,
+    lock,
+    messages,
+    system,
+)
 from uaclient.cli import setup_logging
 from uaclient.entitlements.fips import FIPSEntitlement
 from uaclient.files import notices
-from uaclient.files.notices import Notice
-from uaclient.system import subp
 
 # Retry sleep backoff algorithm if lock is held.
 # Lock may be held by auto-attach on systems with ubuntu-advantage-pro.
@@ -33,7 +39,7 @@ MAX_RETRIES_ON_LOCK_HELD = 7
 
 def run_command(cmd, cfg: config.UAConfig):
     try:
-        out, _ = subp(cmd.split(), capture=True)
+        out, _ = system.subp(cmd.split(), capture=True)
         logging.debug("Successfully executed cmd: {}".format(cmd))
     except exceptions.ProcessExecutionError as exec_error:
         msg = (
@@ -121,15 +127,13 @@ def process_reboot_operations(cfg: config.UAConfig):
             process_remaining_deltas(cfg)
 
             cfg.delete_cache_key("marker-reboot-cmds")
-            notices.remove(Notice.REBOOT_SCRIPT_FAILED)
+            notices.remove(notices.Notice.REBOOT_SCRIPT_FAILED)
             logging.debug("Successfully ran all commands on reboot.")
         except Exception as e:
             msg = "Failed running commands on reboot."
             msg += str(e)
             logging.error(msg)
-            notices.add(
-                Notice.REBOOT_SCRIPT_FAILED,
-            )
+            notices.add(notices.Notice.REBOOT_SCRIPT_FAILED)
 
 
 def main(cfg: config.UAConfig):

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -63,33 +63,31 @@ def fix_pro_pkg_holds(cfg: config.UAConfig):
         return
     for service in status_cache.get("services", []):
         if service.get("name") == "fips":
-            service_status = service.get("status")
-            if service_status == "enabled":
-                ent_cls = FIPSEntitlement
-                logging.debug(
-                    "Attempting to remove Ubuntu Pro FIPS package holds"
-                )
-                entitlement = ent_cls(cfg)
-                try:
-                    entitlement.setup_apt_config()  # Removes package holds
-                    logging.debug(
-                        "Successfully removed Ubuntu Pro FIPS package holds"
-                    )
-                except Exception as e:
-                    logging.exception(e)
-                    logging.warning(
-                        "Could not remove Ubuntu PRO FIPS package holds"
-                    )
-                try:
-                    entitlement.install_packages(cleanup_on_failure=False)
-                except exceptions.UserFacingError as e:
-                    logging.error(e.msg)
-                    logging.warning(
-                        "Failed to install packages at boot: {}".format(
-                            ", ".join(entitlement.packages)
-                        )
-                    )
-                    sys.exit(1)
+            if service.get("status") == "enabled":
+                # fips was enabled, fix the holds
+                break
+            else:
+                # fips was not enabled, don't do anything
+                return
+
+    fips = FIPSEntitlement(cfg)
+    logging.debug("Attempting to remove Ubuntu Pro FIPS package holds")
+    try:
+        fips.setup_apt_config()  # Removes package holds
+        logging.debug("Successfully removed Ubuntu Pro FIPS package holds")
+    except Exception as e:
+        logging.error(e)
+        logging.warning("Could not remove Ubuntu Pro FIPS package holds")
+    try:
+        fips.install_packages(cleanup_on_failure=False)
+    except exceptions.UserFacingError as e:
+        logging.error(e.msg)
+        logging.warning(
+            "Failed to install packages at boot: {}".format(
+                ", ".join(fips.packages)
+            )
+        )
+        sys.exit(1)
 
 
 def refresh_contract(cfg: config.UAConfig):

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -25,7 +25,7 @@ from uaclient import (
     exceptions,
     lock,
     messages,
-    system,
+    upgrade_lts_contract,
 )
 from uaclient.cli import setup_logging
 from uaclient.entitlements.fips import FIPSEntitlement
@@ -35,26 +35,6 @@ from uaclient.files import notices
 # Lock may be held by auto-attach on systems with ubuntu-advantage-pro.
 SLEEP_ON_LOCK_HELD = 1
 MAX_RETRIES_ON_LOCK_HELD = 7
-
-
-def run_command(cmd, cfg: config.UAConfig):
-    try:
-        out, _ = system.subp(cmd.split(), capture=True)
-        logging.debug("Successfully executed cmd: {}".format(cmd))
-    except exceptions.ProcessExecutionError as exec_error:
-        msg = (
-            "Failed running cmd: {}\n"
-            "Return code: {}\n"
-            "Stderr: {}\n"
-            "Stdout: {}".format(
-                cmd, exec_error.exit_code, exec_error.stderr, exec_error.stdout
-            )
-        )
-
-        cfg.delete_cache_key("marker-reboot-cmds")
-
-        logging.warning(msg)
-        sys.exit(1)
 
 
 def fix_pro_pkg_holds(cfg: config.UAConfig):
@@ -100,8 +80,7 @@ def refresh_contract(cfg: config.UAConfig):
 
 
 def process_remaining_deltas(cfg: config.UAConfig):
-    cmd = "/usr/bin/python3 /usr/lib/ubuntu-advantage/upgrade_lts_contract.py"
-    run_command(cmd=cmd, cfg=cfg)
+    upgrade_lts_contract.process_contract_delta_after_apt_lock(cfg)
 
 
 def process_reboot_operations(cfg: config.UAConfig):

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -30,11 +30,6 @@ from uaclient.cli import setup_logging
 from uaclient.entitlements.fips import FIPSEntitlement
 from uaclient.files import notices, state_files
 
-# Retry sleep backoff algorithm if lock is held.
-# Lock may be held by auto-attach on systems with ubuntu-advantage-pro.
-SLEEP_ON_LOCK_HELD = 1
-MAX_RETRIES_ON_LOCK_HELD = 7
-
 
 def fix_pro_pkg_holds(cfg: config.UAConfig):
     status_cache = cfg.read_cache("status-cache")
@@ -49,80 +44,73 @@ def fix_pro_pkg_holds(cfg: config.UAConfig):
                 # fips was not enabled, don't do anything
                 return
 
-    fips = FIPSEntitlement(cfg)
     logging.debug("Attempting to remove Ubuntu Pro FIPS package holds")
+    fips = FIPSEntitlement(cfg)
     try:
         fips.setup_apt_config()  # Removes package holds
         logging.debug("Successfully removed Ubuntu Pro FIPS package holds")
     except Exception as e:
         logging.error(e)
         logging.warning("Could not remove Ubuntu Pro FIPS package holds")
+
     try:
         fips.install_packages(cleanup_on_failure=False)
-    except exceptions.UserFacingError as e:
-        logging.error(e.msg)
+    except exceptions.UserFacingError:
         logging.warning(
             "Failed to install packages at boot: {}".format(
                 ", ".join(fips.packages)
             )
         )
-        sys.exit(1)
+        raise
 
 
 def refresh_contract(cfg: config.UAConfig):
     try:
         contract.request_updated_contract(cfg)
-    except exceptions.UrlError as exc:
-        logging.exception(exc)
+    except exceptions.UrlError:
         logging.warning(messages.REFRESH_CONTRACT_FAILURE)
-        sys.exit(1)
+        raise
 
 
-def process_remaining_deltas(cfg: config.UAConfig):
-    upgrade_lts_contract.process_contract_delta_after_apt_lock(cfg)
+def main(cfg: config.UAConfig) -> int:
+    if not state_files.reboot_cmd_marker_file.is_present:
+        logging.debug("Skipping reboot_cmds. Marker file not present")
+        notices.remove(notices.Notice.REBOOT_SCRIPT_FAILED)
+        return 0
 
-
-def process_reboot_operations(cfg: config.UAConfig):
     if not cfg.is_attached:
         logging.debug("Skipping reboot_cmds. Machine is unattached")
         state_files.reboot_cmd_marker_file.delete()
-        return
+        notices.remove(notices.Notice.REBOOT_SCRIPT_FAILED)
+        return 0
 
-    if state_files.reboot_cmd_marker_file.is_present:
-        logging.debug("Running process contract deltas on reboot ...")
-
-        try:
+    logging.debug("Running reboot commands...")
+    try:
+        with lock.SpinLock(cfg=cfg, lock_holder="pro-reboot-cmds"):
             fix_pro_pkg_holds(cfg)
             refresh_contract(cfg)
-            process_remaining_deltas(cfg)
-
+            upgrade_lts_contract.process_contract_delta_after_apt_lock(cfg)
+            # cleanup state after a succesful run
             state_files.reboot_cmd_marker_file.delete()
             notices.remove(notices.Notice.REBOOT_SCRIPT_FAILED)
-            logging.debug("Successfully ran all commands on reboot.")
-        except Exception as e:
-            msg = "Failed running commands on reboot."
-            msg += str(e)
-            logging.error(msg)
-            notices.add(notices.Notice.REBOOT_SCRIPT_FAILED)
 
-
-def main(cfg: config.UAConfig):
-    """Retry running process_reboot_operations on LockHeldError
-
-    :raises: LockHeldError when lock still held by auto-attach after retries.
-             UserFacingError for all other errors
-    """
-    try:
-        with lock.SpinLock(
-            cfg=cfg,
-            lock_holder="ua-reboot-cmds",
-            sleep_time=SLEEP_ON_LOCK_HELD,
-            max_retries=MAX_RETRIES_ON_LOCK_HELD,
-        ):
-            process_reboot_operations(cfg=cfg)
     except exceptions.LockHeldError as e:
         logging.warning("Lock not released. %s", str(e.msg))
-        sys.exit(1)
+        notices.add(notices.Notice.REBOOT_SCRIPT_FAILED)
+        return 1
+    except exceptions.UserFacingError as e:
+        logging.error(
+            "Error while running commands on reboot: %s, %s", e.msg_code, e.msg
+        )
+        notices.add(notices.Notice.REBOOT_SCRIPT_FAILED)
+        return 1
+    except Exception as e:
+        logging.error("Failed running commands on reboot. Error: %s", str(e))
+        notices.add(notices.Notice.REBOOT_SCRIPT_FAILED)
+        return 1
+
+    logging.debug("Successfully ran all commands on reboot.")
+    return 0
 
 
 if __name__ == "__main__":
@@ -133,4 +121,4 @@ if __name__ == "__main__":
     )
     cfg = config.UAConfig()
     setup_logging(logging.INFO, logging.DEBUG, log_file=cfg.log_file)
-    main(cfg=cfg)
+    sys.exit(main(cfg=cfg))

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -28,15 +28,6 @@ from uaclient import contract, defaults, system
 from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
 
-version_to_codename = {
-    "14.04": "trusty",
-    "16.04": "xenial",
-    "18.04": "bionic",
-    "20.04": "focal",
-    "22.04": "jammy",
-    "22.10": "kinetic",
-}
-
 # We consider the past release for LTSs to be the last LTS,
 # because we don't have any services available on non-LTS.
 # This makes it safer for us to try to process contract deltas.
@@ -64,16 +55,7 @@ def process_contract_delta_after_apt_lock() -> None:
     print(msg)
     logging.debug(msg)
 
-    current_version = system.parse_os_release()["VERSION_ID"]
-    current_release = version_to_codename.get(current_version)
-
-    if current_release is None:
-        msg = "Unable to get release codename for version: {}".format(
-            current_version
-        )
-        print(msg)
-        logging.warning(msg)
-        sys.exit(1)
+    current_release = system.get_release_info().series
 
     past_release = current_codename_to_past_codename.get(current_release)
     if past_release is None:

--- a/systemd/ua-reboot-cmds.service
+++ b/systemd/ua-reboot-cmds.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=Ubuntu Advantage reboot cmds
+Description=Ubuntu Pro reboot cmds
 ConditionPathExists=/var/lib/ubuntu-advantage/marker-reboot-cmds-required
-Wants=ua-auto-attach.service
+ConditionPathExists=/var/lib/ubuntu-advantage/private/machine-token.json
 After=ua-auto-attach.service
 
 [Service]

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -376,7 +376,7 @@ def add_auth_apt_repo(
     except ValueError:  # Then we have a bearer token
         username = "bearer"
         password = credentials
-    series = system.get_platform_info()["series"]
+    series = system.get_release_info().series
     if repo_url.endswith("/"):
         repo_url = repo_url[:-1]
     assert_valid_apt_credentials(repo_url, username, password)

--- a/uaclient/apt_news.py
+++ b/uaclient/apt_news.py
@@ -81,7 +81,7 @@ def do_selectors_apply(
         return True
 
     if selectors.codenames is not None:
-        if system.get_platform_info()["series"] not in selectors.codenames:
+        if system.get_release_info().series not in selectors.codenames:
             return False
 
     if selectors.clouds is not None:

--- a/uaclient/clouds/gcp.py
+++ b/uaclient/clouds/gcp.py
@@ -105,7 +105,7 @@ class UAAutoAttachGCPInstance(AutoAttachCloudInstance):
         )
 
     def should_poll_for_pro_license(self) -> bool:
-        series = system.get_platform_info()["series"]
+        series = system.get_release_info().series
         if series not in GCP_LICENSES:
             LOG.info("This series isn't supported for GCP auto-attach.")
             return False
@@ -132,5 +132,5 @@ class UAAutoAttachGCPInstance(AutoAttachCloudInstance):
         license_ids = [license["id"] for license in licenses]
         self.etag = headers.get("ETag", None)
 
-        series = system.get_platform_info()["series"]
+        series = system.get_release_info().series
         return GCP_LICENSES.get(series) in license_ids

--- a/uaclient/clouds/tests/test_gcp.py
+++ b/uaclient/clouds/tests/test_gcp.py
@@ -5,6 +5,7 @@ from urllib.error import HTTPError
 import mock
 import pytest
 
+from uaclient import system
 from uaclient.clouds.gcp import (
     LAST_ETAG,
     LICENSES_URL,
@@ -123,7 +124,12 @@ class TestUAAutoAttachGCPInstance:
                 None,
                 False,
                 ([], {}),
-                {"series": "xenial"},
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="xenial",
+                    pretty_version="",
+                ),
                 None,
                 False,
                 [
@@ -136,7 +142,12 @@ class TestUAAutoAttachGCPInstance:
                 None,
                 False,
                 ([{"id": "8045211386737108299"}], {}),
-                {"series": "xenial"},
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="xenial",
+                    pretty_version="",
+                ),
                 None,
                 True,
                 [
@@ -149,7 +160,12 @@ class TestUAAutoAttachGCPInstance:
                 None,
                 False,
                 ([{"id": "8045211386737108299"}], {}),
-                {"series": "bionic"},
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="bionic",
+                    pretty_version="",
+                ),
                 None,
                 False,
                 [
@@ -162,7 +178,12 @@ class TestUAAutoAttachGCPInstance:
                 None,
                 False,
                 ([{"id": "6022427724719891830"}], {}),
-                {"series": "bionic"},
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="bionic",
+                    pretty_version="",
+                ),
                 None,
                 True,
                 [
@@ -175,7 +196,12 @@ class TestUAAutoAttachGCPInstance:
                 None,
                 False,
                 ([{"id": "599959289349842382"}], {}),
-                {"series": "focal"},
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="focal",
+                    pretty_version="",
+                ),
                 None,
                 True,
                 [
@@ -188,7 +214,12 @@ class TestUAAutoAttachGCPInstance:
                 None,
                 False,
                 ([{"id": "8045211386737108299"}], {"ETag": "test-etag"}),
-                {"series": "xenial"},
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="xenial",
+                    pretty_version="",
+                ),
                 "test-etag",
                 True,
                 [
@@ -201,7 +232,12 @@ class TestUAAutoAttachGCPInstance:
                 None,
                 False,
                 ([{"id": "wrong"}], {"ETag": "test-etag"}),
-                {"series": "xenial"},
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="xenial",
+                    pretty_version="",
+                ),
                 "test-etag",
                 False,
                 [
@@ -214,7 +250,12 @@ class TestUAAutoAttachGCPInstance:
                 None,
                 True,
                 ([{"id": "8045211386737108299"}], {"ETag": "test-etag"}),
-                {"series": "xenial"},
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="xenial",
+                    pretty_version="",
+                ),
                 "test-etag",
                 True,
                 [
@@ -228,7 +269,12 @@ class TestUAAutoAttachGCPInstance:
                 "existing-etag",
                 True,
                 ([{"id": "8045211386737108299"}], {"ETag": "test-etag"}),
-                {"series": "xenial"},
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="xenial",
+                    pretty_version="",
+                ),
                 "test-etag",
                 True,
                 [
@@ -242,12 +288,12 @@ class TestUAAutoAttachGCPInstance:
             ),
         ),
     )
-    @mock.patch(M_PATH + "system.get_platform_info")
+    @mock.patch(M_PATH + "system.get_release_info")
     @mock.patch(M_PATH + "util.readurl")
     def test_is_license_present(
         self,
         m_readurl,
-        m_get_platform_info,
+        m_get_release_info,
         existing_etag,
         wait_for_change,
         metadata_response,
@@ -259,7 +305,7 @@ class TestUAAutoAttachGCPInstance:
         instance = UAAutoAttachGCPInstance()
         instance.etag = existing_etag
         m_readurl.return_value = metadata_response
-        m_get_platform_info.return_value = platform_info
+        m_get_release_info.return_value = platform_info
 
         result = instance.is_pro_license_present(
             wait_for_change=wait_for_change
@@ -273,18 +319,58 @@ class TestUAAutoAttachGCPInstance:
     @pytest.mark.parametrize(
         "platform_info, expected_result",
         (
-            ({"series": "xenial"}, True),
-            ({"series": "bionic"}, True),
-            ({"series": "focal"}, True),
-            ({"series": "non_lts"}, False),
-            ({"series": "jammy"}, True),
+            (
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="xenial",
+                    pretty_version="",
+                ),
+                True,
+            ),
+            (
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="bionic",
+                    pretty_version="",
+                ),
+                True,
+            ),
+            (
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="focal",
+                    pretty_version="",
+                ),
+                True,
+            ),
+            (
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="non_lts",
+                    pretty_version="",
+                ),
+                False,
+            ),
+            (
+                system.ReleaseInfo(
+                    distribution="",
+                    release="",
+                    series="jammy",
+                    pretty_version="",
+                ),
+                True,
+            ),
         ),
     )
-    @mock.patch(M_PATH + "system.get_platform_info")
+    @mock.patch(M_PATH + "system.get_release_info")
     def test_should_poll_for_license(
-        self, m_get_platform_info, platform_info, expected_result
+        self, m_get_release_info, platform_info, expected_result
     ):
-        m_get_platform_info.return_value = platform_info
+        m_get_release_info.return_value = platform_info
         instance = UAAutoAttachGCPInstance()
         result = instance.should_poll_for_pro_license()
         assert expected_result == result

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -92,7 +92,6 @@ class UAConfig:
         "machine-access-cis": DataPath("machine-access-cis.json", True),
         "lock": DataPath("lock", False),
         "status-cache": DataPath("status.json", False),
-        "marker-reboot-cmds": DataPath("marker-reboot-cmds-required", False),
     }  # type: Dict[str, DataPath]
 
     ua_scoped_proxy_options = ("ua_apt_http_proxy", "ua_apt_https_proxy")

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -342,23 +342,27 @@ class UAContractClient(serviceclient.UAServiceClient):
         """Return a dict of platform-related data for contract requests"""
         if not machine_id:
             machine_id = system.get_machine_id(self.cfg)
-        platform = system.get_platform_info()
-        platform_os = platform.copy()
-        arch = platform_os.pop("arch")
         return {
             "machineId": machine_id,
-            "architecture": arch,
-            "os": platform_os,
+            "architecture": system.get_dpkg_arch(),
+            "os": {
+                "type": "Linux",
+                "distribution": system.get_release_info().distribution,
+                "release": system.get_release_info().release,
+                "series": system.get_release_info().series,
+                "version": system.get_release_info().pretty_version,
+                "kernel": system.get_kernel_info().uname_release,
+                "virt": system.get_virt_type(),
+            },
         }
 
     def _get_platform_basic_info(self):
         """Return a dict of platform basic info for some contract requests"""
-        platform = system.get_platform_info()
         return {
-            "architecture": platform["arch"],
-            "series": platform["series"],
-            "kernel": platform["kernel"],
-            "virt": platform["virt"],
+            "architecture": system.get_dpkg_arch(),
+            "series": system.get_release_info().series,
+            "kernel": system.get_kernel_info().uname_release,
+            "virt": system.get_virt_type(),
         }
 
     def _get_activity_info(self, machine_id: Optional[str] = None):
@@ -733,7 +737,7 @@ def apply_contract_overrides(
         )
 
     series_name = (
-        system.get_platform_info()["series"] if series is None else series
+        system.get_release_info().series if series is None else series
     )
     cloud_type, _ = get_cloud_type()
     orig_entitlement = orig_access.get("entitlement", {})

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -686,19 +686,18 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             if functor() != expected_result:
                 return ApplicabilityStatus.INAPPLICABLE, error_message
         affordances = entitlement_cfg["entitlement"].get("affordances", {})
-        platform = system.get_platform_info()
         affordance_arches = affordances.get("architectures", None)
         if (
             self.affordance_check_arch
             and affordance_arches is not None
-            and platform["arch"] not in affordance_arches
+            and system.get_dpkg_arch() not in affordance_arches
         ):
             deduplicated_arches = util.deduplicate_arches(affordance_arches)
             return (
                 ApplicabilityStatus.INAPPLICABLE,
                 messages.INAPPLICABLE_ARCH.format(
                     title=self.title,
-                    arch=platform["arch"],
+                    arch=system.get_dpkg_arch(),
                     supported_arches=", ".join(deduplicated_arches),
                 ),
             )
@@ -706,12 +705,13 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         if (
             self.affordance_check_series
             and affordance_series is not None
-            and platform["series"] not in affordance_series
+            and system.get_release_info().series not in affordance_series
         ):
             return (
                 ApplicabilityStatus.INAPPLICABLE,
                 messages.INAPPLICABLE_SERIES.format(
-                    title=self.title, series=platform["version"]
+                    title=self.title,
+                    series=system.get_release_info().pretty_version,
                 ),
             )
         kernel_info = system.get_kernel_info()

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -31,7 +31,7 @@ class ESMBaseEntitlement(repo.RepoEntitlement):
         return enable_performed
 
     def setup_local_esm_repo(self) -> None:
-        series = system.get_platform_info()["series"]
+        series = system.get_release_info().series
         # Ugly? Yes, but so is python < 3.8 without removeprefix
         assert self.name.startswith("esm-")
         esm_name = self.name[len("esm-") :]

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -126,7 +126,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         2. Install the corresponding hmac version of that package
            when available.
         """
-        series = system.get_platform_info().get("series", "")
+        series = system.get_release_info().series
 
         if system.is_container():
             return FIPS_CONTAINER_CONDITIONAL_PACKAGES.get(series, [])
@@ -246,7 +246,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         if cloud_id is None:
             cloud_id = ""
 
-        series = system.get_platform_info().get("series", "")
+        series = system.get_release_info().series
         blocked_message = messages.FIPS_BLOCK_ON_CLOUD.format(
             series=series.title(), cloud=cloud_titles.get(cloud_id)
         )

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -399,7 +399,7 @@ class RepoEntitlement(base.UAEntitlement):
         :param run_apt_update: If after removing the apt update
             command after removing the apt files.
         """
-        series = system.get_platform_info()["series"]
+        series = system.get_release_info().series
         repo_filename = self.repo_list_file_tmpl.format(name=self.name)
         entitlement = self.cfg.machine_token_file.entitlements[self.name].get(
             "entitlement", {}

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 import mock
 import pytest
 
-from uaclient import messages, util
+from uaclient import messages, system, util
 from uaclient.entitlements import base
 from uaclient.entitlements.entitlement_status import (
     ApplicabilityStatus,
@@ -945,7 +945,10 @@ class TestUaEntitlementProcessContractDeltas:
         ),
     )
     @mock.patch(
-        "uaclient.system.get_platform_info", return_value={"series": "example"}
+        "uaclient.system.get_release_info",
+        return_value=system.ReleaseInfo(
+            distribution="", release="", series="example", pretty_version=""
+        ),
     )
     def test_process_contract_deltas_does_nothing_when_delta_remains_entitled(
         self, m_platform_info, concrete_entitlement_factory, orig_access, delta

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -3,7 +3,7 @@
 import mock
 import pytest
 
-from uaclient import apt, messages
+from uaclient import apt, messages, system
 from uaclient.entitlements.cis import CIS_DOCS_URL, CISEntitlement
 from uaclient.entitlements.entitlement_status import ApplicationStatus
 
@@ -40,10 +40,12 @@ class TestCISEntitlementEnable:
     @mock.patch("uaclient.apt.setup_apt_proxy")
     @mock.patch("uaclient.system.should_reboot")
     @mock.patch("uaclient.system.subp")
-    @mock.patch("uaclient.system.get_platform_info")
+    @mock.patch("uaclient.system.get_kernel_info")
+    @mock.patch("uaclient.system.get_release_info")
     def test_enable_configures_apt_sources_and_auth_files(
         self,
-        m_platform_info,
+        m_release_info,
+        m_kernel_info,
         m_subp,
         m_should_reboot,
         m_setup_apt_proxy,
@@ -60,7 +62,19 @@ class TestCISEntitlementEnable:
                 return info[key]
             return info
 
-        m_platform_info.side_effect = fake_platform
+        m_release_info.return_value = system.ReleaseInfo(
+            distribution="", release="", series="xenial", pretty_version=""
+        )
+        m_kernel_info.return_value = system.KernelInfo(
+            uname_machine_arch="x86_64",
+            uname_release="4.15.0-00-generic",
+            proc_version_signature_version=None,
+            major=None,
+            minor=None,
+            patch=None,
+            abi=None,
+            flavor=None,
+        )
         m_subp.return_value = ("fakeout", "")
         m_apt_policy.return_value = "fakeout"
         m_should_reboot.return_value = False

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -8,7 +8,6 @@ from uaclient.entitlements.esm import ESMAppsEntitlement, ESMInfraEntitlement
 
 M_PATH = "uaclient.entitlements.esm.ESMInfraEntitlement."
 M_REPOPATH = "uaclient.entitlements.repo."
-M_GETPLATFORM = M_REPOPATH + "system.get_platform_info"
 
 
 @pytest.fixture(params=[ESMAppsEntitlement, ESMInfraEntitlement])
@@ -18,7 +17,8 @@ def entitlement(request, entitlement_factory):
 
 @mock.patch("uaclient.jobs.update_messaging.update_motd_messages")
 @mock.patch(
-    "uaclient.system.get_platform_info", return_value={"series": "xenial"}
+    "uaclient.system.get_release_info",
+    return_value=mock.MagicMock(series="xenial"),
 )
 class TestESMEntitlementDisable:
     @pytest.mark.parametrize("silent", [False, True])
@@ -26,7 +26,7 @@ class TestESMEntitlementDisable:
     def test_disable_returns_false_on_can_disable_false_and_does_nothing(
         self,
         m_can_disable,
-        _m_platform_info,
+        _m_get_release_info,
         m_update_apt_and_motd_msgs,
         silent,
     ):
@@ -57,7 +57,7 @@ class TestESMEntitlementDisable:
         self,
         m_active_esm,
         m_lts,
-        _m_platform_info,
+        _m_get_release_info,
         m_update_apt_and_motd_msgs,
         is_active_esm,
         is_lts,
@@ -96,7 +96,7 @@ class TestESMEntitlementDisable:
 class TestUpdateESMCaches:
     @pytest.mark.parametrize("file_exists", (False, True))
     @mock.patch("uaclient.apt.os.path.exists")
-    @mock.patch("uaclient.apt.system.get_platform_info")
+    @mock.patch("uaclient.apt.system.get_release_info")
     @mock.patch("uaclient.apt.system.write_file")
     @mock.patch("uaclient.apt.os.makedirs")
     @mock.patch("uaclient.apt.gpg.export_gpg_key")
@@ -105,12 +105,12 @@ class TestUpdateESMCaches:
         m_export_gpg,
         m_makedirs,
         m_write_file,
-        m_get_platform_info,
+        m_get_release_info,
         m_exists,
         file_exists,
         entitlement,
     ):
-        m_get_platform_info.return_value = {"series": "example"}
+        m_get_release_info.return_value = mock.MagicMock(series="example")
         m_exists.return_value = file_exists
 
         entitlement.setup_local_esm_repo()

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -233,3 +233,6 @@ user_config_file = DataObjectFile(
     DataObjectFileFormat.JSON,
     optional_type_errors_become_null=True,
 )
+
+
+reboot_cmd_marker_file = UAFile("marker-reboot-cmds-required")

--- a/uaclient/livepatch.py
+++ b/uaclient/livepatch.py
@@ -305,7 +305,7 @@ def on_supported_kernel() -> Optional[bool]:
         return None
 
     arch = util.standardize_arch_name(kernel_info.uname_machine_arch)
-    codename = system.get_platform_info()["series"]
+    codename = system.get_release_info().series
 
     lp_api_kernel_ver = "{major}.{minor}".format(
         major=kernel_info.major, minor=kernel_info.minor

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -338,7 +338,7 @@ class CVE:
         if hasattr(self, "_packages_status"):
             return self._packages_status  # type: ignore
         self._packages_status = {}
-        series = system.get_platform_info()["series"]
+        series = system.get_release_info().series
         for package in self.response["packages"]:
             for pkg_status in package["statuses"]:
                 if pkg_status["release_codename"] == series:
@@ -426,7 +426,7 @@ class USN:
         """
         if hasattr(self, "_release_packages"):
             return self._release_packages
-        series = system.get_platform_info()["series"]
+        series = system.get_release_info().series
         self._release_packages = {}  # type: Dict[str, Dict[str, Any]]
         # Organize source and binary packages under a common source package key
         for pkg in self.response.get("release_packages", {}).get(series, []):

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -21,7 +21,7 @@ from uaclient.system import (
     REBOOT_PKGS_FILE_PATH,
     get_distro_info,
     get_kernel_info,
-    get_platform_info,
+    get_release_info,
     is_current_series_lts,
     is_supported,
     load_file,
@@ -47,7 +47,7 @@ class RebootStatus(Enum):
 
 @lru_cache(maxsize=None)
 def get_origin_information_to_service_map():
-    series = get_platform_info()["series"]
+    series = get_release_info().series
     return {
         ("Ubuntu", "{}-security".format(series)): "standard-security",
         ("UbuntuESMApps", "{}-apps-security".format(series)): "esm-apps",
@@ -420,7 +420,7 @@ def _print_package_summary(
 
 
 def _print_interim_release_support():
-    series = get_platform_info()["series"]
+    series = get_release_info().series
     eol_date = get_distro_info(series).eol
     date = "{}/{}".format(str(eol_date.month), str(eol_date.year))
     print(messages.SS_INTERIM_SUPPORT.format(date=date))
@@ -428,7 +428,7 @@ def _print_interim_release_support():
 
 
 def _print_lts_support():
-    series = get_platform_info()["series"]
+    series = get_release_info().series
     if is_supported(series):
         eol_date = get_distro_info(series).eol
         print(messages.SS_LTS_SUPPORT.format(date=str(eol_date.year)))
@@ -445,7 +445,7 @@ def _print_service_support(
     available_updates: int,
     is_attached: bool,
 ):
-    series = get_platform_info()["series"]
+    series = get_release_info().series
     eol_date_esm = get_distro_info(series).eol_esm
     if service_status == ApplicationStatus.ENABLED:
         message = messages.SS_SERVICE_ENABLED.format(
@@ -526,7 +526,7 @@ def security_status(cfg: UAConfig):
     esm_apps_status = ESMAppsEntitlement(cfg).application_status()[0]
     esm_apps_applicability = ESMAppsEntitlement(cfg).applicability_status()[0]
 
-    series = get_platform_info()["series"]
+    series = get_release_info().series
     is_lts = is_current_series_lts()
     is_attached = get_ua_info(cfg)["attached"]
 
@@ -643,7 +643,7 @@ def list_esm_infra_packages(cfg):
     for update, _ in security_upgradable_versions:
         infra_updates.add(update.package)
 
-    series = get_platform_info()["series"]
+    series = get_release_info().series
     is_lts = is_current_series_lts()
 
     esm_infra_status = ESMInfraEntitlement(cfg).application_status()[0]

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import os
 import sys
 import textwrap
 from collections import OrderedDict
@@ -25,7 +24,7 @@ from uaclient.entitlements.entitlement_status import (
     UserFacingConfigStatus,
     UserFacingStatus,
 )
-from uaclient.files import notices
+from uaclient.files import notices, state_files
 from uaclient.files.notices import Notice
 from uaclient.messages import TxtColor
 
@@ -341,7 +340,7 @@ def _get_config_status(cfg) -> Dict[str, Any]:
         status_desc = messages.LOCK_HELD.format(
             pid=lock_pid, lock_holder=lock_holder
         ).msg
-    elif os.path.exists(cfg.data_path("marker-reboot-cmds")):
+    elif state_files.reboot_cmd_marker_file.is_present:
         status_val = userStatus.REBOOTREQUIRED.value
         operation = "configuration changes"
         status_desc = messages.ENABLE_REBOOT_REQUIRED_TMPL.format(

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -152,7 +152,7 @@ def get_machine_id(cfg) -> str:
 
 @lru_cache(maxsize=None)
 def get_release_info() -> ReleaseInfo:
-    os_release = parse_os_release()
+    os_release = _parse_os_release()
     distribution = os_release.get("NAME", "UNKNOWN")
     pretty_version = re.sub(r"\.\d LTS", " LTS", os_release.get("VERSION", ""))
     series = os_release.get("VERSION_CODENAME", "")
@@ -243,7 +243,7 @@ def is_container(run_path: str = "/run") -> bool:
 
 
 @lru_cache(maxsize=None)
-def parse_os_release() -> Dict[str, str]:
+def _parse_os_release() -> Dict[str, str]:
     try:
         file_contents = load_file("/etc/os-release")
     except FileNotFoundError:

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -58,10 +58,12 @@ b/release-updates, now 1.2+3 arch123 [i,a]
 
 
 class TestAddPPAPinning:
-    @mock.patch("uaclient.system.get_platform_info")
-    def test_write_apt_pin_file_to_apt_preferences(self, m_platform, tmpdir):
+    @mock.patch("uaclient.system.get_release_info")
+    def test_write_apt_pin_file_to_apt_preferences(
+        self, m_get_release_info, tmpdir
+    ):
         """Write proper apt pin file to specified apt_preference_file."""
-        m_platform.return_value = {"series": "xenial"}
+        m_get_release_info.return_value = mock.MagicMock(series="xenial")
         pref_file = tmpdir.join("preffile").strpath
         assert None is add_ppa_pinning(
             pref_file,
@@ -294,11 +296,12 @@ class TestAddAuthAptRepo:
     @mock.patch("uaclient.apt.get_apt_auth_file_from_apt_config")
     @mock.patch("uaclient.apt.assert_valid_apt_credentials")
     @mock.patch(
-        "uaclient.system.get_platform_info", return_value={"series": "xenial"}
+        "uaclient.system.get_release_info",
+        return_value=mock.MagicMock(series="xenial"),
     )
     def test_add_auth_apt_repo_writes_sources_file(
         self,
-        m_platform,
+        m_get_release_info,
         m_valid_creds,
         m_get_apt_auth_file,
         m_subp,
@@ -334,11 +337,12 @@ class TestAddAuthAptRepo:
     @mock.patch("uaclient.apt.get_apt_auth_file_from_apt_config")
     @mock.patch("uaclient.apt.assert_valid_apt_credentials")
     @mock.patch(
-        "uaclient.system.get_platform_info", return_value={"series": "xenial"}
+        "uaclient.system.get_release_info",
+        return_value=mock.MagicMock(series="xenial"),
     )
     def test_add_auth_apt_repo_ignores_suites_not_matching_series(
         self,
-        m_platform,
+        m_get_release_info,
         m_valid_creds,
         m_get_apt_auth_file,
         m_subp,
@@ -382,11 +386,12 @@ class TestAddAuthAptRepo:
     @mock.patch("uaclient.apt.get_apt_auth_file_from_apt_config")
     @mock.patch("uaclient.apt.assert_valid_apt_credentials")
     @mock.patch(
-        "uaclient.system.get_platform_info", return_value={"series": "xenial"}
+        "uaclient.system.get_release_info",
+        return_value=mock.MagicMock(series="xenial"),
     )
     def test_add_auth_apt_repo_comments_updates_suites_on_non_update_machine(
         self,
-        m_platform,
+        m_get_release_info,
         m_valid_creds,
         m_get_apt_auth_file,
         m_subp,
@@ -427,11 +432,12 @@ class TestAddAuthAptRepo:
     @mock.patch("uaclient.apt.get_apt_auth_file_from_apt_config")
     @mock.patch("uaclient.apt.assert_valid_apt_credentials")
     @mock.patch(
-        "uaclient.system.get_platform_info", return_value={"series": "xenial"}
+        "uaclient.system.get_release_info",
+        return_value=mock.MagicMock(series="xenial"),
     )
     def test_add_auth_apt_repo_writes_username_password_to_auth_file(
         self,
-        m_platform,
+        m_get_release_info,
         m_valid_creds,
         m_get_apt_auth_file,
         m_subp,
@@ -463,11 +469,12 @@ class TestAddAuthAptRepo:
     @mock.patch("uaclient.apt.get_apt_auth_file_from_apt_config")
     @mock.patch("uaclient.apt.assert_valid_apt_credentials")
     @mock.patch(
-        "uaclient.system.get_platform_info", return_value={"series": "xenial"}
+        "uaclient.system.get_release_info",
+        return_value=mock.MagicMock(series="xenial"),
     )
     def test_add_auth_apt_repo_writes_bearer_resource_token_to_auth_file(
         self,
-        m_platform,
+        m_get_release_info,
         m_valid_creds,
         m_get_apt_auth_file,
         m_subp,

--- a/uaclient/tests/test_apt_news.py
+++ b/uaclient/tests/test_apt_news.py
@@ -159,7 +159,7 @@ class TestAptNews:
         ],
     )
     @mock.patch(M_PATH + "get_cloud_type")
-    @mock.patch(M_PATH + "system.get_platform_info")
+    @mock.patch(M_PATH + "system.get_release_info")
     def test_do_selectors_apply(
         self,
         m_get_platform_info,
@@ -175,7 +175,7 @@ class TestAptNews:
             cfg = FakeConfig.for_attached_machine()
         else:
             cfg = FakeConfig()
-        m_get_platform_info.return_value = {"series": series}
+        m_get_platform_info.return_value = mock.MagicMock(series=series)
         m_get_cloud_type.return_value = cloud_type
         assert expected == apt_news.do_selectors_apply(cfg, selectors)
 

--- a/uaclient/tests/test_livepatch.py
+++ b/uaclient/tests/test_livepatch.py
@@ -546,7 +546,7 @@ class TestOnSupportedKernel:
             "cli_result",
             "get_kernel_info_result",
             "standardize_arch_name_result",
-            "get_platform_info_result",
+            "get_release_info_result",
             "cache_result",
             "api_result",
             "cache_call_args",
@@ -613,7 +613,7 @@ class TestOnSupportedKernel:
                     patch=None,
                 ),
                 "amd64",
-                {"series": "xenial"},
+                mock.MagicMock(series="xenial"),
                 (True, True),
                 None,
                 [mock.call("5.6", "generic", "amd64", "xenial")],
@@ -634,7 +634,7 @@ class TestOnSupportedKernel:
                     patch=None,
                 ),
                 "amd64",
-                {"series": "xenial"},
+                mock.MagicMock(series="xenial"),
                 (True, False),
                 None,
                 [mock.call("5.6", "generic", "amd64", "xenial")],
@@ -655,7 +655,7 @@ class TestOnSupportedKernel:
                     patch=None,
                 ),
                 "amd64",
-                {"series": "xenial"},
+                mock.MagicMock(series="xenial"),
                 (True, None),
                 None,
                 [mock.call("5.6", "generic", "amd64", "xenial")],
@@ -676,7 +676,7 @@ class TestOnSupportedKernel:
                     patch=None,
                 ),
                 "amd64",
-                {"series": "xenial"},
+                mock.MagicMock(series="xenial"),
                 (False, None),
                 True,
                 [mock.call("5.6", "generic", "amd64", "xenial")],
@@ -687,7 +687,7 @@ class TestOnSupportedKernel:
     )
     @mock.patch(M_PATH + "_on_supported_kernel_api")
     @mock.patch(M_PATH + "_on_supported_kernel_cache")
-    @mock.patch(M_PATH + "system.get_platform_info")
+    @mock.patch(M_PATH + "system.get_release_info")
     @mock.patch(M_PATH + "util.standardize_arch_name")
     @mock.patch(M_PATH + "system.get_kernel_info")
     @mock.patch(M_PATH + "_on_supported_kernel_cli")
@@ -696,13 +696,13 @@ class TestOnSupportedKernel:
         m_supported_cli,
         m_get_kernel_info,
         m_standardize_arch_name,
-        m_get_platform_info,
+        m_get_release_info,
         m_supported_cache,
         m_supported_api,
         cli_result,
         get_kernel_info_result,
         standardize_arch_name_result,
-        get_platform_info_result,
+        get_release_info_result,
         cache_result,
         api_result,
         cache_call_args,
@@ -712,7 +712,7 @@ class TestOnSupportedKernel:
         m_supported_cli.return_value = cli_result
         m_get_kernel_info.return_value = get_kernel_info_result
         m_standardize_arch_name.return_value = standardize_arch_name_result
-        m_get_platform_info.return_value = get_platform_info_result
+        m_get_release_info.return_value = get_release_info_result
         m_supported_cache.return_value = cache_result
         m_supported_api.return_value = api_result
         assert on_supported_kernel.__wrapped__() == expected

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -41,7 +41,7 @@ class TestMain:
         ) in caplog_text()
 
     @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
-    @mock.patch("lib.reboot_cmds.subp")
+    @mock.patch("lib.reboot_cmds.system.subp")
     def test_main_unattached_removes_marker(
         self,
         m_subp,
@@ -55,14 +55,14 @@ class TestMain:
         assert "Skipping reboot_cmds. Machine is unattached" in caplog_text()
         assert 0 == m_subp.call_count
 
-    @mock.patch("lib.reboot_cmds.subp")
+    @mock.patch("lib.reboot_cmds.system.subp")
     def test_main_noops_when_no_marker(self, m_subp, FakeConfig):
         cfg = FakeConfig()
         assert None is cfg.read_cache("marker-reboot-cmds")
         main(cfg=cfg)
         assert 0 == m_subp.call_count
 
-    @mock.patch("lib.reboot_cmds.subp")
+    @mock.patch("lib.reboot_cmds.system.subp")
     def test_main_unattached_removes_marker_file(
         self,
         m_subp,
@@ -115,7 +115,7 @@ class TestFixProPkgHolds:
 class TestRunCommand:
     @pytest.mark.parametrize("caplog_text", [logging.WARN], indirect=True)
     @mock.patch("sys.exit")
-    @mock.patch("lib.reboot_cmds.subp")
+    @mock.patch("lib.reboot_cmds.system.subp")
     def test_run_command_failure(self, m_subp, m_exit, caplog_text):
         cmd = "foobar"
         m_cfg = mock.MagicMock()

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -1,162 +1,195 @@
-import logging
-
 import mock
 import pytest
 
-from lib.reboot_cmds import fix_pro_pkg_holds, main, process_reboot_operations
-from uaclient import messages
-from uaclient.exceptions import ProcessExecutionError
-from uaclient.files.notices import Notice
+from lib.reboot_cmds import fix_pro_pkg_holds, main
+from uaclient import exceptions
+from uaclient.testing.helpers import does_not_raise
 
 M_FIPS_PATH = "uaclient.entitlements.fips.FIPSEntitlement."
 
 
-class TestMain:
-    @pytest.mark.parametrize("caplog_text", [logging.WARNING], indirect=True)
-    def test_retries_on_lock_file(self, FakeConfig, caplog_text):
-        cfg = FakeConfig.for_attached_machine()
-        with pytest.raises(SystemExit) as excinfo:
-            with mock.patch(
-                "uaclient.config.UAConfig.check_lock_info"
-            ) as m_check_lock:
-                m_check_lock.return_value = (123, "pro auto-attach")
-                with mock.patch("time.sleep") as m_sleep:
-                    main(cfg=cfg)
-        assert [
-            mock.call(1),
-            mock.call(1),
-            mock.call(1),
-            mock.call(1),
-            mock.call(1),
-            mock.call(1),
-        ] == m_sleep.call_args_list
-        assert 1 == excinfo.value.code
-        assert (
-            "Lock not released. Unable to perform: ua-reboot-cmds"
-        ) in caplog_text()
-
-    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
-    @mock.patch(
-        "uaclient.files.state_files.reboot_cmd_marker_file",
-        new_callable=mock.PropertyMock,
-    )
-    def test_main_unattached_removes_marker(
-        self,
-        m_reboot_cmd_marker_file,
-        FakeConfig,
-        caplog_text,
-    ):
-        cfg = FakeConfig()
-        m_reboot_cmd_marker_file.is_present = True
-        main(cfg=cfg)
-        assert [mock.call()] == m_reboot_cmd_marker_file.delete.call_args_list
-        assert "Skipping reboot_cmds. Machine is unattached" in caplog_text()
-
-    @mock.patch(
-        "uaclient.files.state_files.reboot_cmd_marker_file",
-        new_callable=mock.PropertyMock,
-    )
-    @mock.patch("lib.reboot_cmds.fix_pro_pkg_holds")
-    def test_main_noops_when_not_attached(
-        self, m_fix_pro_pkg_holds, m_reboot_cmd_marker_file, FakeConfig
-    ):
-        m_reboot_cmd_marker_file.is_present = True
-        cfg = FakeConfig()
-        main(cfg=cfg)
-        assert [] == m_fix_pro_pkg_holds.call_args_list
-
-    @mock.patch(
-        "uaclient.files.state_files.reboot_cmd_marker_file",
-        new_callable=mock.PropertyMock,
-    )
-    @mock.patch("lib.reboot_cmds.fix_pro_pkg_holds")
-    def test_main_noops_when_no_marker(
-        self,
-        m_fix_pro_pkg_holds,
-        m_reboot_cmd_marker_file,
-        FakeConfig,
-    ):
-        m_reboot_cmd_marker_file.is_present = False
-        cfg = FakeConfig.for_attached_machine()
-        main(cfg=cfg)
-        assert [] == m_fix_pro_pkg_holds.call_args_list
-
-
-M_REPO_PATH = "uaclient.entitlements"
-
-
+@mock.patch("uaclient.entitlements.fips.FIPSEntitlement.install_packages")
+@mock.patch("uaclient.entitlements.fips.FIPSEntitlement.setup_apt_config")
+@mock.patch("uaclient.entitlements.fips.FIPSEntitlement.application_status")
 class TestFixProPkgHolds:
-    @pytest.mark.parametrize("caplog_text", [logging.WARN], indirect=True)
-    @pytest.mark.parametrize("fips_status", ("enabled", "disabled"))
-    @mock.patch("sys.exit")
-    @mock.patch(M_FIPS_PATH + "install_packages")
-    @mock.patch(M_FIPS_PATH + "setup_apt_config")
-    @mock.patch("uaclient.files.notices.NoticesManager.remove")
-    def test_calls_setup_apt_config_and_install_packages_when_enabled(
+    @pytest.mark.parametrize(
+        [
+            "fips_status",
+            "fips_setup_apt_config_side_effect",
+            "fips_install_packages_side_effect",
+            "expected_fips_setup_apt_config_calls",
+            "expected_fips_install_packages_calls",
+            "expected_raises",
+        ],
+        [
+            ("disabled", None, None, [], [], does_not_raise()),
+            (
+                "enabled",
+                None,
+                None,
+                [mock.call()],
+                [mock.call(cleanup_on_failure=False)],
+                does_not_raise(),
+            ),
+            (
+                "enabled",
+                Exception(),
+                None,
+                [mock.call()],
+                [mock.call(cleanup_on_failure=False)],
+                does_not_raise(),
+            ),
+            (
+                "enabled",
+                Exception(),
+                exceptions.UserFacingError(""),
+                [mock.call()],
+                [mock.call(cleanup_on_failure=False)],
+                pytest.raises(exceptions.UserFacingError),
+            ),
+        ],
+    )
+    def test_fix_pro_pkg_holds(
         self,
-        m_remove_notice,
-        setup_apt_config,
-        install_packages,
-        exit,
+        m_fips_status,
+        m_fips_setup_apt_config,
+        m_fips_install_packages,
         fips_status,
+        fips_setup_apt_config_side_effect,
+        fips_install_packages_side_effect,
+        expected_fips_setup_apt_config_calls,
+        expected_fips_install_packages_calls,
+        expected_raises,
         FakeConfig,
-        caplog_text,
     ):
+        m_fips_setup_apt_config.side_effect = fips_setup_apt_config_side_effect
+        m_fips_install_packages.side_effect = fips_install_packages_side_effect
         cfg = FakeConfig()
         fake_status_cache = {
             "services": [{"name": "fips", "status": fips_status}]
         }
         cfg.write_cache("status-cache", fake_status_cache)
 
-        fix_pro_pkg_holds(cfg=cfg)
-        if fips_status == "enabled":
-            assert [mock.call()] == setup_apt_config.call_args_list
-            assert [
-                mock.call(cleanup_on_failure=False)
-            ] == install_packages.call_args_list
-        else:
-            assert 0 == setup_apt_config.call_count
-            assert 0 == install_packages.call_count
-            assert 0 == len(m_remove_notice.call_args_list)
-        assert 0 == exit.call_count
+        with expected_raises:
+            fix_pro_pkg_holds(cfg)
 
-
-class TestProcessRebootOperations:
-    @pytest.mark.parametrize("caplog_text", [logging.ERROR], indirect=True)
-    @mock.patch("uaclient.config.UAConfig.delete_cache_key")
-    @mock.patch("uaclient.config.UAConfig.check_lock_info")
-    @mock.patch("uaclient.files.notices.NoticesManager.add")
-    @mock.patch("lib.reboot_cmds.fix_pro_pkg_holds")
-    def test_process_reboot_operations_create_notice_when_it_fails(
-        self,
-        m_fix_pro_pkg_holds,
-        m_add_notice,
-        m_check_lock_info,
-        _m_delete_cache_key,
-        FakeConfig,
-        caplog_text,
-    ):
-        m_check_lock_info.return_value = (0, 0)
-        m_fix_pro_pkg_holds.side_effect = ProcessExecutionError("error")
-
-        cfg = FakeConfig.for_attached_machine()
-        with mock.patch("os.path.exists", return_value=True):
-            with mock.patch("uaclient.config.UAConfig.write_cache"):
-                process_reboot_operations(cfg=cfg)
-
-        expected_calls = [
-            mock.call(
-                Notice.REBOOT_SCRIPT_FAILED,
-                messages.REBOOT_SCRIPT_FAILED,
-            ),
-        ]
-
-        assert expected_calls == m_add_notice.call_args_list
-
-        expected_msgs = [
-            "Failed running commands on reboot.",
-            "Invalid command specified 'error'.",
-        ]
-        assert all(
-            expected_msg in caplog_text() for expected_msg in expected_msgs
+        assert (
+            expected_fips_setup_apt_config_calls
+            == m_fips_setup_apt_config.call_args_list
         )
+        assert (
+            expected_fips_install_packages_calls
+            == m_fips_install_packages.call_args_list
+        )
+
+
+@mock.patch("uaclient.files.notices.add")
+@mock.patch("uaclient.files.notices.remove")
+@mock.patch(
+    "uaclient.upgrade_lts_contract.process_contract_delta_after_apt_lock"
+)  # noqa: E501
+@mock.patch("lib.reboot_cmds.refresh_contract")
+@mock.patch("lib.reboot_cmds.fix_pro_pkg_holds")
+@mock.patch("uaclient.lock.SpinLock")
+@mock.patch(
+    "uaclient.config.UAConfig.is_attached",
+    new_callable=mock.PropertyMock,
+)
+@mock.patch(
+    "uaclient.files.state_files.reboot_cmd_marker_file",
+    new_callable=mock.PropertyMock,
+)
+class TestMain:
+    @pytest.mark.parametrize(
+        [
+            "marker_file_present",
+            "is_attached",
+            "expected_delete_marker",
+            "expected_calls",
+            "expected_ret",
+        ],
+        [
+            (False, False, False, False, 0),
+            (True, False, True, False, 0),
+            (False, True, False, False, 0),
+            (True, True, True, True, 0),
+        ],
+    )
+    def test_main_success_cases(
+        self,
+        m_reboot_cmd_marker_file,
+        m_is_attached,
+        m_spin_lock,
+        m_fix_pro_pkg_holds,
+        m_refresh_contract,
+        m_process_contract_delta_after_apt_lock,
+        m_notices_remove,
+        m_notices_add,
+        marker_file_present,
+        is_attached,
+        expected_delete_marker,
+        expected_calls,
+        expected_ret,
+        FakeConfig,
+    ):
+        m_is_attached.return_value = is_attached
+        m_reboot_cmd_marker_file.is_present = marker_file_present
+        assert expected_ret == main(FakeConfig())
+
+        # no notices are added in any success scenario
+        assert [] == m_notices_add.call_args_list
+        # any existing notice should always be cleaned up on success
+        assert [mock.call(mock.ANY)] == m_notices_remove.call_args_list
+
+        if expected_delete_marker:
+            assert [
+                mock.call()
+            ] == m_reboot_cmd_marker_file.delete.call_args_list
+        else:
+            assert [] == m_reboot_cmd_marker_file.delete.call_args_list
+
+        if expected_calls:
+            assert [
+                mock.call(cfg=mock.ANY, lock_holder="pro-reboot-cmds")
+            ] == m_spin_lock.call_args_list
+            assert [mock.call(mock.ANY)] == m_fix_pro_pkg_holds.call_args_list
+            assert [mock.call(mock.ANY)] == m_refresh_contract.call_args_list
+            assert [
+                mock.call(mock.ANY)
+            ] == m_process_contract_delta_after_apt_lock.call_args_list
+        else:
+            assert [] == m_spin_lock.call_args_list
+            assert [] == m_fix_pro_pkg_holds.call_args_list
+            assert [] == m_refresh_contract.call_args_list
+            assert [] == m_process_contract_delta_after_apt_lock.call_args_list
+
+    @pytest.mark.parametrize(
+        [
+            "error",
+            "expected_ret",
+        ],
+        [
+            (Exception(), 1),
+            (exceptions.LockHeldError("", "", 1), 1),
+            (exceptions.UserFacingError(""), 1),
+        ],
+    )
+    def test_main_error_cases(
+        self,
+        m_reboot_cmd_marker_file,
+        m_is_attached,
+        m_spin_lock,
+        m_fix_pro_pkg_holds,
+        m_refresh_contract,
+        m_process_contract_delta_after_apt_lock,
+        m_notices_remove,
+        m_notices_add,
+        error,
+        expected_ret,
+        FakeConfig,
+    ):
+        m_is_attached.return_value = True
+        m_reboot_cmd_marker_file.is_present = True
+        m_fix_pro_pkg_holds.side_effect = error
+        assert expected_ret == main(FakeConfig())
+        assert [mock.call(mock.ANY)] == m_notices_add.call_args_list

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -99,6 +99,7 @@ class TestFixProPkgHolds:
             "services": [{"name": "fips", "status": fips_status}]
         }
         cfg.write_cache("status-cache", fake_status_cache)
+
         fix_pro_pkg_holds(cfg=cfg)
         if fips_status == "enabled":
             assert [mock.call()] == setup_apt_config.call_args_list

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -223,17 +223,17 @@ class TestGetCVEAffectedPackageStatus:
             ("focal", {"samba": "1000"}, {}),
         ),
     )
-    @mock.patch("uaclient.security.system.get_platform_info")
+    @mock.patch("uaclient.security.system.get_release_info")
     def test_affected_packages_status_filters_by_installed_pkgs_and_series(
         self,
-        get_platform_info,
+        m_get_release_info,
         series,
         installed_packages,
         expected_status,
         FakeConfig,
     ):
         """Package statuses are filtered if not installed"""
-        get_platform_info.return_value = {"series": series}
+        m_get_release_info.return_value = mock.MagicMock(series=series)
         client = UASecurityClient(FakeConfig())
         cve = CVE(client, SAMPLE_CVE_RESPONSE)
         affected_packages = get_cve_affected_source_packages_status(
@@ -448,11 +448,11 @@ class TestUSN:
             ("series-example-3", {}),
         ),
     )
-    @mock.patch("uaclient.system.get_platform_info")
+    @mock.patch("uaclient.system.get_release_info")
     def test_release_packages_returns_source_and_binary_pkgs_for_series(
-        self, get_platform_info, series, expected, FakeConfig
+        self, m_get_release_info, series, expected, FakeConfig
     ):
-        get_platform_info.return_value = {"series": series}
+        m_get_release_info.return_value = mock.MagicMock(series=series)
         client = UASecurityClient(FakeConfig())
         usn = USN(client, SAMPLE_USN_RESPONSE)
 
@@ -475,12 +475,14 @@ class TestUSN:
             ),
         ),
     )
-    @mock.patch("uaclient.system.get_platform_info")
+    @mock.patch("uaclient.system.get_release_info")
     def test_release_packages_errors_on_sparse_source_url(
-        self, get_platform_info, source_link, error_msg, FakeConfig
+        self, m_get_release_info, source_link, error_msg, FakeConfig
     ):
         """Raise errors when USN metadata contains no valid source_link."""
-        get_platform_info.return_value = {"series": "series-example-1"}
+        m_get_release_info.return_value = mock.MagicMock(
+            series="series-example-1"
+        )
         client = UASecurityClient(FakeConfig())
         sparse_md = copy.deepcopy(SAMPLE_USN_RESPONSE)
         sparse_md["release_packages"]["series-example-1"].append(
@@ -893,11 +895,11 @@ class TestQueryInstalledPkgSources:
         ),
     )
     @mock.patch("uaclient.security.system.subp")
-    @mock.patch("uaclient.system.get_platform_info")
+    @mock.patch("uaclient.system.get_release_info")
     def test_result_keyed_by_source_package_name(
-        self, get_platform_info, subp, dpkg_out, results
+        self, m_get_release_info, subp, dpkg_out, results
     ):
-        get_platform_info.return_value = {"series": "bionic"}
+        m_get_release_info.return_value = mock.MagicMock(series="bionic")
         subp.return_value = dpkg_out, ""
         assert results == query_installed_source_pkg_versions()
         _format = "-f=${Package},${Source},${Version},${db:Status-Status}\n"
@@ -2341,15 +2343,15 @@ class TestGetUSNAffectedPackagesStatus:
             ),
         ),
     )
-    @mock.patch("uaclient.system.get_platform_info")
+    @mock.patch("uaclient.system.get_release_info")
     def test_pkgs_come_from_release_packages_if_usn_has_no_cves(
         self,
-        m_platform_info,
+        m_get_release_info,
         installed_packages,
         affected_packages,
         FakeConfig,
     ):
-        m_platform_info.return_value = {"series": "bionic"}
+        m_get_release_info.return_value = mock.MagicMock(series="bionic")
 
         cfg = FakeConfig()
         client = UASecurityClient(cfg=cfg)

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -852,19 +852,23 @@ class TestStatus:
         )
         assert expected_dt == status.status(cfg=cfg)["expires"]
 
+    @mock.patch(
+        "uaclient.files.state_files.reboot_cmd_marker_file",
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch("uaclient.status.get_available_resources", return_value={})
     def test_nonroot_user_does_not_use_cache(
         self,
         _m_get_available_resources,
+        m_reboot_cmd_marker_file,
         _m_should_reboot,
         m_remove_notice,
         m_on_supported_kernel,
         FakeConfig,
     ):
-
+        m_reboot_cmd_marker_file.is_present = True
         cached_status = {"pass": True}
         cfg = FakeConfig()
-        cfg.write_cache("marker-reboot-cmds", "")  # To indicate a reboot reqd
         cfg.write_cache("status-cache", cached_status)
         before = status.status(cfg=cfg)
 

--- a/uaclient/tests/test_system.py
+++ b/uaclient/tests/test_system.py
@@ -496,9 +496,9 @@ LOGO=ubuntu-logo
     )
     @mock.patch("uaclient.system.load_file")
     def test_parse_os_release(self, m_load_file, content, expected):
-        """parse_os_release returns a dict of values from /etc/os-release."""
+        """_parse_os_release returns a dict of values from /etc/os-release."""
         m_load_file.return_value = content
-        assert expected == system.parse_os_release.__wrapped__()
+        assert expected == system._parse_os_release.__wrapped__()
         assert m_load_file.call_args_list == [mock.call("/etc/os-release")]
 
 
@@ -561,7 +561,7 @@ class TestGetReleaseInfo:
             ),
         ),
     )
-    @mock.patch("uaclient.system.parse_os_release")
+    @mock.patch("uaclient.system._parse_os_release")
     def test_get_release_info_error(
         self, m_parse_os_release, version, expected_exception
     ):
@@ -654,7 +654,7 @@ class TestGetReleaseInfo:
     )
     @mock.patch("uaclient.system.get_kernel_info")
     @mock.patch("uaclient.system.get_dpkg_arch")
-    @mock.patch("uaclient.system.parse_os_release")
+    @mock.patch("uaclient.system._parse_os_release")
     @mock.patch("uaclient.system.get_virt_type")
     def test_get_release_info_with_version(
         self,

--- a/uaclient/tests/test_upgrade_lts_contract.py
+++ b/uaclient/tests/test_upgrade_lts_contract.py
@@ -33,8 +33,8 @@ class TestUpgradeLTSContract:
         new_callable=mock.PropertyMock,
         return_value=True,
     )
-    @mock.patch("lib.upgrade_lts_contract.parse_os_release")
-    @mock.patch("lib.upgrade_lts_contract.subp")
+    @mock.patch("lib.upgrade_lts_contract.system.parse_os_release")
+    @mock.patch("lib.upgrade_lts_contract.system.subp")
     def test_upgrade_cancel_when_current_version_not_supported(
         self, m_subp, m_parse_os, m_is_attached, capsys, caplog_text
     ):
@@ -64,8 +64,8 @@ class TestUpgradeLTSContract:
         new_callable=mock.PropertyMock,
         return_value=True,
     )
-    @mock.patch("lib.upgrade_lts_contract.parse_os_release")
-    @mock.patch("lib.upgrade_lts_contract.subp")
+    @mock.patch("lib.upgrade_lts_contract.system.parse_os_release")
+    @mock.patch("lib.upgrade_lts_contract.system.subp")
     def test_upgrade_cancel_when_past_version_not_supported(
         self, m_subp, m_parse_os, m_is_attached, capsys, caplog_text
     ):
@@ -99,9 +99,9 @@ class TestUpgradeLTSContract:
         new_callable=mock.PropertyMock,
         return_value=True,
     )
-    @mock.patch("lib.upgrade_lts_contract.parse_os_release")
-    @mock.patch("lib.upgrade_lts_contract.subp")
-    @mock.patch("lib.upgrade_lts_contract.process_entitlements_delta")
+    @mock.patch("lib.upgrade_lts_contract.system.parse_os_release")
+    @mock.patch("lib.upgrade_lts_contract.system.subp")
+    @mock.patch("lib.upgrade_lts_contract.contract.process_entitlements_delta")
     @mock.patch("lib.upgrade_lts_contract.time.sleep")
     def test_upgrade_contract_when_apt_lock_is_held(
         self,

--- a/uaclient/upgrade_lts_contract.py
+++ b/uaclient/upgrade_lts_contract.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+"""
+This function is called from lib/upgrade_lts_contract.py and from
+lib/reboot_cmds.py
+
+This function should be used after running do-release-upgrade in a machine.
+It will detect any contract deltas between the release before
+do-release-upgrade and the current release. If we find any differences in
+the uaclient contract between those releases, we will apply that difference
+in the upgraded release.
+
+For example, suppose we are on Trusty and we are upgrading to Xenial. We found
+that the apt url for esm services on trusty:
+
+https://esm.ubuntu.com/ubuntu
+
+While on Xenial, the apt url is:
+
+https://esm.ubuntu.com/infra/ubuntu
+
+This script will detect differences like that and update the Xenial system
+to reflect them.
+"""
+
+import logging
+import sys
+import time
+
+from uaclient import contract, defaults, system
+from uaclient.config import UAConfig
+
+# We consider the past release for LTSs to be the last LTS,
+# because we don't have any services available on non-LTS.
+# This makes it safer for us to try to process contract deltas.
+# For example, we had "jammy": "focal" even when Impish was
+# still supported.
+current_codename_to_past_codename = {
+    "xenial": "trusty",
+    "bionic": "xenial",
+    "focal": "bionic",
+    "jammy": "focal",
+    "kinetic": "jammy",
+}
+
+
+def process_contract_delta_after_apt_lock(cfg: UAConfig) -> None:
+    logging.debug("Check whether to upgrade-lts-contract")
+    if not cfg.is_attached:
+        logging.debug("Skipping upgrade-lts-contract. Machine is unattached")
+        return
+    out, _err = system.subp(["lsof", "/var/lib/apt/lists/lock"], rcs=[0, 1])
+    msg = "Starting upgrade-lts-contract."
+    if out:
+        msg += " Retrying every 10 seconds waiting on released apt lock"
+    print(msg)
+    logging.debug(msg)
+
+    current_release = system.get_release_info().series
+
+    past_release = current_codename_to_past_codename.get(current_release)
+    if past_release is None:
+        msg = "Could not find past release for: {}".format(current_release)
+        print(msg)
+        logging.warning(msg)
+        sys.exit(1)
+
+    past_entitlements = UAConfig(
+        series=past_release,
+    ).machine_token_file.entitlements
+    new_entitlements = UAConfig(
+        series=current_release,
+    ).machine_token_file.entitlements
+
+    retry_count = 0
+    while out:
+        # Loop until apt hold is released at the end of `do-release-upgrade`
+        time.sleep(10)
+        out, _err = system.subp(
+            ["lsof", "/var/lib/apt/lists/lock"], rcs=[0, 1]
+        )
+        retry_count += 1
+
+    msg = "upgrade-lts-contract processing contract deltas: {} -> {}".format(
+        past_release, current_release
+    )
+    print(msg)
+    logging.debug(msg)
+
+    contract.process_entitlements_delta(
+        cfg=cfg,
+        past_entitlements=past_entitlements,
+        new_entitlements=new_entitlements,
+        allow_enable=True,
+        series_overrides=False,
+    )
+    msg = "upgrade-lts-contract succeeded after {} retries".format(retry_count)
+    print(msg)
+    logging.debug(msg)
+
+
+def remove_private_esm_apt_cache():
+    system.ensure_folder_absent(defaults.ESM_APT_ROOTDIR)


### PR DESCRIPTION
no-lp no-gh

Part of my technical debt ticket was to simplify our systemd services. I think we still need this service and I think it should remain a separate service. But the it could use some updating to line up with our more recent patterns of file and status access.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Make sure the reboot-cmds behavior hasn't changed. The new integration test _should_ cover this, but maybe do your own experiments too.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
