### PR TITLE
Add variant support to realtime-kernel (SC-1465)

### DIFF
--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -109,6 +109,47 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
             Installed: (none)
             """
+        When I set the machine token overlay to the following yaml
+        """
+        machineTokenInfo:
+          contractInfo:
+            resourceEntitlements:
+              - type: realtime-kernel
+                overrides:
+                  - directives:
+                      additionalPackages:
+                        - nvidia-prime
+                    selector:
+                      platform: nvidia-tegra
+                  - directives:
+                      additionalPackages:
+                        - intel-pkg
+                    selector:
+                      platform: intel-iotg
+        """
+        And I run `pro enable realtime-kernel --variant nvidia-tegra` with sudo
+        Then I will see the following on stdout:
+        """
+        One moment, checking your subscription first
+        Updating package lists
+        Installing Real-time Nvidia Tegra Kernel packages
+        Real-time Nvidia Tegra Kernel enabled
+        """
+        When I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        realtime-kernel\* yes +enabled +Ubuntu kernel with PREEMPT_RT patches integrated
+
+         \* This service has options, use pro status --all to see more details.
+        """
+         When I run `pro status --all` as non-root
+         Then stdout matches regexp:
+         """
+         realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
+         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
+         ├ nvidia-tegra   yes +enabled   +RT kernel optimized for NVidia Tegra platforms
+         └ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+         """
 
         Examples: ubuntu release
             | release |

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -109,6 +109,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
             Installed: (none)
             """
+        When I verify that running `pro enable realtime-kernel --access-only --variant nvidia-tegra` `with sudo` exits `1`
+        Then I will see the following on stderr:
+        """
+        Error: Cannot use --access-only together with --variant.
+        """
         When I set the machine token overlay to the following yaml
         """
         machineTokenInfo:

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -50,71 +50,91 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I attach `contract_token` with sudo and options `--no-auto-enable`
         Then I verify that running `pro enable realtime-kernel` `as non-root` exits `1`
         And I will see the following on stderr:
-            """
-            This command must be run as root (try using sudo).
-            """
+        """
+        This command must be run as root (try using sudo).
+        """
         When I run `pro enable realtime-kernel` `with sudo` and stdin `y`
         Then stdout matches regexp:
-            """
-            One moment, checking your subscription first
-            The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated.
+        """
+        One moment, checking your subscription first
+        The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated.
 
-            .*This will change your kernel. To revert to your original kernel, you will need
-            to make the change manually..*
+        .*This will change your kernel. To revert to your original kernel, you will need
+        to make the change manually..*
 
-            Do you want to continue\? \[ default = Yes \]: \(Y/n\) Updating package lists
-            Installing Real-time kernel packages
-            Real-time kernel enabled
-            A reboot is required to complete install.
-            """
+        Do you want to continue\? \[ default = Yes \]: \(Y/n\) Updating package lists
+        Installing Real-time kernel packages
+        Real-time kernel enabled
+        A reboot is required to complete install.
+        """
         When I run `apt-cache policy ubuntu-realtime` as non-root
         Then stdout does not match regexp:
-            """
-            .*Installed: \(none\)
-            """
+        """
+        .*Installed: \(none\)
+        """
         And stdout matches regexp:
-            """
-            \s* 500 https://esm.ubuntu.com/realtime/ubuntu <release>/main amd64 Packages
-            """
+        """
+        \s* 500 https://esm.ubuntu.com/realtime/ubuntu <release>/main amd64 Packages
+        """
         When I verify that running `pro enable realtime-kernel` `with sudo` exits `1`
         Then stdout matches regexp
-            """
-            One moment, checking your subscription first
-            Real-time kernel is already enabled.
-            See: sudo pro status
-            """
+        """
+        One moment, checking your subscription first
+        Real-time kernel is already enabled.
+        See: sudo pro status
+        """
         When I reboot the machine
         When I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            realtime
-            """
+        """
+        realtime
+        """
         When I run `pro disable realtime-kernel` `with sudo` and stdin `y`
         Then stdout matches regexp:
-            """
-            This will remove the boot order preference for the Real-time kernel and
-            disable updates to the Real-time kernel.
+        """
+        This will remove the boot order preference for the Real-time kernel and
+        disable updates to the Real-time kernel.
 
-            This will NOT fully remove the kernel from your system.
+        This will NOT fully remove the kernel from your system.
 
-            After this operation is complete you must:
-              - Ensure a different kernel is installed and configured to boot
-              - Reboot into that kernel
-              - Fully remove the realtime kernel packages from your system
-                  - This might look something like `apt remove linux\*realtime`,
-                    but you must ensure this is correct before running it.
-            """
+        After this operation is complete you must:
+          - Ensure a different kernel is installed and configured to boot
+          - Reboot into that kernel
+          - Fully remove the realtime kernel packages from your system
+              - This might look something like `apt remove linux\*realtime`,
+                but you must ensure this is correct before running it.
+        """
         When I run `apt-cache policy ubuntu-realtime` as non-root
         Then stdout contains substring
-            """
-            Installed: (none)
-            """
+        """
+        Installed: (none)
+        """
         When I verify that running `pro enable realtime-kernel --access-only --variant nvidia-tegra` `with sudo` exits `1`
         Then I will see the following on stderr:
         """
         Error: Cannot use --access-only together with --variant.
         """
-        When I set the machine token overlay to the following yaml
+        When I run `pro status` as non-root
+        Then stdout does not match regexp:
+        """
+         \* Service has variants
+        """
+        When I run `pro status --all` as non-root
+        Then stdout does not match regexp:
+        """
+        realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
+        ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
+        ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVidia Tegra platforms
+        """
+        And stdout matches regexp:
+        """
+        realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
+        """
+        # We need to disable this job before adding the overlay, because we might
+        # write the machine token to disk with the override content
+        When I run `pro config set update_messaging_timer=0` with sudo
+        And I set the machine token overlay to the following yaml
         """
         machineTokenInfo:
           contractInfo:
