### PR TITLE
`pro status` improvements (SC-1360)

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -8,18 +8,23 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
     Scenario Outline: Attached command in a non-lts ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `pro status --all` as non-root
+        And I run `pro status` as non-root
         Then stdout matches regexp:
-            """
-            SERVICE       +ENTITLED  STATUS    DESCRIPTION
-            cc-eal        +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
-            cis           +yes      +n/a      +Security compliance and audit tools
-            esm-apps      +yes      +n/a      +Expanded Security Maintenance for Applications
-            esm-infra     +yes      +n/a      +Expanded Security Maintenance for Infrastructure
-            fips          +yes      +n/a      +NIST-certified core packages
-            fips-updates  +yes      +n/a      +NIST-certified core packages with priority security updates
-            livepatch     +yes      +n/a      +Canonical Livepatch service
-            """
+        """
+        No Ubuntu Pro services are available to this system.
+        """
+        When I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE       +ENTITLED  STATUS    DESCRIPTION
+        cc-eal        +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
+        cis           +yes      +n/a      +Security compliance and audit tools
+        esm-apps      +yes      +n/a      +Expanded Security Maintenance for Applications
+        esm-infra     +yes      +n/a      +Expanded Security Maintenance for Infrastructure
+        fips          +yes      +n/a      +NIST-certified core packages
+        fips-updates  +yes      +n/a      +NIST-certified core packages with priority security updates
+        livepatch     +yes      +n/a      +Canonical Livepatch service
+        """
 
         Examples: ubuntu release
             | release |

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -13,6 +13,10 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
         No Ubuntu Pro services are available to this system.
         """
+        And stdout matches regexp:
+        """
+        For a list of all Ubuntu Pro services, run 'pro status --all'
+        """
         When I run `pro status --all` as non-root
         Then stdout matches regexp:
         """
@@ -24,6 +28,10 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         fips          +yes      +n/a      +NIST-certified core packages
         fips-updates  +yes      +n/a      +NIST-certified core packages with priority security updates
         livepatch     +yes      +n/a      +Canonical Livepatch service
+        """
+        And stdout does not match regexp:
+        """
+        For a list of all Ubuntu Pro services, run 'pro status --all'
         """
 
         Examples: ubuntu release

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -101,6 +101,7 @@ Feature: Attached status
         ros             +yes      +disabled +Security Updates for the Robot Operating System
         ros-updates     +yes      +disabled +All Updates for the Robot Operating System
 
+        For a list of all Ubuntu Pro services, run 'pro status --all'
         Enable services with: pro enable <service>
         """
         When I verify root and non-root `pro status --all` calls have the same output
@@ -143,6 +144,7 @@ Feature: Attached status
         fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
         usg             +yes      +disabled +Security compliance and audit tools
 
+        For a list of all Ubuntu Pro services, run 'pro status --all'
         Enable services with: pro enable <service>
         """
         When I verify root and non-root `pro status --all` calls have the same output
@@ -181,6 +183,7 @@ Feature: Attached status
         esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
 
+        For a list of all Ubuntu Pro services, run 'pro status --all'
         Enable services with: pro enable <service>
         """
         When I verify root and non-root `pro status --all` calls have the same output

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -61,6 +61,8 @@ Feature: Unattached status
         ros             +yes       +Security Updates for the Robot Operating System
         ros-updates     +yes       +All Updates for the Robot Operating System
 
+        For a list of all Ubuntu Pro services, run 'pro status --all'
+
         This machine is not attached to an Ubuntu Pro subscription.
         See https://ubuntu.com/pro
         """
@@ -106,6 +108,8 @@ Feature: Unattached status
         FEATURES
         allow_beta: True
 
+        For a list of all Ubuntu Pro services, run 'pro status --all'
+
         This machine is not attached to an Ubuntu Pro subscription.
         See https://ubuntu.com/pro
         """ 
@@ -130,6 +134,8 @@ Feature: Unattached status
         fips-updates    +yes       +NIST-certified core packages with priority security updates
         livepatch       +yes       +Canonical Livepatch service
         usg             +yes       +Security compliance and audit tools
+
+        For a list of all Ubuntu Pro services, run 'pro status --all'
 
         This machine is not attached to an Ubuntu Pro subscription.
         See https://ubuntu.com/pro
@@ -173,6 +179,8 @@ Feature: Unattached status
         FEATURES
         allow_beta: True
 
+        For a list of all Ubuntu Pro services, run 'pro status --all'
+
         This machine is not attached to an Ubuntu Pro subscription.
         See https://ubuntu.com/pro
         """ 
