### PR TITLE
subp: use system environment vars by default (SC-1529)

### DIFF
--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -429,8 +429,13 @@ def _subp(
     bytes_args = [
         x if isinstance(x, bytes) else x.encode("utf-8") for x in args
     ]
-    if env:
+
+    # If env is None, subprocess.Popen will use the process environment
+    # variables by default, as stated here:
+    # https://docs.python.org/3.5/library/subprocess.html?highlight=subprocess#popen-constructor
+    if env is not None:
         env.update(os.environ)
+
     if rcs is None:
         rcs = [0]
     redacted_cmd = util.redact_sensitive_logs(" ".join(args))


### PR DESCRIPTION
no-lp

## Proposed Commit Message
subp: use system environment vars by default

We are now always using the default system environment variable when running a subprocess command. This will allow user setting to be propagated to other tools we run during some Pro operations.

Fixes: #2527

## Test Steps
Run the new unit test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