@@ -152,14 +172,14 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         For a list of all Ubuntu Pro services and variants, run 'pro status --all'
         """
-         When I run `pro status --all` as non-root
-         Then stdout matches regexp:
-         """
-         realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
-         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
-         ├ nvidia-tegra   yes +enabled   +RT kernel optimized for NVidia Tegra platforms
-         └ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-         """
+        When I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
+        ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
+        ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+        └ nvidia-tegra   yes +enabled   +RT kernel optimized for NVidia Tegra platforms
+        """
         When I verify that running `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `N` exits `1`
         Then stdout matches regexp:
         """
@@ -192,56 +212,56 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Variants:
 
           * generic: Generic version of the RT kernel (default)
-          * nvidia-tegra: RT kernel optimized for NVidia Tegra platforms
           * intel-iotg: RT kernel optimized for Intel IOTG platform
+          * nvidia-tegra: RT kernel optimized for NVidia Tegra platforms
         """
         When I run `pro disable realtime-kernel` `with sudo` and stdin `y`
         Then stdout matches regexp:
-            """
-            This will remove the boot order preference for the Real-time kernel and
-            disable updates to the Real-time kernel.
-            
-            This will NOT fully remove the kernel from your system.
-            
-            After this operation is complete you must:
-              - Ensure a different kernel is installed and configured to boot
-              - Reboot into that kernel
-              - Fully remove the realtime kernel packages from your system
-                  - This might look something like `apt remove linux\*realtime`,
-                    but you must ensure this is correct before running it.
-            """
-         When I run `pro status` as non-root
-         Then stdout matches regexp:
-         """
-         realtime-kernel\* +yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
-         """
-         When I run `pro status --all` as non-root
-         Then stdout matches regexp:
-         """
-         realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
-         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
-         ├ nvidia-tegra   yes +disabled   +RT kernel optimized for NVidia Tegra platforms
-         └ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-         """
-         When I run `pro detach --assume-yes` with sudo
-         And I run `pro status` as non-root
-         Then stdout matches regexp:
-         """
-         realtime-kernel +yes +Ubuntu kernel with PREEMPT_RT patches integrated
-         """
-         When I run `pro status --all` as non-root
-         Then stdout matches regexp:
-         """
-         realtime-kernel +yes +Ubuntu kernel with PREEMPT_RT patches integrated
-         """
-         And stdout does not match regexp:
-         """
-         nvidia-tegra
-         """
-         And stdout does not match regexp:
-         """
-         intel-iotg
-         """
+        """
+        This will remove the boot order preference for the Real-time kernel and
+        disable updates to the Real-time kernel.
+
+        This will NOT fully remove the kernel from your system.
+
+        After this operation is complete you must:
+          - Ensure a different kernel is installed and configured to boot
+          - Reboot into that kernel
+          - Fully remove the realtime kernel packages from your system
+              - This might look something like `apt remove linux\*realtime`,
+                but you must ensure this is correct before running it.
+        """
+        When I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        realtime-kernel\* +yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
+        """
+        When I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
+        ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
+        ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVidia Tegra platforms
+        """
+        When I run `pro detach --assume-yes` with sudo
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        realtime-kernel +yes +Ubuntu kernel with PREEMPT_RT patches integrated
+        """
+        When I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        realtime-kernel +yes +Ubuntu kernel with PREEMPT_RT patches integrated
+        """
+        And stdout does not match regexp:
+        """
+        nvidia-tegra
+        """
+        And stdout does not match regexp:
+        """
+        intel-iotg
+        """
 
         Examples: ubuntu release
             | release |

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -195,6 +195,53 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
           * nvidia-tegra: RT kernel optimized for NVidia Tegra platforms
           * intel-iotg: RT kernel optimized for Intel IOTG platform
         """
+        When I run `pro disable realtime-kernel` `with sudo` and stdin `y`
+        Then stdout matches regexp:
+            """
+            This will remove the boot order preference for the Real-time kernel and
+            disable updates to the Real-time kernel.
+            
+            This will NOT fully remove the kernel from your system.
+            
+            After this operation is complete you must:
+              - Ensure a different kernel is installed and configured to boot
+              - Reboot into that kernel
+              - Fully remove the realtime kernel packages from your system
+                  - This might look something like `apt remove linux\*realtime`,
+                    but you must ensure this is correct before running it.
+            """
+         When I run `pro status` as non-root
+         Then stdout matches regexp:
+         """
+         realtime-kernel\* +yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
+         """
+         When I run `pro status --all` as non-root
+         Then stdout matches regexp:
+         """
+         realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
+         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
+         ├ nvidia-tegra   yes +disabled   +RT kernel optimized for NVidia Tegra platforms
+         └ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+         """
+         When I run `pro detach --assume-yes` with sudo
+         And I run `pro status` as non-root
+         Then stdout matches regexp:
+         """
+         realtime-kernel +yes +Ubuntu kernel with PREEMPT_RT patches integrated
+         """
+         When I run `pro status --all` as non-root
+         Then stdout matches regexp:
+         """
+         realtime-kernel +yes +Ubuntu kernel with PREEMPT_RT patches integrated
+         """
+         And stdout does not match regexp:
+         """
+         nvidia-tegra
+         """
+         And stdout does not match regexp:
+         """
+         intel-iotg
+         """
 
         Examples: ubuntu release
             | release |

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -125,12 +125,12 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
                       additionalPackages:
                         - nvidia-prime
                     selector:
-                      platform: nvidia-tegra
+                      variant: nvidia-tegra
                   - directives:
                       additionalPackages:
                         - intel-pkg
                     selector:
-                      platform: intel-iotg
+                      variant: intel-iotg
         """
         And I run `pro enable realtime-kernel --variant nvidia-tegra` with sudo
         Then I will see the following on stdout:

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -170,6 +170,31 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         Cannot enable Real-time Intel IOTG Kernel when Real-time Nvidia Tegra Kernel is enabled.
         """
+        When I run `pro help realtime-kernel` as non-root
+        Then I will see the following on stdout:
+        """
+        Name:
+        realtime-kernel
+
+        Entitled:
+        yes
+
+        Status:
+        enabled
+
+        Help:
+        The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated.
+        It services latency-dependent use cases by providing deterministic response times.
+        The Real-time kernel meets stringent preemption specifications and is suitable for
+        telco applications and dedicated devices in industrial automation and robotics.
+        The Real-time kernel is currently incompatible with FIPS and Livepatch. 
+
+        Variants:
+
+          * generic: Generic version of the RT kernel (default)
+          * nvidia-tegra: RT kernel optimized for NVidia Tegra platforms
+          * intel-iotg: RT kernel optimized for Intel IOTG platform
+        """
 
         Examples: ubuntu release
             | release |

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -160,6 +160,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
          ├ nvidia-tegra   yes +enabled   +RT kernel optimized for NVidia Tegra platforms
          └ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
          """
+        When I verify that running `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `N` exits `1`
+        Then stdout matches regexp:
+        """
+        Real-time Intel IOTG Kernel cannot be enabled with Real-time Nvidia Tegra Kernel.
+        Disable Real-time Nvidia Tegra Kernel and proceed to enable Real-time Intel IOTG Kernel\? \(y/N\)
+        """
+        And stdout matches regexp:
+        """
+        Cannot enable Real-time Intel IOTG Kernel when Real-time Nvidia Tegra Kernel is enabled.
+        """
 
         Examples: ubuntu release
             | release |

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -313,6 +313,12 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
         └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVIDIA Tegra platform
         """
+        When I verify that running `pro enable realtime-kernel --variant nonexistent` `with sudo` exits `1`
+        Then I will see the following on stdout:
+        """
+        One moment, checking your subscription first
+        could not find entitlement named "nonexistent"
+        """
         When I run `pro detach --assume-yes` with sudo
         And I run `pro status` as non-root
         Then stdout matches regexp:

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -187,11 +187,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         └ intel-iotg     yes +enabled  +RT kernel optimized for Intel IOTG platform
         """
         When I verify that running `pro enable realtime-kernel` `with sudo` exits `1`
-        Then stdout matches regexp:
+        Then stdout contains substring:
         """
         Real-time kernel is already enabled.
         """
         When I run `pro disable realtime-kernel --assume-yes` with sudo
+        When I run `apt-cache policy hello` as non-root
+        Then stdout contains substring:
+        """
+        Installed: (none)
+        """
 
         # Test multiple variants
         When I set the machine token overlay to the following yaml

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -125,7 +125,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
         ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVidia Tegra platforms
+        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVIDIA Tegra platforms
         """
         And stdout matches regexp:
         """
@@ -162,8 +162,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         to make the change manually..*
 
         Do you want to continue\? \[ default = Yes \]: \(Y/n\) Updating package lists
-        Installing Real-time Nvidia Tegra Kernel packages
-        Real-time Nvidia Tegra Kernel enabled
+        Installing Real-time NVIDIA Tegra Kernel packages
+        Real-time NVIDIA Tegra Kernel enabled
         """
         When I run `pro status` as non-root
         Then stdout matches regexp:
@@ -183,17 +183,17 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
         ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-        └ nvidia-tegra   yes +enabled   +RT kernel optimized for NVidia Tegra platforms
+        └ nvidia-tegra   yes +enabled   +RT kernel optimized for NVIDIA Tegra platforms
         """
         When I verify that running `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `N` exits `1`
         Then stdout matches regexp:
         """
-        Real-time Intel IOTG Kernel cannot be enabled with Real-time Nvidia Tegra Kernel.
-        Disable Real-time Nvidia Tegra Kernel and proceed to enable Real-time Intel IOTG Kernel\? \(y/N\)
+        Real-time Intel IOTG Kernel cannot be enabled with Real-time NVIDIA Tegra Kernel.
+        Disable Real-time NVIDIA Tegra Kernel and proceed to enable Real-time Intel IOTG Kernel\? \(y/N\)
         """
         And stdout matches regexp:
         """
-        Cannot enable Real-time Intel IOTG Kernel when Real-time Nvidia Tegra Kernel is enabled.
+        Cannot enable Real-time Intel IOTG Kernel when Real-time NVIDIA Tegra Kernel is enabled.
         """
         When I run `pro help realtime-kernel` as non-root
         Then I will see the following on stdout:
@@ -218,7 +218,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
           * generic: Generic version of the RT kernel (default)
           * intel-iotg: RT kernel optimized for Intel IOTG platform
-          * nvidia-tegra: RT kernel optimized for NVidia Tegra platforms
+          * nvidia-tegra: RT kernel optimized for NVIDIA Tegra platforms
         """
         When I run `pro disable realtime-kernel` `with sudo` and stdin `y`
         Then stdout matches regexp:
@@ -246,7 +246,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
         ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVidia Tegra platforms
+        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVIDIA Tegra platforms
         """
         When I run `pro detach --assume-yes` with sudo
         And I run `pro status` as non-root

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -152,11 +152,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
                     selector:
                       variant: intel-iotg
         """
-        And I run `pro enable realtime-kernel --variant nvidia-tegra` with sudo
-        Then I will see the following on stdout:
+        When I run `pro enable realtime-kernel --variant nvidia-tegra` `with sudo` and stdin `y`
+        Then stdout matches regexp:
         """
         One moment, checking your subscription first
-        Updating package lists
+        The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated.
+
+        .*This will change your kernel. To revert to your original kernel, you will need
+        to make the change manually..*
+
+        Do you want to continue\? \[ default = Yes \]: \(Y/n\) Updating package lists
         Installing Real-time Nvidia Tegra Kernel packages
         Real-time Nvidia Tegra Kernel enabled
         """

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -145,9 +145,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
                 overrides:
                   - directives:
                       additionalPackages:
-                        - hello
+                        - ubuntu-intel-iot-realtime
                     selector:
                       variant: intel-iotg
+                    affordances:
+                      platformChecks: {"cpu_vendor_ids": ["intel"]}
         """
         When I run `pro enable realtime-kernel --assume-yes` with sudo
         When I run `pro status --all` as non-root
@@ -213,9 +215,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
                       variant: nvidia-tegra
                   - directives:
                       additionalPackages:
-                        - hello
+                        - ubuntu-intel-iot-realtime
                     selector:
                       variant: intel-iotg
+                    affordances:
+                      platformChecks: {"cpu_vendor_ids": ["intel"]}
         """
         When I run `pro enable realtime-kernel --variant nvidia-tegra` `with sudo` and stdin `y`
         Then stdout matches regexp:

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -125,7 +125,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
         ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVIDIA Tegra platforms
+        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVIDIA Tegra platform
         """
         And stdout matches regexp:
         """
@@ -248,7 +248,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
         ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-        └ nvidia-tegra   yes +enabled   +RT kernel optimized for NVIDIA Tegra platforms
+        └ nvidia-tegra   yes +enabled   +RT kernel optimized for NVIDIA Tegra platform
         """
         When I verify that running `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `N` exits `1`
         Then stdout matches regexp:
