### PR TITLE
postinst: more specific regex for ua_config warning

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -443,7 +443,7 @@ case "$1" in
           migrate_user_config_post
       fi
 
-      if grep -q "ua_config:" /etc/ubuntu-advantage/uaclient.conf; then
+      if grep -q "^ua_config:" /etc/ubuntu-advantage/uaclient.conf; then
           echo "Warning: uaclient.conf uses old ua_config field. Please remove and use" >&2
           echo "         pro config set to configure any custom settings." >&2
       fi


### PR DESCRIPTION
no-jira no-lp no-gh

The old warning would be shown even if ua_config: was commented out. By ensuring we only warn when the line begins with ua_config: we don't warn in this situation where it is unnecessary.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
On the previous version of pro-client edit uaclient.conf to say
```
#ua_config:
{{ <- this causes the migration to fail
```
Then upgrade to this version. Ensure there is no warning about "ua_config" being present in the config

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
