### PR TITLE
tests: fix jammy status tests due to variants

### DIFF
--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -200,6 +200,8 @@ Feature: Attached status
         fips-updates    +yes      +n/a      +NIST-certified core packages with priority security updates
         livepatch       +yes      +n/a      +Canonical Livepatch service
         realtime-kernel +yes      +n/a      +Ubuntu kernel with PREEMPT_RT patches integrated
+        ├ generic       +yes      +n/a      +Generic version of the RT kernel \(default\)
+        └ intel-iotg    +yes      +n/a      +RT kernel optimized for Intel IOTG platform
         ros             +yes      +n/a      +Security Updates for the Robot Operating System
         ros-updates     +yes      +n/a      +All Updates for the Robot Operating System
         usg             +yes      +disabled +Security compliance and audit tools


### PR DESCRIPTION
## Why is this needed?
There is one jammy tests that is now affected because of the new variants work. We are fixing it by reflecting the variants on the expected output of pro status --all

## Test Steps
Run the modified integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
