### PR TITLE
tests: require contract token in the correct tests

### DIFF
--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -2,6 +2,7 @@ Feature: APT Messages
 
     @series.xenial
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario Outline: APT JSON Hook prints package counts correctly on xenial
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -101,6 +102,7 @@ Feature: APT Messages
     @series.bionic
     @series.xenial
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario Outline: APT Hook advertises esm-infra on upgrade
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -159,6 +161,7 @@ Feature: APT Messages
     @series.focal
     @series.jammy
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario Outline: APT Hook advertises esm-apps on upgrade
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -219,6 +222,7 @@ Feature: APT Messages
 
     @series.all
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario Outline: APT News
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -645,6 +649,7 @@ Feature: APT Messages
     @series.kinetic
     @series.lunar
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario Outline: APT Hook do not advertises esm-apps on upgrade for interim releases
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -945,7 +945,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.xenial
     @series.bionic
-    @uses.config.contract_token
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable ros on a machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
@@ -1160,7 +1159,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
     @series.xenial
-    @uses.config.contract_token
     @uses.config.machine_type.lxd-container
     Scenario Outline: APT auth file is edited correctly on enable
         Given a `<release>` machine with ubuntu-advantage-tools installed

--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -1,4 +1,3 @@
-@uses.config.contract_token
 Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
     @series.all
@@ -53,6 +52,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
     @series.lts
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario Outline: Run collect-logs on an attached machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -2,6 +2,7 @@ Feature: Logs in Json Array Formatter
 
     @series.all
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario Outline: The log file can be successfully parsed as json array
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt update` with sudo

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -3,6 +3,7 @@ Feature: MOTD Messages
     @series.xenial
     @series.bionic
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario Outline: Contract update prevents contract expiration messages
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -1,9 +1,9 @@
-@uses.config.contract_token
 Feature: Security status command behavior
 
     @series.xenial
     @series.bionic
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario Outline: Run security status with JSON/YAML format
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -93,6 +93,7 @@ Feature: Security status command behavior
 
     @series.xenial
     @uses.config.machine_type.lxd-vm
+    @uses.config.contract_token
     Scenario: Check for livepatch CVEs in security-status on an Ubuntu machine
         Given a `xenial` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -112,6 +113,7 @@ Feature: Security status command behavior
 
     @series.xenial
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario: Run security status in an Ubuntu machine
         Given a `xenial` machine with ubuntu-advantage-tools installed
         When I install third-party / unknown packages in the machine
@@ -454,6 +456,7 @@ Feature: Security status command behavior
 
     @series.focal
     @uses.config.machine_type.lxd-container
+    @uses.config.contract_token
     Scenario: Run security status in an Ubuntu machine
         Given a `focal` machine with ubuntu-advantage-tools installed
         When I install third-party / unknown packages in the machine

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -1,10 +1,10 @@
-@uses.config.contract_token
 Feature: Upgrade between releases when uaclient is unattached
 
     @slow
     @series.all
     @uses.config.machine_type.lxd-container
     @upgrade
+    @uses.config.contract_token
     Scenario Outline: Unattached upgrade
         Given a `<release>` machine with ubuntu-advantage-tools installed
         # Local PPAs are prepared and served only when testing with local debs


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because now we have the tests which require a token to run well defined.
If the whole feature requires attachment, require it on feature level. If the feature does not imply attachment, require it on scenario level.

## Test Steps
Run the CI suite without a token, see that no test fails because you don't have the token, and that those which require the token were skipped.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly - aha
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
