### PR TITLE
fix: check candidate related to package origin 

### DIFF
--- a/features/fix.feature
+++ b/features/fix.feature
@@ -511,6 +511,26 @@ Feature: Ua fix command behaviour
         .*✔.* USN-5378-2 \[related\] does not affect your system.
         .*✔.* USN-5378-3 \[related\] is resolved.
         """
+        When I run `pro detach --assume-yes` with sudo
+        And I run `sed -i "/xenial-updates/d" /etc/apt/sources.list` with sudo
+        And I run `sed -i "/xenial-security/d" /etc/apt/sources.list` with sudo
+        And I run `apt-get update` with sudo
+        And I run `apt-get install squid -y` with sudo
+        And I verify that running `pro fix CVE-2020-25097` `as non-root` exits `1`
+        Then stdout matches regexp:
+        """
+        CVE-2020-25097: Squid vulnerabilities
+         - https://ubuntu.com/security/CVE-2020-25097
+
+        1 affected source package is installed: squid3
+        \(1/1\) squid3:
+        A fix is available in Ubuntu standard updates.
+        - Cannot install package squid-common version 3.5.12-1ubuntu7.16
+        - Cannot install package squid version 3.5.12-1ubuntu7.16
+
+        1 package is still affected: squid3
+        .*✘.* CVE-2020-25097 is not resolved
+        """
 
         Examples: ubuntu release details
            | release |

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -264,7 +264,9 @@ def get_esm_cache():
     return cache
 
 
-def get_pkg_candidate_version(pkg: str) -> Optional[str]:
+def get_pkg_candidate_version(
+    pkg: str, check_esm_cache: bool = False
+) -> Optional[str]:
     with PreserveAptCfg(get_apt_cache) as cache:
         try:
             package = cache[pkg]
@@ -278,6 +280,8 @@ def get_pkg_candidate_version(pkg: str) -> Optional[str]:
 
     if not pkg_candidate:
         return None
+    elif not check_esm_cache:
+        return pkg_candidate
 
     with PreserveAptCfg(get_esm_cache) as esm_cache:
         if esm_cache:

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -93,6 +93,10 @@ SECURITY_ISSUE_NOT_RESOLVED = FAIL_X + " {issue}{extra_info} is not resolved."
 SECURITY_ISSUE_UNAFFECTED = (
     OKGREEN_CHECK + " {issue}{extra_info} does not affect your system."
 )
+SECURITY_PKG_STILL_AFFECTED = FormattedNamedMessage(
+    "security-pkg-still-affected",
+    "{num_pkgs} package{s} {verb} still affected: {pkgs}",
+)
 SECURITY_AFFECTED_PKGS = (
     "{count} affected source package{plural_str} installed"
 )

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -1173,8 +1173,9 @@ def _handle_released_package_fixes(
 
                 upgrade_pkgs = []
                 for binary_pkg in binary_pkgs:
+                    check_esm_cache = pocket != UBUNTU_STANDARD_UPDATES_POCKET
                     candidate_version = apt.get_pkg_candidate_version(
-                        binary_pkg.binary_pkg
+                        binary_pkg.binary_pkg, check_esm_cache=check_esm_cache
                     )
                     if candidate_version and apt.compare_versions(
                         binary_pkg.fixed_version, candidate_version, "le"

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -1235,14 +1235,15 @@ def _format_unfixed_packages_msg(unfixed_pkgs: List[UnfixedPackage]) -> str:
     :returns: A string containing the message output for the unfixed
               packages.
     """
-    num_pkgs_unfixed = len(unfixed_pkgs)
+    sorted_pkgs = sorted({pkg.pkg for pkg in unfixed_pkgs})
+    num_pkgs_unfixed = len(sorted_pkgs)
     return textwrap.fill(
-        "{} package{} {} still affected: {}".format(
-            num_pkgs_unfixed,
-            "s" if num_pkgs_unfixed > 1 else "",
-            "are" if num_pkgs_unfixed > 1 else "is",
-            ", ".join(sorted(pkg.pkg for pkg in unfixed_pkgs)),
-        ),
+        messages.SECURITY_PKG_STILL_AFFECTED.format(
+            num_pkgs=num_pkgs_unfixed,
+            s="s" if num_pkgs_unfixed > 1 else "",
+            verb="are" if num_pkgs_unfixed > 1 else "is",
+            pkgs=", ".join(sorted_pkgs),
+        ).msg,
         width=PRINT_WRAP_WIDTH,
         subsequent_indent="    ",
     )

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -1704,8 +1704,6 @@ A fix is available in Ubuntu standard updates.\n"""
                     dry_run=False,
                 )
         out, err = capsys.readouterr()
-        print(out)
-        print(expected)
         assert expected in out
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed Commit Message
fix: check candidate related to package origin 

When checking the candidate version during the pro fix command, we must ensure that we are fetching the candidate version for the origin that the CVE/USN says contains the fix

## Test Steps
Run the modified integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
