### PR TITLE
contract: rename function to align with backend

### DIFF
--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -88,7 +88,7 @@ def auto_attach(
         auto-attach support.
     """
     contract_client = contract.UAContractClient(cfg)
-    tokenResponse = contract_client.request_auto_attach_contract_token(
+    tokenResponse = contract_client.get_contract_token_for_cloud_instance(
         instance=cloud
     )
 

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -83,12 +83,12 @@ class TestAutoAttach:
     @mock.patch(M_PATH + "attach_with_token")
     @mock.patch(
         M_PATH
-        + "contract.UAContractClient.request_auto_attach_contract_token",
+        + "contract.UAContractClient.get_contract_token_for_cloud_instance",
         return_value={"contractToken": "token"},
     )
     def test_happy_path_on_auto_attach(
         self,
-        m_request_auto_attach_contract_token,
+        _m_get_contract_token_for_cloud_instances,
         m_attach_with_token,
         FakeConfig,
     ):
@@ -101,13 +101,14 @@ class TestAutoAttach:
         ] == m_attach_with_token.call_args_list
 
     @mock.patch(
-        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
+        M_PATH
+        + "contract.UAContractClient.get_contract_token_for_cloud_instance"  # noqa
     )
     @mock.patch(M_PATH + "identity.get_instance_id", return_value="my-iid")
     def test_raise_unexpected_errors(
         self,
         _m_get_instance_id,
-        m_request_auto_attach_contract_token,
+        m_get_contract_token_for_cloud_instances,
         FakeConfig,
     ):
         """Any unexpected errors will be raised."""
@@ -119,7 +120,7 @@ class TestAutoAttach:
             ),
             error_response={"message": "something unexpected"},
         )
-        m_request_auto_attach_contract_token.side_effect = unexpected_error
+        m_get_contract_token_for_cloud_instances.side_effect = unexpected_error
 
         with pytest.raises(ContractAPIError) as excinfo:
             auto_attach(cfg, fake_instance_factory())

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -279,9 +279,7 @@ class TestActionAttach:
     @mock.patch("uaclient.system.should_reboot", return_value=False)
     @mock.patch("uaclient.files.notices.NoticesManager.remove")
     @mock.patch("uaclient.timer.update_messaging.update_motd_messages")
-    @mock.patch(
-        M_PATH + "contract.UAContractClient.request_contract_machine_attach"
-    )
+    @mock.patch(M_PATH + "contract.UAContractClient.add_contract_machine")
     @mock.patch("uaclient.actions.status", return_value=("", 0))
     @mock.patch("uaclient.status.format_tabular")
     def test_happy_path_with_token_arg(

--- a/uaclient/timer/metering.py
+++ b/uaclient/timer/metering.py
@@ -17,6 +17,6 @@ def metering_enabled_resources(cfg: config.UAConfig) -> bool:
         return False
 
     contract = UAContractClient(cfg)
-    contract.report_machine_activity()
+    contract.update_activity_token()
 
     return True

--- a/uaclient/timer/tests/test_update_messaging.py
+++ b/uaclient/timer/tests/test_update_messaging.py
@@ -50,21 +50,21 @@ class TestGetContractExpiryStatus:
         (("2040-05-08T19:02:26Z", False), ("2042-05-08T19:02:26Z", True)),
     )
     @mock.patch("uaclient.files.MachineTokenFile.write")
-    @mock.patch(M_PATH + "contract.UAContractClient.get_updated_contract_info")
+    @mock.patch(M_PATH + "contract.UAContractClient.get_contract_machine")
     def test_update_contract_expiry(
         self,
-        get_updated_contract_info,
-        machine_token_write,
+        m_get_contract_machine,
+        m_machine_token_write,
         expiry,
         is_updated,
     ):
-        get_updated_contract_info.return_value = {
+        m_get_contract_machine.return_value = {
             "machineTokenInfo": {"contractInfo": {"effectiveTo": expiry}}
         }
         if is_updated:
-            1 == machine_token_write.call_count
+            1 == m_machine_token_write.call_count
         else:
-            0 == machine_token_write.call_count
+            0 == m_machine_token_write.call_count
 
 
 class TestUpdateMotdMessages:

--- a/uaclient/timer/update_messaging.py
+++ b/uaclient/timer/update_messaging.py
@@ -44,9 +44,7 @@ def update_contract_expiry(cfg: UAConfig):
         .get("id", None)
     )
     contract_client = contract.UAContractClient(cfg)
-    resp = contract_client.get_updated_contract_info(
-        machine_token, contract_id
-    )
+    resp = contract_client.get_contract_machine(machine_token, contract_id)
     resp_expiry = (
         resp.get("machineTokenInfo", {})
         .get("contractInfo", {})


### PR DESCRIPTION
## Why is this needed?
We are renaming some of the contract module methods to align with their definition on the contract backend.
The idea is to make it easier to communicate with the contract team and to debug the code together


## Test Steps
Verify that no integration tests are now breaking because of this change

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
