### PR TITLE
logging: setup logging with defaults before the config is read (SC-1428)

### DIFF
--- a/apport/source_ubuntu-advantage-tools.py
+++ b/apport/source_ubuntu-advantage-tools.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 
 from apport.hookutils import attach_file_if_exists
+from uaclient import defaults
 from uaclient.actions import collect_logs
 from uaclient.config import UAConfig
 
@@ -12,7 +13,7 @@ def add_info(report, ui=None):
     cfg = UAConfig()
     with tempfile.TemporaryDirectory() as output_dir:
         collect_logs(cfg, output_dir)
-        auto_include_log_files = [
+        auto_include_log_files = {
             "cloud-id.txt",
             "cloud-id.txt-error",
             "ua-status.json",
@@ -24,6 +25,9 @@ def add_info(report, ui=None):
             os.path.basename(cfg.timer_log_file),
             os.path.basename(cfg.daemon_log_file),
             os.path.basename(cfg.data_path("jobs-status")),
-        ]
+            os.path.basename(defaults.CONFIG_DEFAULTS["log_file"]),
+            os.path.basename(defaults.CONFIG_DEFAULTS["timer_log_file"]),
+            os.path.basename(defaults.CONFIG_DEFAULTS["daemon_log_file"]),
+        }
         for f in auto_include_log_files:
             attach_file_if_exists(report, os.path.join(output_dir, f), key=f)

--- a/lib/apt_news.py
+++ b/lib/apt_news.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
 
-from uaclient import apt
+from uaclient import apt, defaults
 from uaclient.apt_news import update_apt_news
 from uaclient.config import UAConfig
 from uaclient.daemon import setup_logging
@@ -22,6 +22,12 @@ def main(cfg: UAConfig):
 
 
 if __name__ == "__main__":
