### PR TITLE
anbox: turn contract directive to cammel case

### DIFF
--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -55,7 +55,7 @@ Feature: Enable anbox on Ubuntu
                   - name: lxd
                   - name: amc
                   - name: anbox-cloud-appliance
-                    classic_confinement_support: true
+                    classicConfinementSupport: true
         """
         And I run `pro enable anbox-cloud --access-only --assume-yes` with sudo
         Then I will see the following on stdout:

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -515,7 +515,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 snap.get_snap_info(snap_name)
             except exceptions.SnapNotInstalledError:
                 classic_confinement_support = snap_pkg.get(
-                    "classic_confinement_support", False
+                    "classicConfinementSupport", False
                 )
 
                 snap.install_snap(

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -1242,7 +1242,7 @@ class TestHandleAdditionalSnaps:
                                 {"name": "test1"},
                                 {
                                     "name": "test2",
-                                    "classic_confinement_support": True,
+                                    "classicConfinementSupport": True,
                                 },
                                 {"name": "test3"},
                             ]


### PR DESCRIPTION
## Why is this needed?
We are changing `classic_confinment_support` to the
cammel case representation. That is because cammel case is the standard support on the Contract server

## Test Steps
Run the modified integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
