### PR TITLE
Security status output improvements (SC-1470) (SC-1471) (SC-1404)

### DIFF
--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -136,10 +136,10 @@ Feature: Security status command behavior
         This machine is NOT attached to an Ubuntu Pro subscription.
 
         Ubuntu Pro with 'esm-infra' enabled provides security updates for
-        Main/Restricted packages until 2026 and has \d+ pending security update[s]?\.
+        Main/Restricted packages until 2026\. There (is|are) \d+ pending security update[s]?\.
 
         Ubuntu Pro with 'esm-apps' enabled provides security updates for
-        Universe/Multiverse packages until 2026 and has \d+ pending security update[s]?\.
+        Universe/Multiverse packages until 2026\. There (is|are) \d+ pending security update[s]?\.
 
         Try Ubuntu Pro with a free personal subscription on up to 5 machines.
         Learn more at https://ubuntu.com/pro
@@ -155,17 +155,18 @@ Feature: Security status command behavior
         and esm-infra is not enabled.
 
         Ubuntu Pro with 'esm-infra' enabled provides security updates for
-        Main/Restricted packages until 2026 and has \d+ pending security update[s]?\.
+        Main/Restricted packages until 2026\. There (is|are) \d+ pending security update[s]?\.
 
         Run 'pro help esm-infra' to learn more
 
-        Package names in .*bold.* currently have an available update
-        with 'esm-infra' enabled
-        Packages:
+        Installed packages with an available esm-infra update:
+        (.|\n)+
+
+        Further installed packages covered by esm-infra:
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I verify root and non-root `pro security-status --esm-apps` calls have the same output
@@ -176,17 +177,18 @@ Feature: Security status command behavior
          +\d+ package[s]? from Ubuntu Universe/Multiverse repository
 
         Ubuntu Pro with 'esm-apps' enabled provides security updates for
-        Universe/Multiverse packages until 2026 and has \d+ pending security update[s]?\.
+        Universe/Multiverse packages until 2026\. There (is|are) \d+ pending security update[s]?\.
 
         Run 'pro help esm-apps' to learn more
 
-        Package names in .*bold.* currently have an available update
-        with 'esm-apps' enabled
-        Packages:
+        Installed packages with an available esm-apps update:
+        (.|\n)+
+
+        Further installed packages covered by esm-apps:
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I attach `contract_token` with sudo
@@ -207,10 +209,10 @@ Feature: Security status command behavior
         This machine is attached to an Ubuntu Pro subscription.
 
         Main/Restricted packages are receiving security updates from
-        Ubuntu Pro with 'esm-infra' enabled until 2026\.
+        Ubuntu Pro with 'esm-infra' enabled until 2026\. There (is|are) \d+ pending security update[s]?\.
 
         Universe/Multiverse packages are receiving security updates from
-        Ubuntu Pro with 'esm-apps' enabled until 2026\.
+        Ubuntu Pro with 'esm-apps' enabled until 2026\. There (is|are) \d+ pending security update[s]?\.
         """
         When I verify root and non-root `pro security-status --esm-infra` calls have the same output
         And I run `pro security-status --esm-infra` as non-root
@@ -220,17 +222,18 @@ Feature: Security status command behavior
          +\d+ packages from Ubuntu Main/Restricted repository
 
         Main/Restricted packages are receiving security updates from
-        Ubuntu Pro with 'esm-infra' enabled until 2026\.
+        Ubuntu Pro with 'esm-infra' enabled until 2026\. There (is|are) \d+ pending security update[s]?\.
 
         Run 'pro help esm-infra' to learn more
 
-        Package names in .*bold.* currently have an available update
-        with 'esm-infra' enabled
-        Packages:
+        Installed packages with an available esm-infra update:
+        (.|\n)+
+
+        Further installed packages covered by esm-infra:
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I verify root and non-root `pro security-status --esm-apps` calls have the same output
@@ -241,17 +244,18 @@ Feature: Security status command behavior
          +\d+ package[s]? from Ubuntu Universe/Multiverse repository
 
         Universe/Multiverse packages are receiving security updates from
-        Ubuntu Pro with 'esm-apps' enabled until 2026\.
+        Ubuntu Pro with 'esm-apps' enabled until 2026\. There (is|are) \d+ pending security update[s]?\.
 
         Run 'pro help esm-apps' to learn more
 
-        Package names in .*bold.* currently have an available update
-        with 'esm-apps' enabled
-        Packages:
+        Installed packages with an available esm-apps update:
+        (.|\n)+
+
+        Further installed packages covered by esm-apps:
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I run `apt upgrade -y` with sudo
@@ -300,10 +304,12 @@ Feature: Security status command behavior
 
         Ubuntu Pro with 'esm-infra' enabled provides security updates for
         Main/Restricted packages until 2026.
+
         Enable esm-infra with: pro enable esm-infra
 
         Ubuntu Pro with 'esm-apps' enabled provides security updates for
         Universe/Multiverse packages until 2026.
+
         Enable esm-apps with: pro enable esm-apps
         """
         When I verify root and non-root `pro security-status --thirdparty` calls have the same output
