### PR TITLE
Add more data to reboot_required endpoint

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -673,7 +673,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  |
            | bionic  |
 
-
     @series.xenial
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable livepatch
@@ -692,7 +691,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I run `pro api u.pro.security.status.reboot_required.v1` with sudo
         Then stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "no"}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"livepatch_enabled": true, "livepatch_enabled_and_kernel_patched": true, "livepatch_state": "applied", "livepatch_support": "supported", "reboot_required": "no", "reboot_required_packages": {"kernel_packages": null, "standard_packages": null}}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
         When I run `pro system reboot-required` as non-root
         Then I will see the following on stdout:
@@ -703,7 +702,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         And I run `pro api u.pro.security.status.reboot_required.v1` as non-root
         Then stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "yes"}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"livepatch_enabled": true, "livepatch_enabled_and_kernel_patched": true, "livepatch_state": "applied", "livepatch_support": "supported", "reboot_required": "yes", "reboot_required_packages": {"kernel_packages": \[\], "standard_packages": \["libc6"\]}}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
         When I run `pro system reboot-required` as non-root
         Then I will see the following on stdout:
@@ -720,7 +719,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         And I run `pro api u.pro.security.status.reboot_required.v1` as non-root
         Then stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "yes-kernel-livepatches-applied"}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"livepatch_enabled": true, "livepatch_enabled_and_kernel_patched": true, "livepatch_state": "applied", "livepatch_support": "supported", "reboot_required": "yes-kernel-livepatches-applied", "reboot_required_packages": {"kernel_packages": \["linux-base"\], "standard_packages": \[\]}}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
         When I run `pro system reboot-required` as non-root
         Then I will see the following on stdout:
