### PR TITLE
Rename more ubuntu-advantage occurrences to ubuntu-pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </h1>
 
 ###### Clean and Consistent CLI for your Ubuntu Pro Systems
-[![Latest Upstream Version](https://img.shields.io/github/v/tag/canonical/ubuntu-advantage-client.svg?label=Latest%20Upstream%20Version&logo=github&logoColor=white&color=33ce57)](https://github.com/canonical/ubuntu-pro-client/tags)
-[![CI](https://github.com/canonical/ubuntu-advantage-client/actions/workflows/ci-base.yaml/badge.svg?branch=main)](https://github.com/canonical/ubuntu-pro-client/actions)
+[![Latest Upstream Version](https://img.shields.io/github/v/tag/canonical/ubuntu-pro-client.svg?label=Latest%20Upstream%20Version&logo=github&logoColor=white&color=33ce57)](https://github.com/canonical/ubuntu-pro-client/tags)
+[![CI](https://github.com/canonical/ubuntu-pro-client/actions/workflows/ci-base.yaml/badge.svg?branch=main)](https://github.com/canonical/ubuntu-pro-client/actions)
 [![Documentation Status](https://readthedocs.com/projects/canonical-ubuntu-pro-client/badge/?version=latest)](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/?badge=latest)
 <br/>
 [![Released Xenial Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/xenial?label=Xenial&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/xenial/+source/ubuntu-advantage-tools)

--- a/debian/control
+++ b/debian/control
@@ -26,8 +26,8 @@ Build-Depends: bash-completion,
                python3-yaml
 Standards-Version: 4.5.1
 Homepage: https://ubuntu.com/advantage
-Vcs-Git: https://github.com/canonical/ubuntu-advantage-client.git
-Vcs-Browser: https://github.com/canonical/ubuntu-advantage-client
+Vcs-Git: https://github.com/canonical/ubuntu-pro-client.git
+Vcs-Browser: https://github.com/canonical/ubuntu-pro-client
 Rules-Requires-Root: no
 
 Package: ubuntu-advantage-tools

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,9 +1,9 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: ubuntu-advantage-script
-Source: https://github.com/CanonicalLtd/ubuntu-advantage-script
+Upstream-Name: ubuntu-pro-client
+Source: https://github.com/canonical/ubuntu-pro-client
 
 Files: *
-Copyright: 2017, Canonical Ltd
+Copyright: 2023, Canonical Ltd
 License: GPL-3.0
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/dev-docs/howtoguides/code_formatting.md
+++ b/dev-docs/howtoguides/code_formatting.md
@@ -1,6 +1,6 @@
 # Code Formatting
 
-The `ubuntu-advantage-client` code base is formatted using
+The `ubuntu-pro-client` code base is formatted using
 [black](https://github.com/psf/black), and imports are sorted with
 [isort](https://github.com/PyCQA/isort).  When making changes, you
 should ensure that your code is blackened and isorted, or it will

--- a/dev-docs/howtoguides/release_a_new_version.md
+++ b/dev-docs/howtoguides/release_a_new_version.md
@@ -133,7 +133,7 @@ If this is your first time releasing ubuntu-advantage-tools, you'll need to do t
 
     a. `git-ubuntu clone ubuntu-advantage-tools; cd ubuntu-advantage-tools`
 
-    b. `git remote add upstream git@github.com:canonical/ubuntu-advantage-client.git`
+    b. `git remote add upstream git@github.com:canonical/ubuntu-pro-client.git`
 
     c. `git fetch upstream`
 
@@ -195,7 +195,7 @@ If this is your first time releasing ubuntu-advantage-tools, you'll need to do t
 
     b. With the package in proposed, perform the steps from `I.3` above but use a `~stableppaX` suffix instead of `~rcX` in the version name, and upload to `ppa:ua-client/stable` instead of staging.
 
-    c. Perform the [Ubuntu-advantage-client SRU verification steps](https://wiki.ubuntu.com/UbuntuAdvantageToolsUpdates). This typically involves running all behave targets with `UACLIENT_BEHAVE_ENABLE_PROPOSED=1 UACLIENT_BEHAVE_CHECK_VERSION=<this-version>` and saving the output.
+    c. Perform the [Ubuntu-advantage-tools SRU verification steps](https://wiki.ubuntu.com/UbuntuAdvantageToolsUpdates). This typically involves running all behave targets with `UACLIENT_BEHAVE_ENABLE_PROPOSED=1 UACLIENT_BEHAVE_CHECK_VERSION=<this-version>` and saving the output.
       * There may also be one-time test scripts added in the `sru/` directory for this release.
 
     d. After all tests have passed, tarball all of the output files and upload them to the SRU bug with a message that looks like this:

--- a/dev-docs/howtoguides/testing.md
+++ b/dev-docs/howtoguides/testing.md
@@ -50,7 +50,7 @@ The testing can be overridden to install ubuntu-advantage-tools from other sourc
 - `archive`: install the latest version available in the archive, not adding any PPA
 - `proposed`: install the package from the -proposed pocket - specially useful for SRU testing (see [the release guide](how_to_release_a_new_version_of_ua.md))
 - `custom`: install from a custom provided PPA. If set, then two other variables need to be set: `UACLIENT_BEHAVE_CUSTOM_PPA=<PPA URL>` and `UACLIENT_BEHAVE_CUSTOM_PPA_KEYID=<signing key for the PPA>`.
-- `local`: install from a local copy of the ubuntu-advantage-client source code
+- `local`: install from a local copy of the ubuntu-pro-client source code
 
 `local` is particularly useful, as it runs the suite against the local code, thus including and validating the latest changes made. It is advised to run any related integration tests against local code changes before pushing them to be reviewed.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -285,7 +285,7 @@ constructive feedback.
 .. _Landscape: https://ubuntu.com/landscape
 .. _Report bugs on Launchpad: https://bugs.launchpad.net/ubuntu-advantage-tools/+filebug
 .. _Code of conduct: https://ubuntu.com/community/code-of-conduct
-.. _Contribute: https://github.com/canonical/ubuntu-advantage-client/blob/main/CONTRIBUTING.md
+.. _Contribute: https://github.com/canonical/ubuntu-pro-client/blob/main/CONTRIBUTING.md
 .. _IRC channel on Libera: https://kiwiirc.com/nextclient/irc.libera.chat/ubuntu-server
 .. _our Discourse forum: https://discourse.ubuntu.com/c/ubuntu-pro/116
 .. _in our FAQ: https://discourse.ubuntu.com/t/ubuntu-pro-faq/34042

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2019 Canonical Ltd.
-# This file is part of ubuntu-advantage-client.  See LICENSE file for license.
+# This file is part of ubuntu-pro-client.  See LICENSE file for license.
 
 import glob
 

--- a/sru/README.md
+++ b/sru/README.md
@@ -1,6 +1,6 @@
 # SRU: Collection of Stable Release Update integration tests
 ## Intent
-This is a collection for scripts which have been manually run during the verification of ubuntu-advantage-client SRUs (Stable Release Updates). These scripts and their results were attached to each SRU process bug in order to pass SRU verification and publish that version of ubuntu-advantage-tools. Each subdirectory name will be the launchpad SRU process bug associated with that release. Within the subdir will be scripts that can be manually run to validate certain features of ubuntu-advantage-tools.
+This is a collection for scripts which have been manually run during the verification of ubuntu-advantage-tools SRUs (Stable Release Updates). These scripts and their results were attached to each SRU process bug in order to pass SRU verification and publish that version of ubuntu-advantage-tools. Each subdirectory name will be the launchpad SRU process bug associated with that release. Within the subdir will be scripts that can be manually run to validate certain features of ubuntu-advantage-tools.
 
 The hope is that we can codify these manual scripts into automated behave integration tests in the future and have less and less of this manual work in subsequent SRUs. In the meantime, have a pool of scripts that exercise certain aspects of ua-tools setup and teardown is helpful reference fo future SRUs, and behave integration test writing.
 

--- a/tools/setup_sbuild.sh
+++ b/tools/setup_sbuild.sh
@@ -32,7 +32,7 @@ do
         sudo schroot -c source:"$name" -u root -d / -- apt-get update
         sudo schroot -c source:"$name" -u root -d / -- apt-get dist-upgrade -y
         sudo schroot -c source:"$name" -u root -d / -- apt-get install -y make dpkg-dev git devscripts equivs
-        sudo schroot -c source:"$name" -u root -d / -- git clone --depth 1 https://github.com/canonical/ubuntu-advantage-client /var/tmp/uac
+        sudo schroot -c source:"$name" -u root -d / -- git clone --depth 1 https://github.com/canonical/ubuntu-pro-client /var/tmp/uac
         sudo schroot -c source:"$name" -u root -d / -- make -f /var/tmp/uac/Makefile deps
         sudo schroot -c source:"$name" -u root -d / -- rm -rf /var/tmp/uac
     done

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -534,12 +534,12 @@ def handle_unicode_characters(message: str) -> str:
     ):
         # Replace our Unicode dash with an ASCII dash if we aren't going to be
         # writing to a utf-8 output; see
-        # https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/859
+        # https://github.com/canonical/ubuntu-pro-client/issues/859
         message = message.replace("\u2014", "-")
 
         # Remove our unicode success/failure marks if we aren't going to be
         # writing to a utf-8 output; see
-        # https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/1463
+        # https://github.com/canonical/ubuntu-pro-client/issues/1463
         message = message.replace(messages.OKGREEN_CHECK + " ", "")
         message = message.replace(messages.FAIL_X + " ", "")
 


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we are not advantage anymore, we are pro now.
Plus copyright is updated.