### PR TITLE
Add new endpoint (SC-1514)

### DIFF
--- a/docs/references/api.md
+++ b/docs/references/api.md
@@ -110,6 +110,8 @@ The currently available endpoints are:
 - [u.pro.security.status.reboot_required.v1](#uprosecuritystatusreboot_requiredv1)
 - [u.pro.packages.summary.v1](#upropackagessummaryv1)
 - [u.pro.packages.updates.v1](#upropackagesupdatesv1)
+- [u.pro.status.is_attached.v1](#uprostatusis_attachedv1)
+- [u.pro.status.enabled_services.v1](#uprostatusenabled_servicesv1)
 - [u.security.package_manifest.v1](#usecuritypackage_manifestv1)
 - [u.unattended_upgrades.status.v1](#uunattended_upgradesstatusv1)
 
@@ -774,6 +776,86 @@ pro api u.pro.packages.updates.v1
         },
     ]
 }
+```
+
+## u.pro.status.is_attached.v1
+
+Introduced in Ubuntu Pro Client Version: `28~`
+
+Shows if the machine is attached to a Pro subscription.
+
+### Args
+
+This endpoint takes no arguments.
+
+### Python API interaction
+
+#### Calling from Python code
+
+```python
+from uaclient.api.u.pro.status.is_attached.v1 import is_attached
+
+result = is_attached()
+```
+
+#### Expected return object:
+
+`uaclient.api.u.pro.status.is_attached.v1.IsAttachedResult`
+
+|Field Name|Type|Description|
+|-|-|-|
+|`is_attached`|*bool*|If the machine is attached to a Pro subscription|
+
+### CLI interaction
+
+#### Calling from the CLI:
+
+```bash
+pro api u.pro.status.is_attached.v1
+```
+
+## u.pro.status.enabled_services.v1
+
+Introduced in Ubuntu Pro Client Version: `28~`
+
+Shows the Pro services that are enabled in the machine.
+
+### Args
+
+This endpoint takes no arguments.
+
+### Python API interaction
+
+#### Calling from Python code
+
+```python
+from uaclient.api.u.pro.status.enabled_services.v1 import enabled_services
+
+result = enabled_services()
+```
+
+#### Expected return object:
+
+`uaclient.api.u.pro.status.enabled_services.v1.EnabledServicesResult`
+
+|Field Name|Type|Description|
+|-|-|-|
+|`enabled_services`|*List[EnabledService]*|A list of EnabledServices objects|
+
+`uaclient.api.u.pro.status.enabled_services.v1.EnabledService`
+
+|Field Name|Type|Description|
+|-|-|-|
+|`name`           |*str*           |name of the service                         |
+|`variant_enabled`|*bool*          |If a variant of the service is enabled      |
+|`variant_name`   |*Optional[str]* |name of the variant, if a variant is enabled|
+
+### CLI interaction
+
+#### Calling from the CLI:
+
+```bash
+pro api u.pro.status.enabled_services.v1
 ```
 
 ## u.security.package_manifest.v1

--- a/features/api.feature
+++ b/features/api.feature
@@ -43,6 +43,11 @@ Feature: Client behaviour for the API endpoints
     """
     {"_schema_version": "v1", "data": {"attributes": {"should_auto_attach": false}, "meta": {"environment_vars": \[\]}, "type": "ShouldAutoAttach"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
     """
+    When I run `ua api u.pro.status.is_attached.v1` with sudo
+    Then stdout matches regexp:
+    """
+    {"_schema_version": "v1", "data": {"attributes": {"is_attached": false}, "meta": {"environment_vars": \[\]}, "type": "IsAttached"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+    """
 
     Examples: ubuntu release
            | release |

--- a/features/api.feature
+++ b/features/api.feature
@@ -48,6 +48,11 @@ Feature: Client behaviour for the API endpoints
     """
     {"_schema_version": "v1", "data": {"attributes": {"is_attached": false}, "meta": {"environment_vars": \[\]}, "type": "IsAttached"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
     """
+    When I run `ua api u.pro.status.enabled_services.v1` with sudo
+    Then stdout matches regexp:
+    """
+    {"_schema_version": "v1", "data": {"attributes": {"enabled_services": \[\]}, "meta": {"environment_vars": \[\]}, "type": "EnabledServices"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+    """
 
     Examples: ubuntu release
            | release |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -222,72 +222,77 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
     Scenario Outline: Attached detach in an ubuntu machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
+        And I run `pro api u.pro.status.enabled_services.v1` as non-root
+        Then stdout matches regexp:
+        """
+        {"_schema_version": "v1", "data": {"attributes": {"enabled_services": \[{"name": "esm-apps", "variant_enabled": false, "variant_name": null}, {"name": "esm-infra", "variant_enabled": false, "variant_name": null}\]}, "meta": {"environment_vars": \[\]}, "type": "EnabledServices"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        """
         Then I verify that running `pro detach` `as non-root` exits `1`
         And stderr matches regexp:
-            """
-            This command must be run as root \(try using sudo\).
-            """
+        """
+        This command must be run as root \(try using sudo\).
+        """
         When I run `pro detach --assume-yes` with sudo
         Then I will see the following on stdout:
-            """
-            Detach will disable the following services:
-                esm-apps
-                esm-infra
-            Updating package lists
-            Updating package lists
-            This machine is now detached.
-            """
+        """
+        Detach will disable the following services:
+            esm-apps
+            esm-infra
+        Updating package lists
+        Updating package lists
+        This machine is now detached.
+        """
        When I run `pro status --all` as non-root
        Then stdout matches regexp:
-          """
-          SERVICE       +AVAILABLE  DESCRIPTION
-          cc-eal        +<cc-eal>   +Common Criteria EAL2 Provisioning Packages
-          """
+       """
+       SERVICE       +AVAILABLE  DESCRIPTION
+       cc-eal        +<cc-eal>   +Common Criteria EAL2 Provisioning Packages
+       """
        Then stdout matches regexp:
-          """
-          esm-apps      +<esm-apps> +Expanded Security Maintenance for Applications
-          esm-infra     +yes        +Expanded Security Maintenance for Infrastructure
-          fips          +<fips>     +NIST-certified core packages
-          fips-updates  +<fips>     +NIST-certified core packages with priority security updates
-          livepatch     +(yes|no)   +(Canonical Livepatch service|Current kernel is not supported)
-          realtime-kernel +<realtime-kernel> +Ubuntu kernel with PREEMPT_RT patches integrated
-          ros           +<ros>      +Security Updates for the Robot Operating System
-          ros-updates   +<ros>      +All Updates for the Robot Operating System
-          """
+       """
+       esm-apps      +<esm-apps> +Expanded Security Maintenance for Applications
+       esm-infra     +yes        +Expanded Security Maintenance for Infrastructure
+       fips          +<fips>     +NIST-certified core packages
+       fips-updates  +<fips>     +NIST-certified core packages with priority security updates
+       livepatch     +(yes|no)   +(Canonical Livepatch service|Current kernel is not supported)
+       realtime-kernel +<realtime-kernel> +Ubuntu kernel with PREEMPT_RT patches integrated
+       ros           +<ros>      +Security Updates for the Robot Operating System
+       ros-updates   +<ros>      +All Updates for the Robot Operating System
+       """
        Then stdout matches regexp:
-          """
-          <cis_or_usg>           +<cis>      +Security compliance and audit tools
-          """
+       """
+       <cis_or_usg>           +<cis>      +Security compliance and audit tools
+       """
        And stdout matches regexp:
-          """
-          This machine is not attached to an Ubuntu Pro subscription.
-          """
+       """
+       This machine is not attached to an Ubuntu Pro subscription.
+       """
        And I verify that running `apt update` `with sudo` exits `0`
        When I attach `contract_token` with sudo
        Then I verify that running `pro enable foobar --format json` `as non-root` exits `1`
        And stdout is a json matching the `ua_operation` schema
        And I will see the following on stdout:
-           """
-           {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-            """
+       """
+       {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
        Then I verify that running `pro enable foobar --format json` `with sudo` exits `1`
        And stdout is a json matching the `ua_operation` schema
        And I will see the following on stdout:
-           """
-           {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-           """
+       """
+       {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+       """
        Then I verify that running `pro detach --format json --assume-yes` `as non-root` exits `1`
        And stdout is a json matching the `ua_operation` schema
        And I will see the following on stdout:
-           """
-           {"_schema_version": "0.1", "errors": [{"message": "This command must be run as root (try using sudo).", "message_code": "nonroot-user", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-           """
+       """
+       {"_schema_version": "0.1", "errors": [{"message": "This command must be run as root (try using sudo).", "message_code": "nonroot-user", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+       """
        When I run `pro detach --format json --assume-yes` with sudo
        Then stdout is a json matching the `ua_operation` schema
        And I will see the following on stdout:
-           """
-           {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": false, "processed_services": ["esm-apps", "esm-infra"], "result": "success", "warnings": []}
-           """
+       """
+       {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": false, "processed_services": ["esm-apps", "esm-infra"], "result": "success", "warnings": []}
+       """
 
        Examples: ubuntu release
            | release | esm-apps | cc-eal | cis | fips | fips-update | ros | cis_or_usg | realtime-kernel |

--- a/features/cloud_pro_clone.feature
+++ b/features/cloud_pro_clone.feature
@@ -13,11 +13,7 @@ Feature: Creating golden images based on Cloud Ubuntu Pro instances
         log_file: /var/log/ubuntu-advantage.log
         """
         When I run `pro auto-attach` with sudo
-        And I run `pro status --format yaml` with sudo
-        Then stdout matches regexp:
-        """
-        attached: true
-        """
+        Then the machine is attached
         When I run `apt install -y jq` with sudo
         When I save the `activityInfo.activityToken` value from the contract
         When I save the `activityInfo.activityID` value from the contract
@@ -37,11 +33,7 @@ Feature: Creating golden images based on Cloud Ubuntu Pro instances
         When I launch a `<release>` machine named `clone` from the snapshot of `system-under-test`
         # The clone will run auto-attach on boot
         When I run `pro status --wait` `with sudo` on the `clone` machine
-        When I run `pro status --format yaml` `with sudo` on the `clone` machine
-        Then stdout matches regexp:
-        """
-        attached: true
-        """
+        Then the machine is attached
         When I run `python3 /usr/lib/ubuntu-advantage/timer.py` `with sudo` on the `clone` machine
         Then I verify that `activityInfo.activityToken` value has been updated on the contract on the `clone` machine
         Then I verify that `activityInfo.activityID` value has been updated on the contract on the `clone` machine

--- a/features/magic_attach.feature
+++ b/features/magic_attach.feature
@@ -47,11 +47,7 @@ Feature: Magic attach flow related tests
 
         Attaching the machine...
         """
-        When I run `pro status --format yaml` with sudo
-        Then stdout matches regexp:
-        """
-        attached: true
-        """
+        And the machine is attached
 
         Examples: ubuntu release
             | release |

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -42,11 +42,7 @@ Feature: Proxy configuration
         .*CONNECT contracts.canonical.com.*
         """
         When I run `pro status` with sudo
-        # Just to verify that the machine is attached
-        Then stdout matches regexp:
-        """
-        esm-infra     +yes      +disabled      +Expanded Security Maintenance for Infrastructure
-        """
+        Then the machine is attached
         When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I run `pro config set ua_apt_http_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
@@ -433,11 +429,7 @@ Feature: Proxy configuration
         .*CONNECT contracts.canonical.com.*
         """
         When I run `pro status` with sudo
-        # Just to verify that the machine is attached
-        Then stdout matches regexp:
-        """
-        esm-infra     +yes      +disabled      +Expanded Security Maintenance for Infrastructure
-        """
+        Then the machine is attached
         When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         When I create the file `/var/lib/ubuntu-advantage/user-config.json` with the following:
         """
@@ -671,11 +663,7 @@ Feature: Proxy configuration
         .*CONNECT contracts.canonical.com.*
         """
         When I run `pro status` with sudo
-        # Just to verify that the machine is attached
-        Then stdout matches regexp:
-        """
-        esm-infra     +yes      +disabled      +Expanded Security Maintenance for Infrastructure
-        """
+        Then the machine is attached
         When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I run `pro config set global_apt_http_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
@@ -1058,11 +1046,7 @@ Feature: Proxy configuration
         And I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I attach `contract_token` with sudo
-        When I run `pro status --format yaml` with sudo
-        Then stdout matches regexp:
-        """
-        attached: true
-        """
+        Then the machine is attached
         When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I run `pro config set apt_http_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -76,6 +76,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         \s* 500 https://esm.ubuntu.com/realtime/ubuntu <release>/main amd64 Packages
         """
+        When I run `pro api u.pro.status.enabled_services.v1` as non-root
+        Then stdout matches regexp:
+        """
+        {"_schema_version": "v1", "data": {"attributes": {"enabled_services": \[{"name": "realtime-kernel", "variant_enabled": false, "variant_name": null}\]}, "meta": {"environment_vars": \[\]}, "type": "EnabledServices"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        """
         When I verify that running `pro enable realtime-kernel` `with sudo` exits `1`
         Then stdout matches regexp
         """
@@ -152,12 +157,17 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
                       platformChecks: {"cpu_vendor_ids": ["intel"]}
         """
         When I run `pro enable realtime-kernel --assume-yes` with sudo
-        When I run `pro status --all` as non-root
+        And I run `pro status --all` as non-root
         Then stdout matches regexp:
         """
         realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
         ├ generic        yes +enabled   +Generic version of the RT kernel \(default\)
         └ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+        """
+        When I run `pro api u.pro.status.enabled_services.v1` as non-root
+        Then stdout matches regexp:
+        """
+        {"_schema_version": "v1", "data": {"attributes": {"enabled_services": \[{"name": "realtime-kernel", "variant_enabled": true, "variant_name": "generic"}\]}, "meta": {"environment_vars": \[\]}, "type": "EnabledServices"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
         When I run `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `y\ny\n`
         Then stdout contains substring:
@@ -172,8 +182,13 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         ├ generic        yes +disabled   +Generic version of the RT kernel \(default\)
         └ intel-iotg     yes +enabled  +RT kernel optimized for Intel IOTG platform
         """
+        When I run `pro api u.pro.status.enabled_services.v1` as non-root
+        Then stdout matches regexp:
+        """
+        {"_schema_version": "v1", "data": {"attributes": {"enabled_services": \[{"name": "realtime-kernel", "variant_enabled": true, "variant_name": "intel-iotg"}\]}, "meta": {"environment_vars": \[\]}, "type": "EnabledServices"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        """
         When I run `pro enable realtime-kernel --variant generic` `with sudo` and stdin `y\ny\n`
-        When I run `pro status --all` as non-root
+        And I run `pro status --all` as non-root
         Then stdout matches regexp:
         """
         realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -181,7 +196,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         └ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
         """
         When I run `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `y\ny\n`
-        When I run `pro status --all` as non-root
+        And I run `pro status --all` as non-root
         Then stdout matches regexp:
         """
         realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -352,7 +367,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     Scenario Outline: Enable Real-time kernel service access-only
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
-        When I run `pro enable realtime-kernel --beta --access-only` with sudo
+        When I run `pro enable realtime-kernel --access-only` with sudo
         Then stdout matches regexp:
         """
         One moment, checking your subscription first

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -336,11 +336,8 @@ Feature: auto-attach retries periodically on failures
         features: {}
         """
         When I wait `60` seconds
-        When I run `ua status --wait --format yaml` with sudo
-        Then stdout contains substring
-        """
-        attached: true
-        """
+        And I run `pro status --wait` with sudo
+        Then the machine is attached
         When I verify that running `systemctl status ubuntu-advantage.service` `as non-root` exits `3`
         Then stdout contains substring
         """

--- a/features/steps/attach.py
+++ b/features/steps/attach.py
@@ -1,4 +1,6 @@
-from behave import when
+import json
+
+from behave import then, when
 
 from features.steps.contract import change_contract_endpoint_to_staging
 from features.steps.shell import (
@@ -66,3 +68,15 @@ def when_i_verify_attach_expired_token_with_json_response(context, spec):
     then_i_verify_that_running_cmd_with_spec_exits_with_codes(
         context=context, cmd_name=cmd, spec=spec, exit_codes=ERROR_CODE
     )
+
+
+@then("the machine is attached")
+def then_the_machine_is_attached(context):
+    when_i_run_command(
+        context,
+        command="pro api u.pro.status.is_attached.v1",
+        user_spec="as non-root",
+    )
+
+    is_attached_resp = json.loads(context.process.stdout.strip())
+    assert is_attached_resp["data"]["attributes"]["is_attached"]

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -26,6 +26,7 @@ from uaclient import (
     messages,
     upgrade_lts_contract,
 )
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.cli import setup_logging
 from uaclient.entitlements.fips import FIPSEntitlement
 from uaclient.files import notices, state_files
@@ -78,7 +79,7 @@ def main(cfg: config.UAConfig) -> int:
         notices.remove(notices.Notice.REBOOT_SCRIPT_FAILED)
         return 0
 
-    if not cfg.is_attached:
+    if not _is_attached(cfg).is_attached:
         logging.debug("Skipping reboot_cmds. Machine is unattached")
         state_files.reboot_cmd_marker_file.delete()
         notices.remove(notices.Notice.REBOOT_SCRIPT_FAILED)

--- a/uaclient/api/api.py
+++ b/uaclient/api/api.py
@@ -26,6 +26,7 @@ VALID_ENDPOINTS = [
     "u.pro.packages.updates.v1",
     "u.pro.security.status.livepatch_cves.v1",
     "u.pro.security.status.reboot_required.v1",
+    "u.pro.status.is_attached.v1",
     "u.pro.version.v1",
     "u.security.package_manifest.v1",
     "u.unattended_upgrades.status.v1",

--- a/uaclient/api/api.py
+++ b/uaclient/api/api.py
@@ -26,6 +26,7 @@ VALID_ENDPOINTS = [
     "u.pro.packages.updates.v1",
     "u.pro.security.status.livepatch_cves.v1",
     "u.pro.security.status.reboot_required.v1",
+    "u.pro.status.enabled_services.v1",
     "u.pro.status.is_attached.v1",
     "u.pro.version.v1",
     "u.security.package_manifest.v1",

--- a/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
@@ -1,0 +1,73 @@
+import mock
+
+from uaclient import entitlements
+from uaclient.api.u.pro.status.enabled_services.v1 import (
+    EnabledService,
+    _enabled_services,
+)
+from uaclient.entitlements.entitlement_status import UserFacingStatus
+
+
+class TestEnabledServicesV1:
+    @mock.patch("uaclient.api.u.pro.status.enabled_services.v1._is_attached")
+    def test_enabled_services(self, m_is_attached):
+        m_is_attached.return_value = mock.MagicMock(is_attached=True)
+
+        m_cls_1 = mock.MagicMock()
+        m_inst_1 = mock.MagicMock(variants={})
+        type(m_inst_1).name = mock.PropertyMock(return_value="ent1")
+        m_inst_1.user_facing_status.return_value = (
+            UserFacingStatus.ACTIVE,
+            "",
+        )
+        m_cls_1.return_value = m_inst_1
+
+        m_variant_cls = mock.MagicMock()
+        m_variant_inst = mock.MagicMock(variant_name="variant")
+        m_variant_inst.user_facing_status.return_value = (
+            UserFacingStatus.ACTIVE,
+            "",
+        )
+        m_variant_cls.return_value = m_variant_inst
+
+        m_cls_2 = mock.MagicMock()
+        m_inst_2 = mock.MagicMock(variants={"variant": m_variant_cls})
+        type(m_inst_2).name = mock.PropertyMock(return_value="ent2")
+        m_inst_2.user_facing_status.return_value = (
+            UserFacingStatus.ACTIVE,
+            "",
+        )
+        m_cls_2.return_value = m_inst_2
+
+        m_cls_3 = mock.MagicMock()
+        m_inst_3 = mock.MagicMock()
+        type(m_inst_3).name = mock.PropertyMock(return_value="ent3")
+        m_inst_3.user_facing_status.return_value = (
+            UserFacingStatus.INACTIVE,
+            "",
+        )
+
+        ents = [m_cls_1, m_cls_2, m_cls_3]
+        expected_enabled_services = [
+            EnabledService(name="ent1"),
+            EnabledService(
+                name="ent2",
+                variant_enabled=True,
+                variant_name="variant",
+            ),
+        ]
+
+        with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
+            actual_enabled_services = _enabled_services(
+                cfg=mock.MagicMock()
+            ).enabled_services
+
+        assert 1 == m_is_attached.call_count
+        assert expected_enabled_services == actual_enabled_services
+
+    @mock.patch("uaclient.api.u.pro.status.enabled_services.v1._is_attached")
+    def test_enabled_services_when_unattached(self, m_is_attached):
+        m_is_attached.return_value = mock.MagicMock(is_attached=False)
+
+        assert [] == _enabled_services(cfg=mock.MagicMock()).enabled_services
+        assert 1 == m_is_attached.call_count

--- a/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
@@ -4,6 +4,7 @@ from uaclient import actions, event_logger, lock, messages, util
 from uaclient.api import exceptions
 from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UAConfig
 from uaclient.data_types import DataObject, Field, StringDataValue, data_list
 from uaclient.entitlements import order_entitlements_for_enabling
@@ -91,7 +92,7 @@ def _full_auto_attach_in_lock(
 ) -> FullAutoAttachResult:
     event.set_event_mode(mode)
 
-    if cfg.is_attached:
+    if _is_attached(cfg).is_attached:
         raise exceptions.AlreadyAttachedError(
             cfg.machine_token_file.account.get("name", "")
         )

--- a/uaclient/api/u/pro/status/enabled_services/v1.py
+++ b/uaclient/api/u/pro/status/enabled_services/v1.py
@@ -1,0 +1,83 @@
+from typing import List, Optional
+
+from uaclient.api.api import APIEndpoint
+from uaclient.api.data_types import AdditionalInfo
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
+from uaclient.config import UAConfig
+from uaclient.data_types import (
+    BoolDataValue,
+    DataObject,
+    Field,
+    StringDataValue,
+    data_list,
+)
+from uaclient.entitlements.entitlement_status import UserFacingStatus
+
+
+class EnabledService(DataObject):
+    fields = [
+        Field("name", StringDataValue),
+        Field("variant_enabled", BoolDataValue),
+        Field("variant_name", StringDataValue, False),
+    ]
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        variant_enabled: bool = False,
+        variant_name: Optional[str] = None
+    ):
+        self.name = name
+        self.variant_enabled = variant_enabled
+        self.variant_name = variant_name
+
+
+class EnabledServicesResult(DataObject, AdditionalInfo):
+    fields = [
+        Field("enabled_services", data_list(EnabledService)),
+    ]
+
+    def __init__(self, *, enabled_services: List[EnabledService]):
+        self.enabled_services = enabled_services
+
+
+def enabled_services() -> EnabledServicesResult:
+    return _enabled_services(UAConfig())
+
+
+def _enabled_services(cfg: UAConfig) -> EnabledServicesResult:
+    from uaclient.entitlements import ENTITLEMENT_CLASSES
+
+    if not _is_attached(cfg).is_attached:
+        return EnabledServicesResult(enabled_services=[])
+
+    enabled_services = []  # type: List[EnabledService]
+    for ent_cls in ENTITLEMENT_CLASSES:
+        ent = ent_cls(cfg)
+        if ent.user_facing_status()[0] == UserFacingStatus.ACTIVE:
+            enabled_service = EnabledService(name=ent.name)
+            for _, variant_cls in ent.variants.items():
+                variant = variant_cls(cfg)
+
+                if variant.user_facing_status()[0] == UserFacingStatus.ACTIVE:
+                    enabled_service = EnabledService(
+                        name=ent.name,
+                        variant_enabled=True,
+                        variant_name=variant.variant_name,
+                    )
+                    break
+
+            enabled_services.append(enabled_service)
+
+    return EnabledServicesResult(
+        enabled_services=sorted(enabled_services, key=lambda x: x.name)
+    )
+
+
+endpoint = APIEndpoint(
+    version="v1",
+    name="EnabledServices",
+    fn=_enabled_services,
+    options_cls=None,
+)

--- a/uaclient/api/u/pro/status/is_attached/v1.py
+++ b/uaclient/api/u/pro/status/is_attached/v1.py
@@ -1,0 +1,29 @@
+from uaclient.api.api import APIEndpoint
+from uaclient.api.data_types import AdditionalInfo
+from uaclient.config import UAConfig
+from uaclient.data_types import BoolDataValue, DataObject, Field
+
+
+class IsAttachedResult(DataObject, AdditionalInfo):
+    fields = [
+        Field("is_attached", BoolDataValue),
+    ]
+
+    def __init__(self, *, is_attached: bool):
+        self.is_attached = is_attached
+
+
+def is_attached() -> IsAttachedResult:
+    return _is_attached(UAConfig())
+
+
+def _is_attached(cfg: UAConfig) -> IsAttachedResult:
+    return IsAttachedResult(is_attached=bool(cfg.machine_token))
+
+
+endpoint = APIEndpoint(
+    version="v1",
+    name="IsAttached",
+    fn=_is_attached,
+    options_cls=None,
+)

--- a/uaclient/apt_news.py
+++ b/uaclient/apt_news.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 import apt_pkg
 
 from uaclient import defaults, messages, system, util
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.clouds.identity import get_cloud_type
 from uaclient.config import UAConfig
 from uaclient.data_types import (
@@ -92,7 +93,7 @@ def do_selectors_apply(
             return False
 
     if selectors.pro is not None:
-        if selectors.pro != cfg.is_attached:
+        if selectors.pro != _is_attached(cfg).is_attached:
             return False
 
     return True

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -47,6 +47,7 @@ from uaclient.api.u.pro.attach.magic.wait.v1 import (
 from uaclient.api.u.pro.security.status.reboot_required.v1 import (
     _reboot_required,
 )
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.apt import AptProxyScope, setup_apt_proxy
 from uaclient.data_types import AttachActionsConfigFile, IncorrectTypeError
 from uaclient.defaults import PRINT_WRAP_WIDTH
@@ -248,7 +249,7 @@ def assert_attached(msg_function=None):
     def wrapper(f):
         @wraps(f)
         def new_f(args, cfg, **kwargs):
-            if not cfg.is_attached:
+            if not _is_attached(cfg).is_attached:
                 if msg_function:
                     command = getattr(args, "command", "")
                     service_names = getattr(args, "service", "")
@@ -271,7 +272,7 @@ def assert_not_attached(f):
 
     @wraps(f)
     def new_f(args, cfg):
-        if cfg.is_attached:
+        if _is_attached(cfg).is_attached:
             raise exceptions.AlreadyAttachedError(
                 cfg.machine_token_file.account.get("name", "")
             )

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -392,11 +392,6 @@ class UAConfig:
         )
 
     @property
-    def is_attached(self):
-        """Report whether this machine configuration is attached to UA."""
-        return bool(self.machine_token)  # machine_token is removed on detach
-
-    @property
     def features(self):
         """Return a dictionary of any features provided in uaclient.conf."""
         features = self.cfg.get("features")

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -12,9 +12,9 @@ from uaclient import (
     system,
     util,
 )
+from uaclient.api.u.pro.status.enabled_services.v1 import _enabled_services
 from uaclient.config import UAConfig
 from uaclient.defaults import ATTACH_FAIL_DATE_FORMAT
-from uaclient.entitlements.entitlement_status import UserFacingStatus
 
 API_V1_CONTEXT_MACHINE_TOKEN = "/v1/context/machines/token"
 API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE = (
@@ -372,25 +372,18 @@ class UAContractClient(serviceclient.UAServiceClient):
 
     def _get_activity_info(self, machine_id: Optional[str] = None):
         """Return a dict of activity info data for contract requests"""
-        from uaclient.entitlements import ENTITLEMENT_CLASSES
-
         if not machine_id:
             machine_id = system.get_machine_id(self.cfg)
 
         # If the activityID is null we should provide the endpoint
         # with the instance machine id as the activityID
         activity_id = self.cfg.machine_token_file.activity_id or machine_id
-
-        enabled_services = [
-            ent(self.cfg).name
-            for ent in ENTITLEMENT_CLASSES
-            if ent(self.cfg).user_facing_status()[0] == UserFacingStatus.ACTIVE
-        ]
+        enabled_services = _enabled_services(self.cfg).enabled_services or []
 
         return {
             "activityID": activity_id,
             "activityToken": self.cfg.machine_token_file.activity_token,
-            "resources": enabled_services,
+            "resources": [service.name for service in enabled_services],
         }
 
 

--- a/uaclient/daemon/poll_for_pro_license.py
+++ b/uaclient/daemon/poll_for_pro_license.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from uaclient import actions, exceptions, lock, system, util
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.clouds import AutoAttachCloudInstance
 from uaclient.clouds.gcp import UAAutoAttachGCPInstance
 from uaclient.clouds.identity import cloud_instance_factory
@@ -32,7 +33,7 @@ def poll_for_pro_license(cfg: UAConfig):
     ):
         LOG.debug("Configured to not auto attach, shutting down")
         return
-    if cfg.is_attached:
+    if _is_attached(cfg).is_attached:
         LOG.debug("Already attached, shutting down")
         return
     if not system.is_current_series_lts():
@@ -87,7 +88,7 @@ def poll_for_pro_license(cfg: UAConfig):
             time.sleep(cfg.polling_error_retry_delay)
             continue
         else:
-            if cfg.is_attached:
+            if _is_attached(cfg).is_attached:
                 # This could have changed during the long poll or sleep
                 LOG.debug("Already attached, shutting down")
                 return

--- a/uaclient/daemon/retry_auto_attach.py
+++ b/uaclient/daemon/retry_auto_attach.py
@@ -8,6 +8,7 @@ from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
     FullAutoAttachOptions,
     full_auto_attach,
 )
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UAConfig
 from uaclient.daemon import AUTO_ATTACH_STATUS_MOTD_FILE
 from uaclient.files import notices, state_files
@@ -89,7 +90,7 @@ def cleanup(cfg: UAConfig):
 
 def retry_auto_attach(cfg: UAConfig) -> None:
     # in case we got started while already attached somehow
-    if cfg.is_attached:
+    if _is_attached(cfg).is_attached:
         return
 
     # pick up where we left off
@@ -145,7 +146,7 @@ def retry_auto_attach(cfg: UAConfig) -> None:
 
         time.sleep(interval)
 
-        if cfg.is_attached:
+        if _is_attached(cfg).is_attached:
             # We attached while sleeping - hooray!
             break
 
@@ -171,7 +172,7 @@ def retry_auto_attach(cfg: UAConfig) -> None:
 
     cleanup(cfg)
 
-    if not cfg.is_attached:
+    if not _is_attached(cfg).is_attached:
         # Total failure!!
         state_files.retry_auto_attach_state_file.write(
             state_files.RetryAutoAttachState(

--- a/uaclient/daemon/tests/test_retry_auto_attach.py
+++ b/uaclient/daemon/tests/test_retry_auto_attach.py
@@ -115,9 +115,13 @@ class TestRetryAutoAttach:
         FakeConfig,
     ):
         with mock.patch(
-            "uaclient.config.UAConfig.is_attached",
+            "uaclient.daemon.retry_auto_attach._is_attached",
             new_callable=mock.PropertyMock,
-            side_effect=[False, True, True],
+            side_effect=[
+                mock.MagicMock(is_attached=False),
+                mock.MagicMock(is_attached=True),
+                mock.MagicMock(is_attached=True),
+            ],
         ):
             cfg = FakeConfig()
             retry_auto_attach(cfg)
@@ -670,9 +674,12 @@ class TestRetryAutoAttach:
             interval_index=18, failure_reason=None
         )
         with mock.patch(
-            "uaclient.config.UAConfig.is_attached",
+            "uaclient.daemon.retry_auto_attach._is_attached",
             new_callable=mock.PropertyMock,
-            side_effect=[False, is_attached_at_end],
+            side_effect=[
+                mock.MagicMock(is_attached=False),
+                mock.MagicMock(is_attached=is_attached_at_end),
+            ],
         ):
             cfg = FakeConfig()
             retry_auto_attach(cfg)

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 
 from uaclient import config, contract, event_logger, messages, system, util
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.defaults import DEFAULT_HELP_FILE
 from uaclient.entitlements.entitlement_status import (
     ApplicabilityStatus,
@@ -892,7 +893,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
     def contract_status(self) -> ContractStatus:
         """Return whether the user is entitled to the entitlement or not"""
-        if not self.cfg.is_attached:
+        if not _is_attached(self.cfg).is_attached:
             return ContractStatus.UNENTITLED
         entitlement_cfg = self.entitlement_cfg
         if entitlement_cfg and entitlement_cfg["entitlement"].get("entitled"):

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -14,6 +14,7 @@ from uaclient import (
     util,
     version,
 )
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UA_CONFIGURABLE_KEYS, UAConfig
 from uaclient.contract import get_available_resources, get_contract_information
 from uaclient.defaults import ATTACH_FAIL_DATE_FORMAT, PRINT_WRAP_WIDTH
@@ -396,7 +397,7 @@ def status(cfg: UAConfig, show_all: bool = False) -> Dict[str, Any]:
 
     Write the status-cache when called by root.
     """
-    if cfg.is_attached:
+    if _is_attached(cfg).is_attached:
         response = _attached_status(cfg)
     else:
         response = _unattached_status(cfg)
@@ -819,7 +820,7 @@ def help(cfg, name):
             "No help available for '{}'".format(name)
         )
 
-    if cfg.is_attached:
+    if _is_attached(cfg).is_attached:
         service_status = _attached_service_status(help_ent, {}, cfg)
         status_msg = service_status["status"]
 

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -203,9 +203,7 @@ class TestCLIParser:
         ),
     )
     @mock.patch("uaclient.status.get_available_resources")
-    @mock.patch(
-        "uaclient.config.UAConfig.is_attached", new_callable=mock.PropertyMock
-    )
+    @mock.patch("uaclient.status._is_attached")
     def test_help_command_when_unnatached(
         self, m_attached, m_available_resources, out_format, expected_return
     ):
@@ -225,7 +223,7 @@ class TestCLIParser:
         m_entitlement_obj = m_entitlement_cls.return_value
         type(m_entitlement_obj).help_info = m_ent_help_info
 
-        m_attached.return_value = False
+        m_attached.return_value = mock.MagicMock(is_attached=False)
 
         m_available_resources.return_value = [
             {"name": "test", "available": True}
@@ -259,9 +257,7 @@ class TestCLIParser:
     )
     @pytest.mark.parametrize("is_beta", (True, False))
     @mock.patch("uaclient.status.get_available_resources")
-    @mock.patch(
-        "uaclient.config.UAConfig.is_attached", new_callable=mock.PropertyMock
-    )
+    @mock.patch("uaclient.status._is_attached")
     def test_help_command_when_attached(
         self, m_attached, m_available_resources, ent_status, ent_msg, is_beta
     ):
@@ -291,7 +287,7 @@ class TestCLIParser:
         m_ent_desc = mock.PropertyMock(return_value="description")
         type(m_entitlement_obj).description = m_ent_desc
 
-        m_attached.return_value = True
+        m_attached.return_value = mock.MagicMock(is_attached=True)
         m_available_resources.return_value = [
             {"name": "test", "available": True}
         ]

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -8,6 +8,7 @@ import mock
 import pytest
 
 from uaclient import event_logger, messages, status, util
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.cli import (
     UA_AUTH_TOKEN_URL,
     action_attach,
@@ -269,7 +270,7 @@ class TestActionAttach:
             main_error_handler(action_attach)(args, cfg)
 
         assert 1 == excinfo.value.code
-        assert cfg.is_attached
+        assert _is_attached(cfg).is_attached
         # Assert updated status cache is written to disk
         assert orig_unattached_status != cfg.read_cache(
             "status-cache"

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -91,10 +91,7 @@ class TestFixProPkgHolds:
 @mock.patch("lib.reboot_cmds.refresh_contract")
 @mock.patch("lib.reboot_cmds.fix_pro_pkg_holds")
 @mock.patch("uaclient.lock.SpinLock")
-@mock.patch(
-    "uaclient.config.UAConfig.is_attached",
-    new_callable=mock.PropertyMock,
-)
+@mock.patch("lib.reboot_cmds._is_attached")
 @mock.patch(
     "uaclient.files.state_files.reboot_cmd_marker_file",
     new_callable=mock.PropertyMock,
@@ -132,7 +129,7 @@ class TestMain:
         expected_ret,
         FakeConfig,
     ):
-        m_is_attached.return_value = is_attached
+        m_is_attached.return_value = mock.MagicMock(is_attached=is_attached)
         m_reboot_cmd_marker_file.is_present = marker_file_present
         assert expected_ret == main(FakeConfig())
 
@@ -188,7 +185,7 @@ class TestMain:
         expected_ret,
         FakeConfig,
     ):
-        m_is_attached.return_value = True
+        m_is_attached.return_value = mock.MagicMock(is_attached=True)
         m_reboot_cmd_marker_file.is_present = True
         m_fix_pro_pkg_holds.side_effect = error
         assert expected_ret == main(FakeConfig())

--- a/uaclient/tests/test_upgrade_lts_contract.py
+++ b/uaclient/tests/test_upgrade_lts_contract.py
@@ -8,14 +8,11 @@ from uaclient.upgrade_lts_contract import process_contract_delta_after_apt_lock
 
 @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
 class TestUpgradeLTSContract:
-    @mock.patch(
-        "uaclient.config.UAConfig.is_attached",
-        new_callable=mock.PropertyMock,
-        return_value=False,
-    )
+    @mock.patch("uaclient.upgrade_lts_contract._is_attached")
     def test_unattached_noops(
         self, m_is_attached, capsys, caplog_text, FakeConfig
     ):
+        m_is_attached.return_value = mock.MagicMock(is_attached=False)
         expected_logs = [
             "Check whether to upgrade-lts-contract",
             "Skipping upgrade-lts-contract. Machine is unattached",
@@ -30,11 +27,7 @@ class TestUpgradeLTSContract:
         for log in expected_logs:
             assert log in debug_logs
 
-    @mock.patch(
-        "uaclient.config.UAConfig.is_attached",
-        new_callable=mock.PropertyMock,
-        return_value=True,
-    )
+    @mock.patch("uaclient.upgrade_lts_contract._is_attached")
     @mock.patch("uaclient.upgrade_lts_contract.system.get_release_info")
     @mock.patch("uaclient.upgrade_lts_contract.system.subp")
     def test_upgrade_cancel_when_past_version_not_supported(
@@ -46,6 +39,7 @@ class TestUpgradeLTSContract:
         caplog_text,
         FakeConfig,
     ):
+        m_is_attached.return_value = mock.MagicMock(is_attached=True)
         m_get_release_info.return_value = mock.MagicMock(series="groovy")
         m_subp.return_value = ("", "")
 
@@ -67,11 +61,7 @@ class TestUpgradeLTSContract:
         for log in expected_msgs + expected_logs:
             assert log in debug_logs
 
-    @mock.patch(
-        "uaclient.config.UAConfig.is_attached",
-        new_callable=mock.PropertyMock,
-        return_value=True,
-    )
+    @mock.patch("uaclient.upgrade_lts_contract._is_attached")
     @mock.patch("uaclient.upgrade_lts_contract.system.get_release_info")
     @mock.patch("uaclient.upgrade_lts_contract.system.subp")
     @mock.patch(
@@ -89,6 +79,7 @@ class TestUpgradeLTSContract:
         caplog_text,
         FakeConfig,
     ):
+        m_is_attached.return_value = mock.MagicMock(is_attached=True)
         m_get_release_info.return_value = mock.MagicMock(series="focal")
 
         m_subp.side_effect = [

--- a/uaclient/timer/metering.py
+++ b/uaclient/timer/metering.py
@@ -3,6 +3,7 @@ Functions to be used when running metering jobs
 """
 
 from uaclient import config
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.cli import assert_lock_file
 from uaclient.contract import UAContractClient
 
@@ -13,7 +14,7 @@ def metering_enabled_resources(cfg: config.UAConfig) -> bool:
     # The reason for that is to avoid potential conflicts with
     # auto-attach, attach and enable operations.
 
-    if not cfg.is_attached:
+    if not _is_attached(cfg).is_attached:
         return False
 
     contract = UAContractClient(cfg)

--- a/uaclient/timer/tests/test_update_messaging.py
+++ b/uaclient/timer/tests/test_update_messaging.py
@@ -337,9 +337,7 @@ class TestUpdateMotdMessages:
     @mock.patch(M_PATH + "system.ensure_file_absent")
     @mock.patch(M_PATH + "update_contract_expiry")
     @mock.patch(M_PATH + "get_contract_expiry_status")
-    @mock.patch(
-        M_PATH + "UAConfig.is_attached", new_callable=mock.PropertyMock
-    )
+    @mock.patch(M_PATH + "_is_attached")
     def test_update_motd_messages(
         self,
         m_is_attached,
@@ -366,7 +364,7 @@ class TestUpdateMotdMessages:
         write_file_calls,
         FakeConfig,
     ):
-        m_is_attached.return_value = attached
+        m_is_attached.return_value = mock.MagicMock(is_attached=attached)
         m_get_contract_expiry_status.side_effect = contract_expiry_statuses
         m_is_current_series_active_esm.return_value = (
             is_current_series_active_esm

--- a/uaclient/timer/update_contract_info.py
+++ b/uaclient/timer/update_contract_info.py
@@ -1,6 +1,7 @@
 import logging
 
 from uaclient import contract, messages, util
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UAConfig
 from uaclient.files import notices
 from uaclient.files.notices import Notice
@@ -9,7 +10,7 @@ LOG = logging.getLogger(__name__)
 
 
 def update_contract_info(cfg: UAConfig) -> bool:
-    if cfg.is_attached:
+    if _is_attached(cfg).is_attached:
         try:
             if contract.is_contract_changed(cfg):
                 notices.add(

--- a/uaclient/timer/update_messaging.py
+++ b/uaclient/timer/update_messaging.py
@@ -16,6 +16,7 @@ from uaclient import contract, defaults, messages, system
 from uaclient.api.u.pro.packages.updates.v1 import (
     _updates as api_u_pro_packages_updates_v1,
 )
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UAConfig
 from uaclient.entitlements import ESMAppsEntitlement, ESMInfraEntitlement
 from uaclient.entitlements.entitlement_status import ApplicationStatus
@@ -66,7 +67,7 @@ def get_contract_expiry_status(
     cfg: UAConfig,
 ) -> Tuple[ContractExpiryStatus, int]:
     """Return a tuple [ContractExpiryStatus, num_days]"""
-    if not cfg.is_attached:
+    if not _is_attached(cfg).is_attached:
         return ContractExpiryStatus.NONE, 0
 
     grace_period = defaults.CONTRACT_EXPIRY_GRACE_PERIOD_DAYS
@@ -96,7 +97,7 @@ def update_motd_messages(cfg: UAConfig) -> bool:
 
     :param cfg: UAConfig instance for this environment.
     """
-    if not cfg.is_attached:
+    if not _is_attached(cfg).is_attached:
         return False
 
     logging.debug("Updating Ubuntu Pro messages for MOTD.")

--- a/uaclient/upgrade_lts_contract.py
+++ b/uaclient/upgrade_lts_contract.py
@@ -28,6 +28,7 @@ import sys
 import time
 
 from uaclient import contract, defaults, system
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UAConfig
 
 # We consider the past release for LTSs to be the last LTS,
@@ -46,7 +47,7 @@ current_codename_to_past_codename = {
 
 def process_contract_delta_after_apt_lock(cfg: UAConfig) -> None:
     logging.debug("Check whether to upgrade-lts-contract")
-    if not cfg.is_attached:
+    if not _is_attached(cfg).is_attached:
         logging.debug("Skipping upgrade-lts-contract. Machine is unattached")
         return
     out, _err = system.subp(["lsof", "/var/lib/apt/lists/lock"], rcs=[0, 1])


### PR DESCRIPTION
no-lp no-gh

## Why is this needed?
We are adding two distinct endpoint that deliver information that can only be seen today through the machine readable output of `pro status`. They are:

* **is_attached**: Verify if the machine is attached to a pro subscription
* **enabled_services**: Display which services are enabled in the machine

## Test Steps
Run the modified integration tests

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
