### PR TITLE
livepatch: check series affordances again

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-advantage-tools (27.14.3) lunar; urgency=medium
+
+  * livepatch: prevent livepatch from auto-enabling and subsequently failing
+    on interim releases (LP: #2013409)
+
+ -- Grant Orndorff <grant.orndorff@canonical.com>  Fri, 31 Mar 2023 10:13:44 -0400
+
 ubuntu-advantage-tools (27.14.2~23.04.1) lunar; urgency=medium
 
   * status:

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -70,3 +70,34 @@ Feature: Livepatch
         Examples: ubuntu release
             | release |
             | focal   |
+
+    @series.kinetic
+    @series.lunar
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: Livepatch is not enabled by default and can't be enabled on interim releases
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `pro status --all` with sudo
+        Then stdout matches regexp:
+        """
+        livepatch +no +Current kernel is not supported
+        """
+        When I attach `contract_token` with sudo
+        When I run `pro status --all` with sudo
+        Then stdout matches regexp:
+        """
+        livepatch +yes +n/a +Canonical Livepatch service
+        """
+        When I verify that running `pro enable livepatch` `with sudo` exits `1`
+        Then stdout contains substring:
+        """
+        Livepatch is not available for Ubuntu <pretty_name>.
+        """
+        When I run `pro status --all` with sudo
+        Then stdout matches regexp:
+        """
+        livepatch +yes +n/a +Canonical Livepatch service
+        """
+        Examples: ubuntu release
+            | release | pretty_name           |
+            | kinetic | 22.10 (Kinetic Kudu)  |
+            | lunar   | 23.04 (Lunar Lobster) |

--- a/tools/run-integration-tests.py
+++ b/tools/run-integration-tests.py
@@ -35,7 +35,7 @@ PLATFORM_SERIES_TESTS = {
     "gcppro": ["xenial", "bionic", "focal", "jammy"],
     "gcppro-fips": ["bionic", "focal"],
     "lxd": ["xenial", "bionic", "focal", "jammy", "kinetic", "lunar"],
-    "vm": ["xenial", "bionic", "focal", "jammy"],
+    "vm": ["xenial", "bionic", "focal", "jammy", "kinetic", "lunar"],
     "upgrade": ["xenial", "bionic", "focal", "jammy", "kinetic"],
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,8 @@ commands =
     behave-vm-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.bionic,series.all,series.lts" --tags="~upgrade"
     behave-vm-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.focal,series.all,series.lts" --tags="~upgrade" --tags="~docker"
     behave-vm-22.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.jammy,series.all,series.lts" --tags="~upgrade"
+    behave-vm-22.10: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.kinetic,series.all" --tags="~upgrade"
+    behave-vm-23.04: behave -v {posargs} --tags="uses.config.machine_type.lxd.vm" --tags="series.lunar,series.all" --tags="~upgrade"
 
     behave-upgrade-16.04: behave -v {posargs} --tags="upgrade" --tags="series.xenial,series.all"
     behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" --tags="series.bionic,series.all"

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -33,9 +33,10 @@ class LivepatchEntitlement(UAEntitlement):
     title = "Livepatch"
     description = "Canonical Livepatch service"
     affordance_check_arch = False
-    affordance_check_series = False
     affordance_check_kernel_min_version = False
     affordance_check_kernel_flavor = False
+    # we do want to check series because livepatch errors on non-lts releases
+    affordance_check_series = True
 
     @property
     def incompatible_services(self) -> Tuple[IncompatibleService, ...]:

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -15,7 +15,7 @@ from uaclient.defaults import CANDIDATE_CACHE_PATH, UAC_RUN_PATH
 from uaclient.exceptions import ProcessExecutionError
 from uaclient.system import subp
 
-__VERSION__ = "27.14.2"
+__VERSION__ = "27.14.3"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 CANDIDATE_REGEX = r"Candidate: (?P<candidate>.*?)\n"


### PR DESCRIPTION
livepatch treats Ubuntu Release version support differently from how it treats kernel version/flavor/arch support. The Ubuntu Release is checked against hardcoded list and causes the canonical-livepatch command to raise errors. Because of this, we need to use the Contract Server-defined series affordance to prevent even attempting to install and run canonical-livepatch on unsupported releases (interim releases).

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`pro attach` on an interim release vm. ensure we don't try (and fail) to enable livepatch

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