@@ -320,7 +326,7 @@ Feature: Security status command behavior
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I verify root and non-root `pro security-status --unavailable` calls have the same output
@@ -338,7 +344,7 @@ Feature: Security status command behavior
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I verify root and non-root `pro security-status --esm-infra` calls have the same output
@@ -356,14 +362,8 @@ Feature: Security status command behavior
 
         Run 'pro help esm-infra' to learn more
 
-        Package names in .*bold.* currently have an available update
-        with 'esm-infra' enabled
-        Packages:
+        Installed packages covered by esm-infra:
         (.|\n)+
-
-        For example, run:
-            apt-cache policy .+
-        to learn more about that package\.
         """
         When I verify root and non-root `pro security-status --esm-apps` calls have the same output
         And I run `pro security-status --esm-apps` as non-root
@@ -377,14 +377,8 @@ Feature: Security status command behavior
 
         Run 'pro help esm-apps' to learn more
 
-        Package names in .*bold.* currently have an available update
-        with 'esm-apps' enabled
-        Packages:
+        Installed packages covered by esm-apps:
         (.|\n)+
-
-        For example, run:
-            apt-cache policy .+
-        to learn more about that package\.
         """
         When I verify that running `pro security-status --thirdparty --unavailable` `as non-root` exits `2`
         Then I will see the following on stderr
@@ -487,7 +481,7 @@ Feature: Security status command behavior
         Main/Restricted packages until 2030.
 
         Ubuntu Pro with 'esm-apps' enabled provides security updates for
-        Universe/Multiverse packages until 2030 and has \d+ pending security update[s]?\.
+        Universe/Multiverse packages until 2030\. There (is|are) \d+ pending security update[s]?\.
 
         Try Ubuntu Pro with a free personal subscription on up to 5 machines.
         Learn more at https://ubuntu.com/pro
@@ -515,17 +509,18 @@ Feature: Security status command behavior
          +\d+ package[s]? from Ubuntu Universe/Multiverse repository
 
         Ubuntu Pro with 'esm-apps' enabled provides security updates for
-        Universe/Multiverse packages until 2030 and has \d+ pending security update[s]?\.
+        Universe/Multiverse packages until 2030\. There (is|are) \d+ pending security update[s]?\.
 
         Run 'pro help esm-apps' to learn more
 
-        Package names in .*bold.* currently have an available update
-        with 'esm-apps' enabled
-        Packages:
+        Installed packages with an available esm-apps update:
+        (.|\n)+
+
+        Further installed packages covered by esm-apps:
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I attach `contract_token` with sudo
@@ -549,7 +544,7 @@ Feature: Security status command behavior
         Ubuntu Pro with 'esm-infra' enabled until 2030.
 
         Universe/Multiverse packages are receiving security updates from
