### PR TITLE
autocomplete: update services and commands

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -252,7 +252,8 @@ Feature: Command behaviour when unattached
           | kinetic |
           | lunar   |
 
-    @series.all
+    @series.xenial
+    @series.bionic
     @uses.config.machine_type.lxd-container
     # Side effect: this verifies that `ua` still works as a command
     Scenario Outline: Verify autocomplete options
@@ -309,6 +310,64 @@ Feature: Command behaviour when unattached
           | release |
           # | xenial  | Can't rely on Xenial because of bash sorting things weirdly
           | bionic  |
+
+    @series.focal
+    @series.jammy
+    @series.lunar
+    @uses.config.machine_type.lxd-container
+    # Side effect: this verifies that `ua` still works as a command
+    Scenario Outline: Verify autocomplete options
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I prepare the autocomplete test
+        And I press tab twice to autocomplete the `ua` command
+        Then stdout matches regexp:
+        """
+        --debug    +auto-attach   +enable   +status\r
+        --help     +collect-logs  +fix      +system\r
+        --version  +config        +help     +version\r
+        api        +detach        +refresh  +\r
+        attach     +disable       +security-status
+        """
+        When I press tab twice to autocomplete the `pro` command
+        Then stdout matches regexp:
+        """
+        --debug    +auto-attach   +enable   +status\r
+        --help     +collect-logs  +fix      +system\r
+        --version  +config        +help     +version\r
+        api        +detach        +refresh  +\r
+        attach     +disable       +security-status
+        """
+        When I press tab twice to autocomplete the `ua enable` command
+        Then stdout matches regexp:
+        """
+        cc-eal  +fips +realtime-kernel +usg\r
+        esm-apps +fips-updates +ros +\r
+        esm-infra +livepatch +ros-updates +\r
+        """
+        When I press tab twice to autocomplete the `pro enable` command
+        Then stdout matches regexp:
+        """
+        cc-eal  +fips +realtime-kernel +usg\r
+        esm-apps +fips-updates +ros +\r
+        esm-infra +livepatch +ros-updates +\r
+        """
+        When I press tab twice to autocomplete the `ua disable` command
+        Then stdout matches regexp:
+        """
+        cc-eal  +fips +realtime-kernel +usg\r
+        esm-apps +fips-updates +ros +\r
+        esm-infra +livepatch +ros-updates +\r
+        """
+        When I press tab twice to autocomplete the `pro disable` command
+        Then stdout matches regexp:
+        """
+        cc-eal  +fips +realtime-kernel +usg\r
+        esm-apps +fips-updates +ros +\r
+        esm-infra +livepatch +ros-updates +\r
+        """
+
+        Examples: ubuntu release
+          | release |
           | focal   |
           | jammy   |
           # | kinetic | There is a very weird error on Kinetic, irrelevant to this test

--- a/tools/ua.bash
+++ b/tools/ua.bash
@@ -1,25 +1,35 @@
 # bash completion for ubuntu-advantage-tools
 
+. /etc/os-release  # For VERSION_ID
+
 _ua_complete()
 {
     local cur_word prev_word services subcmds base_params
     cur_word="${COMP_WORDS[COMP_CWORD]}"
     prev_word="${COMP_WORDS[COMP_CWORD-1]}"
 
-    services=$(python3 -c "from uaclient.entitlements import valid_services; from uaclient.config import UAConfig; print(*valid_services(cfg=UAConfig()), sep=' ')
-")
-    subcmds=$(pro --help | awk '/^\s*$|^\s{5,}|Available|Use/ {next;} /Flags:/{check=1;next}/Use ubuntu-avantage/{check=0}check{ if ( $1 ~ /,/ ) { print $2} else print $1}')
+    if [ "$VERSION_ID" = "16.04" ] || [ "$VERSION_ID" == "18.04" ]; then
+        services="cc-eal cis esm-apps esm-infra fips fips-updates livepatch realtime-kernel ros ros-updates"
+    else
+        services="cc-eal esm-apps esm-infra fips fips-updates livepatch realtime-kernel ros ros-updates usg"
+    fi
+
+    subcmds="--debug --help --version api attach auto-attach collect-logs config detach disable enable fix help refresh security-status status system version"
     base_params=""
+
     case ${COMP_CWORD} in
         1)
+            # shellcheck disable=SC2207
             COMPREPLY=($(compgen -W "$base_params $subcmds" -- $cur_word))
             ;;
         2)
             case ${prev_word} in
                 disable)
+                    # shellcheck disable=SC2207
                     COMPREPLY=($(compgen -W "$services" -- $cur_word))
                     ;;
                 enable)
+                    # shellcheck disable=SC2207
                     COMPREPLY=($(compgen -W "$services" -- $cur_word))
                     ;;
             esac


### PR DESCRIPTION
## Why is this needed?
Instead of relying on pro --help and the valid_services function, we are now directly listing the available services and commands. The reason for that is because the past approach was making unwanted requests to the contract server.

Fixes: #2556


## Test Steps
Check if the modified integration tests are still working

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
