### PR TITLE
Typo Fix in get_rid_of_corrupt_lock.md

### DIFF
--- a/docs/howtoguides/get_rid_of_corrupt_lock.md
+++ b/docs/howtoguides/get_rid_of_corrupt_lock.md
@@ -2,7 +2,7 @@
 
 Some pro commands (`attach`, `enable`, `detach` and `disable`) will potentially change the
 internal state of your system. Since those commands can run in parallel, we have a lock file
-mechanism to guarantee that only one of these commands can run at the same time. The lock follow
+mechanism to guarantee that only one of these commands can run at the same time. The lock follows
 this pattern:
 
 ```


### PR DESCRIPTION
missing s on follows

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer -->

```
summary: Minor Typo Fix 

First time proposing a change to Canonical Documentation.
I've looked at some of the contributing docs but I'm not sure if this is the correct way to go about proposing a Minor typo fix. 
Sorry if this is too minor of a fix or not the correct process. 
Please let me know if there is a better way (such as batching typo fixes) or any feedback in contributing. 

Thanks
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
