### PR TITLE
security_status: use cache mechanism for apt.Cache

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -212,14 +212,14 @@ def get_apt_cache_policy(
 
 
 @lru_cache(maxsize=None)
-def _get_apt_cache():
+def get_apt_cache():
     import apt  # type: ignore
 
     return apt.Cache()
 
 
 def get_pkg_candidate_version(pkg: str) -> Optional[str]:
-    cache = _get_apt_cache()
+    cache = get_apt_cache()
 
     try:
         package = cache[pkg]

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -57,12 +57,23 @@ def get_origin_information_to_service_map():
     }
 
 
+def _setup_apt_cache():
+    import apt  # type: ignore
+    import apt_pkg
+
+    for key in apt_pkg.config.keys():
+        apt_pkg.config.clear(key)
+    apt_pkg.init()
+
+    return apt.Cache()
+
+
 def get_installed_packages_by_origin() -> DefaultDict[
     "str", List[apt.package.Package]
 ]:
+    cache = _setup_apt_cache()
     result = defaultdict(list)
 
-    cache = apt.Cache()
     installed_packages = [package for package in cache if package.is_installed]
     result["all"] = installed_packages
 

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -522,7 +522,7 @@ class TestSecurityStatus:
     @mock.patch(M_PATH + "status", return_value={"attached": False})
     @mock.patch(M_PATH + "get_origin_for_package", return_value="main")
     @mock.patch(M_PATH + "filter_security_updates")
-    @mock.patch(M_PATH + "apt.Cache")
+    @mock.patch(M_PATH + "_setup_apt_cache")
     def test_security_status_dict(
         self,
         m_cache,


### PR DESCRIPTION
## Proposed Commit Message
security_status: use cache mechanism for apt.Cache

There is problem on the apt library when we import and use both apt_pkg and apt in the same module. For example, once we create the esm cache, that affects the apt.Cache creation. To avoid that, we are now better isolating the apt.Cache creation to handle potential configuration changes caused by the esm cache

## Test Steps
Launch a xenial container and install a package that contains this fix.
After running `apt-get update` on the container, run the following script and check that all results should be consistent:

```python
from uaclient.api.u.pro.packages.updates.v1 import updates
from uaclient.system import subp

result = updates()
print(result.summary)
result = updates()
print(result.summary)
subp(["apt-get", "upgrade", "-y"])
result = updates()
print(result.summary)

```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