@@ -194,6 +202,8 @@ Feature: Unattached status
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         livepatch       +yes       +Canonical Livepatch service
         realtime-kernel +yes       +Ubuntu kernel with PREEMPT_RT patches integrated
+
+        For a list of all Ubuntu Pro services, run 'pro status --all'
 
         This machine is not attached to an Ubuntu Pro subscription.
         See https://ubuntu.com/pro
@@ -234,6 +244,8 @@ Feature: Unattached status
 
         FEATURES
         allow_beta: True
+
+        For a list of all Ubuntu Pro services, run 'pro status --all'
 
         This machine is not attached to an Ubuntu Pro subscription.
         See https://ubuntu.com/pro

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1688,7 +1688,7 @@ def action_status(args, *, cfg: config.UAConfig):
         event.info("")
 
     event.set_output_content(status)
-    output = ua_status.format_tabular(status)
+    output = ua_status.format_tabular(status, show_all_hint=not show_all)
     event.info(util.handle_unicode_characters(output))
     event.process_events()
     return ret

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1247,3 +1247,7 @@ LIVEPATCH_APPLICATION_STATUS_CLIENT_FAILURE = NamedMessage(
 STATUS_NO_SERVICES_AVAILABLE = (
     """No Ubuntu Pro services are available to this system."""
 )
+
+STATUS_ALL_HINT = (
+    "For a list of all Ubuntu Pro services, run 'pro status --all'"
+)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1243,3 +1243,7 @@ LIVEPATCH_APPLICATION_STATUS_CLIENT_FAILURE = NamedMessage(
     "livepatch-client-failure",
     "canonical-livepatch status didn't finish successfully",
 )
+
+STATUS_NO_SERVICES_AVAILABLE = (
+    """No Ubuntu Pro services are available to this system."""
+)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -604,7 +604,7 @@ def format_expires(expires: Optional[datetime]) -> str:
     return expires.strftime("%c %Z")
 
 
-def format_tabular(status: Dict[str, Any]) -> str:
+def format_tabular(status: Dict[str, Any], show_all_hint: bool = False) -> str:
     """Format status dict for tabular output."""
     if not status.get("attached"):
         if status.get("simulated"):
@@ -659,6 +659,9 @@ def format_tabular(status: Dict[str, Any]) -> str:
             for key, value in sorted(status["features"].items()):
                 content.append("{}: {}".format(key, value))
 
+        if show_all_hint:
+            content.extend(["", messages.STATUS_ALL_HINT])
+
         content.extend(["", messages.UNATTACHED.msg])
         if livepatch.on_supported_kernel() is False:
             content.extend(
@@ -705,8 +708,11 @@ def format_tabular(status: Dict[str, Any]) -> str:
         content.append("\nFEATURES")
         for key, value in sorted(status["features"].items()):
             content.append("{}: {}".format(key, value))
+    content.append("")
 
-    content.append("\nEnable services with: pro enable <service>")
+    if show_all_hint:
+        content.append(messages.STATUS_ALL_HINT)
+    content.append("Enable services with: pro enable <service>")
     pairs = []
 
     account_name = status["account"]["name"]

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -608,7 +608,7 @@ def format_tabular(status: Dict[str, Any], show_all_hint: bool = False) -> str:
     """Format status dict for tabular output."""
     if not status.get("attached"):
         if status.get("simulated"):
-            if not status["services"]:
+            if not status.get("services", None):
                 return messages.STATUS_NO_SERVICES_AVAILABLE
 
             content = [
@@ -620,11 +620,11 @@ def format_tabular(status: Dict[str, Any], show_all_hint: bool = False) -> str:
                     description="DESCRIPTION",
                 )
             ]
-            for service in status["services"]:
+            for service in status.get("services", []):
                 content.append(STATUS_SIMULATED_TMPL.format(**service))
             return "\n".join(content)
 
-        if not status["services"]:
+        if not status.get("services", None):
             content = [messages.STATUS_NO_SERVICES_AVAILABLE]
         else:
             content = [
@@ -634,17 +634,17 @@ def format_tabular(status: Dict[str, Any], show_all_hint: bool = False) -> str:
                     description="DESCRIPTION",
                 )
             ]
