### PR TITLE
reboot-required: livepatch is working when "nothing-to-apply"

### DIFF
--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -265,7 +265,10 @@ def get_reboot_status():
         and our_kernel_version is not None
         and our_kernel_version == lp_status.kernel
         and lp_status.livepatch is not None
-        and lp_status.livepatch.state == "applied"
+        and (
+            lp_status.livepatch.state == "applied"
+            or lp_status.livepatch.state == "nothing-to-apply"
+        )
         and lp_status.supported == "supported"
     ):
         return RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -735,7 +735,7 @@ class TestRebootStatus:
             (
                 "nothing-to-apply",
                 "supported",
-                RebootStatus.REBOOT_REQUIRED,
+                RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED,
                 "4.15.0-187.198-generic",
             ),
             (


### PR DESCRIPTION
no-jira no-lp no-gh

This state also indicates that because Livepatch seems to be working correctly for your kernel. It just means no Livepatches have been issued yet.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
In a fresh jammy vm with this version of pro-client installed:
- fake a kernel reboot-required by running `touch /run/reboot-required && echo "linux-image" >> /run/reboot-required.pkgs`
- `pro attach`
-  ensure `canonical-livepatch status --format json` says "nothing-to-apply"
- ensure `pro system reboot-required` says "yes-kernel-livepatches-applied"

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
