### PR TITLE
debian/README: add file with basic explanation on the source code

### DIFF
--- a/debian/README.source
+++ b/debian/README.source
@@ -1,0 +1,38 @@
+===================================
+Packaging of ubuntu-advantage-tools
+===================================
+
+Development code
+===================================
+
+The development branches of ubuntu-advantage-tools are hosted in GitHub, at:
+https://github.com/canonical/ubuntu-pro-client
+
+New pull requests with contributions either to the codebase itself or to the
+documentation branches should always be opened in GitHub.
+
+Package source code
+===================================
+
+The source code used to build the package is hosted in Launchpad, at:
+https://git.launchpad.net/ubuntu/+source/ubuntu-advantage-tools
+
+The development branch in Launchpad is equivalent to the release branch in
+GitHub. Everytime a new version is released, the content of the GitHub release
+branch is brought in a Merge Request to the Launchpad development branch.
+
+Particularities
+===================================
+
+- ubuntu-advantage-tools ships the same features and bugfixes to all
+  supported Ubuntu releases. This means the package is practically the
+  same across all LTS releases, including the ones in ESM period, and in
+  the interim releases. (The only differences are the specific dependencies,
+  dealt with in the debian/ files when building the package).
+
+- Some test-related files and folders are present in the source package, but
+  are ignored when building the binary packages. debian/rules specifies
+  'pybuild' as the build system, and unit tests / integration tests are
+  excluded in 'setup.py'. As a consequence, changes to the tests are less
+  relevant in SRU reviews: they stil reflect what is being tested in each
+  release, but they do not cause any impact to the stable releases.


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it brings a readme file explaining where the u-a-t source code lives, and files from the source package that are not present in the binaries - and thus don't need a very strict review on SRUs.

This is enough to
Fix: #2463 

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: (well this itself is documentation but different)

## Does this PR require extra reviews?
 - [x] Yes - sergiodj
 - [ ] No
