### PR TITLE
ignore any unicode char if we can't print it

### DIFF
--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -690,6 +690,7 @@ class TestHandleUnicodeCharacters:
             (messages.OKGREEN_CHECK + " test", "test"),
             (messages.FAIL_X + " fail", "fail"),
             ("\u2014 blah", "- blah"),
+            ("\xfcblah", "blah"),
         ),
     )
     def test_handle_unicode_characters(

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -543,6 +543,9 @@ def handle_unicode_characters(message: str) -> str:
         message = message.replace(messages.OKGREEN_CHECK + " ", "")
         message = message.replace(messages.FAIL_X + " ", "")
 
+        # Now we remove any remaining unicode characters from the string
+        message = message.encode("ascii", "ignore").decode()
+
     return message
 
 


### PR DESCRIPTION
no-gh no-jira

## Why is this needed?
If we cannot handle unicode characters in the output we remove any of those characters from the message.
This is to guarantee that users that are not using UTF-8 by default can still use the tool

## Test Steps
Run the new unittest added

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
