### PR TITLE
ci: change bug-refs action to post comment

### DIFF
--- a/.github/actions/bug-refs/index.js
+++ b/.github/actions/bug-refs/index.js
@@ -1,6 +1,59 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 
+const commentHeader = "<!-- ubuntu-pro-client-bug-refs -->";
+
+function createCommentBody(commits, title) {
+    let newComment = "";
+    newComment += commentHeader;
+    newComment += "\n";
+
+    newComment += "Jira: ";
+    const jiraMatches = title.toLocaleUpperCase().match(/SC-\d+/g);
+    if (jiraMatches === null || jiraMatches.length === 0) {
+        newComment += "This PR is not related to a Jira item. (The PR title does not include a SC-#### reference)\n";
+    } else {
+        const jiraID = jiraMatches[0];
+        newComment += `[${jiraID}](https://warthogs.atlassian.net/browse/${jiraID})\n`;
+    }
+    newComment += "\n";
+
+    let lpBugs = [];
+    let ghIssues = [];
+    commits.forEach(commit => {
+        const message = commit.commit.message.toLocaleUpperCase();
+        lpBugs = lpBugs.concat(Array.from(message.matchAll(/LP: #(\d+)/g)).map(m => m[1]));
+        ghIssues = ghIssues.concat(Array.from(message.matchAll(/FIXES: #(\d+)/g)).map(m => m[1]));
+        ghIssues = ghIssues.concat(Array.from(message.matchAll(/CLOSES: #(\d+)/g)).map(m => m[1]));
+    });
+
+    newComment += "GitHub Issues:";
+    if (ghIssues.length === 0) {
+        newComment += " No GitHub issues are fixed by this PR. (No commits have Fixes: #### references)\n";
+    } else {
+        newComment += "\n";
+        ghIssues.forEach(issue => {
+            newComment += `- Fixes: #${issue}\n`;
+        });
+    }
+    newComment += "\n";
+
+    newComment += "Launchpad Bugs:";
+    if (lpBugs.length === 0) {
+        newComment += " No Launchpad bugs are fixed by this PR. (No commits have LP: #### references)\n";
+    } else {
+        newComment += "\n";
+        lpBugs.forEach(bug => {
+            newComment += `- LP: [#${bug}](https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/${bug})\n`;
+        });
+    }
+    newComment += "\n";
+
+    newComment += "👍 this comment to confirm that this is correct.";
+
+    return newComment;
+}
+
 async function run() {
     const context = github.context;
     if (context.eventName !== "pull_request") {
@@ -8,18 +61,6 @@ async function run() {
         'The event that triggered this action was not a pull request, skipping.'
       );
       return;
-    }
-
-    const body = context.payload.pull_request.body.toLocaleUpperCase();
-    const ignoreJira = body.includes("NO-JIRA");
-    const ignoreLaunchpad = body.includes("NO-LP");
-    const ignoreGithub = body.includes("NO-GH");
-
-    const errorMessages = [];
-
-    const title = context.payload.pull_request.title;
-    if (!ignoreJira && !title.toLocaleUpperCase().includes("SC-")) {
-        errorMessages.push("The PR title does not include a Jira SC-#### reference.\nEither add one or add 'no-jira' to the PR description.");
     }
 
     const client = github.getOctokit(
@@ -30,28 +71,33 @@ async function run() {
         repo: context.issue.repo,
         pull_number: context.issue.number,
     });
-
-    let launchpadPresent = false;
-    let githubPresent = false;
-    commits.data.forEach(commit => {
-        const message = commit.commit.message.toLocaleUpperCase();
-        if (message.includes("LP: #")) {
-            launchpadPresent = true;
-        }
-        if (message.includes("FIXES: #") || message.includes("CLOSES: #")) {
-            githubPresent = true;
-        }
+    const comments = await client.rest.issues.listComments({
+        owner: context.issue.owner,
+        repo: context.issue.repo,
+        issue_number: context.issue.number,
     });
-
-    if (!ignoreLaunchpad && !launchpadPresent) {
-        errorMessages.push("None of the commits include a Launchpad bug reference.\nEither add one or add 'no-lp' to the PR description.");
-    }
-    if (!ignoreGithub && !githubPresent) {
-        errorMessages.push("None of the commits include a Github bug reference.\nEither add one or add 'no-gh' to the PR description.");
-    }
-
-    if (errorMessages.length > 0) {
-        core.setFailed(errorMessages.join("\n\n"));
+    const theComment = comments.data.find(c => c.body.includes(commentHeader));
+    if (theComment) {
+        // comment already exists, update it appropriately
+        const existingBody = theComment.body;
+        const newBody = createCommentBody(commits.data, context.payload.pull_request.title);
+        if (existingBody !== newBody) {
+            client.rest.issues.updateComment({
+                owner: context.issue.owner,
+                repo: context.issue.repo,
+                comment_id: theComment.id,
+                body: newBody,
+            });
+        }
+    } else {
+        // first run, comment doesn't exist yet
+        const newBody = createCommentBody(commits.data, context.payload.pull_request.title);
+        client.rest.issues.createComment({
+            owner: context.issue.owner,
+            repo: context.issue.repo,
+            issue_number: context.issue.number,
+            body: newBody,
+        });
     }
 }
 


### PR DESCRIPTION
## Why is this needed?
This PR is exploring adding a comment to each PR explaining the results of the bug-refs (future "does doc PR also exist") action.

We no-longer need to write no-jira no-lp no-gh. Instead we'll just ack the comment, and part of review is making sure the comment is acked and correct.

