### PR TITLE
tests: fail if installing from 'prebuilt' but no debs are found

### DIFF
--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -1,12 +1,18 @@
 import datetime
 import logging
+import sys
 from typing import Dict, NamedTuple
 
 from behave import given, when
 from pycloudlib.instance import BaseInstance  # type: ignore
 
 from features.steps.ubuntu_advantage_tools import when_i_install_uat
-from features.util import SUT, InstallationSource, build_debs
+from features.util import (
+    SUT,
+    InstallationSource,
+    build_debs,
+    get_debs_for_series,
+)
 
 MachineTuple = NamedTuple(
     "MachineTuple", [("series", str), ("instance", BaseInstance)]
@@ -140,6 +146,18 @@ def given_a_sut_machine(context, series, machine_type=None):
             series,
             sbuild_output_to_terminal=context.pro_config.sbuild_output_to_terminal,  # noqa: E501
         )
+
+    if context.pro_config.install_from == InstallationSource.PREBUILT:
+        deb_paths = get_debs_for_series(context.pro_config.debs_path, series)
+        if not deb_paths:
+            logging.error(
+                (
+                    "UACLIENT_BEHAVE_INSTALL_FROM is set to 'prebuilt', "
+                    "but no debs for series {} were found in"
+                    "UACLIENT_BEHAVE_DEBS_PATH"
+                ).format(series)
+            )
+            sys.exit(1)
 
     if context.pro_config.snapshot_strategy:
         if "builder" not in context.snapshots:

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import re
 
 from behave import then, when
@@ -7,7 +6,12 @@ from behave import then, when
 from features.steps.files import when_i_create_file_with_content
 from features.steps.packages import when_i_apt_install
 from features.steps.shell import when_i_run_command, when_i_run_shell_command
-from features.util import SUT, InstallationSource, build_debs
+from features.util import (
+    SUT,
+    InstallationSource,
+    build_debs,
+    get_debs_for_series,
+)
 
 
 @when("I install ubuntu-advantage-tools")
@@ -25,12 +29,7 @@ def when_i_install_uat(context, machine_name=SUT):
                 context, "ubuntu-advantage-pro", machine_name=machine_name
             )
     elif context.pro_config.install_from is InstallationSource.PREBUILT:
-        debs_path = context.pro_config.debs_path
-        deb_paths = [
-            os.path.join(debs_path, deb_file)
-            for deb_file in os.listdir(debs_path)
-            if series in deb_file
-        ]
+        deb_paths = get_debs_for_series(context.pro_config.debs_path, series)
         logging.info("using debs: {}".format(deb_paths))
         for deb_path in deb_paths:
             if "pro" not in deb_path or is_pro:

--- a/features/util.py
+++ b/features/util.py
@@ -149,6 +149,14 @@ def repo_state_hash(
     return hashlib.md5(output_to_hash).hexdigest()
 
 
+def get_debs_for_series(debs_path: str, series: str) -> List[str]:
+    return [
+        os.path.join(debs_path, deb_file)
+        for deb_file in os.listdir(debs_path)
+        if series in deb_file
+    ]
+
+
 def build_debs(
     series: str,
     chroot: Optional[str] = None,


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because if we set the install_from and debs_path variables correctly, but the debs_path has no debs for the specific series, we silently run the test with whatever version if u-a-t is in the image. This leads to unexpected errors.

## Test Steps
Create some empty folder, run CI with debs_path pointing there and set install_from to prebuilt.
See it crash.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly I guess
 - [ ] Changes here need to be documented, and this was done in: 

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
