### PR TITLE
Release 28 verification fixes

### DIFF
--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -98,6 +98,7 @@ Feature: APT Messages
            | release | standard-pkg                                                          | infra-pkg                                            | apps-pkg     |
            | xenial  | accountsservice=0.6.40-2ubuntu10 libaccountsservice0=0.6.40-2ubuntu10 | curl=7.47.0-1ubuntu2 libcurl3-gnutls=7.47.0-1ubuntu2 | hello=2.10-1 |
 
+    @series.bionic
     @series.xenial
     @uses.config.machine_type.lxd-container
     Scenario Outline: APT Hook advertises esm-infra on upgrade
@@ -116,7 +117,7 @@ Feature: APT Messages
         Calculating upgrade...
         The following security updates require Ubuntu Pro with 'esm-infra' enabled:
           ([-+.\w\s]*)
-        Learn more about Ubuntu Pro for 16\.04 at https:\/\/ubuntu\.com\/16-04
+        Learn more about Ubuntu Pro for <version>\.04 at https:\/\/ubuntu\.com\/<version>-04
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded\.
         """
         When I run `apt-get upgrade` with sudo
@@ -151,10 +152,10 @@ Feature: APT Messages
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded\.
         """
         Examples: ubuntu release
-          | release |
-          | xenial  |
+          | release | version |
+          | xenial  | 16      |
+          | bionic  | 18      |
 
-    @series.bionic
     @series.focal
     @series.jammy
     @uses.config.machine_type.lxd-container

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -1103,7 +1103,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     # Overall test for overrides; in the future, when many services
     # have overrides, we can consider removing this
-    # FIPS is a good choice because we expect to have it
+    # esm-infra is a good choice because it doesn't already have
+    # other overrides that would interfere with the test
     @series.focal
     @uses.config.machine_type.aws.generic
     Scenario: Cloud overrides for a generic aws Focal instance
@@ -1113,30 +1114,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         machineTokenInfo:
           contractInfo:
             resourceEntitlements:
-              - type: fips
-                entitled: true
-                affordances:
-                  architectures:
-                    - amd64
-                    - ppc64el
-                    - ppc64le
-                    - s390x
-                    - x86_64
-                  series:
-                    - xenial
-                    - bionic
-                    - focal
-                directives:
-                  additionalPackages:
-                   - ubuntu-fips
-                  aptKey: E23341B2A1467EDBF07057D6C1997C40EDE22758
-                  aptURL: https://esm.ubuntu.com/fips
-                  suites:
-                    - xenial
-                    - bionic
-                    - focal
-                obligations:
-                  enableByDefault: false
+              - type: esm-infra
                 overrides:
                   - selector:
                       series: focal
@@ -1149,8 +1127,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
                       additionalPackages:
                         - some-package-aws
         """
-        And I attach `contract_token` with sudo
-        And I verify that running `pro enable fips --assume-yes` `with sudo` exits `1`
+        And I attach `contract_token` with sudo and options `--no-auto-enable`
+        And I verify that running `pro enable esm-infra` `with sudo` exits `1`
         Then stderr matches regexp:
         """
         Stderr: E: Unable to locate package some-package-aws

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -153,4 +153,4 @@ Feature: MOTD Messages
         Examples: ubuntu release
            | release | service   |
            | xenial  | esm-infra |
-           | bionic  | esm-apps  |
+           | bionic  | esm-infra |

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -241,7 +241,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
         fips          +yes +<fips-s> +NIST-certified core packages
         fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
-        livepatch     +yes +enabled  +Canonical Livepatch service
+        livepatch     +yes +<livepatch-s>  +(Canonical Livepatch service|Current kernel is not supported)
         """
         Then stdout matches regexp:
         """
@@ -259,7 +259,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
         fips          +yes +<fips-s> +NIST-certified core packages
         fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
-        livepatch     +yes +enabled  +Canonical Livepatch service
+        livepatch     +yes +<livepatch-s>  +(Canonical Livepatch service|Current kernel is not supported)
         """
         Then stdout matches regexp:
         """
@@ -335,11 +335,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
 
         Examples: ubuntu release
-           | release | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | cis_or_usg |
-           | xenial  | disabled | disabled | disabled | libkrad0  | jq       | cis        |
-           | bionic  | disabled | disabled | disabled | libkrad0  | bundler  | cis        |
-           | focal   | disabled | n/a      | disabled | hello     | ant      | usg        |
-           | jammy   | n/a      | n/a      | n/a      | hello     | hello    | usg        |
+           | release | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | cis_or_usg | livepatch-s |
+           | xenial  | disabled | disabled | disabled | libkrad0  | jq       | cis        | enabled     |
+           | bionic  | disabled | disabled | disabled | libkrad0  | bundler  | cis        | enabled     |
+           | focal   | disabled | n/a      | disabled | hello     | ant      | usg        | enabled     |
+           | jammy   | n/a      | n/a      | disabled | hello     | hello    | usg        | warning     |
 
 
     @series.lts
@@ -464,7 +464,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | xenial  | disabled | disabled | disabled | libkrad0  | jq       | enabled   | cis        |
            | bionic  | disabled | disabled | disabled | libkrad0  | bundler  | enabled   | cis        |
            | focal   | disabled | n/a      | disabled | hello     | ant      | enabled   | usg        |
-           | jammy   | n/a      | n/a      | n/a      | hello     | hello    | enabled   | usg        |
+           | jammy   | n/a      | n/a      | disabled | hello     | hello    | enabled   | usg        |
 
     @series.lts
     @uses.config.machine_type.gcp.pro
@@ -588,7 +588,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | xenial  | n/a      | disabled | disabled | libkrad0  | jq       | warning   | Current kernel is not supported | cis        |
            | bionic  | disabled | disabled | disabled | libkrad0  | bundler  | enabled   | Canonical Livepatch service     | cis        |
            | focal   | disabled | n/a      | disabled | hello     | ant      | enabled   | Canonical Livepatch service     | usg        |
-           | jammy   | n/a      | n/a      | n/a      | hello     | hello    | enabled   | Canonical Livepatch service     | usg        |
+           | jammy   | n/a      | n/a      | disabled | hello     | hello    | warning   | Current kernel is not supported | usg        |
 
     @series.lts
     @uses.config.machine_type.gcp.pro

--- a/tools/run-integration-tests.py
+++ b/tools/run-integration-tests.py
@@ -24,7 +24,7 @@ TOKEN_TO_ENVVAR = {
 }
 
 PLATFORM_SERIES_TESTS = {
-    "azuregeneric": ["xenial", "bionic", "focal", "jammy"],
+    "azuregeneric": ["xenial", "bionic", "focal", "jammy", "kinetic"],
     "azurepro": ["xenial", "bionic", "focal", "jammy"],
     "azurepro-fips": ["xenial", "bionic", "focal"],
     "awsgeneric": ["xenial", "bionic", "focal", "jammy"],


### PR DESCRIPTION
These were the extra test fixes needed on top of the release branch for verifying 28.1

First commit is already in main. The second will be brought over to main in a separate PR.