### PR TITLE
fix: ignore non-USN items on related usns

### DIFF
--- a/features/fix.feature
+++ b/features/fix.feature
@@ -687,6 +687,125 @@ Feature: Ua fix command behaviour
 
         .*✔.* USN-4038-3 is resolved.
         """
+        When I run `pro fix USN-6130-1` as non-root
+        Then stdout matches regexp:
+        """
+        USN-6130-1: Linux kernel vulnerabilities
+        Found CVEs:
+         - https://ubuntu.com/security/CVE-2023-30456
+         - https://ubuntu.com/security/CVE-2023-1380
+         - https://ubuntu.com/security/CVE-2023-32233
+         - https://ubuntu.com/security/CVE-2023-31436
+
+        Fixing requested USN-6130-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6130-1 does not affect your system.
+
+        Found related USNs:
+        - USN-6033-1
+        - USN-6122-1
+        - USN-6123-1
+        - USN-6124-1
+        - USN-6127-1
+        - USN-6131-1
+        - USN-6132-1
+        - USN-6135-1
+        - USN-6149-1
+        - USN-6150-1
+        - USN-6162-1
+        - USN-6173-1
+        - USN-6175-1
+        - USN-6186-1
+
+        Fixing related USNs:
+        - USN-6033-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6033-1 does not affect your system.
+
+        - USN-6122-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6122-1 does not affect your system.
+
+        - USN-6123-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6123-1 does not affect your system.
+
+        - USN-6124-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6124-1 does not affect your system.
+
+        - USN-6127-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6127-1 does not affect your system.
+
+        - USN-6131-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6131-1 does not affect your system.
+
+        - USN-6132-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6132-1 does not affect your system.
+
+        - USN-6135-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6135-1 does not affect your system.
+
+        - USN-6149-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6149-1 does not affect your system.
+
+        - USN-6150-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6150-1 does not affect your system.
+
+        - USN-6162-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6162-1 does not affect your system.
+
+        - USN-6173-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6173-1 does not affect your system.
+
+        - USN-6175-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6175-1 does not affect your system.
+
+        - USN-6186-1
+        No affected source packages are installed.
+
+        .*✔.* USN-6186-1 does not affect your system.
+
+        Summary:
+        .*✔.* USN-6130-1 \[requested\] does not affect your system.
+        .*✔.* USN-6033-1 \[related\] does not affect your system.
+        .*✔.* USN-6122-1 \[related\] does not affect your system.
+        .*✔.* USN-6123-1 \[related\] does not affect your system.
+        .*✔.* USN-6124-1 \[related\] does not affect your system.
+        .*✔.* USN-6127-1 \[related\] does not affect your system.
+        .*✔.* USN-6131-1 \[related\] does not affect your system.
+        .*✔.* USN-6132-1 \[related\] does not affect your system.
+        .*✔.* USN-6135-1 \[related\] does not affect your system.
+        .*✔.* USN-6149-1 \[related\] does not affect your system.
+        .*✔.* USN-6150-1 \[related\] does not affect your system.
+        .*✔.* USN-6162-1 \[related\] does not affect your system.
+        .*✔.* USN-6173-1 \[related\] does not affect your system.
+        .*✔.* USN-6175-1 \[related\] does not affect your system.
+        .*✔.* USN-6186-1 \[related\] does not affect your system.
+        """
 
     @series.bionic
     @uses.config.machine_type.lxd-container

--- a/uaclient/security.py
+++ b/uaclient/security.py
@@ -601,6 +601,10 @@ def get_related_usns(usn, client):
     related_usns = {}
     for cve in usn.cves:
         for related_usn_id in cve.notices_ids:
+            # We should ignore any other item that is not a USN
+            # For example, LSNs
+            if not related_usn_id.startswith("USN-"):
+                continue
             if related_usn_id == usn.id:
                 continue
             if related_usn_id not in related_usns:

--- a/uaclient/tests/test_security.py
+++ b/uaclient/tests/test_security.py
@@ -2427,6 +2427,26 @@ class TestGetRelatedUSNs:
 
         assert [] == get_related_usns(usn, client)
 
+    def test_usns_ignore_non_usns_items(self, FakeConfig):
+        expected_value = mock.MagicMock(id="USN-1235-1")
+
+        def fake_get_notice(notice_id):
+            return expected_value
+
+        m_client = mock.MagicMock()
+        m_client.get_notice.side_effect = fake_get_notice
+
+        m_usn = mock.MagicMock(
+            cves=[
+                mock.MagicMock(
+                    notices_ids=["USN-1235-1", "LSN-0088-1"],
+                )
+            ],
+            id="USN-8796-1",
+        )
+
+        assert [expected_value] == get_related_usns(m_usn, m_client)
+
 
 class TestGetUSNAffectedPackagesStatus:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Why is this needed?
When we are gathering related USNs, we must ensure that they are indeed USNs. To do that, we are ignoring any security id that doesn't start with USN

## Test Steps
Run the new integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
