### PR TITLE
tests: bump pycloudlib version

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -2,11 +2,8 @@
 behave
 jsonschema
 PyHamcrest
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@e7c4a42eb98a914b084b253c3f96c960de42e8fa
+pycloudlib==1!2.1.1
 toml==0.10
 
-
-# Simplestreams is not found on PyPi so pull from repo directly
-git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d
 ipdb
 


### PR DESCRIPTION
NO-JIRA NO-LP NO-GH

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
tests: bump pycloudlib version

Consume pycloudlib from PyPI (https://pypi.org/project/pycloudlib/)

Drop simplestreams dependency as it was an indirect one from pycloudlib
and it is not required anymore.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