-            for service in status["services"]:
+            for service in status.get("services", []):
                 descr_override = service.get("description_override")
                 description = (
                     descr_override
                     if descr_override
-                    else service["description"]
+                    else service.get("description", "")
                 )
                 content.append(
                     STATUS_UNATTACHED_TMPL.format(
-                        name=service["name"],
-                        available=service["available"],
+                        name=service.get("name", ""),
+                        available=service.get("available", ""),
                         description=description,
                     )
                 )
@@ -656,7 +656,7 @@ def format_tabular(status: Dict[str, Any], show_all_hint: bool = False) -> str:
 
         if status.get("features"):
             content.append("\nFEATURES")
-            for key, value in sorted(status["features"].items()):
+            for key, value in sorted(status.get("features", {}).items()):
                 content.append("{}: {}".format(key, value))
 
         if show_all_hint:
@@ -670,22 +670,22 @@ def format_tabular(status: Dict[str, Any], show_all_hint: bool = False) -> str:
         return "\n".join(content)
 
     service_warnings = []
-    if not status["services"]:
+    if not status.get("services", None):
         content = [messages.STATUS_NO_SERVICES_AVAILABLE]
     else:
         content = [STATUS_HEADER]
-        for service_status in status["services"]:
-            entitled = service_status["entitled"]
+        for service_status in status.get("services", []):
+            entitled = service_status.get("entitled", "")
             descr_override = service_status.get("description_override")
             description = (
                 descr_override
                 if descr_override
-                else service_status["description"]
+                else service_status.get("description", "")
             )
             fmt_args = {
-                "name": service_status["name"],
+                "name": service_status.get("name", ""),
                 "entitled": colorize(entitled),
-                "status": colorize(service_status["status"]),
+                "status": colorize(service_status.get("status", "")),
                 "description": description,
             }
             warning = service_status.get("warning", None)
@@ -706,7 +706,7 @@ def format_tabular(status: Dict[str, Any], show_all_hint: bool = False) -> str:
 
     if status.get("features"):
         content.append("\nFEATURES")
-        for key, value in sorted(status["features"].items()):
+        for key, value in sorted(status.get("features", {}).items()):
             content.append("{}: {}".format(key, value))
     content.append("")
 
@@ -715,17 +715,19 @@ def format_tabular(status: Dict[str, Any], show_all_hint: bool = False) -> str:
     content.append("Enable services with: pro enable <service>")
     pairs = []
 
-    account_name = status["account"]["name"]
+    account_name = status.get("account", {}).get("name", "unknown")
     if account_name:
         pairs.append(("Account", account_name))
 
-    contract_name = status["contract"]["name"]
+    contract_name = status.get("contract", {}).get("name", "unknown")
     if contract_name:
         pairs.append(("Subscription", contract_name))
 
-    if status["origin"] != "free":
-        pairs.append(("Valid until", format_expires(status["expires"])))
-        tech_support_level = status["contract"]["tech_support_level"]
+    if status.get("origin", None) != "free":
+        pairs.append(("Valid until", format_expires(status.get("expires"))))
+        tech_support_level = status.get("contract", {}).get(
+            "tech_support_level", "unknown"
+        )
         pairs.append(("Technical support level", colorize(tech_support_level)))
 
     if pairs:

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -110,6 +110,8 @@ esm-apps         yes        Expanded Security Maintenance for Applications
 esm-infra        yes        Expanded Security Maintenance for Infrastructure
 livepatch        yes        Canonical Livepatch service
 
+For a list of all Ubuntu Pro services, run 'pro status --all'
+
 This machine is not attached to an Ubuntu Pro subscription.
 See https://ubuntu.com/pro
 """  # noqa: E501
@@ -140,6 +142,7 @@ esm-apps         no        {dash}         Expanded Security Maintenance for Appl
 esm-infra        no        {dash}         Expanded Security Maintenance for Infrastructure
 livepatch        no        {dash}         Canonical Livepatch service
 {notices}{features}
+For a list of all Ubuntu Pro services, run 'pro status --all'
 Enable services with: pro enable <service>
 
                 Account: test_account


### PR DESCRIPTION
Instead of showing an empty services table on pro status, just put a message saying no service is available. Plus, add a hint for the `-all` flag if one wants to see everything Ubuntu Pro has to offer.

## Test Steps
Integration tests properly added/modified.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No

no-lp no-gh
