### PR TITLE
variant: save info on public machine token file

### DIFF
--- a/uaclient/contract_data_types.py
+++ b/uaclient/contract_data_types.py
@@ -91,6 +91,18 @@ class AccountInfo(DataObject):
         self.externalAccountIDs = externalAccountIDs
 
 
+class PlatformChecks(DataObject):
+    fields = [
+        Field("cpu_vendor_ids", data_list(StringDataValue), False),
+    ]
+
+    def __init__(
+        self,
+        cpu_vendor_ids: Optional[List[str]],
+    ):
+        self.cpu_vendor_ids = cpu_vendor_ids
+
+
 class Affordances(DataObject):
     fields = [
         Field("architectures", data_list(StringDataValue), False),
@@ -100,6 +112,7 @@ class Affordances(DataObject):
         Field("minKernelVersion", StringDataValue, False),
         Field("tier", StringDataValue, False),
         Field("supportLevel", StringDataValue, False),
+        Field("platformChecks", PlatformChecks, False),
     ]
 
     def __init__(
@@ -111,6 +124,7 @@ class Affordances(DataObject):
         minKernelVersion: Optional[str],
         tier: Optional[str],
         supportLevel: Optional[str],
+        platformChecks: Optional[PlatformChecks],
     ):
         self.architectures = architectures
         self.presentedAs = presentedAs
@@ -119,6 +133,7 @@ class Affordances(DataObject):
         self.minKernelVersion = minKernelVersion
         self.tier = tier
         self.supportLevel = supportLevel
+        self.platformChecks = platformChecks
 
 
 class Obligations(DataObject):
@@ -176,15 +191,18 @@ class OverrideSelector(DataObject):
     fields = [
         Field("series", StringDataValue, False),
         Field("cloud", StringDataValue, False),
+        Field("variant", StringDataValue, False),
     ]
 
     def __init__(
         self,
         series: Optional[str],
         cloud: Optional[str],
+        variant: Optional[str],
     ):
         self.series = series
         self.cloud = cloud
+        self.variant = variant
 
 
 class Override(DataObject):

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -579,6 +579,7 @@ def depth_first_merge_overlay_dict(base_dict, overlay_dict):
         merge_id_key_map = {
             "availableResources": "name",
             "resourceEntitlements": "type",
+            "overrides": "selector",
         }
         values_to_append = []
         id_key = merge_id_key_map.get(key)


### PR DESCRIPTION
## Why is this needed?
Save variant related information on the public machine token file. This allow non-root users to see variant information when running pro status

## Test Steps
1. Launch a jammy machine
2. Attach a staging token
3. run pro status as non-root and confirm that you can variant information

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