@@ -283,7 +283,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
           * generic: Generic version of the RT kernel (default)
           * intel-iotg: RT kernel optimized for Intel IOTG platform
-          * nvidia-tegra: RT kernel optimized for NVIDIA Tegra platforms
+          * nvidia-tegra: RT kernel optimized for NVIDIA Tegra platform
         """
         When I run `pro disable realtime-kernel` `with sudo` and stdin `y`
         Then stdout matches regexp:
@@ -311,7 +311,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
         ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVIDIA Tegra platforms
+        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVIDIA Tegra platform
         """
         When I run `pro detach --assume-yes` with sudo
         And I run `pro status` as non-root

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -139,8 +139,13 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Then stdout matches regexp:
         """
         realtime-kernel\* yes +enabled +Ubuntu kernel with PREEMPT_RT patches integrated
+        usg +yes +disabled +Security compliance and audit tools
 
-         \* This service has options, use pro status --all to see more details.
+         \* Service has variants
+        """
+        Then stdout contains substring:
+        """
+        For a list of all Ubuntu Pro services and variants, run 'pro status --all'
         """
          When I run `pro status --all` as non-root
          Then stdout matches regexp:

--- a/features/steps/shell.py
+++ b/features/steps/shell.py
@@ -43,10 +43,12 @@ def when_i_run_command(
     machine_name=SUT,
 ):
     command = process_template_vars(context, command)
-
     prefix = get_command_prefix_for_user_spec(user_spec)
-
     full_cmd = prefix + shlex.split(command)
+
+    if stdin is not None:
+        stdin = stdin.replace("\\n", "\n")
+
     result = context.machines[machine_name].instance.execute(
         full_cmd, stdin=stdin
     )

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -103,7 +103,8 @@ def enable_entitlement_by_name(
     *,
     assume_yes: bool = False,
     allow_beta: bool = False,
-    access_only: bool = False
+    access_only: bool = False,
+    variant: str = ""
 ):
     """
     Constructs an entitlement based on the name provided. Passes kwargs onto
@@ -111,7 +112,9 @@ def enable_entitlement_by_name(
     :raise EntitlementNotFoundError: If no entitlement with the given name is
         found, then raises this error.
     """
-    ent_cls = entitlements.entitlement_factory(cfg=cfg, name=name)
+    ent_cls = entitlements.entitlement_factory(
+        cfg=cfg, name=name, variant=variant
+    )
     entitlement = ent_cls(
         cfg,
         assume_yes=assume_yes,

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -148,6 +148,9 @@ class UAArgumentParser(argparse.ArgumentParser):
             self.description = "\n".join(
                 [self.base_desc] + service_descriptions
             )
+
+            self.description += "\n\n" + messages.PRO_HELP_SERVICE_INFO.msg
+
         super().print_help(file=file)
 
     @staticmethod

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1265,6 +1265,14 @@ def action_enable(args, *, cfg, **kwargs):
 
     @return: 0 on success, 1 otherwise
     """
+    variant = getattr(args, "variant", "")
+    access_only = args.access_only
+
+    if variant and access_only:
+        raise exceptions.InvalidOptionCombination(
+            option1="--access-only", option2="--variant"
+        )
+
     event.info(messages.REFRESH_CONTRACT_ENABLE)
     try:
         contract.request_updated_contract(cfg)
@@ -1285,8 +1293,8 @@ def action_enable(args, *, cfg, **kwargs):
                 ent_name,
                 assume_yes=args.assume_yes,
                 allow_beta=args.beta,
-                access_only=args.access_only,
-                variant=getattr(args, "variant", ""),
+                access_only=access_only,
+                variant=variant,
             )
             ua_status.status(cfg=cfg)  # Update the status cache
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -937,6 +937,12 @@ def _perform_disable(entitlement, cfg, *, assume_yes, update_status=True):
 
     @return: True on success, False otherwise
     """
+    # Make sure we have the correct variant of the service
+    # This can affect what packages get uninstalled
+    variant = entitlement.enabled_variant
+    if variant is not None:
+        entitlement = variant
+
     ret, reason = entitlement.disable()
 
     if not ret:

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -742,6 +742,11 @@ def enable_parser(parser, cfg: config.UAConfig):
         default="cli",
         help=("output enable in the specified format (default: cli)"),
     )
+    parser.add_argument(
+        "--variant",
+        action="store",
+        help=("The name of the variant to use when enabling the service"),
+    )
     return parser
 
 
@@ -1281,6 +1286,7 @@ def action_enable(args, *, cfg, **kwargs):
                 assume_yes=args.assume_yes,
                 allow_beta=args.beta,
                 access_only=args.access_only,
+                variant=getattr(args, "variant", ""),
             )
             ua_status.status(cfg=cfg)  # Update the status cache
 
@@ -1698,7 +1704,7 @@ def action_status(args, *, cfg: config.UAConfig):
         event.info("")
 
     event.set_output_content(status)
-    output = ua_status.format_tabular(status, show_all_hint=not show_all)
+    output = ua_status.format_tabular(status, show_all=show_all)
     event.info(util.handle_unicode_characters(output))
     event.process_events()
     return ret

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import socket
 from typing import Any, Dict, List, Optional, Tuple
@@ -699,7 +700,7 @@ def _select_overrides(
             OVERRIDE_SELECTOR_WEIGHTS["series_overrides"]
         ] = series_overrides
 
