### PR TITLE
Release 28 rc feedback

### DIFF
--- a/systemd/ua-auto-attach.service
+++ b/systemd/ua-auto-attach.service
@@ -1,5 +1,15 @@
+# This unit is delivered by the ubuntu-advantage-pro package and should
+# only be installed on Ubuntu Pro images for use in public clouds that
+# support them (AWS, Azure, GCP).
+# On boot, if the instance has not already successfully attached to Ubuntu
+# Pro services, it will attempt to "auto attach" by querying the cloud's
+# attested metadata and sending it to https://contracts.canonical.com.
+# If Canonical servers successfully verify that the metadata says this
+# instance is entitled to Ubuntu Pro, then it allows the attachment
+# process to continue and Ubuntu Pro services get enabled.
+
 [Unit]
-Description=Ubuntu Advantage auto attach
+Description=Ubuntu Pro auto attach
 Before=cloud-config.service
 After=cloud-config.target
 

--- a/systemd/ua-reboot-cmds.service
+++ b/systemd/ua-reboot-cmds.service
@@ -1,3 +1,10 @@
+# On machines that are currently attached to Ubuntu Pro services, sometimes an action
+# is required immediately after the next reboot.
+# In those situations, a marker file is created that activates this service on the next boot.
+# Circumstances that could cause this include:
+#   - Upgrading from one LTS to the next LTS: to account for service availability changes between releases
+#   - Pro FIPS images with outstanding apt hold on FIPS packages: to clear the holds
+
 [Unit]
 Description=Ubuntu Pro reboot cmds
 ConditionPathExists=/var/lib/ubuntu-advantage/marker-reboot-cmds-required

--- a/systemd/ua-timer.service
+++ b/systemd/ua-timer.service
@@ -1,5 +1,12 @@
+# On machines that are currently attached to Ubuntu Pro services, some tasks need to run
+# periodically in the background to maintain the state of the Ubuntu Pro services.
+# These include:
+#  - Periodically ping https://contracts.canonical.com for metering and to check the contract expiration
+#  - If this contract is about to expire, add notification messages to MOTD
+# Triggered by ua-timer.timer
+
 [Unit]
-Description=Ubuntu Advantage Timer for running repeated jobs
+Description=Ubuntu Pro Timer for running repeated jobs
 After=network.target network-online.target systemd-networkd.service ua-auto-attach.service
 
 [Service]

--- a/systemd/ua-timer.timer
+++ b/systemd/ua-timer.timer
@@ -1,3 +1,5 @@
+# See ua-timer.service for a description of why this exists.
+
 [Unit]
 Description=Ubuntu Pro Timer for running repeated jobs
 # Only run if attached

--- a/systemd/ubuntu-advantage.service
+++ b/systemd/ubuntu-advantage.service
@@ -1,5 +1,5 @@
-# This service runs on GCP to enable auto-attaching to Ubuntu Advantage
-# services when an Ubuntu Pro license is added to a GCP machine.
+# This service runs on GCP and Azure to enable auto-attaching to Ubuntu Pro
+# services when an Ubuntu Pro license is added to a machine.
 # It also serves as the retry service if an auto-attach fails and will
 # retry for up to one month after the failed attempt.
 # If you are uninterested in Ubuntu Pro services, then you can safely

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -253,14 +253,14 @@ class RepoEntitlement(base.UAEntitlement):
             event.info("Installing {title} packages".format(title=self.title))
 
         if self.apt_noninteractive:
-            env = {"DEBIAN_FRONTEND": "noninteractive"}
+            override_env_vars = {"DEBIAN_FRONTEND": "noninteractive"}
             apt_options = [
                 "--allow-downgrades",
                 '-o Dpkg::Options::="--force-confdef"',
                 '-o Dpkg::Options::="--force-confold"',
             ]
         else:
-            env = {}
+            override_env_vars = None
             apt_options = []
 
         try:
@@ -269,7 +269,7 @@ class RepoEntitlement(base.UAEntitlement):
                 packages=package_list,
                 apt_options=apt_options,
                 error_msg=msg.msg,
-                env=env,
+                override_env_vars=override_env_vars,
             )
         except exceptions.UserFacingError:
             if cleanup_on_failure:

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -192,7 +192,7 @@ class TestCommonCriteriaEntitlementEnable:
                     ["apt-get", "install", "--assume-yes"] + prerequisite_pkgs,
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
-                    env={},
+                    override_env_vars=None,
                 )
             )
         else:
