### PR TITLE
chore: add constraints to the Python 3.10 testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,12 @@ setuptools_version = 45.2.0
 [testenv:py38-test]
 setuptools_version = 45.2.0
 
+[testenv:py310-flake8]
+setuptools_version = 59.6.0
+
+[testenv:py310-test]
+setuptools_version = 59.6.0
+
 [testenv]
 allowlist_externals=/usr/bin/bash
 deps =
@@ -27,6 +33,7 @@ deps =
     py35: -cuaclient/tests/constraints/constraints-xenial.txt
     py36: -cuaclient/tests/constraints/constraints-bionic.txt
     py38: -cuaclient/tests/constraints/constraints-focal.txt
+    py310: -cuaclient/tests/constraints/constraints-jammy.txt
     mypy: -rtypes-requirements.txt
     mypy: -cuaclient/tests/constraints/constraints-mypy.txt
     black: -rdev-requirements.txt

--- a/uaclient/tests/constraints/constraints-jammy.txt
+++ b/uaclient/tests/constraints/constraints-jammy.txt
@@ -1,0 +1,8 @@
+attrs==21.2
+flake8==4.0.1
+py==1.10
+pycodestyle==2.8.0
+pyflakes==2.4.0
+pytest==6.2.5
+pytest-cov==3.0.0
+pyyaml==5.4.1


### PR DESCRIPTION
Those match the package versions released in Jammy.

## Why is this needed?
This PR solves all of our problems because we need to verify that all works well not only using Python3.10, shipped in Jammy, but also all other dependencies with specific versions.

## Test Steps
`tox -e py310-test`
`tox -e py310-flake8`
verify that all is good

## Checklist
 - [kinda] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No

no-jira no-lp no-gh