### PR TITLE
Fix simulate status

### DIFF
--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -518,7 +518,7 @@ def simulate_status(
     inapplicable_resources = [
         resource["name"]
         for resource in sorted(resources, key=lambda x: x["name"])
-        if not resource["available"]
+        if not resource["available"] or resource["available"] == "no"
     ]
 
     for resource in resources:


### PR DESCRIPTION
## Why is this needed?
On the --simulate-with-token status flow, we are not addressing the proper status cache format when checking for inapplicable services. Because of that, some services might appear as available. This change address the situation where we are evaluating service availability from the status cache and the contract response

## Test Steps
Run status as root and run the simulate command in a bionic/focal/jammy container and verify that the services listed there are correct


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