-        Ubuntu Pro with 'esm-apps' enabled until 2030\.
+        Ubuntu Pro with 'esm-apps' enabled until 2030\. There (is|are) \d+ pending security update[s]?\.
         """
         When I verify root and non-root `pro security-status --esm-infra` calls have the same output
         And I run `pro security-status --esm-infra` as non-root
@@ -571,17 +566,18 @@ Feature: Security status command behavior
          +\d+ package[s]? from Ubuntu Universe/Multiverse repository
 
         Universe/Multiverse packages are receiving security updates from
-        Ubuntu Pro with 'esm-apps' enabled until 2030\.
+        Ubuntu Pro with 'esm-apps' enabled until 2030\. There (is|are) \d+ pending security update[s]?\.
 
         Run 'pro help esm-apps' to learn more
 
-        Package names in .*bold.* currently have an available update
-        with 'esm-apps' enabled
-        Packages:
+        Installed packages with an available esm-apps update:
+        (.|\n)+
+
+        Further installed packages covered by esm-apps:
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I run `apt upgrade -y` with sudo
@@ -629,10 +625,12 @@ Feature: Security status command behavior
 
         Ubuntu Pro with 'esm-infra' enabled provides security updates for
         Main/Restricted packages until 2030.
+
         Enable esm-infra with: pro enable esm-infra
 
         Ubuntu Pro with 'esm-apps' enabled provides security updates for
         Universe/Multiverse packages until 2030.
+
         Enable esm-apps with: pro enable esm-apps
         """
         When I verify root and non-root `pro security-status --thirdparty` calls have the same output
@@ -649,7 +647,7 @@ Feature: Security status command behavior
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I verify root and non-root `pro security-status --unavailable` calls have the same output
@@ -667,7 +665,7 @@ Feature: Security status command behavior
         (.|\n)+
 
         For example, run:
-            apt-cache policy .+
+            apt-cache show .+
         to learn more about that package\.
         """
         When I verify root and non-root `pro security-status --esm-infra` calls have the same output
@@ -697,14 +695,8 @@ Feature: Security status command behavior
 
         Run 'pro help esm-apps' to learn more
 
-        Package names in .*bold.* currently have an available update
-        with 'esm-apps' enabled
-        Packages:
+        Installed packages covered by esm-apps:
         (.|\n)+
-
-        For example, run:
-            apt-cache policy .+
-        to learn more about that package\.
         """
         When I verify that running `pro security-status --thirdparty --unavailable` `as non-root` exits `2`
         Then I will see the following on stderr

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -393,6 +393,70 @@ Feature: Security status command behavior
                                [--thirdparty | --unavailable | --esm-infra | --esm-apps]
         argument --unavailable: not allowed with argument --thirdparty
         """
+        When I run `rm /var/lib/apt/periodic/update-success-stamp` with sudo
+        And I run `pro security-status` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ package[s]? from Ubuntu Main/Restricted repository
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+         +\d+ package[s]? from a third party
+         +\d+ package[s]? no longer available for download
+
+        To get more information about the packages, run
+            pro security-status --help
+        for a list of available options\.
+
+        The system apt cache may be outdated\. Make sure to run
+            sudo apt-get update
+        to get the latest package information from apt\.
+
+        This machine is NOT receiving security patches because the LTS period has ended
+        and esm-infra is not enabled.
+        This machine is attached to an Ubuntu Pro subscription.
+
+        Ubuntu Pro with 'esm-infra' enabled provides security updates for
+        Main/Restricted packages until 2026.
+
+        Enable esm-infra with: pro enable esm-infra
+
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2026.
+
+        Enable esm-apps with: pro enable esm-apps
+        """
+        When I run `touch -d '-2 days' /var/lib/apt/periodic/update-success-stamp` with sudo
+        And I run `pro security-status` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ package[s]? from Ubuntu Main/Restricted repository
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+         +\d+ package[s]? from a third party
+         +\d+ package[s]? no longer available for download
+
+        To get more information about the packages, run
+            pro security-status --help
+        for a list of available options\.
+
+        The system apt information was updated 2 day\(s\) ago\. Make sure to run
+            sudo apt-get update
+        to get the latest package information from apt\.
+
+        This machine is NOT receiving security patches because the LTS period has ended
+        and esm-infra is not enabled.
+        This machine is attached to an Ubuntu Pro subscription.
+
+        Ubuntu Pro with 'esm-infra' enabled provides security updates for
+        Main/Restricted packages until 2026.
+
+        Enable esm-infra with: pro enable esm-infra
+
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2026.
+
+        Enable esm-apps with: pro enable esm-apps
+        """
 
     @series.focal
     @uses.config.machine_type.lxd.container
@@ -649,6 +713,70 @@ Feature: Security status command behavior
                                [--thirdparty | --unavailable | --esm-infra | --esm-apps]
         argument --unavailable: not allowed with argument --thirdparty
         """
