### PR TITLE
Release 28.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+ubuntu-advantage-tools (28.1) mantic; urgency=medium
+
+  * New upstream release 28.1 (LP: #2017949)
+    - fips: ensure shim-signed is updated to the version in the fips repo
+      if necessary
+    - status: fix bug where an existing status cache could influence the
+      simulated status output
+
+ -- Grant Orndorff <grant.orndorff@canonical.com>  Mon, 26 Jun 2023 15:05:11 -0400
+
 ubuntu-advantage-tools (28) mantic; urgency=medium
 
   * d/ubuntu-advantage-tools.postinst:

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -27,6 +27,7 @@ CONDITIONAL_PACKAGES_EVERYWHERE = [
     "strongswan-hmac",
     "openssh-client",
     "openssh-server",
+    "shim-signed",
 ]
 CONDITIONAL_PACKAGES_OPENSSH_HMAC = [
     "openssh-client-hmac",
@@ -112,6 +113,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         "libgcrypt20",
         "libgcrypt20-hmac",
         "fips-initramfs-generic",
+        "shim-signed",
     ]
 
     @property

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -507,20 +507,14 @@ def simulate_status(
             event.info("This token is not valid.\n" + message.msg + "\n")
             ret = 1
 
-    status_cache = cfg.read_cache("status-cache")
-    if status_cache:
-        resources = status_cache.get("services")
-    else:
-        resources = get_available_resources(cfg)
-
-    entitlements = contract_info.get("resourceEntitlements", [])
-
+    resources = get_available_resources(cfg)
     inapplicable_resources = [
         resource["name"]
         for resource in sorted(resources, key=lambda x: x["name"])
         if not resource["available"]
     ]
 
+    entitlements = contract_info.get("resourceEntitlements", [])
     for resource in resources:
         entitlement_name = resource.get("name", "")
         try:

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -15,7 +15,7 @@ from uaclient.defaults import CANDIDATE_CACHE_PATH, UAC_RUN_PATH
 from uaclient.exceptions import ProcessExecutionError
 from uaclient.system import subp
 
-__VERSION__ = "28"
+__VERSION__ = "28.1"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 CANDIDATE_REGEX = r"Candidate: (?P<candidate>.*?)\n"


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
`pro enable fips && reboot` on a focal machine with secureboot resulted in a broken machine.
`pro status && pro status --simulate-with-token token` resulted in inaccurate availability results.
We consider these show-stoppers for release 28.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
tox -e behave-lxd-18.04 -- features/unattached_status.feature -n "Simulate"
tox -e behave-lxd-20.04 -- features/unattached_status.feature -n "Simulate"
tox -e behave-lxd-22.04 -- features/unattached_status.feature -n "Simulate"
tox -e behave-vm-20.04 -- features/enable_fips_vm.feature:394
tox -e behave-vm-20.04 -- features/enable_fips_vm.feature:540
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
