### PR TITLE
save uaclient.conf backup after config migration

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -328,11 +328,21 @@ cleanup_old_motd_files() {
 
 migrate_user_config_post() {
     # LP: #2004280
+    preinst_file="/etc/ubuntu-advantage/uaclient.conf.preinst-backup"
+    bkp_file="/etc/ubuntu-advantage/uaclient.conf.dpkg-bak"
+
     if [ -f /etc/ubuntu-advantage/uaclient.conf.preinst-backup ]; then
         # This script modifies the preinst-backup version of the file in-place
         /usr/bin/python3 /usr/lib/ubuntu-advantage/migrate_user_config.py
+
+        if cmp --silent $preinst_file $bkp_file; then
+            # This should only happen if we failed to perform the migration.
+            # Therefore, there is no need to keep the backup file around
+            rm -f $bkp_file
+        fi
+
         # Overwrite uaclient.conf with the now-migrated version from preinst
-        mv /etc/ubuntu-advantage/uaclient.conf.preinst-backup /etc/ubuntu-advantage/uaclient.conf
+        mv $preinst_file /etc/ubuntu-advantage/uaclient.conf
         # just in case this temp file was left behind
         rm -f /etc/ubuntu-advantage/uaclient.conf.preinst-backup-migrated-temp
     fi

--- a/debian/ubuntu-advantage-tools.preinst
+++ b/debian/ubuntu-advantage-tools.preinst
@@ -14,6 +14,9 @@ migrate_user_config_pre() {
     if [ "$curr_conf_hash" != "$expected_conf_hash" ]; then
         # Back up existing conffile in case of an error unwind
         cp -a /etc/ubuntu-advantage/uaclient.conf /etc/ubuntu-advantage/uaclient.conf.preinst-backup
+        # Create this backup in case the user has made some comments on the config file.
+        # In that way, the user can retrive them if they want to
+        cp -a /etc/ubuntu-advantage/uaclient.conf /etc/ubuntu-advantage/uaclient.conf.dpkg-bak
         # Insert the new about-to-be-installed uaclient.conf to avoid conffile prompts
         cat > /etc/ubuntu-advantage/uaclient.conf <<EOT
 contract_url: https://contracts.canonical.com

--- a/sru/release-27.14/test-migrate-user-config.sh
+++ b/sru/release-27.14/test-migrate-user-config.sh
@@ -74,6 +74,11 @@ function test_normal_upgrade {
     lxc exec $name -- cat /etc/ubuntu-advantage/uaclient.conf
     echo "-------------------------------------------"
     echo -e "\n-------------------------------------------"
+    echo "** Show no uaclient.conf.dpkg-bak"
+    echo "-------------------------------------------"
+    lxc exec $name -- sh -c "ls -al  /etc/ubuntu-advantage/uaclient.conf.dpkg-bak || true"
+    echo "-------------------------------------------"
+    echo -e "\n-------------------------------------------"
     echo "** Show user config"
     echo "-------------------------------------------"
     lxc exec $name -- sh -c "ls -al /var/lib/ubuntu-advantage/user-config.json || true"
@@ -130,6 +135,11 @@ function test_apt_news_false_upgrade {
     echo "** Show uaclient.conf"
     echo "-------------------------------------------"
     lxc exec $name -- cat /etc/ubuntu-advantage/uaclient.conf
+    echo "-------------------------------------------"
+    echo -e "\n-------------------------------------------"
+    echo "** Show uaclient.conf.dpkg-bak"
+    echo "-------------------------------------------"
+    lxc exec $name -- cat /etc/ubuntu-advantage/uaclient.conf.dpkg-bak
     echo "-------------------------------------------"
     echo -e "\n-------------------------------------------"
     echo "** Show user config"
@@ -196,6 +206,11 @@ function test_uaclient_conf_changes_upgrade {
     echo "** Show uaclient.conf"
     echo "-------------------------------------------"
     lxc exec $name -- cat /etc/ubuntu-advantage/uaclient.conf
+    echo "-------------------------------------------"
+    echo -e "\n-------------------------------------------"
+    echo "** Show uaclient.conf.dpkg-bak"
+    echo "-------------------------------------------"
+    lxc exec $name -- cat /etc/ubuntu-advantage/uaclient.conf.dpkg-bak
     echo "-------------------------------------------"
     echo -e "\n-------------------------------------------"
     echo "** Show user config"


### PR DESCRIPTION
## Proposed Commit Message
save uaclient.conf backup after config migration

Since we are now migrating some of the uaclient.conf items into a different file, we are also leaving a backup file behind, uaclient.conf.dpkg-bak, in case the user has made some comments on the original config file. This will allow the user to retrieve those comments if needed

## Test Steps
Run the modified `sru/release-27.14/test-migrate-user-config.sh` test script

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