+    setup_logging(
+        logging.INFO,
+        logging.DEBUG,
+        defaults.CONFIG_DEFAULTS["log_file"],
+        logger=logging.getLogger(),
+    )
     cfg = UAConfig()
     setup_logging(
         logging.INFO,

--- a/lib/auto_attach.py
+++ b/lib/auto_attach.py
@@ -13,7 +13,7 @@ their side.
 import logging
 import sys
 
-from uaclient import messages, system
+from uaclient import defaults, messages, system
 from uaclient.api.exceptions import (
     AlreadyAttachedError,
     AutoAttachDisabledError,
@@ -103,6 +103,12 @@ def main(cfg: UAConfig):
 
 
 if __name__ == "__main__":
+    setup_logging(
+        logging.INFO,
+        logging.DEBUG,
+        defaults.CONFIG_DEFAULTS["log_file"],
+        logger=logging.getLogger(),
+    )
     cfg = UAConfig()
     setup_logging(
         logging.INFO,

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -4,6 +4,7 @@ import sys
 
 from systemd.daemon import notify  # type: ignore
 
+from uaclient import defaults
 from uaclient.config import UAConfig
 from uaclient.daemon import (
     poll_for_pro_license,
@@ -15,6 +16,12 @@ LOG = logging.getLogger("pro")
 
 
 def main() -> int:
+    setup_logging(
+        logging.INFO,
+        logging.DEBUG,
+        defaults.CONFIG_DEFAULTS["daemon_log_file"],
+        logger=LOG,
+    )
     cfg = UAConfig()
     setup_logging(
         logging.INFO, logging.DEBUG, log_file=cfg.daemon_log_file, logger=LOG

--- a/lib/esm_cache.py
+++ b/lib/esm_cache.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from uaclient import defaults
 from uaclient.apt import update_esm_caches
 from uaclient.config import UAConfig
 from uaclient.daemon import setup_logging
@@ -18,6 +19,12 @@ def main(cfg: UAConfig) -> None:
 
 
 if __name__ == "__main__":
+    setup_logging(
+        logging.INFO,
+        logging.DEBUG,
+        defaults.CONFIG_DEFAULTS["log_file"],
+        logger=logging.getLogger(),
+    )
     cfg = UAConfig()
     setup_logging(
         logging.INFO,

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -18,7 +18,7 @@ import logging
 import os
 import sys
 
-from uaclient import config, contract, exceptions, lock, messages
+from uaclient import config, contract, defaults, exceptions, lock, messages
 from uaclient.cli import setup_logging
 from uaclient.entitlements.fips import FIPSEntitlement
 from uaclient.files import notices
@@ -152,6 +152,11 @@ def main(cfg: config.UAConfig):
 
 
 if __name__ == "__main__":
+    setup_logging(
+        logging.INFO,
+        logging.DEBUG,
+        defaults.CONFIG_DEFAULTS["log_file"],
+    )
     cfg = config.UAConfig()
     setup_logging(logging.INFO, logging.DEBUG, log_file=cfg.log_file)
     main(cfg=cfg)

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional
 
+from uaclient import defaults
 from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
 from uaclient.exceptions import InvalidFileFormatError
@@ -184,6 +185,12 @@ def run_jobs(cfg: UAConfig, current_time: datetime):
 
 
 if __name__ == "__main__":
+    setup_logging(
+        logging.CRITICAL,
+        logging.DEBUG,
+        defaults.CONFIG_DEFAULTS["timer_log_file"],
+        logger=LOG,
+    )
     cfg = UAConfig()
     current_time = datetime.now(timezone.utc)
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1835,6 +1835,8 @@ def setup_logging(console_level, log_level, log_file=None, logger=None):
     if log_file is None:
         cfg = config.UAConfig()
         log_file = cfg.log_file
+    if isinstance(log_level, str):
+        log_level = log_level.upper()
     console_formatter = util.LogFormatter()
     if logger is None:
         # Then we configure the root logger
@@ -1957,6 +1959,11 @@ def main_error_handler(func):
 
 @main_error_handler
 def main(sys_argv=None):
+    setup_logging(
+        logging.INFO,
+        defaults.CONFIG_DEFAULTS["log_level"],
+        defaults.CONFIG_DEFAULTS["log_file"],
+    )
     if not sys_argv:
         sys_argv = sys.argv
     cfg = config.UAConfig()

--- a/uaclient/data_types.py
+++ b/uaclient/data_types.py
@@ -1,9 +1,12 @@
 import datetime
 import json
+import logging
 from enum import Enum
 from typing import Any, List, Optional, Type, TypeVar, Union
 
 from uaclient import exceptions, messages, util
+
+LOG = logging.getLogger(__name__)
 
 
 class IncorrectTypeError(exceptions.UserFacingError):
@@ -290,16 +293,13 @@ class DataObject(DataValue):
                     val = field.data_cls.from_value(val)
                 except IncorrectTypeError as e:
                     if not field.required and optional_type_errors_become_null:
-                        # SC-1428: we should warn here, but this currently runs
-                        # before setup_logging() in the case of
-                        # user-config.json.
-                        #
-                        # logging.warning(
-                        #     "{} is wrong type (expected {} but got {}) but "
-                        #     "considered optional - treating as null".format(
-                        #         field.key, e.expected_type, e.got_type
-                        #     )
-                        # )
+                        LOG.warning(
+                            "%s is wrong type (expected %s but got %s) but "
+                            "considered optional - treating as null",
+                            field.key,
+                            e.expected_type,
+                            e.got_type,
+                        )
                         val = None
                     else:
                         raise IncorrectFieldTypeError(e, field.dict_key)

--- a/uaclient/tests/test_cli_api.py
+++ b/uaclient/tests/test_cli_api.py
@@ -25,7 +25,8 @@ positional arguments:
 
 class TestActionAPI:
     @mock.patch("uaclient.cli.entitlements.valid_services", return_value=[])
-    def test_api_help(self, valid_services, capsys):
+    @mock.patch("uaclient.cli.setup_logging")
+    def test_api_help(self, _m_setup_logging, valid_services, capsys):
         with pytest.raises(SystemExit):
             with mock.patch("sys.argv", ["/usr/bin/ua", "api", "--help"]):
                 main()

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -655,7 +655,10 @@ class TestActionAttach:
 
 @mock.patch(M_PATH + "contract.get_available_resources")
 class TestParser:
-    def test_attach_help(self, _m_resources, capsys, FakeConfig):
+    @mock.patch("uaclient.cli.setup_logging")
+    def test_attach_help(
+        self, _m_resources, _m_setup_logging, capsys, FakeConfig
+    ):
         with pytest.raises(SystemExit):
             with mock.patch("sys.argv", ["/usr/bin/pro", "attach", "--help"]):
                 with mock.patch(

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -41,8 +41,11 @@ def test_non_root_users_are_rejected(we_are_currently_root, FakeConfig):
 
 
 class TestActionAutoAttach:
+    @mock.patch("uaclient.cli.setup_logging")
     @mock.patch(M_PATH + "contract.get_available_resources")
-    def test_auto_attach_help(self, _m_resources, capsys, FakeConfig):
+    def test_auto_attach_help(
+        self, _m_resources, _m_setup_logging, capsys, FakeConfig
+    ):
         with pytest.raises(SystemExit):
             with mock.patch(
                 "sys.argv", ["/usr/bin/ua", "auto-attach", "--help"]

--- a/uaclient/tests/test_cli_collect_logs.py
+++ b/uaclient/tests/test_cli_collect_logs.py
@@ -29,8 +29,11 @@ Collect logs and relevant system information into a tarball.
 
 
 class TestActionCollectLogs:
+    @mock.patch("uaclient.cli.setup_logging")
     @mock.patch(M_PATH + "contract.get_available_resources")
-    def test_collect_logs_help(self, _m_resources, capsys, FakeConfig):
+    def test_collect_logs_help(
+        self, _m_resources, _m_setup_logging, capsys, FakeConfig
+    ):
         with pytest.raises(SystemExit):
             with mock.patch(
                 "sys.argv", ["/usr/bin/ua", "collect-logs", "--help"]

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -52,8 +52,11 @@ Flags:
 
 
 class TestDisable:
+    @mock.patch("uaclient.cli.setup_logging")
     @mock.patch("uaclient.cli.contract.get_available_resources")
-    def test_disable_help(self, _m_resources, capsys, FakeConfig):
+    def test_disable_help(
+        self, _m_resources, _m_setup_logging, capsys, FakeConfig
+    ):
         with pytest.raises(SystemExit):
             with mock.patch("sys.argv", ["/usr/bin/ua", "disable", "--help"]):
                 with mock.patch(

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -36,10 +36,12 @@ Flags:
 
 @mock.patch("uaclient.contract.request_updated_contract")
 class TestActionEnable:
+    @mock.patch("uaclient.cli.setup_logging")
     @mock.patch("uaclient.cli.contract.get_available_resources")
     def test_enable_help(
         self,
         _m_resources,
+        _m_setup_logging,
         _request_updated_contract,
         capsys,
         FakeConfig,

--- a/uaclient/tests/test_cli_fix.py
+++ b/uaclient/tests/test_cli_fix.py
@@ -30,8 +30,11 @@ Flags:
 
 
 class TestActionFix:
+    @mock.patch("uaclient.cli.setup_logging")
     @mock.patch("uaclient.cli.contract.get_available_resources")
-    def test_fix_help(self, _m_resources, capsys, FakeConfig):
+    def test_fix_help(
+        self, _m_resources, _m_setup_logging, capsys, FakeConfig
+    ):
         with pytest.raises(SystemExit):
             with mock.patch("sys.argv", ["/usr/bin/ua", "fix", "--help"]):
                 with mock.patch(

--- a/uaclient/tests/test_cli_reboot_required.py
+++ b/uaclient/tests/test_cli_reboot_required.py
@@ -22,7 +22,8 @@ for the machine regarding reboot:
 
 
 class TestActionRebootRequired:
-    def test_enable_help(self, capsys, FakeConfig):
+    @mock.patch("uaclient.cli.setup_logging")
+    def test_enable_help(self, _m_setup_logging, capsys, FakeConfig):
         with pytest.raises(SystemExit):
             with mock.patch(
                 "sys.argv",

--- a/uaclient/tests/test_cli_refresh.py
+++ b/uaclient/tests/test_cli_refresh.py
@@ -28,8 +28,11 @@ Flags:
 
 
 class TestActionRefresh:
+    @mock.patch("uaclient.cli.setup_logging")
     @mock.patch("uaclient.cli.contract.get_available_resources")
-    def test_refresh_help(self, _m_resources, capsys, FakeConfig):
+    def test_refresh_help(
+        self, _m_resources, _m_setup_logging, capsys, FakeConfig
+    ):
         with pytest.raises(SystemExit):
             with mock.patch("sys.argv", ["/usr/bin/ua", "refresh", "--help"]):
                 with mock.patch(

--- a/uaclient/tests/test_cli_security_status.py
+++ b/uaclient/tests/test_cli_security_status.py
@@ -54,8 +54,10 @@ complete status on Ubuntu Pro services, run 'pro status'.
 @mock.patch(M_PATH + "security_status.security_status_dict")
 @mock.patch(M_PATH + "contract.get_available_resources")
 class TestActionSecurityStatus:
+    @mock.patch(M_PATH + "setup_logging")
     def test_security_status_help(
         self,
+        _m_setup_logging,
         _m_resources,
         _m_security_status_dict,
         _m_security_status,
@@ -119,8 +121,10 @@ class TestActionSecurityStatus:
             assert m_security_status.call_args_list == [mock.call(cfg)]
             assert m_security_status.call_count == 1
 
+    @mock.patch(M_PATH + "setup_logging")
     def test_error_on_wrong_format(
         self,
+        _m_setup_logging,
         _m_resources,
         _m_security_status_dict,
         _m_security_status,

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -339,8 +339,10 @@ Flags:
     return_value=RESPONSE_CONTRACT_INFO,
 )
 class TestActionStatus:
+    @mock.patch(M_PATH + "setup_logging")
     def test_status_help(
         self,
+        _m_setup_logging,
         _m_get_contract_information,
         _m_get_available_resources,
         _m_should_reboot,

--- a/uaclient/tests/test_data_types.py
+++ b/uaclient/tests/test_data_types.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import List, Optional
 
 import pytest
@@ -696,7 +697,8 @@ class TestDataObject:
         assert do.string == "something"
         assert d == do.to_dict()
 
-    def test_optional_type_errors_become_null(self):
+    @pytest.mark.parametrize("caplog_text", [logging.WARNING], indirect=True)
+    def test_optional_type_errors_become_null(self, caplog_text):
         result = ExampleDataObject.from_dict(
             {
                 **example_data_object_dict_with_optionals,
@@ -723,6 +725,11 @@ class TestDataObject:
         assert result.enum_opt_list is None
         assert result.dt_opt is None
         assert result.dtlist_opt is None
+        logs = caplog_text()
+        assert (
+            "string_opt is wrong type (expected str but got int) but "
+            "considered optional - treating as null"
+        ) in logs
 
     @pytest.mark.parametrize(
         "d",


### PR DESCRIPTION
Continuation of #2486.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
logging: setup logging with defaults before the config is read

Previously, we didn’t call setup_logging until after reading
the config (because the config can affect how we setup logging).

Set up the logging with defaults before reading the config to
capture logs from the start of the cli and lib entry-points.

Capture those default log files in apport.

data_types: warn on wrong data types.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
$ ./tools/test-in-lxd.sh
$ pro status

# The first log entries come from loading the UAConfig and proxy staff from cli.py.
$ head /var/log/ubuntu-advantage.log
["2023-03-14T10:50:12.797", "DEBUG", "uaclient.config", "parse_config", 670, "Using client configuration file at /etc/ubuntu-advantage/uaclient.conf", {}]
["2023-03-14T10:50:12.797", "DEBUG", "root", "load_file", 373, "Reading file: /etc/ubuntu-advantage/uaclient.conf", {}]
["2023-03-14T10:50:12.804", "DEBUG", "root", "configure_web_proxy", 289, "Setting no_proxy: 169.254.169.254,[fd00:ec2::254],metadata", {}]
["2023-03-14T10:50:12.805", "DEBUG", "root", "main", 1950, "Executed with sys.argv: ['/usr/bin/pro', 'status']", {}]
...
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
