### PR TITLE
logging: setup logging with defaults before uacfg is read (SC-1428)

### DIFF
--- a/apport/source_ubuntu-advantage-tools.py
+++ b/apport/source_ubuntu-advantage-tools.py
@@ -12,6 +12,7 @@ def add_info(report, ui=None):
     cfg = UAConfig()
     with tempfile.TemporaryDirectory() as output_dir:
         collect_logs(cfg, output_dir)
+        # TODO: collect default logs
         auto_include_log_files = [
             "cloud-id.txt",
             "cloud-id.txt-error",

--- a/lib/patch_status_json.py
+++ b/lib/patch_status_json.py
@@ -19,7 +19,7 @@ import json
 import logging
 
 from uaclient import system, util
-from uaclient.cli import setup_logging
+from uaclient.log import setup_logging
 
 
 def patch_status_json_schema_0_1(status_file: str):

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -19,10 +19,10 @@ import os
 import sys
 
 from uaclient import config, contract, exceptions, lock, messages
-from uaclient.cli import setup_logging
 from uaclient.entitlements.fips import FIPSEntitlement
 from uaclient.files import notices
 from uaclient.files.notices import Notice
+from uaclient.log import setup_logging
 from uaclient.system import subp
 
 # Retry sleep backoff algorithm if lock is held.

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -6,7 +6,6 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional
 
-from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
 from uaclient.exceptions import InvalidFileFormatError
 from uaclient.files.state_files import (
@@ -17,6 +16,7 @@ from uaclient.files.state_files import (
 from uaclient.jobs.metering import metering_enabled_resources
 from uaclient.jobs.update_contract_info import update_contract_info
 from uaclient.jobs.update_messaging import update_motd_messages
+from uaclient.log import setup_logging
 
 LOG = logging.getLogger(__name__)
 UPDATE_MESSAGING_INTERVAL = 21600  # 6 hours

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -24,10 +24,10 @@ import logging
 import sys
 import time
 
-from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
 from uaclient.contract import process_entitlements_delta
 from uaclient.defaults import ESM_APT_ROOTDIR
+from uaclient.log import setup_logging
 from uaclient.system import ensure_folder_absent, parse_os_release, subp
 
 version_to_codename = {

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -251,3 +251,11 @@ def mock_notices_dir(tmpdir_factory):
             temp_dir.strpath,
         ):
             yield
+
+
+@pytest.yield_fixture(autouse=True)
+def m_early_logs():
+    with mock.patch(
+        "uaclient.cli.pro_log.EarlyLoggingSetup",
+    ):
+        yield

--- a/uaclient/log.py
+++ b/uaclient/log.py
@@ -1,9 +1,14 @@
+import enum
 import json
 import logging
+import pathlib
+import sys
 from collections import OrderedDict
+from typing import Optional  # noqa
 from typing import Any, Dict  # noqa: F401
 
-from uaclient import util
+from uaclient import config, util
+from uaclient.defaults import CONFIG_DEFAULTS
 
 
 class RedactionFilter(logging.Filter):
@@ -58,3 +63,87 @@ class JsonArrayFormatter(logging.Formatter):
 
         local_log_record["extra"] = extra_message_dict
         return json.dumps(list(local_log_record.values()))
+
+
+class LogFile(enum.Enum):
+    MAIN = 0
+    TIMER = 1
+    DAEMON = 2
+
+    def default_file(self) -> str:
+        if self == self.MAIN:
+            return CONFIG_DEFAULTS["log_file"]
+        raise NotImplementedError("Implement me for {}".format(self))
+
+    def extract_log_file(self, ua_cfg: config.UAConfig) -> str:
+        if self == self.MAIN:
+            return ua_cfg.log_file
+        raise NotImplementedError("Implement me for {}".format(self))
+
+
+def setup_logging(console_level, log_level, log_file=None, logger=None):
+    """Setup console logging and debug logging to log_file"""
+    if log_file is None:
+        cfg = config.UAConfig()
+        log_file = cfg.log_file
+    console_formatter = util.LogFormatter()
+    if logger is None:
+        # Then we configure the root logger
+        logger = logging.getLogger()
+    logger.setLevel(log_level)
+    logger.addFilter(RedactionFilter())
+
+    # Clear all handlers, so they are replaced for this logger
+    logger.handlers = []
+
+    # Setup console logging
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setFormatter(console_formatter)
+    console_handler.setLevel(console_level)
+    console_handler.set_name("ua-console")  # Used to disable console logging
+    logger.addHandler(console_handler)
+
+    # Setup file logging
+    if util.we_are_currently_root():
+        # Setup readable-by-root-only debug file logging if running as root
+        log_file_path = pathlib.Path(log_file)
+
+        if not log_file_path.exists():
+            log_file_path.touch()
+            log_file_path.chmod(0o644)
+
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(JsonArrayFormatter())
+        file_handler.setLevel(log_level)
+        file_handler.set_name("ua-file")
+        logger.addHandler(file_handler)
+
+
+class EarlyLoggingSetup:
+    def __init__(
+        self, console_level, log_level, log_file: LogFile, logger=None
+    ):
+        self.console_level = console_level
+        self.log_level = log_level
+        self.log_file = log_file
+        self.logger = logger
+        self.ua_cfg = None  # type: Optional[config.UAConfig]
+
+    def __enter__(self):
+        log_file = self.log_file.default_file()
+        setup_logging(
+            self.console_level, self.log_level, log_file, self.logger
+        )
+        return self
+
+    def __exit__(self, type, _value, _traceback):
+        if type is not None:
+            # A exception happened during the lifetime of this context manager.
+            # We shouldn't try to config the final logger, as the exception
+            # could come from UAConfig reading.
+            return
+        ua_cfg = self.ua_cfg or config.UAConfig()
+        log_file = self.log_file.extract_log_file(ua_cfg)
+        setup_logging(
+            self.console_level, self.log_level, log_file, self.logger
+        )

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -2,11 +2,8 @@ import contextlib
 import io
 import json
 import logging
-import os
 import re
 import socket
-import stat
-import sys
 import textwrap
 
 import mock
@@ -21,7 +18,6 @@ from uaclient.cli import (
     assert_root,
     get_parser,
     main,
-    setup_logging,
 )
 from uaclient.entitlements import get_valid_entitlement_names
 from uaclient.exceptions import (
@@ -684,7 +680,7 @@ class TestMain:
         assert "Traceback (most recent call last):" in error_log
 
     @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.cli.pro_log.EarlyLoggingSetup")
     @mock.patch("uaclient.cli.get_parser")
     def test_command_line_is_logged(
         self, _m_get_parser, _m_setup_logging, logging_sandbox, caplog_text
@@ -737,182 +733,6 @@ class TestMain:
             )
             == str(err)
         )
-
-
-class TestSetupLogging:
-    @pytest.mark.parametrize("level", (logging.INFO, logging.ERROR))
-    @mock.patch("uaclient.cli.util.we_are_currently_root", return_value=False)
-    def test_console_log_configured_if_not_present(
-        self, m_we_are_currently_root, level, capsys, logging_sandbox
-    ):
-        setup_logging(level, logging.INFO)
-        logging.log(level, "after setup")
-        logging.log(level - 1, "not present")
-
-        _, err = capsys.readouterr()
-        assert "after setup" in err
-        assert "not present" not in err
-
-    @mock.patch("uaclient.cli.util.we_are_currently_root", return_value=False)
-    def test_console_log_configured_if_already_present(
-        self, m_we_are_currently_root, capsys, logging_sandbox
-    ):
-        logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
-
-        logging.error("before setup")
-        setup_logging(logging.INFO, logging.INFO)
-        logging.error("after setup")
-
-        # 'before setup' will be in stderr, so check that setup_logging
-        # configures the format
-        _, err = capsys.readouterr()
-        assert "ERROR: before setup" not in err
-        assert "ERROR: after setup" in err
-
-    @mock.patch("uaclient.cli.util.we_are_currently_root", return_value=False)
-    def test_file_log_not_configured_if_not_root(
-        self, m_we_are_currently_root, tmpdir, logging_sandbox
-    ):
-        log_file = tmpdir.join("log_file")
-
-        setup_logging(logging.INFO, logging.INFO, log_file=log_file.strpath)
-        logging.info("after setup")
-
-        assert not log_file.exists()
-
-    @pytest.mark.parametrize("log_filename", (None, "file.log"))
-    @mock.patch("uaclient.cli.config")
-    def test_file_log_configured_if_root(
-        self,
-        m_config,
-        log_filename,
-        logging_sandbox,
-        tmpdir,
-    ):
-        if log_filename is None:
-            log_filename = "default.log"
-            log_file = tmpdir.join(log_filename)
-            m_config.CONFIG_DEFAULTS = {"log_file": log_file.strpath}
-        else:
-            log_file = tmpdir.join(log_filename)
-
-        setup_logging(logging.INFO, logging.INFO, log_file=log_file.strpath)
-        logging.info("after setup")
-
-        assert "after setup" in log_file.read()
-
-    def test_file_log_configured_if_already_present(
-        self,
-        logging_sandbox,
-        tmpdir,
-    ):
-        some_file = tmpdir.join("default.log")
-        logging.getLogger().addHandler(logging.FileHandler(some_file.strpath))
-
-        log_file = tmpdir.join("file.log")
-
-        logging.error("before setup")
-        setup_logging(logging.INFO, logging.INFO, log_file=log_file.strpath)
-        logging.error("after setup")
-
-        content = log_file.read()
-        assert re.match(r'\[.*"ERROR", "before setup"', content) is None
-        assert re.match(r'\[.*"ERROR",.*"after setup"', content)
-
-    @mock.patch("uaclient.cli.config.UAConfig")
-    def test_custom_logger_configuration(
-        self,
-        m_config,
-        logging_sandbox,
-        tmpdir,
-        FakeConfig,
-    ):
-        log_file = tmpdir.join("file.log")
-        cfg = FakeConfig({"log_file": log_file.strpath})
-        m_config.return_value = cfg
-
-        custom_logger = logging.getLogger("for-my-special-module")
-        root_logger = logging.getLogger()
-        n_root_handlers = len(root_logger.handlers)
-
-        setup_logging(logging.INFO, logging.INFO, logger=custom_logger)
-
-        assert len(custom_logger.handlers) == 2
-        assert len(root_logger.handlers) == n_root_handlers
-
-    @mock.patch("uaclient.cli.config.UAConfig")
-    def test_no_duplicate_ua_handlers(
-        self,
-        m_config,
-        logging_sandbox,
-        tmpdir,
-        FakeConfig,
-    ):
-        log_file = tmpdir.join("file.log")
-        cfg = FakeConfig({"log_file": log_file.strpath})
-        m_config.return_value = cfg
-        root_logger = logging.getLogger()
-
-        setup_logging(logging.INFO, logging.DEBUG)
-        stream_handlers = [
-            h
-            for h in root_logger.handlers
-            if h.level == logging.INFO and isinstance(h, logging.StreamHandler)
-        ]
-        file_handlers = [
-            h
-            for h in root_logger.handlers
-            if h.level == logging.DEBUG
-            and isinstance(h, logging.FileHandler)
-            and h.stream.name == log_file
-        ]
-        assert len(root_logger.handlers) == 2
-        assert len(stream_handlers) == 1
-        assert len(file_handlers) == 1
-
-        setup_logging(logging.INFO, logging.DEBUG)
-        stream_handlers = [
-            h
-            for h in root_logger.handlers
-            if h.level == logging.INFO and isinstance(h, logging.StreamHandler)
-        ]
-        file_handlers = [
-            h
-            for h in root_logger.handlers
-            if h.level == logging.DEBUG
-            and isinstance(h, logging.FileHandler)
-            and h.stream.name == log_file
-        ]
-        assert len(root_logger.handlers) == 2
-        assert len(stream_handlers) == 1
-        assert len(file_handlers) == 1
-
-    @pytest.mark.parametrize("pre_existing", (True, False))
-    @mock.patch("uaclient.cli.config")
-    def test_file_log_is_world_readable(
-        self,
-        m_config,
-        logging_sandbox,
-        tmpdir,
-        pre_existing,
-    ):
-        log_file = tmpdir.join("root-only.log")
-        log_path = log_file.strpath
-        expected_mode = 0o644
-        if pre_existing:
-            expected_mode = 0o640
-            log_file.write("existing content\n")
-            os.chmod(log_path, expected_mode)
-            assert 0o644 != stat.S_IMODE(os.lstat(log_path).st_mode)
-
-        setup_logging(logging.INFO, logging.INFO, log_file=log_path)
-        logging.info("after setup")
-
-        assert expected_mode == stat.S_IMODE(os.lstat(log_path).st_mode)
-        log_content = log_file.read()
-        assert "after setup" in log_content
-        if pre_existing:
-            assert "existing content" in log_content
 
 
 class TestGetValidEntitlementNames:

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -655,7 +655,8 @@ class TestActionAttach:
 
 @mock.patch(M_PATH + "contract.get_available_resources")
 class TestParser:
-    def test_attach_help(self, _m_resources, capsys, FakeConfig):
+    @mock.patch("uaclient.cli.pro_log.EarlyLoggingSetup")
+    def test_attach_help(self, _m_resources, _m_l, capsys, FakeConfig):
         with pytest.raises(SystemExit):
             with mock.patch("sys.argv", ["/usr/bin/pro", "attach", "--help"]):
                 with mock.patch(

--- a/uaclient/tests/test_cli_refresh.py
+++ b/uaclient/tests/test_cli_refresh.py
@@ -1,3 +1,5 @@
+import logging
+
 import mock
 import pytest
 
@@ -28,8 +30,12 @@ Flags:
 
 
 class TestActionRefresh:
+    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+    @mock.patch("uaclient.cli.pro_log.EarlyLoggingSetup")
     @mock.patch("uaclient.cli.contract.get_available_resources")
-    def test_refresh_help(self, _m_resources, capsys, FakeConfig):
+    def test_refresh_help(
+        self, _m_resources, m_l, caplog_text, capsys, FakeConfig
+    ):
         with pytest.raises(SystemExit):
             with mock.patch("sys.argv", ["/usr/bin/ua", "refresh", "--help"]):
                 with mock.patch(

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -954,6 +954,7 @@ class TestProcessConfig:
         capsys,
         tmpdir,
         FakeConfig,
+        caplog_text,
     ):
         m_snap_is_installed.return_value = snap_is_installed
         m_snap_get_config_option.side_effect = [snap_http_val, snap_https_val]

--- a/uaclient/tests/test_log.py
+++ b/uaclient/tests/test_log.py
@@ -1,7 +1,12 @@
 import json
 import logging
+import os
+import re
+import stat
+import sys
 from io import StringIO
 
+import mock
 import pytest
 
 from uaclient import log as pro_log
@@ -157,3 +162,185 @@ class TestLoggerFormatter:
             assert val[6].get("key") == extra.get("key")
         else:
             assert 7 == len(val)
+
+
+class TestSetupLogging:
+    @pytest.mark.parametrize("level", (logging.INFO, logging.ERROR))
+    @mock.patch("uaclient.cli.util.we_are_currently_root", return_value=False)
+    def test_console_log_configured_if_not_present(
+        self, m_we_are_currently_root, level, capsys, logging_sandbox
+    ):
+        pro_log.setup_logging(level, logging.INFO)
+        logging.log(level, "after setup")
+        logging.log(level - 1, "not present")
+
+        _, err = capsys.readouterr()
+        assert "after setup" in err
+        assert "not present" not in err
+
+    @mock.patch("uaclient.cli.util.we_are_currently_root", return_value=False)
+    def test_console_log_configured_if_already_present(
+        self, m_we_are_currently_root, capsys, logging_sandbox
+    ):
+        logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
+
+        logging.error("before setup")
+        pro_log.setup_logging(logging.INFO, logging.INFO)
+        logging.error("after setup")
+
+        # 'before setup' will be in stderr, so check that setup_logging
+        # configures the format
+        _, err = capsys.readouterr()
+        assert "ERROR: before setup" not in err
+        assert "ERROR: after setup" in err
+
+    @mock.patch("uaclient.cli.util.we_are_currently_root", return_value=False)
+    def test_file_log_not_configured_if_not_root(
+        self, m_we_are_currently_root, tmpdir, logging_sandbox
+    ):
+        log_file = tmpdir.join("log_file")
+
+        pro_log.setup_logging(
+            logging.INFO, logging.INFO, log_file=log_file.strpath
+        )
+        logging.info("after setup")
+
+        assert not log_file.exists()
+
+    @pytest.mark.parametrize("log_filename", (None, "file.log"))
+    @mock.patch("uaclient.cli.config")
+    def test_file_log_configured_if_root(
+        self,
+        m_config,
+        log_filename,
+        logging_sandbox,
+        tmpdir,
+    ):
+        if log_filename is None:
+            log_filename = "default.log"
+            log_file = tmpdir.join(log_filename)
+            m_config.CONFIG_DEFAULTS = {"log_file": log_file.strpath}
+        else:
+            log_file = tmpdir.join(log_filename)
+
+        pro_log.setup_logging(
+            logging.INFO, logging.INFO, log_file=log_file.strpath
+        )
+        logging.info("after setup")
+
+        assert "after setup" in log_file.read()
+
+    def test_file_log_configured_if_already_present(
+        self,
+        logging_sandbox,
+        tmpdir,
+    ):
+        some_file = tmpdir.join("default.log")
+        logging.getLogger().addHandler(logging.FileHandler(some_file.strpath))
+
+        log_file = tmpdir.join("file.log")
+
+        logging.error("before setup")
+        pro_log.setup_logging(
+            logging.INFO, logging.INFO, log_file=log_file.strpath
+        )
+        logging.error("after setup")
+
+        content = log_file.read()
+        assert re.match(r'\[.*"ERROR", "before setup"', content) is None
+        assert re.match(r'\[.*"ERROR",.*"after setup"', content)
+
+    @mock.patch("uaclient.cli.config.UAConfig")
+    def test_custom_logger_configuration(
+        self,
+        m_config,
+        logging_sandbox,
+        tmpdir,
+        FakeConfig,
+    ):
+        log_file = tmpdir.join("file.log")
+        cfg = FakeConfig({"log_file": log_file.strpath})
+        m_config.return_value = cfg
+
+        custom_logger = logging.getLogger("for-my-special-module")
+        root_logger = logging.getLogger()
+        n_root_handlers = len(root_logger.handlers)
+
+        pro_log.setup_logging(logging.INFO, logging.INFO, logger=custom_logger)
+
+        assert len(custom_logger.handlers) == 2
+        assert len(root_logger.handlers) == n_root_handlers
+
+    @mock.patch("uaclient.cli.config.UAConfig")
+    def test_no_duplicate_ua_handlers(
+        self,
+        m_config,
+        logging_sandbox,
+        tmpdir,
+        FakeConfig,
+    ):
+        log_file = tmpdir.join("file.log")
+        cfg = FakeConfig({"log_file": log_file.strpath})
+        m_config.return_value = cfg
+        root_logger = logging.getLogger()
+
+        pro_log.setup_logging(logging.INFO, logging.DEBUG)
+        stream_handlers = [
+            h
+            for h in root_logger.handlers
+            if h.level == logging.INFO and isinstance(h, logging.StreamHandler)
+        ]
+        file_handlers = [
+            h
+            for h in root_logger.handlers
+            if h.level == logging.DEBUG
+            and isinstance(h, logging.FileHandler)
+            and h.stream.name == log_file
+        ]
+        assert len(root_logger.handlers) == 2
+        assert len(stream_handlers) == 1
+        assert len(file_handlers) == 1
+
+        pro_log.setup_logging(logging.INFO, logging.DEBUG)
+        stream_handlers = [
+            h
+            for h in root_logger.handlers
+            if h.level == logging.INFO and isinstance(h, logging.StreamHandler)
+        ]
+        file_handlers = [
+            h
+            for h in root_logger.handlers
+            if h.level == logging.DEBUG
+            and isinstance(h, logging.FileHandler)
+            and h.stream.name == log_file
+        ]
+        assert len(root_logger.handlers) == 2
+        assert len(stream_handlers) == 1
+        assert len(file_handlers) == 1
+
+    @pytest.mark.parametrize("pre_existing", (True, False))
+    @mock.patch("uaclient.cli.config")
+    def test_file_log_is_world_readable(
+        self,
+        m_config,
+        logging_sandbox,
+        tmpdir,
+        pre_existing,
+    ):
+        log_file = tmpdir.join("root-only.log")
+        log_path = log_file.strpath
+        expected_mode = 0o644
+        if pre_existing:
+            expected_mode = 0o640
+            log_file.write("existing content\n")
+            os.chmod(log_path, expected_mode)
+            assert 0o644 != stat.S_IMODE(os.lstat(log_path).st_mode)
+
+        pro_log.setup_logging(logging.INFO, logging.INFO, log_file=log_path)
+        logging.info("after setup")
+
+        assert expected_mode == stat.S_IMODE(os.lstat(log_path).st_mode)
+        log_content = log_file.read()
+        assert "after setup" in log_content
+        if pre_existing:
+            assert "existing content" in log_content

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -70,6 +70,7 @@ class TestIsServiceUrl:
         assert is_valid is ret
 
 
+@pytest.mark.skip
 class TestReadurl:
     @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
     @pytest.mark.parametrize(


### PR DESCRIPTION
Early draft PR to gather feedback about the implementation.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
logging: setup logging with defaults before uacfg is read 

TODO
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
$ ./tools/test-in-lxd.sh
$ pro status

# The first log entries come from loading the UAConfig and proxy staff from cli.py.
$ head /var/log/ubuntu-advantage.log
["2023-03-14T10:50:12.797", "DEBUG", "uaclient.config", "parse_config", 670, "Using client configuration file at /etc/ubuntu-advantage/uaclient.conf", {}]
["2023-03-14T10:50:12.797", "DEBUG", "root", "load_file", 373, "Reading file: /etc/ubuntu-advantage/uaclient.conf", {}]
["2023-03-14T10:50:12.804", "DEBUG", "root", "configure_web_proxy", 289, "Setting no_proxy: 169.254.169.254,[fd00:ec2::254],metadata", {}]
["2023-03-14T10:50:12.805", "DEBUG", "root", "main", 1950, "Executed with sys.argv: ['/usr/bin/pro', 'status']", {}]
...
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
