### PR TITLE
apt: modify check for Acquire keys for esm cache

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -251,7 +251,7 @@ def get_esm_cache():
         # Take care to initialize the cache with only the
         # Acquire configuration preserved
         for key in apt_pkg.config.keys():
-            if "Acquire" not in key:
+            if not re.search("^Acquire", key):
                 apt_pkg.config.clear(key)
         apt_pkg.config.set("Dir", ESM_APT_ROOTDIR)
         apt_pkg.init()


### PR DESCRIPTION
## Proposed Commit Message
apt: modify check for Acquire keys for esm cache

Use regex to guarantee that only `Acquire` keys are left in the apt configuration when creating the esm cache

## Test Steps
Check if the esm-cache creation is still working as expected

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
