### PR TITLE
tests: do not delete user ssh keys on cleanup

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -524,9 +524,11 @@ def after_all(context):
 
     if context.pro_config.destroy_instances:
         try:
-            key_pair = context.pro_config.default_cloud.api.key_pair
-            os.remove(key_pair.private_key_path)
-            os.remove(key_pair.public_key_path)
+            if context.pro_config.default_cloud._ssh_key_managed:
+                key_pair = context.pro_config.default_cloud.api.key_pair
+                os.remove(key_pair.private_key_path)
+                os.remove(key_pair.public_key_path)
+
         except Exception as e:
             logging.error(
                 "Failed to delete instance ssh keys:\n{}".format(str(e))


### PR DESCRIPTION
## Why is this needed?

If we have not set the ssh keys when running integration tests, we might accidentally delete the ssh keys stored in the user .ssh folder. We are checking to see if the keys are stored in that folder before deleting it

## Test Steps
Run any integration test requesting the `wip` tag to be present. Certify that no test will run and the `.ssh` keys are not deleted.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
