### PR TITLE
Docs front page overhaul

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -9,6 +9,14 @@ h1, h2, h3, h4, h5, h6, .sidebar-tree .current-page>.reference, button, input, o
     font-weight: 400;
 }
 
+.sidebar-tree .toctree-l2.has-children>.reference {
+    font-weight: 300;
+}
+
+li.toctree-l3 {
+    font-weight: 200;
+}
+
 div.page, li.scroll-current>.reference, dl.glossary dt, dl.simple dt, dl:not([class]) dt {
     font-weight: 300;
     line-height: 1.5;

--- a/docs/explanations.rst
+++ b/docs/explanations.rst
@@ -48,8 +48,9 @@ Other Pro features explained
 
 ..  toctree::
     :maxdepth: 1
-    
+
     explanations/cves_and_usns_explained.md
+    explanations/about_esm.md
     explanations/what_are_the_timer_jobs.md
     explanations/what_is_the_daemon.md
     explanations/why_trusty_is_no_longer_supported.md

--- a/docs/explanations/about_esm.md
+++ b/docs/explanations/about_esm.md
@@ -1,0 +1,63 @@
+# About ESM, esm-apps and esm-infra
+
+## Expanded Security Maintenance (ESM)
+In the earlier version of Ubuntu Pro, when security fixes were only guaranteed
+for packages in the 'main' repository, ESM used to be known as *Extended
+Security Maintenance*. At that time, it referred to the additional five years
+of security coverage that Pro provided after the standard five years' of
+security coverage expired. It *extended* the security coverage to ten years.
+This has since become known as `esm-infra` (more on that below!).
+
+Since then, Pro has grown considerably in the size and scope of what it
+provides. Where we originally only guaranteed security maintenance for
+packages in the 'main' repository, we have now *expanded* the scope of our
+security fixes to also include packages in the 'universe' repository. So, when
+Pro went into General Availability in early 2023 and became available to all,
+ESM became *Expanded Security Maintenance* to reflect the expanded scope of
+our coverage. 
+
+## What are 'main' and 'universe'?
+
+There are tens of thousands of Ubuntu packages, all organised into sets in
+*repositories*.
+
+'*Main*' is the set of packages we identified as our focus when we launched
+Ubuntu - they are packages that are either installed on every machine, or very
+widely used for all kinds of deployments, from desktop to cloud. When we
+launched Ubuntu LTS, we made a commitment to security-support these packages
+and their dependencies in 'main' for five years, free of charge. There were
+initially about 1,000 packages in 'main', and today that number has grown to
+about 2,300 per Ubuntu release.
+
+The '*universe*' repository holds all of the other open source packages in
+Ubuntu; from Debian and the Ubuntu community. 'Universe' is a much bigger
+repository, with over 23,000 packages per release. Historically those packages
+came with no security maintenance commitment from Canonical. Nevertheless,
+Canonical and the Ubuntu community provided best-effort maintenance for those
+packages. With the launch of Ubuntu Pro, all of the packages of Ubuntu
+'universe' get the same security maintenance commitment from Canonical as
+packages in Ubuntu 'main'.
+
+## What are `esm-infra` and `esm-apps`?
+
+There are two streams of broad-based security updates for packages; we label
+these '*apps*' (for applications) and '*infra*' (for infrastructure).
+
+The `esm-apps` stream covers all 'universe' packages for ten years from the
+release of the LTS. 
+
+The `esm-infra` stream covers 'main' packages for the period after the
+standard five year security maintenance of 'main' packages ends. We call this
+'infra' because it is commonly used to build our private cloud, storage and
+Kubernetes clusters, where 'universe' packages are not typically deployed. 
+
+Commercial and enterprise customers can get a lower-cost Ubuntu Pro
+(infra-only) subscription only the 'infra' components are needed, which equates
+to our original ESM offering.
+
+## How can I enable `esm-infra` and `esm-apps`?
+
+You can manage `esm-infra` and `esm-apps` using `pro` on the command line. To
+find out how, read our guide on
+[enabling and disabling these services](../howtoguides/enable_esm_infra.md)
+on your machine.

--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -11,92 +11,84 @@ understand and adapt the steps to fit your specific requirements.
 How to use ``pro`` commands
 ===========================
 
-``attach``
+``pro attach``
 ----------
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 1
 
-    Get an Ubuntu Pro token and attach to a subscription <howtoguides/get_token_and_attach.md>
-    Attach with a configuration file <howtoguides/how_to_attach_with_config_file.md>
+   Get an Ubuntu Pro token and attach to a subscription <howtoguides/get_token_and_attach.md>
+   Attach with a configuration file <howtoguides/how_to_attach_with_config_file.md>
 
-``collect-logs``
+``pro collect-logs``
 ----------------
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 1
+   
+   Collect data logs for bug reporting <howtoguides/how_to_collect_logs.md>
 
-    Collect data logs for bug reporting <howtoguides/how_to_collect_logs.md>
-
-``config``
+``pro config``
 ----------
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 2
+   
+   howtoguides/configure_index
 
-    Disable or re-enable APT News <howtoguides/disable_enable_apt_news.md>
-    Configure a proxy <howtoguides/configure_proxies.md>
-    Configure a timer job <howtoguides/configuring_timer_jobs.md>
-
-``enable``
+``pro enable``
 ----------
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 2
+      
+   howtoguides/enable_index
 
-    Enable Pro Services in a Dockerfile <howtoguides/enable_in_dockerfile.md>
-    Enable CC EAL <howtoguides/enable_cc.md>
-    Enable CIS <howtoguides/enable_cis.md>
-    Enable Expanded Security Maintenance for Infrastructure <howtoguides/enable_esm_infra.md>
-    Enable FIPS <howtoguides/enable_fips.md>
-    Enable Livepatch <howtoguides/enable_livepatch.md>
-    Enable Real-Time Kernel <howtoguides/enable_realtime_kernel.md>
-
-``fix``
+``pro fix``
 -------
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 1
 
-    Run `fix` in "dry run" mode <howtoguides/how_to_run_fix_in_dry_run_mode.md>
-    Skip fixing related USNs <howtoguides/how_to_not_fix_related_usns.md>
+   Run `fix` in "dry run" mode <howtoguides/how_to_run_fix_in_dry_run_mode.md>
+   Skip fixing related USNs <howtoguides/how_to_not_fix_related_usns.md>
 
-``refresh``
+``pro refresh``
 -----------
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 1
 
-    Update MOTD and APT messages <howtoguides/update_motd_messages.md>
+   Update MOTD and APT messages <howtoguides/update_motd_messages.md>
 
-``status``
+``pro status``
 ----------
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 1
 
-    Simulate the `attach` operation <howtoguides/how_to_simulate_attach.md>
+   Simulate the `attach` operation <howtoguides/how_to_simulate_attach.md>
 
-``version``
+``pro version``
 -----------
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 1
 
-    Check Ubuntu Pro Client version <howtoguides/check_pro_version>
+   Check Ubuntu Pro Client version <howtoguides/check_pro_version>
 
-``lock``
+``pro lock``
 -----------
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 1
 
-    Get rid of corrupted locks <howtoguides/get_rid_of_corrupt_lock.md>
+   Get rid of corrupted locks <howtoguides/get_rid_of_corrupt_lock.md>
     
 Create a ``pro`` Golden Image
 =============================
 
-..  toctree::
-    :maxdepth: 1
+.. toctree::
+   :maxdepth: 1
 
-    Create a customised Cloud Ubuntu Pro image <howtoguides/create_pro_golden_image.md>
+   Create a customised Cloud Ubuntu Pro image <howtoguides/create_pro_golden_image.md>

--- a/docs/howtoguides/configure_index.rst
+++ b/docs/howtoguides/configure_index.rst
@@ -1,0 +1,9 @@
+How to configure...
+*******************
+
+.. toctree::
+   :maxdepth: 1
+   
+   Displaying APT News <disable_enable_apt_news.md>
+   A proxy <configure_proxies.md>
+   A timer job <configuring_timer_jobs.md>

--- a/docs/howtoguides/enable_esm_infra.md
+++ b/docs/howtoguides/enable_esm_infra.md
@@ -1,32 +1,84 @@
-# How to enable Expanded Security Maintenance for Infrastructure (`esm-infra`)
+# How to manage Expanded Security Maintenance (ESM) services
 
-For Ubuntu LTS releases, `esm-infra` will be automatically enabled after
-attaching the Ubuntu Pro Client to your account. After `ubuntu-advantage-tools`
-is installed and your machine is attached, `esm-infra` should be enabled. If
-`esm-infra` is not enabled, you can enable it with the following command:
+For Ubuntu LTS releases, ESM for Infrastructure (`esm-infra`) and ESM for
+Applications (`esm-apps`) are automatically enabled after you attach the
+Ubuntu Pro Client susbscription to your account. However, if you chose to
+disable them initially, you can enable them at any time from the command line
+using the Ubuntu Pro Client (`pro`).
 
-```console
-$ sudo pro enable esm-infra
+## Check the status of the services
+
+After you have attached your subscription and installed the
+`ubuntu-advantage-tools` package, you can check if `esm-apps` and `esm-infra`
+are installed by running the following command:
+
+```bash
+pro status
 ```
 
-With the `esm-infra` repository enabled, especially on Ubuntu 14.04 and 16.04,
-you may see a number of additional package updates available that were not
-available previously.
-
-Even if your system had indicated that it was up to date before installing the
-`ubuntu-advantage-tools` and attaching, make sure to check for new package
-updates after `esm-infra` is enabled using `apt upgrade`. If you have cron jobs
-set to install updates, or other unattended upgrades configured, be aware that
-this will likely result in a number of package updates with the `esm-infra`
-content.
-
-Running `apt upgrade` will now apply all available package updates, including
-the ones in `esm-infra`.
+This will show you which services are enabled or disabled on your machine:
 
 ```console
-$ sudo apt upgrade
+SERVICE          ENTITLED  STATUS    DESCRIPTION
+esm-apps         yes       enabled   Expanded Security Maintenance for Applications
+esm-infra        yes       enabled   Expanded Security Maintenance for Infrastructure
+livepatch        yes       enabled   Canonical Livepatch service
+realtime-kernel  yes       disabled  Ubuntu kernel with PREEMPT_RT patches integrated
 ```
+
+## Enable `esm-apps` and `esm-infra`
+
+If either of the `esm-apps` or `esm-infra` services are disabled and you want
+to enable them, run the following command to enable ESM-Infra:
+
+```bash
+sudo pro enable esm-infra
+```
+
+Or the following for ESM-Apps:
+
+```bash
+sudo pro enable esm-apps
+```
+
+## Update your packages
+
+When you enable the ESM-Infra and/or ESM-Apps repositories, especially on
+Ubuntu 14.04 and 16.04, you may see a number of package updates available that
+were not available previously.
+
+Even if your system indicated that it was up to date before installing
+`ubuntu-advantage-tools`, make sure to check for new package updates after
+you enable `esm-infra` or `esm-apps`:
+
+```bash
+sudo apt upgrade
+```
+
+If you have cron jobs set to install updates, or other unattended upgrades
+configured, be aware that this will likely result in a number of packages being
+updated with the `esm-infra` and `esm-apps` content.
+
+Running `apt upgrade` will apply all available package updates, including
+the ones in `esm-infra` and `esm-apps`.
+
+## Disable the services
+
+If you wish to disable the services, you can use the following command to
+disable ESM-Infra:
+
+```bash
+sudo pro disable esm-infra
+```
+
+Or the following command to disable ESM-Apps:
+
+```bash
+sudo pro disable esm-apps
+```
+
 
 ```{seealso}
-For more information, see https://ubuntu.com/security/esm
+For more information about ESM-Apps and ESM-Infra, see
+[our explanatory guide](../explanations/about_esm).
 ```

--- a/docs/howtoguides/enable_index.rst
+++ b/docs/howtoguides/enable_index.rst
@@ -1,0 +1,13 @@
+How to enable...
+****************
+
+.. toctree::
+   :maxdepth: 1
+      
+   Pro Services in a Dockerfile <enable_in_dockerfile.md>
+   CC EAL <enable_cc.md>
+   CIS <enable_cis.md>
+   ESM-Infra and ESM-Apps <enable_esm_infra.md>
+   FIPS <enable_fips.md>
+   Livepatch <enable_livepatch.md>
+   Real-Time Kernel <enable_realtime_kernel.md>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,27 +1,121 @@
 Ubuntu Pro Client
 #################
 
-The Ubuntu Pro Client (``pro``) is the official tool to enable Canonical
-offerings on your system.
+`Ubuntu Pro`_ is a suite of security services provided by Canonical. Whether
+you’re an enterprise customer deploying systems at scale or want security
+patching for your personal Ubuntu LTS at home, the Ubuntu Pro Client (``pro``)
+is the command-line tool that will help you manage the services you need.
 
-``pro`` provides support to view, enable, and disable the following Canonical
-services:
+The Ubuntu Pro Client comes pre-installed on every Ubuntu system. You can run
+``pro help`` in your terminal window to see a list of the ``pro``
+services and commands available, or get started :doc:`with our hands-on tutorial<tutorials/basic_commands>` to try it out in a virtual environment.
 
-- `Common Criteria EAL2 (CC EAL) Certification Tooling`_
-- `CIS Benchmark Audit Tooling`_
-- `Ubuntu Security Guide (USG) Tooling`_
-- `Ubuntu Expanded Security Maintenance (ESM)`_
-- `Robot Operating System (ROS) Expanded Security Maintenance`_
-- `FIPS 140-2 Certified Modules (and optional non-certified patches)`_
-- `Livepatch`_
+Which services are for me?
+==========================
 
-If you need any of those services for your machine, ``pro`` is the right tool
-for you. 
+Ubuntu Pro is a broad subscription designed to meet many different needs. You are unlikely to want to use all of these tools and services at the same time, so you are free to select the precise stream of updates and versions you want to apply on any given machine covered by your Pro subscription. 
 
-``pro`` is already installed on every Ubuntu system. Try it out by running
-``pro help``!
+To help you navigate the various services offered through Ubuntu Pro, click on the tab that best represents your situation for our suggestions on which services might be of interest to you. For example, Pro includes a set of package versions that are compliant with FIPS regulations. You will only want these versions on machines that *need* to meet FIPS requirements, so you can choose to enable that stream specifically on those machines.
 
------
+.. tab-set::
+
+    .. tab-item:: Commercial or enterprise
+
+       * **Expanded Security Maintenance (ESM)**
+             
+         If you're using an Ubuntu LTS -- Desktop or Server -- in a commercial setting and don't want the inconvenience and downtime of upgrading to a newer LTS yet, you can get additional security support through `Expanded Security Maintenance (ESM)`_. We recommend it for everyone using Pro, and it's enabled by default. It includes two services:
+     
+         * ``esm-infra`` provides security updates for packages in the Ubuntu "main" repository (packages from Ubuntu) for five additional years beyond the standard five years of security maintenance of "main" packages.
+     
+         * ``esm-apps`` covers packages in the "universe" repository (which are from Debian and the community) for ten years after the LTS release. 
+ 
+         * Whether you need one or both of these depends on your subscription. If you're not sure which services best support the needs of your organisation, contact us for `a security assessment`_.
+
+       * **Livepatch**
+
+         Ubuntu `Livepatch`_ reduces costly unplanned maintenance by patching vulnerabilities while the system runs. It removes the need to immediately reboot the kernel after an upgrade so that you can schedule downtime for when it's convenient. This tooling is available through ``livepatch``.
+         
+         * Find out more about what Livepatch can do for your organisation in the `Livepatch documentation`_, or find out :doc:`how to enable it<howtoguides/enable_livepatch>`.
+         
+       * **Landscape** (coming soon!)
+         
+         `Landscape`_
+         
+       Want more information?
+
+    .. tab-item:: Certification and hardening
+
+       Ubuntu provides security compliance, `certifications, and hardening`_:
+       
+       * **FIPS 140-2**
+       
+         * `FIPS 140-2 Certified Modules`_ are available through ``fips``.
+         
+         * Compliant but non-certified patches are available through ``fips-updates``.
+         
+         * For more details about managing FIPS, check out this guide. <-- note we need a guide, which also includes which services are incompatible with fips   
+       
+       * **CIS benchmarking**
+       
+         * Center for Internet Security `(CIS) Benchmark`_ tooling is available with ``cis``, up to (and including) 20.04 LTS.
+         * In the 20.04 LTS we introduced the `Ubuntu Security Guide (USG)`_ tooling through ``usg``, which replaces ``cis`` in releases after 20.04 LTS. 
+         
+         * Find out :doc:`how to manage CIS and USG<howtoguides/enable_cis>` with the Pro Client.
+       
+       * **Common Criteria**
+       
+         * `Common Criteria EAL2 (CC EAL)`_ certification tooling is available through ``cc-eal``. The Ubuntu 18.04 LTS and 16.04 LTS have both been certified.
+         
+         * Find out :doc:`how to enable CC EAL<howtoguides/enable_cc>` on your LTS.
+       
+       Want more information?
+
+    .. tab-item:: Personal user on LTS
+
+       * **Expanded Security Maintenance (ESM)**
+             
+         If you're using Pro on an LTS machine (Desktop or Server) and don't want to upgrade to a newer LTS yet, you can get additional security support through `Expanded Security Maintenance (ESM)`_. We recommend it for everyone using Pro, and it's enabled by default. It includes two services:
+     
+         * ``esm-infra`` provides security updates for packages in the Ubuntu "main" repository (packages from Ubuntu) for five additional years beyond the standard five years of security maintenance of "main" packages.
+     
+         * ``esm-apps`` covers packages in the "universe" repository (which are from Debian and the community) for ten years after the LTS release. 
+ 
+         * Read more :doc:`about esm-apps and esm-infra<explanations/about_esm>`.
+
+       * **Livepatch**
+
+         Ubuntu `Livepatch`_ removes the need to immediately reboot your machine after a patch is applied to the kernel, so you can perform device reboots when it's convenient for you. Although it's lightweight, it may not be suitable on a very small system with limited memory. Check our `list of supported kernels`_ if you're unsure.
+
+         * Find out :doc:`how to enable Livepatch<howtoguides/enable_livepatch>`
+
+       Want more information?
+
+    .. tab-item:: Other security services
+
+       * **ROS ESM**
+         
+         Our Robot Operating System Expanded Security Maintenance (`ROS ESM`_) service provides security maintenance for ROS LTS releases, starting with ROS Kinetic on Ubuntu 16.04 -- including packages from the Ubuntu 'universe' repository.
+         
+         
+         * ``ros`` provides all of the same security coverage as you get with ESM, plus more than 600 packages for ROS 1 Kinetic and Melodic, and ROS 2 Foxy. 
+          
+         * ``ros-updates`` also gives you access to non-security updates.
+         
+         * Want to know how to enable ROS ESM? Check out `this introductory guide`_ by the ROS team to get started.
+   
+       * **Real-time kernel**
+         
+         The Ubuntu 22.04 LTS brought the new, enterprise-grade `real-time kernel`_, which reduces kernel latencies and ensures predictable performance for time-sensitive task execution. It was designed to deliver stable, ultra-low latency and security for critical telco infrastructure, but has applications across a wide variety of industries.
+         
+         * Find out `more information about real-time Ubuntu`_ and what it can do for your organisation. 
+         
+         * Or see our guide on :doc:`how to enable the real-time kernel<howtoguides/enable_realtime_kernel>`. 
+   
+       Want more information?
+
+
+Explore our documentation
+=========================
 
 .. grid:: 1 1 2 2
    :gutter: 3
@@ -29,25 +123,25 @@ for you.
    .. grid-item-card:: **Tutorials**
        :link: tutorials
        :link-type: doc
-      
+
        Get started - a hands-on introduction to Ubuntu Pro Client for new users
 
    .. grid-item-card:: **How-to guides**
        :link: howtoguides
        :link-type: doc
-      
+
        Step-by-step guides covering key operations and common tasks
-    
+
    .. grid-item-card:: **Explanation**
        :link: explanations
        :link-type: doc
-          
+
        Discussion and clarification of key topics
-    
+
    .. grid-item-card:: **Reference**
        :link: references
        :link-type: doc
-      
+
        Technical information - specifications, APIs, architecture
 
 -----
@@ -60,7 +154,7 @@ using it!
 
 - **Have questions?**
   You might find the answers `in our FAQ`_.
-  
+
 - **Having trouble?**
   We would like to help! To get help on a specific page in this documentation,
   simply click on the "Give feedback" link at the top of that page. This
@@ -70,7 +164,7 @@ using it!
 
 - **Found a bug?**
   You can `Report bugs on Launchpad`_!
-  
+
 - **Want to give feedback?**
   If you have any comments, requests or suggestions that you'd like to share,
   we'd be very happy to receive them! Please feel free to reach out on
@@ -92,13 +186,13 @@ constructive feedback.
    :maxdepth: 2
 
    Tutorials <tutorials.rst>
-   
+
 .. toctree::
    :hidden:
    :maxdepth: 2
-
+   
    How-to guides <howtoguides.rst>
-
+   
 .. toctree::
    :hidden:
    :maxdepth: 2
@@ -110,15 +204,24 @@ constructive feedback.
    :maxdepth: 2
 
    Reference <references.rst>
-   
+
 .. LINKS:
-.. _Common Criteria EAL2 (CC EAL) Certification Tooling: https://ubuntu.com/security/cc
-.. _CIS Benchmark Audit Tooling: https://ubuntu.com/security/cis
-.. _Ubuntu Security Guide (USG) Tooling: https://ubuntu.com/security/certifications/docs/usg
-.. _Ubuntu Expanded Security Maintenance (ESM): https://ubuntu.com/security/esm
-.. _Robot Operating System (ROS) Expanded Security Maintenance: https://ubuntu.com/robotics/ros-esm
-.. _FIPS 140-2 Certified Modules (and optional non-certified patches): https://ubuntu.com/security/fips
+.. _Ubuntu Pro: https://ubuntu.com/pro
+.. _Common Criteria EAL2 (CC EAL): https://ubuntu.com/security/cc
+.. _certifications, and hardening: https://ubuntu.com/security/certifications
+.. _(CIS) Benchmark: https://ubuntu.com/security/cis
+.. _Ubuntu Security Guide (USG): https://ubuntu.com/security/certifications/docs/usg
+.. _Expanded Security Maintenance (ESM): https://ubuntu.com/security/esm
+.. _a security assessment: https://ubuntu.com/contact-us/form?product=pro
+.. _ROS ESM: https://ubuntu.com/robotics/ros-esm
+.. _this introductory guide: https://discourse.ubuntu.com/t/ros-esm-user-introduction/26206
+.. _FIPS 140-2 Certified Modules: https://ubuntu.com/security/fips
 .. _Livepatch: https://ubuntu.com/security/livepatch
+.. _Livepatch documentation: https://ubuntu.com/security/livepatch/docs
+.. _list of supported kernels: https://ubuntu.com/security/livepatch/docs/livepatch/reference/kernels
+.. _real-time kernel: https://ubuntu.com/realtime-kernel
+.. _more information about real-time Ubuntu: https://ubuntu.com/kernel/real-time/contact-us
+.. _Landscape: https://ubuntu.com/landscape
 .. _Report bugs on Launchpad: https://bugs.launchpad.net/ubuntu-advantage-tools/+filebug
 .. _Code of conduct: https://ubuntu.com/community/code-of-conduct
 .. _Contribute: https://github.com/canonical/ubuntu-advantage-client/blob/main/CONTRIBUTING.md

--- a/docs/references/network_requirements.md
+++ b/docs/references/network_requirements.md
@@ -10,7 +10,7 @@ access to:
 
 ```{seealso}
 
-You can also refer to our [Proxy Configuration guide](/../howtoguides/configure_proxies.md)
+You can also refer to our [Proxy Configuration guide](../howtoguides/configure_proxies.md)
 to learn how to inform Ubuntu Pro Client of HTTP(S)/APT proxies.
 ```
 


### PR DESCRIPTION
- Revamp docs front page giving context for Pro services
- Add tabs to separate services by user pathways
- Add links to some relevant pages in our own docs
- Add new explanation page on ESM services (from FAQ)
- Change LHS nav menu to collapse some how-tos
- Expand "how to enable esm-infra" to include esm-apps
- Also added content on how to disable these

## Proposed Commit Message
```
Docs front page overhaul

- As previously discussed, revamped front page in an effort to make it
  more useful to users and easier to navigate.
- Used the opportunity to add some of the FAQ content to the docs.
- Made some changes to the LHS navigation bar to make it easier to use.
```
no-lp no-gh no-jira