@@ -204,7 +204,7 @@ class TestCommonCriteriaEntitlementEnable:
                     ["apt-get", "update"],
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
-                    env={},
+                    override_env_vars=None,
                 ),
                 mock.call(
                     [
@@ -218,7 +218,7 @@ class TestCommonCriteriaEntitlementEnable:
                     + entitlement.packages,
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
-                    env={"DEBIAN_FRONTEND": "noninteractive"},
+                    override_env_vars={"DEBIAN_FRONTEND": "noninteractive"},
                 ),
             ]
         )

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -106,7 +106,7 @@ class TestCISEntitlementEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env={},
+                override_env_vars=None,
             ),
             mock.call(
                 [
@@ -120,7 +120,7 @@ class TestCISEntitlementEnable:
                 + entitlement.packages,
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env={"DEBIAN_FRONTEND": "noninteractive"},
+                override_env_vars={"DEBIAN_FRONTEND": "noninteractive"},
             ),
         ]
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -365,7 +365,7 @@ class TestFIPSEntitlementEnable:
                 + patched_packages,
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env={"DEBIAN_FRONTEND": "noninteractive"},
+                override_env_vars={"DEBIAN_FRONTEND": "noninteractive"},
             )
         )
 
@@ -383,7 +383,7 @@ class TestFIPSEntitlementEnable:
                     ],
                     capture=True,
                     retry_sleeps=apt.APT_RETRIES,
-                    env={"DEBIAN_FRONTEND": "noninteractive"},
+                    override_env_vars={"DEBIAN_FRONTEND": "noninteractive"},
                 )
             )
 
@@ -392,13 +392,13 @@ class TestFIPSEntitlementEnable:
                 ["apt-mark", "showholds"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env={},
+                override_env_vars=None,
             ),
             mock.call(
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env={},
+                override_env_vars=None,
             ),
         ]
         subp_calls += install_cmd
@@ -851,7 +851,7 @@ class TestFIPSEntitlementRemovePackages:
             ],
             capture=True,
             retry_sleeps=apt.APT_RETRIES,
-            env={"DEBIAN_FRONTEND": "noninteractive"},
+            override_env_vars={"DEBIAN_FRONTEND": "noninteractive"},
         )
         if "ubuntu-fips" in installed_pkgs:
             assert [remove_cmd] == m_subp.call_args_list
@@ -1121,7 +1121,7 @@ class TestFipsEntitlementInstallPackages:
                         '-o Dpkg::Options::="--force-confold"',
                     ],
                     error_msg="Could not enable {}.".format(entitlement.title),
-                    env={"DEBIAN_FRONTEND": "noninteractive"},
+                    override_env_vars={"DEBIAN_FRONTEND": "noninteractive"},
                 )
             )
 

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -466,7 +466,7 @@ class TestRepoEnable:
                 ["apt-get", "update"],
                 capture=True,
                 retry_sleeps=apt.APT_RETRIES,
-                env={},
+                override_env_vars=None,
             )
         ]
 
@@ -491,7 +491,7 @@ class TestRepoEnable:
                         ],
                         capture=True,
                         retry_sleeps=apt.APT_RETRIES,
-                        env={},
+                        override_env_vars=None,
                     )
                 )
                 expected_output = (

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -1675,7 +1675,7 @@ def upgrade_packages_and_attach(
             apt.run_apt_command(
                 cmd=["apt-get", "install", "--only-upgrade", "-y"]
                 + upgrade_pkgs,
-                env={"DEBIAN_FRONTEND": "noninteractive"},
+                override_env_vars={"DEBIAN_FRONTEND": "noninteractive"},
             )
         except Exception as e:
             msg = getattr(e, "msg", str(e))


### PR DESCRIPTION
See https://code.launchpad.net/~orndorffgrant/ubuntu/+source/ubuntu-advantage-tools/+git/ubuntu-advantage-tools/+merge/443833/comments/1184537 for the reasoning behind these changes.

Copying the commit message about the changes to subp env here for convenience:
```
refactor: replace confusing env arg to subp

The only reason the env argument was used was for inserting values that
were intended to be additional environment variables on top of the
current process' environment. There were also issues with modifying
default arg values and modifying caller-provided dicts to the env
argument.

To address this, I'm renaming the argument to make it clear it is
treated differently than the stdlib's "env" argument to various
subprocess functions. I've also removed all related default arg values
of {} to avoid accidentally modifying them. And I've changed the
use of the new argument to correctly extend os.environ without
modifying caller state.
```