### PR TITLE
cache: use user owned cache for livepatch support

### DIFF
--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -5,6 +5,10 @@ Feature: Livepatch
     @uses.config.machine_type.lxd.vm
     Scenario Outline: Attached livepatch status shows warning when on unsupported kernel
         Given a `<release>` machine with ubuntu-advantage-tools installed
+        Then I verify that no files exist matching `/home/ubuntu/.cache/ubuntu-pro/livepatch-kernel-support-cache.json`
+        When I run `pro status` as non-root
+        Then I verify that files exist matching `/home/ubuntu/.cache/ubuntu-pro/livepatch-kernel-support-cache.json`
+        Then I verify that no files exist matching `/run/ubuntu-advantage/livepatch-kernel-support-cache.json`
         When I run `pro status` with sudo
         Then stdout matches regexp:
         """
@@ -14,6 +18,7 @@ Feature: Livepatch
         """
         Supported livepatch kernels are listed here: https://ubuntu.com/security/livepatch/docs/kernels
         """
+        Then I verify that files exist matching `/run/ubuntu-advantage/livepatch-kernel-support-cache.json`
         When I attach `contract_token` with sudo
         When I run `pro status` with sudo
         Then stdout matches regexp:

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -7,7 +7,6 @@ any of our dependencies installed.
 
 UAC_ETC_PATH = "/etc/ubuntu-advantage/"
 UAC_RUN_PATH = "/run/ubuntu-advantage/"
-UAC_TMP_PATH = "/tmp/ubuntu-advantage/"
 DEFAULT_DATA_DIR = "/var/lib/ubuntu-advantage"
 MACHINE_TOKEN_FILE = "machine-token.json"
 PRIVATE_SUBDIR = "/private"
@@ -69,4 +68,4 @@ ROOT_READABLE_MODE = 0o600
 WORLD_READABLE_MODE = 0o644
 NOTICES_PERMANENT_DIRECTORY = DEFAULT_DATA_DIR + "/notices/"
 NOTICES_TEMPORARY_DIRECTORY = UAC_RUN_PATH + "notices/"
-USER_LOG_FILE_PATH = "ubuntu-pro/ubuntu-pro.log"
+USER_CACHE_SUBDIR = "ubuntu-pro"

--- a/uaclient/files/files.py
+++ b/uaclient/files/files.py
@@ -59,6 +59,13 @@ class UAFile:
         system.ensure_file_absent(self.path)
 
 
+class UserCacheFile(UAFile):
+    def __init__(self, name: str):
+        super().__init__(
+            name, directory=system.get_user_cache_dir(), private=False
+        )
+
+
 class MachineTokenFile:
     def __init__(
         self,

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -12,7 +12,7 @@ from uaclient.data_types import (
     data_list,
 )
 from uaclient.files.data_types import DataObjectFile, DataObjectFileFormat
-from uaclient.files.files import UAFile
+from uaclient.files.files import UAFile, UserCacheFile
 
 SERVICES_ONCE_ENABLED = "services-once-enabled"
 
@@ -167,11 +167,7 @@ class LivepatchSupportCacheData(DataObject):
 
 livepatch_support_cache = DataObjectFile(
     LivepatchSupportCacheData,
-    UAFile(
-        "livepatch-kernel-support-cache.json",
-        directory=defaults.UAC_TMP_PATH,
-        private=False,
-    ),
+    UserCacheFile("livepatch-kernel-support-cache.json"),
     file_format=DataObjectFileFormat.JSON,
 )
 

--- a/uaclient/log.py
+++ b/uaclient/log.py
@@ -1,11 +1,10 @@
 import json
 import logging
 import os
-import pathlib
 from collections import OrderedDict
 from typing import Any, Dict, List  # noqa: F401
 
-from uaclient import defaults, util
+from uaclient import defaults, system, util
 
 
 class RedactionFilter(logging.Filter):
@@ -63,16 +62,8 @@ class JsonArrayFormatter(logging.Formatter):
 
 
 def get_user_log_file() -> str:
-    """Gets the correct user log_file storage location
-
-    returns XDG_CACHE_HOME env variable, if it is set,
-    If not set, we return the default path
-    """
-    user_cache = os.environ.get("XDG_CACHE_HOME")
-    log_file = defaults.USER_LOG_FILE_PATH
-    if user_cache:
-        return user_cache + "/" + log_file
-    return pathlib.Path.home().as_posix() + "/.cache/" + log_file
+    """Gets the correct user log_file storage location"""
+    return system.get_user_cache_dir() + "/ubuntu-pro.log"
 
 
 def get_all_user_log_files() -> List[str]:
@@ -87,7 +78,8 @@ def get_all_user_log_files() -> List[str]:
             "/home/"
             + user_directory
             + "/.cache/"
-            + defaults.USER_LOG_FILE_PATH
+            + defaults.USER_CACHE_SUBDIR
+            + "/ubuntu-pro.log"
         )
         if os.path.isfile(user_path):
             log_files.append(user_path)

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -12,7 +12,7 @@ from functools import lru_cache
 from shutil import rmtree
 from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
 
-from uaclient import exceptions, messages, util
+from uaclient import defaults, exceptions, messages, util
 
 REBOOT_FILE_CHECK_PATH = "/var/run/reboot-required"
 REBOOT_PKGS_FILE_PATH = "/var/run/reboot-required.pkgs"
@@ -594,3 +594,14 @@ def get_systemd_job_state(job_name: str) -> bool:
         return False
 
     return out.strip() == "active"
+
+
+def get_user_cache_dir() -> str:
+    if util.we_are_currently_root():
+        return defaults.UAC_RUN_PATH
+
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        return xdg_cache_home + "/" + defaults.USER_CACHE_SUBDIR
+
+    return os.path.expanduser("~") + "/.cache/" + defaults.USER_CACHE_SUBDIR

--- a/uaclient/tests/test_system.py
+++ b/uaclient/tests/test_system.py
@@ -1085,3 +1085,36 @@ class TestGetCpuInfo:
         assert vendor_id == system.get_cpu_info.__wrapped__().vendor_id
         assert model == system.get_cpu_info.__wrapped__().model
         assert stepping == system.get_cpu_info.__wrapped__().stepping
+
+
+class TestGetUserCacheDir:
+    @pytest.mark.parametrize(
+        [
+            "is_root",
+            "xdg_cache_home",
+            "expanduser_result",
+            "expected",
+        ],
+        (
+            (True, None, None, "/run/ubuntu-advantage/"),
+            (False, None, "/home/user", "/home/user/.cache/ubuntu-pro"),
+            (False, "/something", "/home/user", "/something/ubuntu-pro"),
+        ),
+    )
+    @mock.patch("os.path.expanduser")
+    @mock.patch("os.environ.get")
+    @mock.patch("uaclient.util.we_are_currently_root")
+    def test_get_user_cache_dir(
+        self,
+        m_we_are_currently_root,
+        m_environ_get,
+        m_expanduser,
+        is_root,
+        xdg_cache_home,
+        expanduser_result,
+        expected,
+    ):
+        m_we_are_currently_root.return_value = is_root
+        m_environ_get.return_value = xdg_cache_home
+        m_expanduser.return_value = expanduser_result
+        assert expected == system.get_user_cache_dir()


### PR DESCRIPTION
Fixes: #2567

no-jira no-lp

Designed so that it should integrate nicely with #2503 
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`time pro status`
see /home/ubuntu/.cache/ubuntu-pro/livepatch-kernel-support-cache.json
`time pro status` - much shorter because cache was used now

change the kernel and reboot
`time pro status` - longer again because cache was invalid
see /home/ubuntu/.cache/ubuntu-pro/livepatch-kernel-support-cache.json was updated
`time pro status` - much shorter because cache was used now

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
