### PR TITLE
tests: fixups discovered while testing lunar

### DIFF
--- a/features/fix.feature
+++ b/features/fix.feature
@@ -6,6 +6,7 @@ Feature: Ua fix command behaviour
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
         When I run `apt remove ca-certificates -y` with sudo
+        When I run `rm -f /etc/ssl/certs/ca-certificates.crt` with sudo
         When I verify that running `ua fix CVE-1800-123456` `as non-root` exits `1`
         Then stderr matches regexp:
             """

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -8,7 +8,7 @@ Feature: Logs in Json Array Formatter
         And I run `apt install jq -y` with sudo
         And I verify that running `pro status` `with sudo` exits `0`
         And I verify that running `pro enable test_entitlement` `with sudo` exits `1`
-        And I run shell command `cat /var/log/ubuntu-advantage.log | jq -r .` as non-root
+        And I run shell command `tail /var/log/ubuntu-advantage.log | jq -r .` as non-root
         Then I will see the following on stderr
         """
         """
@@ -16,7 +16,7 @@ Feature: Logs in Json Array Formatter
         And I verify that running `pro refresh` `with sudo` exits `0`
         And I verify that running `pro status` `with sudo` exits `0`
         And I verify that running `pro enable test_entitlement` `with sudo` exits `1`
-        And I run shell command `cat /var/log/ubuntu-advantage.log | jq -r .` as non-root
+        And I run shell command `tail /var/log/ubuntu-advantage.log | jq -r .` as non-root
         Then I will see the following on stderr
         """
         """


### PR DESCRIPTION
removing ca-certificates doesn't actually remove the file anymore

the log file may have old non-json lines at the beginning from test setup