### PR TITLE
cli: warn users not to use human readable output in scripts (SC-1553)

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -192,8 +192,12 @@ Feature: Command behaviour when unattached
         When I reboot the machine
         Then I verify that no files exist matching `/run/ubuntu-advantage/candidate-version`
         When I run `pro status` with sudo
-        Then I will see the following on stderr
+        Then stderr does not match regexp:
         """
+        .*\[info\].* A new version is available: 99.9.9
+        Please run:
+            sudo apt-get install ubuntu-advantage-tools
+        to get the latest version with new features and bug fixes.
         """
         And I verify that files exist matching `/run/ubuntu-advantage/candidate-version`
         # We forge a candidate to see results
@@ -211,8 +215,12 @@ Feature: Command behaviour when unattached
         to get the latest version with new features and bug fixes.
         """
         When I run `pro status --format json` as non-root
-        Then I will see the following on stderr
+        Then stderr does not match regexp:
         """
+        .*\[info\].* A new version is available: 99.9.9
+        Please run:
+            sudo apt-get install ubuntu-advantage-tools
+        to get the latest version with new features and bug fixes.
         """
         When I run `pro config show` as non-root
         Then stderr matches regexp:
@@ -233,14 +241,22 @@ Feature: Command behaviour when unattached
         \"code\": \"new-version-available\"
         """
         When I run `pro api u.pro.version.v1` as non-root
-        Then I will see the following on stderr
+        Then stderr does not match regexp:
         """
+        .*\[info\].* A new version is available: 99.9.9
+        Please run:
+            sudo apt-get install ubuntu-advantage-tools
+        to get the latest version with new features and bug fixes.
         """
         When I run `apt-get update` with sudo
         # apt-get update will bring a new candidate, which is the current installed version
         And I run `pro status` as non-root
-        Then I will see the following on stderr
+        Then stderr does not match regexp:
         """
+        .*\[info\].* A new version is available: 99.9.9
+        Please run:
+            sudo apt-get install ubuntu-advantage-tools
+        to get the latest version with new features and bug fixes.
         """
 
         Examples: ubuntu release

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -424,3 +424,98 @@ Feature: Command behaviour when unattached
           | kinetic | python3.10     |                         |
           # Lunar has a BIG error message explaining why this is a clear user error...
           | lunar   | python3.11     | --break-system-packages |
+
+
+    @series.all
+    @uses.config.machine_type.lxd-container
+    Scenario Outline: Warn users not to redirect/pipe human readable output
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run shell command `pro version | cat` as non-root
+        Then I will see the following on stderr
+        """
+        """
+        When I run shell command `pro version > version_out` as non-root
+        Then I will see the following on stderr
+        """
+        """
+        When I run shell command `pro status | cat` as non-root
+        Then I will see the following on stderr
+        """
+        WARNING: this output is intended to be human readable, and subject to change.
+        In scripts, prefer using machine readable data from the `pro api` command,
+        or use `pro status --format json`.
+        """
+        When I run shell command `pro status | cat` with sudo
+        Then I will see the following on stderr
+        """
+        WARNING: this output is intended to be human readable, and subject to change.
+        In scripts, prefer using machine readable data from the `pro api` command,
+        or use `pro status --format json`.
+        """
+        When I run shell command `pro status > status_out` as non-root
+        Then I will see the following on stderr
+        """
+        WARNING: this output is intended to be human readable, and subject to change.
+        In scripts, prefer using machine readable data from the `pro api` command,
+        or use `pro status --format json`.
+        """
+        When I run shell command `pro status > status_out` with sudo
+        Then I will see the following on stderr
+        """
+        WARNING: this output is intended to be human readable, and subject to change.
+        In scripts, prefer using machine readable data from the `pro api` command,
+        or use `pro status --format json`.
+        """
+        When I run shell command `pro status --format tabular | cat` as non-root
+        Then I will see the following on stderr
+        """
+        WARNING: this output is intended to be human readable, and subject to change.
+        In scripts, prefer using machine readable data from the `pro api` command,
+        or use `pro status --format json`.
+        """
+        When I run shell command `pro status --format tabular > status_out` as non-root
+        Then I will see the following on stderr
+        """
+        WARNING: this output is intended to be human readable, and subject to change.
+        In scripts, prefer using machine readable data from the `pro api` command,
+        or use `pro status --format json`.
+        """
+        When I run shell command `pro status --format json | cat` as non-root
+        Then I will see the following on stderr
+        """
+        """
+        When I run shell command `pro status --format json > status_out` as non-root
+        Then I will see the following on stderr
+        """
+        """
+        When I run shell command `pro security-status | cat` as non-root
+        Then I will see the following on stderr
+        """
+        WARNING: this output is intended to be human readable, and subject to change.
+        In scripts, prefer using machine readable data from the `pro api` command,
+        or use `pro security-status --format json`.
+        """
+        When I run shell command `pro security-status > status_out` as non-root
+        Then I will see the following on stderr
+        """
+        WARNING: this output is intended to be human readable, and subject to change.
+        In scripts, prefer using machine readable data from the `pro api` command,
+        or use `pro security-status --format json`.
+        """
+        When I run shell command `pro security-status --format json | cat` as non-root
+        Then I will see the following on stderr
+        """
+        """
+        When I run shell command `pro security-status --format json > status_out` as non-root
+        Then I will see the following on stderr
+        """
+        """
+
+        Examples: ubuntu release
+          | release |
+          | xenial  |
+          | bionic  |
+          | focal   |
+          | jammy   |
+          | kinetic |
+          | lunar   |

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1865,6 +1865,21 @@ def _warn_about_new_version(cmd_args=None) -> None:
         logging.warning(NEW_VERSION_NOTICE.format(version=new_version))
 
 
+def _warn_about_output_redirection(cmd_args) -> None:
+    """Warn users that the user readable output may change."""
+    if (
+        cmd_args.command in ("status", "security-status")
+        and not sys.stdout.isatty()
+    ):
+        if hasattr(cmd_args, "format") and cmd_args.format in ("json", "yaml"):
+            return
+        logging.warning(
+            messages.WARNING_HUMAN_READABLE_OUTPUT.format(
+                command=cmd_args.command
+            )
+        )
+
+
 def setup_logging(console_level, log_level, log_file=None, logger=None):
     """Setup console logging and debug logging to log_file
 
@@ -2037,6 +2052,9 @@ def main(sys_argv=None):
         logging.debug(
             "Executed with environment variables: %r" % pro_environment
         )
+
+    _warn_about_output_redirection(args)
+
     return_value = args.action(args, cfg=cfg)
 
     _warn_about_new_version(args)

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -1332,3 +1332,9 @@ PRO_HELP_SERVICE_INFO = NamedMessage(
     "pro-help-service-info",
     "Use pro help <service> to get more details about each service",
 )
+
+WARNING_HUMAN_READABLE_OUTPUT = """\
+WARNING: this output is intended to be human readable, and subject to change.
+In scripts, prefer using machine readable data from the `pro api` command,
+or use `pro {command} --format json`.
+"""


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we will change human readable outputs and, if people are scripting it, we want to warn them that there is machine readable output instead.

## Test Steps
Run the new integration test

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
