### PR TITLE
Isolate apt imports and getters

### DIFF
--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -8,15 +8,21 @@ from typing import Any, Dict
 import mock
 import pytest
 
-from uaclient import event_logger
-from uaclient.config import UAConfig
-from uaclient.files.notices import NoticeFileDetails
-from uaclient.files.state_files import UserConfigData
-
 # We are doing this because we are sure that python3-apt comes with the distro,
 # but it cannot be installed in a virtual environment to be properly tested.
+# Those need to be mocked here, before importing our modules, so the pytest
+# virtualenv doesn't cry because it can't find the modules
 sys.modules["apt"] = mock.MagicMock()
 sys.modules["apt_pkg"] = mock.MagicMock()
+
+# Useless try/except to make flake8 happy \_("/)_/
+try:
+    from uaclient import event_logger
+    from uaclient.config import UAConfig
+    from uaclient.files.notices import NoticeFileDetails
+    from uaclient.files.state_files import UserConfigData
+except ImportError:
+    raise
 
 
 @pytest.yield_fixture(scope="session", autouse=True)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -93,12 +93,8 @@ class RepoEntitlement(base.UAEntitlement):
     def _perform_disable(self, silent=False):
         if hasattr(self, "remove_packages"):
             self.remove_packages()
-        self._cleanup(silent=silent)
-        return True
-
-    def _cleanup(self, silent: bool = False) -> None:
-        """Clean up the entitlement without checks or messaging"""
         self.remove_apt_config(silent=silent)
+        return True
 
     def application_status(
         self,
@@ -264,7 +260,7 @@ class RepoEntitlement(base.UAEntitlement):
             )
         except exceptions.UserFacingError:
             if cleanup_on_failure:
-                self._cleanup()
+                self.remove_apt_config()
             raise
 
     def setup_apt_config(self, silent: bool = False) -> None:

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1060,7 +1060,7 @@ class TestFipsEntitlementInstallPackages:
         self, m_run_apt, entitlement
     ):
         m_run_apt.side_effect = exceptions.UserFacingError("error")
-        with mock.patch.object(entitlement, "_cleanup"):
+        with mock.patch.object(entitlement, "remove_apt_config"):
             with pytest.raises(exceptions.UserFacingError):
                 entitlement.install_packages()
 

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -9,7 +9,7 @@ from typing import Any, DefaultDict, Dict, List, Tuple, Union  # noqa: F401
 import apt  # type: ignore
 
 from uaclient import livepatch, messages
-from uaclient.apt import get_esm_cache
+from uaclient.apt import get_apt_cache, get_esm_cache
 from uaclient.config import UAConfig
 from uaclient.entitlements import ESMAppsEntitlement, ESMInfraEntitlement
 from uaclient.entitlements.entitlement_status import (
@@ -62,7 +62,7 @@ def get_installed_packages_by_origin() -> DefaultDict[
 ]:
     result = defaultdict(list)
 
-    cache = apt.Cache()
+    cache = get_apt_cache()
     installed_packages = [package for package in cache if package.is_installed]
     result["all"] = installed_packages
 

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -522,7 +522,7 @@ class TestSecurityStatus:
     @mock.patch(M_PATH + "status", return_value={"attached": False})
     @mock.patch(M_PATH + "get_origin_for_package", return_value="main")
     @mock.patch(M_PATH + "filter_security_updates")
-    @mock.patch(M_PATH + "apt.Cache")
+    @mock.patch(M_PATH + "get_apt_cache")
     def test_security_status_dict(
         self,
         m_cache,


### PR DESCRIPTION
This is an alternative to #2488

It's kind of a rearrangement of it actually, putting imports on top of files (so we know when those will happen, instead of relying on runtime) and making sure caches are loaded from specific getter functions.

TODO: check the extent we can lru_cache things.

## Test Steps
unit + integration + same script as in 2488

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
