### PR TITLE
apt: restore apt configuration after creating the esm cache

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -237,6 +237,13 @@ def get_esm_cache():
     except Exception:
         cache = {}
 
+    # We need to restore the apt cache configuration after creating our cache,
+    # otherwise we may break people interacting with the library after
+    # importing our modules.
+    for key in apt_pkg.config.keys():
+        apt_pkg.config.clear(key)
+    apt_pkg.init()
+
     return cache
 
 


### PR DESCRIPTION
When the esm cache is created, the apt_pkg.config globals are set to values a regular user of the library wouldn't expect. We need to set it back to the defaults, by clearing the config and calling init() again, so any subsequent call of apt.* will read the globals the same way it would without our interference.

LP: #2008280

## Test Steps
All tests works as expected, plus:

- import apt
- import our updates endpoint
- run our updates function
- run apt.Cache()
- make sure you got the system cache normally

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