@@ -731,7 +730,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         And I run `pro api u.pro.security.status.reboot_required.v1` with sudo
         Then stdout matches regexp:
         """
-        {"_schema_version": "v1", "data": {"attributes": {"reboot_required": "yes"}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        {"_schema_version": "v1", "data": {"attributes": {"livepatch_enabled": true, "livepatch_enabled_and_kernel_patched": true, "livepatch_state": "applied", "livepatch_support": "supported", "reboot_required": "yes", "reboot_required_packages": {"kernel_packages": \["linux-base"\], "standard_packages": \["dbus"\]}}, "meta": {"environment_vars": \[\]}, "type": "RebootRequired"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
         When I run `pro system reboot-required` as non-root
         Then I will see the following on stdout:

--- a/uaclient/api/tests/test_api_u_pro_security_status_reboot_required_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_security_status_reboot_required_v1.py
@@ -4,24 +4,124 @@ import pytest
 from uaclient.api.u.pro.security.status.reboot_required.v1 import (
     _reboot_required,
 )
+from uaclient.livepatch import LivepatchPatchStatus, LivepatchStatusStatus
 from uaclient.security_status import RebootStatus
+from uaclient.system import RebootRequiredPkgs
 
 PATH = "uaclient.api.u.pro.security.status.reboot_required.v1."
 
 
 class TestRebootStatus:
     @pytest.mark.parametrize(
-        "reboot_state",
         (
-            (RebootStatus.REBOOT_REQUIRED),
-            (RebootStatus.REBOOT_NOT_REQUIRED),
-            (RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED),
+            "reboot_state,reboot_required_pkgs,livepatch_status,"
+            "expected_standard_pkgs,expected_kernel_pkgs,"
+            "expected_livepatch_enabled_and_kernel,"
+            "expected_livepatch_enabled,expected_livepatch_state,"
+            "expected_livepatch_support"
+        ),
+        (
+            (
+                RebootStatus.REBOOT_REQUIRED,
+                RebootRequiredPkgs(
+                    standard_packages=["pkg1"], kernel_packages=["linux-base"]
+                ),
+                LivepatchStatusStatus(
+                    kernel=None,
+                    livepatch=LivepatchPatchStatus(
+                        state="nothing-to-apply", fixes=None, version=None
+                    ),
+                    supported="supported",
+                ),
+                ["pkg1"],
+                ["linux-base"],
+                True,
+                True,
+                "nothing-to-apply",
+                "supported",
+            ),
+            (
+                RebootStatus.REBOOT_NOT_REQUIRED,
+                None,
+                None,
+                None,
+                None,
+                False,
+                False,
+                None,
+                None,
+            ),
+            (
+                RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED,
+                RebootRequiredPkgs(
+                    standard_packages=[], kernel_packages=["linux-base"]
+                ),
+                LivepatchStatusStatus(
+                    kernel=None,
+                    livepatch=LivepatchPatchStatus(
+                        state="applied", fixes=None, version=None
+                    ),
+                    supported="supported",
+                ),
+                [],
+                ["linux-base"],
+                True,
+                True,
+                "applied",
+                "supported",
+            ),
+            (
+                RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED,
+                RebootRequiredPkgs(
+                    standard_packages=[], kernel_packages=["linux-base"]
+                ),
+                LivepatchStatusStatus(
+                    kernel=None,
+                    livepatch=LivepatchPatchStatus(
+                        state="unknown", fixes=None, version=None
+                    ),
+                    supported="unknown",
+                ),
+                [],
+                ["linux-base"],
+                False,
+                True,
+                "unknown",
+                "unknown",
+            ),
         ),
     )
+    @mock.patch(PATH + "status")
+    @mock.patch(PATH + "get_reboot_required_pkgs")
     @mock.patch(PATH + "get_reboot_status")
-    def test_reboot_status_api(self, m_get_reboot_status, reboot_state):
+    def test_reboot_status_api(
+        self,
+        m_get_reboot_status,
+        m_get_reboot_required_pkgs,
+        m_livepatch_status,
+        reboot_state,
+        reboot_required_pkgs,
+        livepatch_status,
+        expected_standard_pkgs,
+        expected_kernel_pkgs,
+        expected_livepatch_enabled_and_kernel,
+        expected_livepatch_enabled,
+        expected_livepatch_state,
+        expected_livepatch_support,
+    ):
         m_get_reboot_status.return_value = reboot_state
+        m_get_reboot_required_pkgs.return_value = reboot_required_pkgs
+        m_livepatch_status.return_value = livepatch_status
+        result = _reboot_required(mock.MagicMock())
+        assert reboot_state.value == result.reboot_required
         assert (
-            reboot_state.value
-            == _reboot_required(mock.MagicMock()).reboot_required
+            expected_standard_pkgs
+            == result.reboot_required_packages.standard_packages
         )
+        assert (
+            expected_livepatch_enabled_and_kernel
+            == result.livepatch_enabled_and_kernel_patched
+        )
+        assert expected_livepatch_enabled == result.livepatch_enabled
+        assert expected_livepatch_state == result.livepatch_state
+        assert expected_livepatch_support == result.livepatch_support

--- a/uaclient/api/tests/test_api_u_pro_security_status_reboot_required_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_security_status_reboot_required_v1.py
@@ -1,17 +1,18 @@
 import mock
 import pytest
 
+from uaclient import livepatch
 from uaclient.api.u.pro.security.status.reboot_required.v1 import (
+    RebootStatus,
+    _get_reboot_status,
     _reboot_required,
 )
-from uaclient.livepatch import LivepatchPatchStatus, LivepatchStatusStatus
-from uaclient.security_status import RebootStatus
 from uaclient.system import RebootRequiredPkgs
 
-PATH = "uaclient.api.u.pro.security.status.reboot_required.v1."
+M_PATH = "uaclient.api.u.pro.security.status.reboot_required.v1."
 
 
-class TestRebootStatus:
+class TestRebootRequired:
     @pytest.mark.parametrize(
         (
             "reboot_state,reboot_required_pkgs,livepatch_status,"
@@ -26,9 +27,9 @@ class TestRebootStatus:
                 RebootRequiredPkgs(
                     standard_packages=["pkg1"], kernel_packages=["linux-base"]
                 ),
-                LivepatchStatusStatus(
+                livepatch.LivepatchStatusStatus(
                     kernel=None,
-                    livepatch=LivepatchPatchStatus(
+                    livepatch=livepatch.LivepatchPatchStatus(
                         state="nothing-to-apply", fixes=None, version=None
                     ),
                     supported="supported",
@@ -56,9 +57,9 @@ class TestRebootStatus:
                 RebootRequiredPkgs(
                     standard_packages=[], kernel_packages=["linux-base"]
                 ),
-                LivepatchStatusStatus(
+                livepatch.LivepatchStatusStatus(
                     kernel=None,
-                    livepatch=LivepatchPatchStatus(
+                    livepatch=livepatch.LivepatchPatchStatus(
                         state="applied", fixes=None, version=None
                     ),
                     supported="supported",
@@ -75,9 +76,9 @@ class TestRebootStatus:
                 RebootRequiredPkgs(
                     standard_packages=[], kernel_packages=["linux-base"]
                 ),
-                LivepatchStatusStatus(
+                livepatch.LivepatchStatusStatus(
                     kernel=None,
-                    livepatch=LivepatchPatchStatus(
+                    livepatch=livepatch.LivepatchPatchStatus(
                         state="unknown", fixes=None, version=None
                     ),
                     supported="unknown",
@@ -91,9 +92,9 @@ class TestRebootStatus:
             ),
         ),
     )
-    @mock.patch(PATH + "status")
-    @mock.patch(PATH + "get_reboot_required_pkgs")
-    @mock.patch(PATH + "get_reboot_status")
+    @mock.patch("uaclient.livepatch.status")
+    @mock.patch(M_PATH + "get_reboot_required_pkgs")
+    @mock.patch(M_PATH + "_get_reboot_status")
     def test_reboot_status_api(
         self,
         m_get_reboot_status,
@@ -125,3 +126,187 @@ class TestRebootStatus:
         assert expected_livepatch_enabled == result.livepatch_enabled
         assert expected_livepatch_state == result.livepatch_state
         assert expected_livepatch_support == result.livepatch_support
+
+
+class TestGetRebootStatus:
+    @mock.patch(M_PATH + "should_reboot", return_value=False)
+    def test_get_reboot_status_no_reboot_needed(self, m_should_reboot):
+        assert _get_reboot_status() == RebootStatus.REBOOT_NOT_REQUIRED
+        assert 1 == m_should_reboot.call_count
+
+    @mock.patch(M_PATH + "get_reboot_required_pkgs")
+    @mock.patch(M_PATH + "should_reboot", return_value=True)
+    def test_get_reboot_status_no_reboot_pkgs_file(
+        self, m_should_reboot, m_get_reboot_required_pkgs
+    ):
+        m_get_reboot_required_pkgs.return_value = None
+        assert _get_reboot_status() == RebootStatus.REBOOT_REQUIRED
+        assert 1 == m_should_reboot.call_count
+        assert 1 == m_get_reboot_required_pkgs.call_count
+
+    @mock.patch("uaclient.livepatch.status")
+    @mock.patch("uaclient.livepatch.is_livepatch_installed", return_value=True)
+    @mock.patch(M_PATH + "get_reboot_required_pkgs")
+    @mock.patch(M_PATH + "should_reboot", return_value=True)
+    def test_get_reboot_status_livepatch_status_none(
+        self,
+        m_should_reboot,
+        m_get_reboot_required_pkgs,
+        _m_is_livepatch_installed,
+        m_livepatch_status,
+    ):
+        m_get_reboot_required_pkgs.return_value = RebootRequiredPkgs(
+            standard_packages=[],
+            kernel_packages=["linux-base", "linux-image-5.4.0-1074"],
+        )
+        m_livepatch_status.return_value = None
+        assert _get_reboot_status() == RebootStatus.REBOOT_REQUIRED
+
+    @pytest.mark.parametrize(
+        "reboot_required_pkgs,expected_state",
+        (
+            (
+                RebootRequiredPkgs(
+                    standard_packages=["pkg1", "pkg2"], kernel_packages=[]
+                ),
+                RebootStatus.REBOOT_REQUIRED,
+            ),
+            (
+                RebootRequiredPkgs(
+                    standard_packages=["pkg2"],
+                    kernel_packages=["linux-base", "linux-image-5.4.0-1074"],
+                ),
+                RebootStatus.REBOOT_REQUIRED,
+            ),
+        ),
+    )
+    @mock.patch(M_PATH + "get_reboot_required_pkgs")
+    @mock.patch(M_PATH + "should_reboot", return_value=True)
+    def test_get_reboot_status_reboot_pkgs_file_present(
+        self,
+        m_should_reboot,
+        m_get_reboot_required_pkgs,
+        reboot_required_pkgs,
+        expected_state,
+    ):
+        m_get_reboot_required_pkgs.return_value = reboot_required_pkgs
+        assert _get_reboot_status() == expected_state
+        assert 1 == m_should_reboot.call_count
+        assert 1 == m_get_reboot_required_pkgs.call_count
+
+    @pytest.mark.parametrize(
+        [
+            "livepatch_state",
+            "supported_state",
+            "expected_state",
+            "kernel_name",
+        ],
+        (
+            (
+                "applied",
+                "supported",
+                RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED,
+                "4.15.0-187.198-generic",
+            ),
+            (
+                "applied",
+                None,
+                RebootStatus.REBOOT_REQUIRED,
+                "4.15.0-187.198-generic",
+            ),
+            ("applied", "supported", RebootStatus.REBOOT_REQUIRED, "test"),
+            (
+                "nothing-to-apply",
+                "supported",
+                RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED,
+                "4.15.0-187.198-generic",
+            ),
+            (
+                "applying",
+                "supported",
+                RebootStatus.REBOOT_REQUIRED,
+                "4.15.0-187.198-generic",
+            ),
+            (
+                "apply-failed",
+                "supported",
+                RebootStatus.REBOOT_REQUIRED,
+                "4.15.0-187.198-generic",
+            ),
+        ),
+    )
+    @mock.patch(M_PATH + "get_kernel_info")
+    @mock.patch("uaclient.livepatch.is_livepatch_installed")
+    @mock.patch("uaclient.livepatch.status")
+    @mock.patch(M_PATH + "get_reboot_required_pkgs")
+    @mock.patch(M_PATH + "should_reboot", return_value=True)
+    def test_get_reboot_status_reboot_pkgs_file_only_kernel_pkgs(
+        self,
+        m_should_reboot,
+        m_get_reboot_required_pkgs,
+        m_livepatch_status,
+        m_is_livepatch_installed,
+        m_kernel_info,
+        livepatch_state,
+        supported_state,
+        expected_state,
+        kernel_name,
+    ):
+        m_kernel_info.return_value = mock.MagicMock(
+            proc_version_signature_version=kernel_name
+        )
+        m_is_livepatch_installed.return_value = True
+        m_get_reboot_required_pkgs.return_value = RebootRequiredPkgs(
+            standard_packages=[],
+            kernel_packages=["linux-base", "linux-image-5.4.0-1074"],
+        )
+        m_livepatch_status.return_value = livepatch.LivepatchStatusStatus(
+            kernel="4.15.0-187.198-generic",
+            livepatch=livepatch.LivepatchPatchStatus(
+                state=livepatch_state, fixes=None, version=None
+            ),
+            supported=supported_state,
+        )
+
+        assert _get_reboot_status() == expected_state
+        assert 1 == m_should_reboot.call_count
+        assert 1 == m_get_reboot_required_pkgs.call_count
+        assert 1 == m_is_livepatch_installed.call_count
+        assert 1 == m_livepatch_status.call_count
+        assert 1 == m_kernel_info.call_count
+
+    @mock.patch(M_PATH + "get_kernel_info")
+    @mock.patch("uaclient.livepatch.is_livepatch_installed")
+    @mock.patch("uaclient.livepatch.status")
+    @mock.patch(M_PATH + "get_reboot_required_pkgs")
+    @mock.patch(M_PATH + "should_reboot", return_value=True)
+    def test_get_reboot_status_fail_parsing_kernel_info(
+        self,
+        m_should_reboot,
+        m_get_reboot_required_pkgs,
+        m_livepatch_status,
+        m_is_livepatch_installed,
+        m_kernel_info,
+    ):
+        m_kernel_info.return_value = mock.MagicMock(
+            proc_version_signature_version=None
+        )
+        m_is_livepatch_installed.return_value = True
+        m_get_reboot_required_pkgs.return_value = RebootRequiredPkgs(
+            standard_packages=[],
+            kernel_packages=["linux-base", "linux-image-5.4.0-1074"],
+        )
+        m_livepatch_status.return_value = livepatch.LivepatchStatusStatus(
+            kernel="4.15.0-187.198-generic",
+            livepatch=livepatch.LivepatchPatchStatus(
+                state="applied", fixes=None, version=None
+            ),
+            supported=None,
+        )
+
+        assert _get_reboot_status() == RebootStatus.REBOOT_REQUIRED
+        assert 1 == m_should_reboot.call_count
+        assert 1 == m_get_reboot_required_pkgs.call_count
+        assert 1 == m_is_livepatch_installed.call_count
+        assert 1 == m_livepatch_status.call_count
+        assert 1 == m_kernel_info.call_count

--- a/uaclient/api/u/pro/security/status/reboot_required/v1.py
+++ b/uaclient/api/u/pro/security/status/reboot_required/v1.py
@@ -1,20 +1,64 @@
+from typing import List, Optional
+
 from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
 from uaclient.config import UAConfig
-from uaclient.data_types import DataObject, Field, StringDataValue
-from uaclient.security_status import get_reboot_status
+from uaclient.data_types import (
+    BoolDataValue,
+    DataObject,
+    Field,
+    StringDataValue,
+    data_list,
+)
+from uaclient.livepatch import status
+from uaclient.security_status import (
+    get_reboot_required_pkgs,
+    get_reboot_status,
+)
+
+
+class RebootRequiredPkgs(DataObject):
+    fields = [
+        Field("standard_packages", data_list(StringDataValue), False),
+        Field("kernel_packages", data_list(StringDataValue), False),
+    ]
+
+    def __init__(
+        self,
+        standard_packages: Optional[List[str]],
+        kernel_packages: Optional[List[str]],
+    ):
+        self.standard_packages = standard_packages
+        self.kernel_packages = kernel_packages
 
 
 class RebootRequiredResult(DataObject, AdditionalInfo):
     fields = [
         Field("reboot_required", StringDataValue),
+        Field("reboot_required_packages", RebootRequiredPkgs),
+        Field("livepatch_enabled_and_kernel_patched", BoolDataValue),
+        Field("livepatch_enabled", BoolDataValue),
+        Field("livepatch_state", StringDataValue, False),
+        Field("livepatch_support", StringDataValue, False),
     ]
 
     def __init__(
         self,
         reboot_required: str,
+        reboot_required_packages: RebootRequiredPkgs,
+        livepatch_enabled_and_kernel_patched: bool,
+        livepatch_enabled: bool,
+        livepatch_state: Optional[str],
+        livepatch_support: Optional[str],
     ):
         self.reboot_required = reboot_required
+        self.reboot_required_packages = reboot_required_packages
+        self.livepatch_enabled_and_kernel_patched = (
+            livepatch_enabled_and_kernel_patched
+        )
+        self.livepatch_enabled = livepatch_enabled
+        self.livepatch_state = livepatch_state
+        self.livepatch_support = livepatch_support
 
 
 def reboot_required() -> RebootRequiredResult:
@@ -22,8 +66,46 @@ def reboot_required() -> RebootRequiredResult:
 
 
 def _reboot_required(cfg: UAConfig) -> RebootRequiredResult:
-    status = get_reboot_status()
-    return RebootRequiredResult(reboot_required=status.value)
+    reboot_status = get_reboot_status()
+    reboot_required_pkgs = get_reboot_required_pkgs()
+    livepatch_status = status()
+
+    if not livepatch_status:
+        livepatch_enabled_and_kernel_patched = False
+        livepatch_enabled = False
+        livepatch_state = None
+        livepatch_support = None
+    else:
+        livepatch_enabled = True
+        livepatch_support = livepatch_status.supported
+        livepatch_state = (
+            livepatch_status.livepatch.state
+            if livepatch_status.livepatch
+            else None
+        )
+        if (
+            livepatch_state not in ("applied", "nothing-to-apply")
+            and livepatch_support != "supported"
+        ):
+            livepatch_enabled_and_kernel_patched = False
+        else:
+            livepatch_enabled_and_kernel_patched = True
+
+    return RebootRequiredResult(
+        reboot_required=reboot_status.value,
+        reboot_required_packages=RebootRequiredPkgs(
+            standard_packages=reboot_required_pkgs.standard_packages
+            if reboot_required_pkgs
+            else None,
+            kernel_packages=reboot_required_pkgs.kernel_packages
+            if reboot_required_pkgs
+            else None,
+        ),
+        livepatch_enabled_and_kernel_patched=livepatch_enabled_and_kernel_patched,  # noqa
+        livepatch_enabled=livepatch_enabled,
+        livepatch_state=livepatch_state,
+        livepatch_support=livepatch_support,
+    )
 
 
 endpoint = APIEndpoint(

--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -5,22 +5,21 @@ import mock
 import pytest
 
 from uaclient import livepatch
+from uaclient.api.u.pro.security.status.reboot_required.v1 import RebootStatus
 from uaclient.entitlements.entitlement_status import (
     ApplicationStatus,
     ContractStatus,
 )
 from uaclient.security_status import (
-    RebootStatus,
     UpdateStatus,
     filter_security_updates,
     get_livepatch_fixed_cves,
     get_origin_for_package,
-    get_reboot_status,
     get_ua_info,
     get_update_status,
     security_status_dict,
 )
-from uaclient.system import KernelInfo, RebootRequiredPkgs
+from uaclient.system import KernelInfo
 
 M_PATH = "uaclient.security_status."
 
@@ -531,7 +530,7 @@ class TestSecurityStatus:
                 == "not-a-security-update"
             )
 
-    @mock.patch(M_PATH + "get_reboot_status")
+    @mock.patch(M_PATH + "_reboot_required")
     @mock.patch(M_PATH + "get_livepatch_fixed_cves", return_value=[])
     @mock.patch(
         M_PATH + "_is_attached", return_value=mock.MagicMock(is_attached=False)
@@ -560,7 +559,9 @@ class TestSecurityStatus:
             "esm-apps": [],
             "standard-security": [],
         }
-        m_reboot_status.return_value = RebootStatus.REBOOT_NOT_REQUIRED
+        m_reboot_status.return_value = mock.MagicMock(
+            reboot_required=RebootStatus.REBOOT_NOT_REQUIRED.value
+        )
 
         expected_output = {
             "_schema_version": "0.1",
@@ -673,190 +674,3 @@ class TestGetLivepatchFixedCVEs:
         assert [
             {"name": "cve-example", "patched": True}
         ] == get_livepatch_fixed_cves()
-
-
-class TestRebootStatus:
-    @mock.patch("uaclient.security_status.should_reboot", return_value=False)
-    def test_get_reboot_status_no_reboot_needed(self, m_should_reboot):
-        assert get_reboot_status() == RebootStatus.REBOOT_NOT_REQUIRED
-        assert 1 == m_should_reboot.call_count
-
-    @mock.patch("uaclient.security_status.get_reboot_required_pkgs")
-    @mock.patch("uaclient.security_status.should_reboot", return_value=True)
-    def test_get_reboot_status_no_reboot_pkgs_file(
-        self, m_should_reboot, m_get_reboot_required_pkgs
-    ):
-        m_get_reboot_required_pkgs.return_value = None
-        assert get_reboot_status() == RebootStatus.REBOOT_REQUIRED
-        assert 1 == m_should_reboot.call_count
-        assert 1 == m_get_reboot_required_pkgs.call_count
-
-    @mock.patch("uaclient.security_status.livepatch.status")
-    @mock.patch(
-        "uaclient.security_status.livepatch.is_livepatch_installed",
-        return_value=True,
-    )
-    @mock.patch("uaclient.security_status.get_reboot_required_pkgs")
-    @mock.patch("uaclient.security_status.should_reboot", return_value=True)
-    def test_get_reboot_status_livepatch_status_none(
-        self,
-        m_should_reboot,
-        m_get_reboot_required_pkgs,
-        _m_is_livepatch_installed,
-        m_livepatch_status,
-    ):
-        m_get_reboot_required_pkgs.return_value = RebootRequiredPkgs(
-            standard_packages=[],
-            kernel_packages=["linux-base", "linux-image-5.4.0-1074"],
-        )
-        m_livepatch_status.return_value = None
-        assert get_reboot_status() == RebootStatus.REBOOT_REQUIRED
-
-    @pytest.mark.parametrize(
-        "reboot_required_pkgs,expected_state",
-        (
-            (
-                RebootRequiredPkgs(
-                    standard_packages=["pkg1", "pkg2"], kernel_packages=[]
-                ),
-                RebootStatus.REBOOT_REQUIRED,
-            ),
-            (
-                RebootRequiredPkgs(
-                    standard_packages=["pkg2"],
-                    kernel_packages=["linux-base", "linux-image-5.4.0-1074"],
-                ),
-                RebootStatus.REBOOT_REQUIRED,
-            ),
-        ),
-    )
-    @mock.patch("uaclient.security_status.get_reboot_required_pkgs")
-    @mock.patch("uaclient.security_status.should_reboot", return_value=True)
-    def test_get_reboot_status_reboot_pkgs_file_present(
-        self,
-        m_should_reboot,
-        m_get_reboot_required_pkgs,
-        reboot_required_pkgs,
-        expected_state,
-    ):
-        m_get_reboot_required_pkgs.return_value = reboot_required_pkgs
-        assert get_reboot_status() == expected_state
-        assert 1 == m_should_reboot.call_count
-        assert 1 == m_get_reboot_required_pkgs.call_count
-
-    @pytest.mark.parametrize(
-        [
-            "livepatch_state",
-            "supported_state",
-            "expected_state",
-            "kernel_name",
-        ],
-        (
-            (
-                "applied",
-                "supported",
-                RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED,
-                "4.15.0-187.198-generic",
-            ),
-            (
-                "applied",
-                None,
-                RebootStatus.REBOOT_REQUIRED,
-                "4.15.0-187.198-generic",
-            ),
-            ("applied", "supported", RebootStatus.REBOOT_REQUIRED, "test"),
-            (
-                "nothing-to-apply",
-                "supported",
-                RebootStatus.REBOOT_REQUIRED_LIVEPATCH_APPLIED,
-                "4.15.0-187.198-generic",
-            ),
-            (
-                "applying",
-                "supported",
-                RebootStatus.REBOOT_REQUIRED,
-                "4.15.0-187.198-generic",
-            ),
-            (
-                "apply-failed",
-                "supported",
-                RebootStatus.REBOOT_REQUIRED,
-                "4.15.0-187.198-generic",
-            ),
-        ),
-    )
-    @mock.patch("uaclient.security_status.get_kernel_info")
-    @mock.patch("uaclient.security_status.livepatch.is_livepatch_installed")
-    @mock.patch("uaclient.security_status.livepatch.status")
-    @mock.patch("uaclient.security_status.get_reboot_required_pkgs")
-    @mock.patch("uaclient.security_status.should_reboot", return_value=True)
-    def test_get_reboot_status_reboot_pkgs_file_only_kernel_pkgs(
-        self,
-        m_should_reboot,
-        m_get_reboot_required_pkgs,
-        m_livepatch_status,
-        m_is_livepatch_installed,
-        m_kernel_info,
-        livepatch_state,
-        supported_state,
-        expected_state,
-        kernel_name,
-    ):
-        m_kernel_info.return_value = mock.MagicMock(
-            proc_version_signature_version=kernel_name
-        )
-        m_is_livepatch_installed.return_value = True
-        m_get_reboot_required_pkgs.return_value = RebootRequiredPkgs(
-            standard_packages=[],
-            kernel_packages=["linux-base", "linux-image-5.4.0-1074"],
-        )
-        m_livepatch_status.return_value = livepatch.LivepatchStatusStatus(
-            kernel="4.15.0-187.198-generic",
-            livepatch=livepatch.LivepatchPatchStatus(
-                state=livepatch_state, fixes=None, version=None
-            ),
-            supported=supported_state,
-        )
-
-        assert get_reboot_status() == expected_state
-        assert 1 == m_should_reboot.call_count
-        assert 1 == m_get_reboot_required_pkgs.call_count
-        assert 1 == m_is_livepatch_installed.call_count
-        assert 1 == m_livepatch_status.call_count
-        assert 1 == m_kernel_info.call_count
-
-    @mock.patch("uaclient.security_status.get_kernel_info")
-    @mock.patch("uaclient.security_status.livepatch.is_livepatch_installed")
-    @mock.patch("uaclient.security_status.livepatch.status")
-    @mock.patch("uaclient.security_status.get_reboot_required_pkgs")
-    @mock.patch("uaclient.security_status.should_reboot", return_value=True)
-    def test_get_reboot_status_fail_parsing_kernel_info(
-        self,
-        m_should_reboot,
-        m_get_reboot_required_pkgs,
-        m_livepatch_status,
-        m_is_livepatch_installed,
-        m_kernel_info,
-    ):
-        m_kernel_info.return_value = mock.MagicMock(
-            proc_version_signature_version=None
-        )
-        m_is_livepatch_installed.return_value = True
-        m_get_reboot_required_pkgs.return_value = RebootRequiredPkgs(
-            standard_packages=[],
-            kernel_packages=["linux-base", "linux-image-5.4.0-1074"],
-        )
-        m_livepatch_status.return_value = livepatch.LivepatchStatusStatus(
-            kernel="4.15.0-187.198-generic",
-            livepatch=livepatch.LivepatchPatchStatus(
-                state="applied", fixes=None, version=None
-            ),
-            supported=None,
-        )
-
-        assert get_reboot_status() == RebootStatus.REBOOT_REQUIRED
-        assert 1 == m_should_reboot.call_count
-        assert 1 == m_get_reboot_required_pkgs.call_count
-        assert 1 == m_is_livepatch_installed.call_count
-        assert 1 == m_livepatch_status.call_count
-        assert 1 == m_kernel_info.call_count


### PR DESCRIPTION
## Why is this needed?
The reboot required enpoint just inform the users if a reboot is required or not. However, it does not provide the data we used to generate that decision. We are updating the endpoint to provide all of this data, allowing our users to better understand the decision making process or even adapt it based on their own needs.


## Test Steps
Run the new integration test added

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
