### PR TITLE
contract: remove small timeout from contract checking request

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -288,7 +288,6 @@ class UAContractClient(serviceclient.UAServiceClient):
             method="GET",
             headers=headers,
             query_params=self._get_platform_basic_info(),
-            timeout=2,
         )
         if headers.get("expires"):
             response["expires"] = headers["expires"]


### PR DESCRIPTION
This request was frequently timing-out with the low value. The low time-out is no longer needed because we aren't calling this endpoint during `pro status` any more and don't plan on adding that back in the future.

By extending this timeout, our integration tests should get less flakey.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
CI should pass completely on the first try :crossed_fingers: 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [n/a] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
