### PR TITLE
apt: use context manager for handling apt config

### DIFF
--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -12,8 +12,9 @@ import pytest
 # but it cannot be installed in a virtual environment to be properly tested.
 # Those need to be mocked here, before importing our modules, so the pytest
 # virtualenv doesn't cry because it can't find the modules
+m_apt_pkg = mock.MagicMock()
 sys.modules["apt"] = mock.MagicMock()
-sys.modules["apt_pkg"] = mock.MagicMock()
+sys.modules["apt_pkg"] = m_apt_pkg
 
 # Useless try/except to make flake8 happy \_("/)_/
 try:
@@ -261,3 +262,8 @@ def mock_notices_dir(tmpdir_factory):
             temp_dir.strpath,
         ):
             yield
+
+
+@pytest.fixture
+def apt_pkg():
+    return m_apt_pkg


### PR DESCRIPTION
## Proposed Commit Message
apt: use context manager for handling apt config

Some apt functions require us to change the global apt config. Since we might be changing behavior on other parts of the code that require apt functionality, we are now using a context manager to guarantee that the original system config is kept after we call an apt function

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