-    general_overrides = entitlement.pop("overrides", [])
+    general_overrides = copy.deepcopy(entitlement.get("overrides", []))
     for override in general_overrides:
         weight = _get_override_weight(
             override.pop("selector"), selector_values

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -504,8 +504,14 @@ def process_entitlement_delta(
                 orig=orig_access, new=new_access
             )
             raise exceptions.UserFacingError(msg=msg.msg, msg_code=msg.name)
+
+        variant = (
+            new_access.get("entitlements", {})
+            .get("obligations", {})
+            .get("use_selector", "")
+        )
         try:
-            ent_cls = entitlement_factory(cfg=cfg, name=name)
+            ent_cls = entitlement_factory(cfg=cfg, name=name, variant=variant)
         except exceptions.EntitlementNotFoundError as exc:
             logging.debug(
                 'Skipping entitlement deltas for "%s". No such class', name

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -30,7 +30,12 @@ API_V1_CONTRACT_INFORMATION = "/v1/contract"
 
 API_V1_MAGIC_ATTACH = "/v1/magic-attach"
 
-OVERRIDE_SELECTOR_WEIGHTS = {"series_overrides": 1, "series": 2, "cloud": 3}
+OVERRIDE_SELECTOR_WEIGHTS = {
+    "series_overrides": 1,
+    "series": 2,
+    "cloud": 3,
+    "variant": 4,
+}
 
 event = event_logger.get_event_logger()
 
@@ -694,11 +699,16 @@ def _get_override_weight(
 
 
 def _select_overrides(
-    entitlement: Dict[str, Any], series_name: str, cloud_type: str
+    entitlement: Dict[str, Any],
+    series_name: str,
+    cloud_type: str,
+    variant: Optional[str] = None,
 ) -> Dict[int, Dict[str, Any]]:
     overrides = {}
 
     selector_values = {"series": series_name, "cloud": cloud_type}
+    if variant:
+        selector_values["variant"] = variant
 
     series_overrides = entitlement.pop("series", {}).pop(series_name, {})
     if series_overrides:
@@ -718,7 +728,9 @@ def _select_overrides(
 
 
 def apply_contract_overrides(
-    orig_access: Dict[str, Any], series: Optional[str] = None
+    orig_access: Dict[str, Any],
+    series: Optional[str] = None,
+    variant: Optional[str] = None,
 ) -> None:
     """Apply series-specific overrides to an entitlement dict.
 
@@ -748,7 +760,9 @@ def apply_contract_overrides(
     cloud_type, _ = get_cloud_type()
     orig_entitlement = orig_access.get("entitlement", {})
 
-    overrides = _select_overrides(orig_entitlement, series_name, cloud_type)
+    overrides = _select_overrides(
+        orig_entitlement, series_name, cloud_type, variant
+    )
 
     for _weight, overrides_to_apply in sorted(overrides.items()):
         for key, value in overrides_to_apply.items():

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -29,7 +29,7 @@ ENTITLEMENT_CLASSES = [
 ]  # type: List[Type[UAEntitlement]]
 
 
-def entitlement_factory(cfg: UAConfig, name: str):
+def entitlement_factory(cfg: UAConfig, name: str, variant: str = ""):
     """Returns a UAEntitlement class based on the provided name.
 
     The return type is Optional[Type[UAEntitlement]].
@@ -42,8 +42,14 @@ def entitlement_factory(cfg: UAConfig, name: str):
         entitlement with the given name is found, then raises this error.
     """
     for entitlement in ENTITLEMENT_CLASSES:
-        if name in entitlement(cfg=cfg).valid_names:
-            return entitlement
+        ent = entitlement(cfg=cfg)
+        if name in ent.valid_names:
+            if not variant:
+                return entitlement
+            elif variant in ent.variants:
+                return ent.variants[variant]
+            else:
+                raise EntitlementNotFoundError(name)
     raise EntitlementNotFoundError(name)
 
 

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -49,7 +49,7 @@ def entitlement_factory(cfg: UAConfig, name: str, variant: str = ""):
             elif variant in ent.variants:
                 return ent.variants[variant]
             else:
-                raise EntitlementNotFoundError(name)
+                raise EntitlementNotFoundError(variant)
     raise EntitlementNotFoundError(name)
 
 

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -131,6 +131,15 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
             self._help_info = help_dict.get(self.name, {}).get("help", "")
 
+            if self.variants:
+                variant_items = [
+                    "  * {}: {}".format(variant_name, variant_cls.description)
+                    for variant_name, variant_cls in self.variants.items()
+                ]
+
+                variant_text = "\n".join(["\nVariants:\n"] + variant_items)
+                self._help_info += variant_text
+
         return self._help_info
 
     # A tuple of 3-tuples with (failure_message, functor, expected_results)

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -119,6 +119,10 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         else:
             return self.name
 
+    def _get_vendor_id(self) -> Optional[str]:
+        """Fetch vendor information for the service."""
+        return None
+
     @property
     def help_info(self) -> str:
         """Help information for the entitlement"""
@@ -834,6 +838,22 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 and kernel_info.minor < min_kern_minor
             ):
                 return ApplicabilityStatus.INAPPLICABLE, invalid_msg
+
+        affordances_vendor_names = affordances.get("vendor_names", None)
+        vendor_id = self._get_vendor_id()
+        if (
+            affordances_vendor_names is not None
+            and vendor_id
+            and vendor_id not in affordances_vendor_names
+        ):
+            return (
+                ApplicabilityStatus.INAPPLICABLE,
+                messages.INAPPLICABLE_VENDOR_NAME.format(
+                    title=self.title,
+                    vendor=vendor_id,
+                    supported_vendors=", ".join(affordances_vendor_names),
+                ),
+            )
         return ApplicabilityStatus.APPLICABLE, None
 
     def contract_status(self) -> ContractStatus:

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -236,6 +236,27 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             if name != self.variant_name
         }
 
+    @property
+    def enabled_variant(self) -> Optional["UAEntitlement"]:
+        """
+        On an enabled service class, return the variant that is enabled.
+        Return None if no variants exist or none are enabled (e.g. access-only)
+        """
+        for variant_cls in self.variants.values():
+            if variant_cls.variant_name == "generic":
+                continue
+            variant = variant_cls(
+                cfg=self.cfg,
+                assume_yes=self.assume_yes,
+                allow_beta=self.allow_beta,
+                called_name=self._called_name,
+                access_only=self.access_only,
+            )
+            status, _ = variant.application_status()
+            if status == ApplicationStatus.ENABLED:
+                return variant
+        return None
+
     # Any custom messages to emit to the console or callables which are
     # handled at pre_enable, pre_disable, pre_install or post_enable stages
     @property

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -197,15 +197,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         return valid_variants
 
-    @property
-    def variants(self) -> Dict[str, Type["UAEntitlement"]]:
-        """
-        Return a list of services that are considered a variant
-        of the main service.
-        """
-        if self.is_variant:
-            return {}
-
+    def _get_valid_variants(self) -> Dict[str, Type["UAEntitlement"]]:
         service_variants = self._get_variants()
         contract_variants = self._get_contract_variants()
 
@@ -219,6 +211,30 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 valid_variants[variant] = service_variants[variant]
 
         return valid_variants if len(valid_variants) > 1 else {}
+
+    @property
+    def variants(self) -> Dict[str, Type["UAEntitlement"]]:
+        """
+        Return a list of services that are considered a variant
+        of the main service.
+        """
+        if self.is_variant:
+            return {}
+        return self._get_valid_variants()
+
+    @property
+    def other_variants(self) -> Dict[str, Type["UAEntitlement"]]:
+        """
+        On a variant, return the other variants of the main service.
+        On a non-variant, returns empty.
+        """
+        if not self.is_variant:
+            return {}
+        return {
+            name: cls
+            for name, cls in self._get_valid_variants().items()
+            if name != self.variant_name
+        }
 
     # Any custom messages to emit to the console or callables which are
     # handled at pre_enable, pre_disable, pre_install or post_enable stages

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -117,6 +117,23 @@ class GenericRealtime(RealtimeKernelEntitlement):
     is_variant = True
     check_packages_are_installed = True
 
+    @property
+    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
+        return (
+            IncompatibleService(
+                NvidiaTegraRealtime,
+                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
+                    service=self.title, variant=NvidiaTegraRealtime.title
+                ),
+            ),
+            IncompatibleService(
+                IntelIotgRealtime,
+                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
+                    service=self.title, variant=IntelIotgRealtime.title
+                ),
+            ),
+        )
+
 
 class NvidiaTegraRealtime(RealtimeKernelEntitlement):
     variant_name = "nvidia-tegra"
@@ -132,6 +149,23 @@ class NvidiaTegraRealtime(RealtimeKernelEntitlement):
     ) -> MessagingOperationsDict:
         return {}
 
+    @property
+    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
+        return (
+            IncompatibleService(
+                GenericRealtime,
+                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
+                    service=self.title, variant=GenericRealtime.title
+                ),
+            ),
+            IncompatibleService(
+                IntelIotgRealtime,
+                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
+                    service=self.title, variant=IntelIotgRealtime.title
+                ),
+            ),
+        )
+
 
 class IntelIotgRealtime(RealtimeKernelEntitlement):
     variant_name = "intel-iotg"
@@ -146,3 +180,20 @@ class IntelIotgRealtime(RealtimeKernelEntitlement):
         self,
     ) -> MessagingOperationsDict:
         return {}
+
+    @property
+    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
+        return (
+            IncompatibleService(
+                NvidiaTegraRealtime,
+                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
+                    service=self.title, variant=NvidiaTegraRealtime.title
+                ),
+            ),
+            IncompatibleService(
+                GenericRealtime,
+                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
+                    service=self.title, variant=GenericRealtime.title
+                ),
+            ),
+        )

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -1,8 +1,8 @@
-from typing import Optional, Tuple  # noqa: F401
+from typing import Dict, Optional, Tuple, Type  # noqa: F401
 
 from uaclient import apt, event_logger, messages, system, util
 from uaclient.entitlements import repo
-from uaclient.entitlements.base import IncompatibleService
+from uaclient.entitlements.base import IncompatibleService, UAEntitlement
 from uaclient.types import (  # noqa: F401
     MessagingOperations,
     MessagingOperationsDict,
@@ -31,6 +31,13 @@ class RealtimeKernelEntitlement(repo.RepoEntitlement):
         )
         event.needs_reboot(reboot_required)
         return reboot_required
+
+    def _get_variants(self) -> Dict[str, Type[UAEntitlement]]:
+        return {
+            GenericRealtime.variant_name: GenericRealtime,
+            NvidiaTegraRealtime.variant_name: NvidiaTegraRealtime,
+            IntelIotgRealtime.variant_name: IntelIotgRealtime,
+        }
 
     @property
     def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
@@ -101,3 +108,41 @@ class RealtimeKernelEntitlement(repo.RepoEntitlement):
                 list(packages),
                 messages.DISABLE_FAILED_TMPL.format(title=self.title),
             )
+
+
+class GenericRealtime(RealtimeKernelEntitlement):
+    variant_name = "generic"
+    title = "Real-time kernel"
+    description = "Generic version of the RT kernel (default)"
+    is_variant = True
+    check_packages_are_installed = True
+
+
+class NvidiaTegraRealtime(RealtimeKernelEntitlement):
+    variant_name = "nvidia-tegra"
+    title = "Real-time Nvidia Tegra Kernel"
+    description = "RT kernel optimized for NVidia Tegra platforms"
+    selector_key = "platform"
+    is_variant = True
+    check_packages_are_installed = True
+
+    @property
+    def messaging(
+        self,
+    ) -> MessagingOperationsDict:
+        return {}
+
+
+class IntelIotgRealtime(RealtimeKernelEntitlement):
+    variant_name = "intel-iotg"
+    title = "Real-time Intel IOTG Kernel"
+    description = "RT kernel optimized for Intel IOTG platform"
+    selector_key = "platform"
+    is_variant = True
+    check_packages_are_installed = True
+
+    @property
+    def messaging(
+        self,
+    ) -> MessagingOperationsDict:
+        return {}

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -138,7 +138,7 @@ class GenericRealtime(RealtimeVariant):
 class NvidiaTegraRealtime(RealtimeVariant):
     variant_name = "nvidia-tegra"
     title = "Real-time NVIDIA Tegra Kernel"
-    description = "RT kernel optimized for NVIDIA Tegra platforms"
+    description = "RT kernel optimized for NVIDIA Tegra platform"
     is_variant = True
     check_packages_are_installed = True
 

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -110,79 +110,45 @@ class RealtimeKernelEntitlement(repo.RepoEntitlement):
             )
 
 
-class GenericRealtime(RealtimeKernelEntitlement):
+class RealtimeVariant(RealtimeKernelEntitlement):
+    @property
+    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
+        incompatible_variants = tuple(
+            [
+                IncompatibleService(
+                    cls,
+                    messages.REALTIME_VARIANT_INCOMPATIBLE.format(
+                        service=self.title, variant=cls.title
+                    ),
+                )
+                for name, cls in self.other_variants.items()
+            ]
+        )
+        return super().incompatible_services + incompatible_variants
+
+
+class GenericRealtime(RealtimeVariant):
     variant_name = "generic"
     title = "Real-time kernel"
     description = "Generic version of the RT kernel (default)"
     is_variant = True
     check_packages_are_installed = True
 
-    @property
-    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
-        return super().incompatible_services + (
-            IncompatibleService(
-                NvidiaTegraRealtime,
-                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
-                    service=self.title, variant=NvidiaTegraRealtime.title
-                ),
-            ),
-            IncompatibleService(
-                IntelIotgRealtime,
-                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
-                    service=self.title, variant=IntelIotgRealtime.title
-                ),
-            ),
-        )
 
-
-class NvidiaTegraRealtime(RealtimeKernelEntitlement):
+class NvidiaTegraRealtime(RealtimeVariant):
     variant_name = "nvidia-tegra"
     title = "Real-time NVIDIA Tegra Kernel"
     description = "RT kernel optimized for NVIDIA Tegra platforms"
     is_variant = True
     check_packages_are_installed = True
 
-    @property
-    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
-        return super().incompatible_services + (
-            IncompatibleService(
-                GenericRealtime,
-                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
-                    service=self.title, variant=GenericRealtime.title
-                ),
-            ),
-            IncompatibleService(
-                IntelIotgRealtime,
-                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
-                    service=self.title, variant=IntelIotgRealtime.title
-                ),
-            ),
-        )
 
-
-class IntelIotgRealtime(RealtimeKernelEntitlement):
+class IntelIotgRealtime(RealtimeVariant):
     variant_name = "intel-iotg"
     title = "Real-time Intel IOTG Kernel"
     description = "RT kernel optimized for Intel IOTG platform"
     is_variant = True
     check_packages_are_installed = True
-
-    @property
-    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
-        return super().incompatible_services + (
-            IncompatibleService(
-                NvidiaTegraRealtime,
-                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
-                    service=self.title, variant=NvidiaTegraRealtime.title
-                ),
-            ),
-            IncompatibleService(
-                GenericRealtime,
-                messages.REALTIME_VARIANT_INCOMPATIBLE.format(
-                    service=self.title, variant=GenericRealtime.title
-                ),
-            ),
-        )
 
     def _get_vendor_id(self):
         return system.get_cpu_info().vendor_id

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -143,12 +143,6 @@ class NvidiaTegraRealtime(RealtimeKernelEntitlement):
     check_packages_are_installed = True
 
     @property
-    def messaging(
-        self,
-    ) -> MessagingOperationsDict:
-        return {}
-
-    @property
     def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
         return super().incompatible_services + (
             IncompatibleService(
@@ -172,12 +166,6 @@ class IntelIotgRealtime(RealtimeKernelEntitlement):
     description = "RT kernel optimized for Intel IOTG platform"
     is_variant = True
     check_packages_are_installed = True
-
-    @property
-    def messaging(
-        self,
-    ) -> MessagingOperationsDict:
-        return {}
 
     @property
     def incompatible_services(self) -> Tuple[IncompatibleService, ...]:

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -119,7 +119,7 @@ class GenericRealtime(RealtimeKernelEntitlement):
 
     @property
     def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
-        return (
+        return super().incompatible_services + (
             IncompatibleService(
                 NvidiaTegraRealtime,
                 messages.REALTIME_VARIANT_INCOMPATIBLE.format(
@@ -150,7 +150,7 @@ class NvidiaTegraRealtime(RealtimeKernelEntitlement):
 
     @property
     def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
-        return (
+        return super().incompatible_services + (
             IncompatibleService(
                 GenericRealtime,
                 messages.REALTIME_VARIANT_INCOMPATIBLE.format(
@@ -181,7 +181,7 @@ class IntelIotgRealtime(RealtimeKernelEntitlement):
 
     @property
     def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
-        return (
+        return super().incompatible_services + (
             IncompatibleService(
                 NvidiaTegraRealtime,
                 messages.REALTIME_VARIANT_INCOMPATIBLE.format(

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -137,8 +137,8 @@ class GenericRealtime(RealtimeKernelEntitlement):
 
 class NvidiaTegraRealtime(RealtimeKernelEntitlement):
     variant_name = "nvidia-tegra"
-    title = "Real-time Nvidia Tegra Kernel"
-    description = "RT kernel optimized for NVidia Tegra platforms"
+    title = "Real-time NVIDIA Tegra Kernel"
+    description = "RT kernel optimized for NVIDIA Tegra platforms"
     is_variant = True
     check_packages_are_installed = True
 

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple, Type  # noqa: F401
+from typing import Any, Dict, Optional, Tuple, Type  # noqa: F401
 
 from uaclient import apt, event_logger, messages, system, util
 from uaclient.entitlements import repo
@@ -150,5 +150,16 @@ class IntelIotgRealtime(RealtimeVariant):
     is_variant = True
     check_packages_are_installed = True
 
-    def _get_vendor_id(self):
-        return system.get_cpu_info().vendor_id
+    def verify_platform_checks(
+        self, platform_checks: Dict[str, Any]
+    ) -> Tuple[bool, Optional[messages.NamedMessage]]:
+        vendor_id = system.get_cpu_info().vendor_id
+        cpu_vendor_ids = platform_checks.get("cpu_vendor_ids", [])
+        if vendor_id in cpu_vendor_ids:
+            return True, None
+        else:
+            return False, messages.INAPPLICABLE_VENDOR_NAME.format(
+                title=self.title,
+                vendor=vendor_id,
+                supported_vendors=",".join(cpu_vendor_ids),
+            )

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -139,7 +139,6 @@ class NvidiaTegraRealtime(RealtimeKernelEntitlement):
     variant_name = "nvidia-tegra"
     title = "Real-time Nvidia Tegra Kernel"
     description = "RT kernel optimized for NVidia Tegra platforms"
-    selector_key = "platform"
     is_variant = True
     check_packages_are_installed = True
 
@@ -171,7 +170,6 @@ class IntelIotgRealtime(RealtimeKernelEntitlement):
     variant_name = "intel-iotg"
     title = "Real-time Intel IOTG Kernel"
     description = "RT kernel optimized for Intel IOTG platform"
-    selector_key = "platform"
     is_variant = True
     check_packages_are_installed = True
 

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -197,3 +197,6 @@ class IntelIotgRealtime(RealtimeKernelEntitlement):
                 ),
             ),
         )
+
+    def _get_vendor_id(self):
+        return system.get_cpu_info().vendor_id

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -1126,8 +1126,7 @@ class TestEntitlementCfg:
                             "additionalPackages": ["test-package-variant"]
                         },
                         "selector": {
-                            "platform": "test-variant",
-                            "cloud": "gcp",
+                            "variant": "test-variant",
                         },
                     },
                     {

--- a/uaclient/entitlements/tests/test_realtime.py
+++ b/uaclient/entitlements/tests/test_realtime.py
@@ -1,0 +1,59 @@
+import mock
+import pytest
+
+from uaclient import messages
+from uaclient.entitlements.entitlement_status import ApplicabilityStatus
+from uaclient.entitlements.realtime import IntelIotgRealtime
+from uaclient.system import CpuInfo
+
+RT_PATH = "uaclient.entitlements.realtime.RealtimeKernelEntitlement."
+
+
+class TestIntelIOTGVariannt:
+    @pytest.mark.parametrize(
+        "cpu_info,expected_status,expected_msg",
+        (
+            (
+                CpuInfo(vendor_id="test", model=None, stepping=None),
+                ApplicabilityStatus.INAPPLICABLE,
+                messages.INAPPLICABLE_VENDOR_NAME.format(
+                    title=IntelIotgRealtime.title,
+                    vendor="test",
+                    supported_vendors="intel",
+                ),
+            ),
+            (
+                CpuInfo(vendor_id="intel", model=None, stepping=None),
+                ApplicabilityStatus.APPLICABLE,
+                None,
+            ),
+        ),
+    )
+    @mock.patch("uaclient.system.get_kernel_info")
+    @mock.patch("uaclient.system.get_cpu_info")
+    def test_applicability_status(
+        self,
+        m_get_cpu_info,
+        _m_get_kernel_info,
+        cpu_info,
+        expected_status,
+        expected_msg,
+        FakeConfig,
+    ):
+        m_get_cpu_info.return_value = cpu_info
+        ent = IntelIotgRealtime(FakeConfig())
+        with mock.patch.object(
+            ent, "_base_entitlement_cfg"
+        ) as m_entitlement_cfg:
+            m_entitlement_cfg.return_value = {
+                "entitlement": {
+                    "affordances": {
+                        "vendor_names": ["intel"],
+                    }
+                }
+            }
+            actual_status, actual_msg = ent.applicability_status()
+            assert (
+                expected_status,
+                expected_msg,
+            ) == ent.applicability_status()

--- a/uaclient/entitlements/tests/test_realtime.py
+++ b/uaclient/entitlements/tests/test_realtime.py
@@ -48,12 +48,14 @@ class TestIntelIOTGVariannt:
             m_entitlement_cfg.return_value = {
                 "entitlement": {
                     "affordances": {
-                        "vendor_names": ["intel"],
+                        "platformChecks": {
+                            "cpu_vendor_ids": ["intel"],
+                        }
                     }
                 }
             }
-            actual_status, actual_msg = ent.applicability_status()
+            actual_ret = ent.applicability_status()
             assert (
                 expected_status,
                 expected_msg,
-            ) == ent.applicability_status()
+            ) == actual_ret

--- a/uaclient/event_logger.py
+++ b/uaclient/event_logger.py
@@ -56,6 +56,13 @@ def format_machine_readable_output(status: Dict[str, Any]) -> Dict[str, Any]:
     # not processed
     status.setdefault("services", [])
 
+    # We are redacting every variant information from the status output
+    # because we still are not sure on the best way to represent this
+    # information on the status machine readable output
+    for service in status.get("services", []):
+        if "variants" in service:
+            service.pop("variants")
+
     return status
 
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -477,3 +477,11 @@ class InvalidLockFile(UserFacingError):
     def __init__(self, lock_file_path):
         msg = messages.INVALID_LOCK_FILE.format(lock_file_path=lock_file_path)
         super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
+class InvalidOptionCombination(UserFacingError):
+    def __init__(self, option1: str, option2: str):
+        msg = messages.INVALID_OPTION_COMBINATION.format(
+            option1=option1, option2=option2
+        )
+        super().__init__(msg=msg.msg, msg_code=msg.name)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1320,3 +1320,8 @@ INVALID_OPTION_COMBINATION = FormattedNamedMessage(
     "invalid-option-combination",
     "Error: Cannot use {option1} together with {option2}.",
 )
+
+PRO_HELP_SERVICE_INFO = NamedMessage(
+    "pro-help-service-info",
+    "Use pro help <service> to get more details about each service",
+)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1300,3 +1300,14 @@ STATUS_NO_SERVICES_AVAILABLE = (
 STATUS_ALL_HINT = (
     "For a list of all Ubuntu Pro services, run 'pro status --all'"
 )
+STATUS_SERVICE_HAS_VARIANTS = " * Service has variants"
+
+STATUS_ALL_HINT_WITH_VARIANTS = """\
+For a list of all Ubuntu Pro services and variants, run 'pro status --all'"""
+
+SERVICE_DISABLED_MISSING_PACKAGE = FormattedNamedMessage(
+    "service-disabled-missing-package",
+    """\
+The {service} service is not enable because the {package} package is
+not installed.""",
+)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -853,7 +853,7 @@ REALTIME_LIVEPATCH_INCOMPATIBLE = NamedMessage(
 )
 REALTIME_VARIANT_INCOMPATIBLE = FormattedNamedMessage(
     "realtime-variant-incompatible",
-    "{service} cannot be enable together with {variant}",
+    "{service} cannot be enabled together with {variant}",
 )
 REALTIME_BETA_FLAG_REQUIRED = NamedMessage(
     "beta-flag-required",
@@ -1319,7 +1319,7 @@ For a list of all Ubuntu Pro services and variants, run 'pro status --all'"""
 SERVICE_DISABLED_MISSING_PACKAGE = FormattedNamedMessage(
     "service-disabled-missing-package",
     """\
-The {service} service is not enable because the {package} package is
+The {service} service is not enabled because the {package} package is
 not installed.""",
 )
 

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1311,3 +1311,8 @@ SERVICE_DISABLED_MISSING_PACKAGE = FormattedNamedMessage(
 The {service} service is not enable because the {package} package is
 not installed.""",
 )
+
+INVALID_OPTION_COMBINATION = FormattedNamedMessage(
+    "invalid-option-combination",
+    "Error: Cannot use {option1} together with {option2}.",
+)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -521,6 +521,13 @@ INAPPLICABLE_ARCH = FormattedNamedMessage(
 Supported platforms are: {supported_arches}.""",
 )
 
+INAPPLICABLE_VENDOR_NAME = FormattedNamedMessage(
+    "inapplicable-vendor-name",
+    """\
+{title} is not available for CPU vendor {vendor}.
+Supported CPU vendors are: {supported_vendors}.""",
+)
+
 NO_ENTITLEMENT_AFFORDANCES_CHECKED = NamedMessage(
     "no-entitlement-affordances-checked", "no entitlement affordances checked"
 )

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -844,6 +844,10 @@ REALTIME_LIVEPATCH_INCOMPATIBLE = NamedMessage(
     "realtime-livepatch-incompatible",
     "Livepatch is not currently supported for the Real-time kernel.",
 )
+REALTIME_VARIANT_INCOMPATIBLE = FormattedNamedMessage(
+    "realtime-variant-incompatible",
+    "{service} cannot be enable together with {variant}",
+)
 REALTIME_BETA_FLAG_REQUIRED = NamedMessage(
     "beta-flag-required",
     "Use `pro enable realtime-kernel --beta` to acknowledge the real-time"

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -119,7 +119,9 @@ DEFAULT_STATUS = {
 def _get_blocked_by_services(ent):
     return [
         {
-            "name": service.entitlement.name,
+            "name": service.entitlement.name
+            if not service.entitlement.is_variant
+            else service.entitlement.variant_name,
             "reason_code": service.named_msg.name,
             "reason": service.named_msg.msg,
         }

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -168,7 +168,7 @@ def _attached_service_status(
 
     blocked_by = _get_blocked_by_services(ent)
 
-    return {
+    service_status = {
         "name": ent.presentation_name,
         "description": ent.description,
         "entitled": contract_status.value,
@@ -178,8 +178,12 @@ def _attached_service_status(
         "available": available,
         "blocked_by": blocked_by,
         "warning": warning,
-        "variants": variants,
     }
+
+    if not ent.is_variant:
+        service_status["variants"] = variants
+
+    return service_status
 
 
 def _attached_status(cfg: UAConfig) -> Dict[str, Any]:

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -48,8 +48,7 @@ AVAILABLE_RESOURCES = [
     {"name": "ros"},
 ]
 
-ALL_SERVICES_WRAPPED_HELP = textwrap.dedent(
-    """
+SERVICES_WRAPPED_HELP = """\
 Client to manage Ubuntu Pro services on a machine.
  - cc-eal: Common Criteria EAL2 Provisioning Packages
    (https://ubuntu.com/cc-eal)
@@ -69,28 +68,8 @@ Client to manage Ubuntu Pro services on a machine.
    (https://ubuntu.com/robotics/ros-esm)
  - ros: Security Updates for the Robot Operating System
    (https://ubuntu.com/robotics/ros-esm)
-"""
-)
 
-SERVICES_WRAPPED_HELP = textwrap.dedent(
-    """
-Client to manage Ubuntu Pro services on a machine.
- - cc-eal: Common Criteria EAL2 Provisioning Packages
-   (https://ubuntu.com/cc-eal)
- - cis: Security compliance and audit tools
-   (https://ubuntu.com/security/certifications/docs/usg)
- - esm-apps: Expanded Security Maintenance for Applications
-   (https://ubuntu.com/security/esm)
- - esm-infra: Expanded Security Maintenance for Infrastructure
-   (https://ubuntu.com/security/esm)
- - fips-updates: NIST-certified core packages with priority security updates
-   (https://ubuntu.com/security/certifications#fips)
- - fips: NIST-certified core packages
-   (https://ubuntu.com/security/certifications#fips)
- - livepatch: Canonical Livepatch service
-   (https://ubuntu.com/security/livepatch)
-"""
-)
+Use pro help <service> to get more details about each service"""
 
 
 @pytest.fixture(params=["direct", "--help", "pro help", "pro help --all"])
@@ -209,10 +188,7 @@ class TestCLIParser:
             "uaclient.cli.defaults.CONFIG_DEFAULTS", defaults_ret
         ):
             out, type_request = get_help()
-        if type_request == "base":
             assert SERVICES_WRAPPED_HELP in out
-        else:
-            assert ALL_SERVICES_WRAPPED_HELP in out
 
     @pytest.mark.parametrize(
         "out_format, expected_return",

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -18,6 +18,7 @@ from uaclient.testing.fakes import FakeContractClient
 
 def entitlement_cls_mock_factory(can_disable, name=None):
     m_instance = mock.MagicMock()
+    m_instance.enabled_variant = None
     m_instance.can_disable.return_value = (can_disable, None)
     m_instance.disable.return_value = (can_disable, None)
     type(m_instance).dependent_services = mock.PropertyMock(return_value=())

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -107,6 +107,7 @@ class TestDisable:
             m_entitlement_cls = mock.Mock()
 
             m_entitlement = m_entitlement_cls.return_value
+            m_entitlement.enabled_variant = None
             m_entitlement.disable.return_value = (disable_return, fail)
 
             entitlements_obj.append(m_entitlement)
@@ -201,6 +202,7 @@ class TestDisable:
 
         m_ent1_cls = mock.Mock()
         m_ent1_obj = m_ent1_cls.return_value
+        m_ent1_obj.enabled_variant = None
         m_ent1_obj.disable.return_value = (
             False,
             CanDisableFailure(
@@ -212,6 +214,7 @@ class TestDisable:
 
         m_ent2_cls = mock.Mock()
         m_ent2_obj = m_ent2_cls.return_value
+        m_ent2_obj.enabled_variant = None
         m_ent2_obj.disable.return_value = (
             False,
             CanDisableFailure(
@@ -223,6 +226,7 @@ class TestDisable:
 
         m_ent3_cls = mock.Mock()
         m_ent3_obj = m_ent3_cls.return_value
+        m_ent3_obj.enabled_variant = None
         m_ent3_obj.disable.return_value = (True, None)
         type(m_ent3_obj).name = mock.PropertyMock(return_value="ent3")
 

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -291,6 +291,8 @@ class TestActionEnable:
         args = mock.MagicMock()
         args.service = ["bogus"]
         args.command = "enable"
+        args.access_only = False
+
         with pytest.raises(exceptions.UserFacingError) as err:
             action_enable(args, cfg)
 
@@ -725,6 +727,7 @@ class TestActionEnable:
         args_mock.service = ["ent1"]
         args_mock.assume_yes = False
         args_mock.beta = False
+        args_mock.access_only = False
 
         with mock.patch(
             "uaclient.entitlements.entitlement_factory",
@@ -792,6 +795,7 @@ class TestActionEnable:
         args_mock = mock.MagicMock()
         args_mock.service = service
         args_mock.beta = beta
+        args_mock.access_only = False
 
         with pytest.raises(exceptions.UserFacingError) as err:
             fake_stdout = io.StringIO()
@@ -953,3 +957,14 @@ class TestActionEnable:
             "warnings": [],
         }
         assert expected == json.loads(fake_stdout.getvalue())
+
+    def test_access_only_cannot_be_used_together_with_variant(
+        self, _m_get_available_resources, FakeConfig
+    ):
+        cfg = FakeConfig.for_attached_machine()
+        args_mock = mock.MagicMock()
+        args_mock.access_only = True
+        args_mock.variant = "variant"
+
+        with pytest.raises(exceptions.InvalidOptionCombination):
+            action_enable(args_mock, cfg)

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -31,6 +31,8 @@ Flags:
                        realtime-kernel.
   --beta               allow beta service to be enabled
   --format {cli,json}  output enable in the specified format (default: cli)
+  --variant VARIANT    The name of the variant to use when enabling the
+                       service
 """
 
 
@@ -419,6 +421,7 @@ class TestActionEnable:
         args.assume_yes = assume_yes
         args.beta = False
         args.access_only = False
+        args.variant = ""
 
         with mock.patch(
             "uaclient.entitlements.entitlement_factory",
@@ -471,7 +474,7 @@ class TestActionEnable:
         m_ent3_obj = m_ent3_cls.return_value
         m_ent3_obj.enable.return_value = (True, None)
 
-        def factory_side_effect(cfg, name, not_found_okay=True):
+        def factory_side_effect(cfg, name, variant):
             if name == "ent2":
                 return m_ent2_cls
             if name == "ent3":
@@ -488,6 +491,7 @@ class TestActionEnable:
         args_mock.access_only = False
         args_mock.assume_yes = assume_yes
         args_mock.beta = False
+        args_mock.variant = ""
 
         expected_msg = "One moment, checking your subscription first\n"
 
@@ -597,8 +601,9 @@ class TestActionEnable:
         args_mock.access_only = False
         args_mock.assume_yes = assume_yes
         args_mock.beta = beta_flag
+        args_mock.variant = ""
 
-        def factory_side_effect(cfg, name, not_found_okay=True):
+        def factory_side_effect(cfg, name, variant):
             if name == "ent2":
                 return m_ent2_cls
             if name == "ent3":
@@ -861,6 +866,7 @@ class TestActionEnable:
         args_mock.assume_yes = False
         args_mock.beta = allow_beta
         args_mock.service = ["testitlement"]
+        args_mock.variant = ""
 
         with mock.patch(
             "uaclient.entitlements.entitlement_factory",

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -163,6 +163,7 @@ SERVICES_JSON_ALL = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
     {
         "description": "Expanded Security Maintenance for Infrastructure",
@@ -174,6 +175,7 @@ SERVICES_JSON_ALL = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
     {
         "description": "NIST-certified core packages",
@@ -185,6 +187,7 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
     {
         "description": (
@@ -198,6 +201,7 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
     {
         "description": "Canonical Livepatch service",
@@ -209,6 +213,7 @@ SERVICES_JSON_ALL = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
     {
         "description": "Ubuntu kernel with PREEMPT_RT patches integrated",
@@ -220,6 +225,7 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
     {
         "description": "Security Updates for the Robot Operating System",
@@ -231,6 +237,7 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
     {
         "description": "All Updates for the Robot Operating System",
@@ -242,6 +249,7 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
 ]
 
@@ -256,6 +264,7 @@ SERVICES_JSON = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
     {
         "description": "Expanded Security Maintenance for Infrastructure",
@@ -267,6 +276,7 @@ SERVICES_JSON = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
     {
         "description": "Canonical Livepatch service",
@@ -278,6 +288,7 @@ SERVICES_JSON = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
+        "variants": {},
     },
 ]
 

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -163,7 +163,6 @@ SERVICES_JSON_ALL = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
     {
         "description": "Expanded Security Maintenance for Infrastructure",
@@ -175,7 +174,6 @@ SERVICES_JSON_ALL = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
     {
         "description": "NIST-certified core packages",
@@ -187,7 +185,6 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
     {
         "description": (
@@ -201,7 +198,6 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
     {
         "description": "Canonical Livepatch service",
@@ -213,7 +209,6 @@ SERVICES_JSON_ALL = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
     {
         "description": "Ubuntu kernel with PREEMPT_RT patches integrated",
@@ -225,7 +220,6 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
     {
         "description": "Security Updates for the Robot Operating System",
@@ -237,7 +231,6 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
     {
         "description": "All Updates for the Robot Operating System",
@@ -249,7 +242,6 @@ SERVICES_JSON_ALL = [
         "available": "no",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
 ]
 
@@ -264,7 +256,6 @@ SERVICES_JSON = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
     {
         "description": "Expanded Security Maintenance for Infrastructure",
@@ -276,7 +267,6 @@ SERVICES_JSON = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
     {
         "description": "Canonical Livepatch service",
@@ -288,7 +278,6 @@ SERVICES_JSON = [
         "available": "yes",
         "blocked_by": [],
         "warning": None,
-        "variants": {},
     },
 ]
 

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -1118,6 +1118,21 @@ class TestApplyContractOverrides:
             }
         }
         if include_overrides:
+            overrides = [
+                {
+                    "selector": {"series": "dontMatch"},
+                    "affordances": {
+                        "some_affordance": ["ubuntuX-series-overriden"]
+                    },
+                },
+                {
+                    "selector": {"cloud": "dontMatch"},
+                    "affordances": {
+                        "some_affordance": ["ubuntuX-cloud-overriden"]
+                    },
+                },
+            ]
+
             orig_access["entitlement"].update(
                 {
                     "series": {
@@ -1127,22 +1142,10 @@ class TestApplyContractOverrides:
                             }
                         }
                     },
-                    "overrides": [
-                        {
-                            "selector": {"series": "dontMatch"},
-                            "affordances": {
-                                "some_affordance": ["ubuntuX-series-overriden"]
-                            },
-                        },
-                        {
-                            "selector": {"cloud": "dontMatch"},
-                            "affordances": {
-                                "some_affordance": ["ubuntuX-cloud-overriden"]
-                            },
-                        },
-                    ],
+                    "overrides": overrides,
                 }
             )
+            expected["entitlement"]["overrides"] = overrides
 
         apply_contract_overrides(orig_access)
         assert expected == orig_access
@@ -1196,6 +1199,24 @@ class TestApplyContractOverrides:
         expected_value,
     ):
         """Apply the expected overrides to orig_access dict when called."""
+        overrides = [
+            {
+                "selector": {"series": series_selector},
+                "affordances": {"some_affordance": ["series_overriden"]},
+            },
+            {
+                "selector": {"cloud": cloud_selector},
+                "affordances": {"some_affordance": ["cloud_overriden"]},
+            },
+            {
+                "selector": {
+                    "series": series_selector,
+                    "cloud": series_cloud_selector,
+                },
+                "affordances": {"some_affordance": ["both_overriden"]},
+            },
+        ]
+
         orig_access = {
             "entitlement": {
                 "affordances": {"some_affordance": ["original_affordance"]},
@@ -1206,33 +1227,14 @@ class TestApplyContractOverrides:
                         }
                     }
                 },
-                "overrides": [
-                    {
-                        "selector": {"series": series_selector},
-                        "affordances": {
-                            "some_affordance": ["series_overriden"]
-                        },
-                    },
-                    {
-                        "selector": {"cloud": cloud_selector},
-                        "affordances": {
-                            "some_affordance": ["cloud_overriden"]
-                        },
-                    },
-                    {
-                        "selector": {
-                            "series": series_selector,
-                            "cloud": series_cloud_selector,
-                        },
-                        "affordances": {"some_affordance": ["both_overriden"]},
-                    },
-                ],
+                "overrides": overrides,
             }
         }
 
         expected = {
             "entitlement": {
-                "affordances": {"some_affordance": [expected_value]}
+                "affordances": {"some_affordance": [expected_value]},
+                "overrides": overrides,
             }
         }
 
@@ -1251,6 +1253,24 @@ class TestApplyContractOverrides:
         self, _m_cloud_type, _m_release_info
     ):
         """Apply different overrides from different matching selectors."""
+        overrides = [
+            {
+                "selector": {"series": "ubuntuX"},
+                "affordances": {"some_affordance": ["series_overriden"]},
+            },
+            {
+                "selector": {"cloud": "cloudX"},
+                "directives": {"some_directive": ["cloud_overriden"]},
+            },
+            {
+                "selector": {"series": "ubuntuX", "cloud": "cloudX"},
+                "obligations": {
+                    "new_obligation": True,
+                    "some_obligation": True,
+                },
+            },
+        ]
+
         orig_access = {
             "entitlement": {
                 "affordances": {"some_affordance": ["original_affordance"]},
@@ -1263,25 +1283,7 @@ class TestApplyContractOverrides:
                         }
                     }
                 },
-                "overrides": [
-                    {
-                        "selector": {"series": "ubuntuX"},
-                        "affordances": {
-                            "some_affordance": ["series_overriden"]
-                        },
-                    },
-                    {
-                        "selector": {"cloud": "cloudX"},
-                        "directives": {"some_directive": ["cloud_overriden"]},
-                    },
-                    {
-                        "selector": {"series": "ubuntuX", "cloud": "cloudX"},
-                        "obligations": {
-                            "new_obligation": True,
-                            "some_obligation": True,
-                        },
-                    },
-                ],
+                "overrides": overrides,
             }
         }
 
@@ -1296,6 +1298,7 @@ class TestApplyContractOverrides:
                     "new_obligation": True,
                     "some_obligation": True,
                 },
+                "overrides": overrides,
             }
         }
 

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -780,7 +780,7 @@ class TestStatus:
                 "blocked_by": [],
                 "description": "RT kernel "
                 "optimized for "
-                "NVidia Tegra "
+                "NVIDIA Tegra "
                 "platforms",
                 "description_override": None,
                 "entitled": "yes",

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -781,7 +781,7 @@ class TestStatus:
                 "description": "RT kernel "
                 "optimized for "
                 "NVIDIA Tegra "
-                "platforms",
+                "platform",
                 "description_override": None,
                 "entitled": "yes",
                 "name": "nvidia-tegra",

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -772,7 +772,6 @@ class TestStatus:
                 "name": "intel-iotg",
                 "status": "n/a",
                 "status_details": "repo details",
-                "variants": {},
                 "warning": None,
             },
             "nvidia-tegra": {
@@ -787,7 +786,6 @@ class TestStatus:
                 "name": "nvidia-tegra",
                 "status": "n/a",
                 "status_details": "repo details",
-                "variants": {},
                 "warning": None,
             },
             "generic": {
@@ -799,7 +797,6 @@ class TestStatus:
                 "name": "generic",
                 "status": "n/a",
                 "status_details": "repo details",
-                "variants": {},
                 "warning": None,
             },
         }


### PR DESCRIPTION
no-lp no-gh

## Proposed Commit Message
Add support for realtime-kernel variants

This PR is adding the whole variant support to the Pro client, while also defining specific variants for the realtime-kernel service. I still need to add the affordances check for the nvidia variant, but this should not block the review for this PR.

## Test Steps
Run the modified realtime-kernel integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
