### PR TITLE
chore: bump development version in the changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-ubuntu-advantage-tools (28.0) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (1:1+devel) UNRELEASED; urgency=medium
 
-  * Open 28.0 for active development
+  * Open a new epoch for active development
 
- -- Chad Smith <chad.smith@canonical.com>  Wed, 19 May 2021 16:35:25 -0600
+ -- Renan Rodrigo <renanrodrigo@canonical.com>  Tue, 20 Jun 2023 14:50:11 -0600
 
 ubuntu-advantage-tools (27.14.4) lunar; urgency=medium
 

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -194,7 +194,7 @@ Feature: Command behaviour when unattached
         When I run `pro status` with sudo
         Then stderr does not match regexp:
         """
-        .*\[info\].* A new version is available: 99.9.9
+        .*\[info\].* A new version is available: 2:99.9.9
         Please run:
             sudo apt-get install ubuntu-advantage-tools
         to get the latest version with new features and bug fixes.
@@ -204,12 +204,12 @@ Feature: Command behaviour when unattached
         When I delete the file `/run/ubuntu-advantage/candidate-version`
         And I create the file `/run/ubuntu-advantage/candidate-version` with the following
         """
-        99.9.9
+        2:99.9.9
         """
         And I run `pro status` as non-root
         Then stderr matches regexp:
         """
-        .*\[info\].* A new version is available: 99.9.9
+        .*\[info\].* A new version is available: 2:99.9.9
         Please run:
             sudo apt-get install ubuntu-advantage-tools
         to get the latest version with new features and bug fixes.
@@ -217,7 +217,7 @@ Feature: Command behaviour when unattached
         When I run `pro status --format json` as non-root
         Then stderr does not match regexp:
         """
-        .*\[info\].* A new version is available: 99.9.9
+        .*\[info\].* A new version is available: 2:99.9.9
         Please run:
             sudo apt-get install ubuntu-advantage-tools
         to get the latest version with new features and bug fixes.
@@ -225,7 +225,7 @@ Feature: Command behaviour when unattached
         When I run `pro config show` as non-root
         Then stderr matches regexp:
         """
-        .*\[info\].* A new version is available: 99.9.9
+        .*\[info\].* A new version is available: 2:99.9.9
         Please run:
             sudo apt-get install ubuntu-advantage-tools
         to get the latest version with new features and bug fixes.
@@ -243,7 +243,7 @@ Feature: Command behaviour when unattached
         When I run `pro api u.pro.version.v1` as non-root
         Then stderr does not match regexp:
         """
-        .*\[info\].* A new version is available: 99.9.9
+        .*\[info\].* A new version is available: 2:99.9.9
         Please run:
             sudo apt-get install ubuntu-advantage-tools
         to get the latest version with new features and bug fixes.
@@ -253,7 +253,7 @@ Feature: Command behaviour when unattached
         And I run `pro status` as non-root
         Then stderr does not match regexp:
         """
-        .*\[info\].* A new version is available: 99.9.9
+        .*\[info\].* A new version is available: 2:99.9.9
         Please run:
             sudo apt-get install ubuntu-advantage-tools
         to get the latest version with new features and bug fixes.

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -15,7 +15,7 @@ from uaclient.defaults import CANDIDATE_CACHE_PATH, UAC_RUN_PATH
 from uaclient.exceptions import ProcessExecutionError
 from uaclient.system import subp
 
-__VERSION__ = "28.0"
+__VERSION__ = "1:1+devel"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 CANDIDATE_REGEX = r"Candidate: (?P<candidate>.*?)\n"


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we used to have 28 as the devel version, but now 28 is being released, and will be followed by 29, 30, etc - bumping an epoch makes the devel version greater than any released version. Making 'devel' part of the version makes it explicit that this is not a supported version.

## Test Steps
build from source locally
install the deb
see version is now `1:1+devel'

## Checklist
 - [n/a] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