+        When I run `rm /var/lib/apt/periodic/update-success-stamp` with sudo
+        And I run `pro security-status` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ package[s]? from Ubuntu Main/Restricted repository
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+         +\d+ package[s]? from a third party
+         +\d+ package[s]? no longer available for download
+
+        To get more information about the packages, run
+            pro security-status --help
+        for a list of available options\.
+
+        The system apt cache may be outdated\. Make sure to run
+            sudo apt-get update
+        to get the latest package information from apt\.
+
+        This machine is receiving security patching for Ubuntu Main/Restricted
+        repository until 2025.
+        This machine is attached to an Ubuntu Pro subscription.
+
+        Ubuntu Pro with 'esm-infra' enabled provides security updates for
+        Main/Restricted packages until 2030.
+
+        Enable esm-infra with: pro enable esm-infra
+
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2030.
+
+        Enable esm-apps with: pro enable esm-apps
+        """
+        When I run `touch -d '-2 days' /var/lib/apt/periodic/update-success-stamp` with sudo
+        And I run `pro security-status` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ package[s]? from Ubuntu Main/Restricted repository
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+         +\d+ package[s]? from a third party
+         +\d+ package[s]? no longer available for download
+
+        To get more information about the packages, run
+            pro security-status --help
+        for a list of available options\.
+
+        The system apt information was updated 2 day\(s\) ago\. Make sure to run
+            sudo apt-get update
+        to get the latest package information from apt\.
+
+        This machine is receiving security patching for Ubuntu Main/Restricted
+        repository until 2025.
+        This machine is attached to an Ubuntu Pro subscription.
+
+        Ubuntu Pro with 'esm-infra' enabled provides security updates for
+        Main/Restricted packages until 2030.
+
+        Enable esm-infra with: pro enable esm-infra
+
+        Ubuntu Pro with 'esm-apps' enabled provides security updates for
+        Universe/Multiverse packages until 2030.
+
+        Enable esm-apps with: pro enable esm-apps
+        """
 
     @series.kinetic
     @uses.config.machine_type.lxd.container
