### PR TITLE
tests: add livepatch interim hwe test (SC-1306)

### DIFF
--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -70,3 +70,25 @@ Feature: Livepatch
         Examples: ubuntu release
             | release |
             | focal   |
+
+    @series.jammy
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Livepatch is supported on interim HWE kernel
+        # This test is intended to ensure that an interim HWE kernel has the correct support status
+        # It should be kept up to date so that it runs on the latest LTS and installs the latest
+        # HWE kernel for that release.
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `apt-get update` with sudo
+        When I run `apt-get install linux-generic-hwe-<release_num> -y` with sudo
+        When I run `DEBIAN_FRONTEND=noninteractive apt-get remove linux-image*-kvm -y` with sudo
+        When I run `update-grub` with sudo
+        When I reboot the machine
+        When I attach `contract_token` with sudo
+        When I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        livepatch +yes +enabled +Canonical Livepatch service
+        """
+        Examples: ubuntu release
+            | release | release_num |
+            | jammy   | 22.04       |


### PR DESCRIPTION
This won't pass until the 6.2 HWE kernel is out for jammy.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the new test manually

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
