### PR TITLE
system: fall back to /usr/lib/os-release

### DIFF
--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -247,11 +247,13 @@ def is_container(run_path: str = "/run") -> bool:
 
 
 @lru_cache(maxsize=None)
-def parse_os_release(release_file: Optional[str] = None) -> Dict[str, str]:
-    if not release_file:
-        release_file = "/etc/os-release"
+def parse_os_release() -> Dict[str, str]:
+    try:
+        file_contents = load_file("/etc/os-release")
+    except FileNotFoundError:
+        file_contents = load_file("/usr/lib/os-release")
     data = {}
-    for line in load_file(release_file).splitlines():
+    for line in file_contents.splitlines():
         key, value = line.split("=", 1)
         if value:
             data[key] = value.strip().strip('"')


### PR DESCRIPTION
Inspired by #2414, but different because, per the [manpage of os-release](https://manpages.ubuntu.com/manpages/lunar/man5/os-release.5.html): "The file /etc/os-release takes precedence over /usr/lib/os-release. Applications should check for the former, and exclusively use its data if it exists, and only fall back to /usr/lib/os-release if it is missing."

Also remove unused argument to parse_os_release

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Tests should still pass

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