@@ -692,6 +820,50 @@ Feature: Security status command behavior
         """
         \d+ packages installed:
          +\d+ packages from Ubuntu Universe/Multiverse repository
+
+        Ubuntu Pro is not available for non-LTS releases\.
+        """
+        When I run `rm /var/lib/apt/periodic/update-success-stamp` with sudo
+        And I run `pro security-status` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ packages from Ubuntu Main/Restricted repository
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+         +\d+ package[s]? from a third party
+         +\d+ package[s]? no longer available for download
+
+        To get more information about the packages, run
+            pro security-status --help
+        for a list of available options\.
+
+        The system apt cache may be outdated\. Make sure to run
+            sudo apt-get update
+        to get the latest package information from apt\.
+
+        Main/Restricted packages receive updates until 7/2023\.
+
+        Ubuntu Pro is not available for non-LTS releases\.
+        """
+        When I run `touch -d '-2 days' /var/lib/apt/periodic/update-success-stamp` with sudo
+        And I run `pro security-status` as non-root
+        Then stdout matches regexp:
+        """
+        \d+ packages installed:
+         +\d+ packages from Ubuntu Main/Restricted repository
+         +\d+ package[s]? from Ubuntu Universe/Multiverse repository
+         +\d+ package[s]? from a third party
+         +\d+ package[s]? no longer available for download
+
+        To get more information about the packages, run
+            pro security-status --help
+        for a list of available options\.
+
+        The system apt information was updated 2 day\(s\) ago\. Make sure to run
+            sudo apt-get update
+        to get the latest package information from apt\.
+
+        Main/Restricted packages receive updates until 7/2023\.
 
         Ubuntu Pro is not available for non-LTS releases\.
         """

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1026,9 +1026,9 @@ and esm-infra is not enabled."""
 
 SS_SERVICE_ADVERTISE = """\
 Ubuntu Pro with '{service}' enabled provides security updates for
-{repository} packages until {year}"""
+{repository} packages until {year}."""
 SS_SERVICE_ADVERTISE_COUNTS = (
-    " and has {updates} pending security update{plural}."
+    " There {verb} {updates} pending security update{plural}."
 )
 
 SS_SERVICE_ENABLED = """\

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1003,6 +1003,16 @@ To get more information about the packages, run
     pro security-status --help
 for a list of available options."""
 
+SS_UPDATE_CALL = """\
+ Make sure to run
+    sudo apt-get update
+to get the latest package information from apt."""
+SS_UPDATE_DAYS = (
+    "The system apt information was updated {days} day(s) ago."
+    + SS_UPDATE_CALL
+)
+SS_UPDATE_UNKNOWN = "The system apt cache may be outdated." + SS_UPDATE_CALL
+
 SS_INTERIM_SUPPORT = "Main/Restricted packages receive updates until {date}."
 SS_LTS_SUPPORT = """\
 This machine is receiving security patching for Ubuntu Main/Restricted

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1056,9 +1056,9 @@ Learn more at {url}
     url=BASE_UA_URL
 )
 
-SS_POLICY_HINT = """\
+SS_SHOW_HINT = """\
 For example, run:
