### PR TITLE
auto-attach: add new return code

### DIFF
--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -64,6 +64,7 @@ def attach_with_token(
         # Persist updated status in the event of partial attach
         ua_status.status(cfg=cfg)
         update_motd_messages(cfg)
+        # raise this exception in case we cannot enable all services
         raise exc
 
     current_iid = identity.get_instance_id()

--- a/uaclient/api/exceptions.py
+++ b/uaclient/api/exceptions.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 from uaclient import messages
 from uaclient.api.errors import APIError
 from uaclient.exceptions import (
@@ -7,6 +5,7 @@ from uaclient.exceptions import (
     ConnectivityError,
     ContractAPIError,
     EntitlementNotFoundError,
+    EntitlementsNotEnabledError,
     InvalidProImage,
     LockHeldError,
     NonAutoAttachImageError,
@@ -24,22 +23,8 @@ __all__ = [
     "NonAutoAttachImageError",
     "UrlError",
     "UserFacingError",
+    "EntitlementsNotEnabledError",
 ]
-
-
-class EntitlementsNotEnabledError(UserFacingError):
-    def __init__(
-        self, failed_services: List[Tuple[str, messages.NamedMessage]]
-    ):
-        info_dicts = [
-            {"name": f[0], "code": f[1].name, "title": f[1].msg}
-            for f in failed_services
-        ]
-        super().__init__(
-            messages.ENTITLEMENTS_NOT_ENABLED_ERROR.msg,
-            messages.ENTITLEMENTS_NOT_ENABLED_ERROR.name,
-            additional_info={"services": info_dicts},
-        )
 
 
 class AutoAttachDisabledError(UserFacingError):

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -1,5 +1,5 @@
 import textwrap
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from urllib import error
 
 from uaclient import messages
@@ -335,6 +335,45 @@ class EntitlementNotFoundError(UserFacingError):
     def __init__(self, entitlement_name: str):
         msg = messages.ENTITLEMENT_NOT_FOUND.format(name=entitlement_name)
         super().__init__(msg=msg.msg, msg_code=msg.name)
+
+
+class EntitlementsNotEnabledError(UserFacingError):
+
+    exit_code = 4
+
+    def __init__(
+        self,
+        failed_services: List[Tuple[str, messages.NamedMessage]],
+        msg: messages.NamedMessage = messages.ENTITLEMENTS_NOT_ENABLED_ERROR,
+    ):
+        info_dicts = [
+            {"name": f[0], "code": f[1].name, "title": f[1].msg}
+            for f in failed_services
+        ]
+        super().__init__(
+            msg=msg.msg,
+            msg_code=msg.name,
+            additional_info={"services": info_dicts},
+        )
+
+
+class AttachFailureDefaultServices(EntitlementsNotEnabledError):
+    def __init__(
+        self, failed_services: List[Tuple[str, messages.NamedMessage]]
+    ):
+        super().__init__(
+            failed_services=failed_services,
+            msg=messages.ATTACH_FAILURE_DEFAULT_SERVICES,
+        )
+
+
+class AttachFailureUnknownError(EntitlementsNotEnabledError):
+    def __init__(
+        self, failed_services: List[Tuple[str, messages.NamedMessage]]
+    ):
+        super().__init__(
+            failed_services=failed_services, msg=messages.UNEXPECTED_ERROR
+        )
 
 
 class UrlError(IOError):

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -478,7 +478,7 @@ ALREADY_ENABLED = FormattedNamedMessage(
 )
 
 ENABLED_FAILED = FormattedNamedMessage(
-    "enable-failes", "Could not enable {title}."
+    "enable-failed", "Could not enable {title}."
 )
 
 UNENTITLED = FormattedNamedMessage(


### PR DESCRIPTION
## Why is this needed?
If we can attach the machine, but we fail to enable any service during the process, we will exit with a return code of 3

## Test Steps
Verify that the new unit test is working as expected

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