-    apt-cache policy {package}
+    apt-cache show {package}
 to learn more about that package."""
 
 SS_NO_THIRD_PARTY = "You have no packages installed from a third party."
@@ -1071,7 +1071,7 @@ SS_SERVICE_HELP = "Run 'pro help {service}' to learn more"
 
 SS_UPDATES_AVAILABLE = "Installed packages with an available {service} update:"
 SS_UPDATES_INSTALLED = "Installed packages with an {service} update applied:"
-SS_OTHER_PACKAGES = "Further installed packages covered by {service}:"
+SS_OTHER_PACKAGES = "{prefix} packages covered by {service}:"
 
 ENTITLEMENT_NOT_FOUND = FormattedNamedMessage(
     "entitlement-not-found",

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1068,11 +1068,10 @@ SS_NO_UNAVAILABLE = (
 SS_NO_INTERIM_PRO_SUPPORT = "Ubuntu Pro is not available for non-LTS releases."
 
 SS_SERVICE_HELP = "Run 'pro help {service}' to learn more"
-SS_BOLD_PACKAGES = """\
-Package names in {bold}bold{end_bold} currently have an available update
-with '{{service}}' enabled""".format(
-    bold=TxtColor.BOLD, end_bold=TxtColor.ENDC
-)
+
+SS_UPDATES_AVAILABLE = "Installed packages with an available {service} update:"
+SS_UPDATES_INSTALLED = "Installed packages with an {service} update applied:"
+SS_OTHER_PACKAGES = "Further installed packages covered by {service}:"
 
 ENTITLEMENT_NOT_FOUND = FormattedNamedMessage(
     "entitlement-not-found",

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -613,7 +613,7 @@ def list_third_party_packages():
         print("")
         print("Packages:")
         _print_package_list(package_names)
-        print(messages.SS_POLICY_HINT.format(package=choice(package_names)))
+        print(messages.SS_SHOW_HINT.format(package=choice(package_names)))
     else:
         print(messages.SS_NO_THIRD_PARTY)
 
@@ -633,7 +633,7 @@ def list_unavailable_packages():
 
         print("Packages:")
         _print_package_list(package_names)
-        print(messages.SS_POLICY_HINT.format(package=choice(package_names)))
+        print(messages.SS_SHOW_HINT.format(package=choice(package_names)))
 
     else:
         print(messages.SS_NO_UNAVAILABLE)
@@ -661,14 +661,20 @@ def list_esm_infra_packages(cfg):
         0
     ]
 
-    installed_package_names = [package.name for package in infra_packages]
-    available_package_names = [package.name for package in infra_updates]
-    remaining_package_names = [
-        package.name
-        for package in all_infra_packages
-        if package.name not in installed_package_names
-        and package.name not in available_package_names
-    ]
+    installed_package_names = sorted(
+        [package.name for package in infra_packages]
+    )
+    available_package_names = sorted(
+        [package.name for package in infra_updates]
+    )
+    remaining_package_names = sorted(
+        [
+            package.name
+            for package in all_infra_packages
+            if package.name not in installed_package_names
+            and package.name not in available_package_names
+        ]
+    )
 
     _print_package_summary(
         packages_by_origin, show_items="esm-infra", always_show=True
@@ -705,16 +711,19 @@ def list_esm_infra_packages(cfg):
             print(messages.SS_UPDATES_INSTALLED.format(service="esm-infra"))
             _print_package_list(installed_package_names)
 
+        hint_list = available_package_names or installed_package_names
         # Check names because packages may have been already listed
         if remaining_package_names:
-            print(messages.SS_OTHER_PACKAGES.format(service="esm-infra"))
-            _print_package_list(remaining_package_names)
-
             print(
-                messages.SS_POLICY_HINT.format(
-                    package=choice(remaining_package_names)
+                messages.SS_OTHER_PACKAGES.format(
+                    prefix="Further installed" if hint_list else "Installed",
+                    service="esm-infra",
                 )
             )
+            _print_package_list(remaining_package_names)
+
+        if hint_list:
+            print(messages.SS_SHOW_HINT.format(package=choice(hint_list)))
 
 
 def list_esm_apps_packages(cfg):
@@ -738,14 +747,20 @@ def list_esm_apps_packages(cfg):
     esm_apps_status = ESMAppsEntitlement(cfg).application_status()[0]
     esm_apps_applicability = ESMAppsEntitlement(cfg).applicability_status()[0]
 
-    installed_package_names = [package.name for package in apps_packages]
-    available_package_names = [package.name for package in apps_updates]
-    remaining_package_names = [
-        package.name
-        for package in all_apps_packages
-        if package.name not in installed_package_names
-        and package.name not in available_package_names
-    ]
+    installed_package_names = sorted(
+        [package.name for package in apps_packages]
+    )
+    available_package_names = sorted(
+        [package.name for package in apps_updates]
+    )
+    remaining_package_names = sorted(
+        [
+            package.name
+            for package in all_apps_packages
+            if package.name not in installed_package_names
+            and package.name not in available_package_names
+        ]
+    )
 
     _print_package_summary(
         packages_by_origin, show_items="esm-apps", always_show=True
@@ -776,13 +791,17 @@ def list_esm_apps_packages(cfg):
             print(messages.SS_UPDATES_INSTALLED.format(service="esm-apps"))
             _print_package_list(installed_package_names)
 
+        hint_list = available_package_names or installed_package_names
+
         # Check names because packages may have been already listed
         if remaining_package_names:
-            print(messages.SS_OTHER_PACKAGES.format(service="esm-apps"))
-            _print_package_list(remaining_package_names)
-
             print(
-                messages.SS_POLICY_HINT.format(
-                    package=choice(remaining_package_names)
+                messages.SS_OTHER_PACKAGES.format(
+                    prefix="Further installed" if hint_list else "Installed",
+                    service="esm-apps",
                 )
             )
+            _print_package_list(remaining_package_names)
+
+        if hint_list:
+            print(messages.SS_SHOW_HINT.format(package=choice(hint_list)))

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -453,31 +453,34 @@ def _print_service_support(
             service=service,
             year=str(eol_date_esm.year),
         )
-        if installed_updates:
-            message += messages.SS_SERVICE_ENABLED_COUNTS.format(
-                updates=installed_updates,
-                plural="" if installed_updates == 1 else "s",
-            )
-        print(message)
     else:
         message = messages.SS_SERVICE_ADVERTISE.format(
             service=service,
             repository=repository,
             year=str(eol_date_esm.year),
         )
-        if available_updates:
-            message += messages.SS_SERVICE_ADVERTISE_COUNTS.format(
-                updates=available_updates,
-                plural="s" if available_updates > 1 else "",
-            )
-        else:
-            message += "."
-        print(message)
-        if (
-            is_attached
-            and service_applicability == ApplicabilityStatus.APPLICABLE
-        ):
-            print(messages.SS_SERVICE_COMMAND.format(service=service))
+
+    if installed_updates:
+        message += messages.SS_SERVICE_ENABLED_COUNTS.format(
+            updates=installed_updates,
+            plural="" if installed_updates == 1 else "s",
+        )
+
+    if available_updates:
+        message += messages.SS_SERVICE_ADVERTISE_COUNTS.format(
+            verb="is" if available_updates == 1 else "are",
+            updates=available_updates,
+            plural="s" if available_updates > 1 else "",
+        )
+    print(message)
+
+    if (
+        is_attached
+        and service_status == ApplicationStatus.DISABLED
+        and service_applicability == ApplicabilityStatus.APPLICABLE
+    ):
+        print("")
+        print(messages.SS_SERVICE_COMMAND.format(service=service))
 
     print("")
 

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -1,6 +1,7 @@
 import re
 import textwrap
 from collections import defaultdict
+from datetime import datetime, timezone
 from enum import Enum
 from functools import lru_cache
 from random import choice
@@ -9,7 +10,12 @@ from typing import Any, DefaultDict, Dict, List, Tuple, Union  # noqa: F401
 import apt  # type: ignore
 
 from uaclient import livepatch, messages
-from uaclient.apt import PreserveAptCfg, get_apt_cache, get_esm_cache
+from uaclient.apt import (
+    PreserveAptCfg,
+    get_apt_cache,
+    get_apt_cache_datetime,
+    get_esm_cache,
+)
 from uaclient.config import UAConfig
 from uaclient.entitlements import ESMAppsEntitlement, ESMInfraEntitlement
 from uaclient.entitlements.entitlement_status import (
@@ -521,6 +527,20 @@ def _print_package_list(
     print(messages.SS_POLICY_HINT.format(package=choice(hint_package_list)))
 
 
+def _print_apt_update_call():
+    last_apt_update = get_apt_cache_datetime()
+    if last_apt_update is None:
+        print(messages.SS_UPDATE_UNKNOWN)
+        print("")
+        return
+
+    now = datetime.now(timezone.utc)
+    time_since_update = now - last_apt_update
+    if time_since_update.days > 0:
+        print(messages.SS_UPDATE_DAYS.format(days=time_since_update.days))
+        print("")
+
+
 def security_status(cfg: UAConfig):
     esm_infra_status = ESMInfraEntitlement(cfg).application_status()[0]
     esm_infra_applicability = ESMInfraEntitlement(cfg).applicability_status()[
@@ -550,6 +570,8 @@ def security_status(cfg: UAConfig):
 
     print(messages.SS_HELP_CALL)
     print("")
+
+    _print_apt_update_call()
 
     if not is_lts:
         if is_supported(series):


### PR DESCRIPTION
Those are output changes to security-status to mitigate some problems while a deeper redesign of the outputs is not defined.
- instead of `apt-cache policy`, tell users to run `apt=cache show` to get information about packages
- only show those hints if calling with `--esm-infra` or `--esm-apps` flags, and if there is some actual relevant package
- always show the counts for installed and available updates from ESM
- organize the package lists for better readability and grepability (is this a word?)

Fixes: #2442
Fixes: #2443

## Test Steps
Check the outputs and integration test changes

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No

no-lp btw