### PR TITLE
docs: fix broken links in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,29 +7,29 @@ from the architecture of the project to how you should test any code changes.
 
 ### How to Guides
 
-* [How to build](./dev-docs/howtoguides/building.md)
-* [How to run the code formatting tools](./dev-docs/howtoguides/code_formatting.md)
-* [How to run the tests](./dev-docs/howtoguides/testing.md)
-* [How to release a new version](./dev-docs/howtoguides/how_to_release_a_new_version_of_ua.md)
-* [How to use the contract staging environment](./dev-docs/howtoguides/use_staging_environment.md)
-* [How to use the magic attach endpoints](./dev-docs/howtoguides/how_to_use_magic_attach_endpoints.md)
+* [How to build](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/howtoguides/building.md)
+* [How to run the code formatting tools](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/howtoguides/code_formatting.md)
+* [How to run the tests](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/howtoguides/testing.md)
+* [How to release a new version](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/howtoguides/how_to_release_a_new_version_of_ua.md)
+* [How to use the contract staging environment](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/howtoguides/use_staging_environment.md)
+* [How to use the magic attach endpoints](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/howtoguides/how_to_use_magic_attach_endpoints.md)
 
 ### Reference
 
-* [Terminology](./dev-docs/references/terminology.md)
-* [Architecture](./dev-docs/references/architecture.md)
-* [Early review sign-off](./dev-docs/references/early_review_signoff.md)
-* [What happens during attach](./dev-docs/references/what_happens_during_attach.md)
-* [Enabling a service](./dev-docs/references/enabling_a_service.md)
-* [Directory layout](./dev-docs/references/directory_layout.md)
-* [Daily Builds](./dev-docs/references/daily_builds.md)
-* [Version String Formatting](./dev-docs/references/version_string_formatting.md)
-* [PR review policy](./dev-docs/references/pr_review_policy.md)
+* [Terminology](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/references/terminology.md)
+* [Architecture](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/references/architecture.md)
+* [Early review sign-off](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/references/early_review_signoff.md)
+* [What happens during attach](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/references/what_happens_during_attach.md)
+* [Enabling a service](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/references/enabling_a_service.md)
+* [Directory layout](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/references/directory_layout.md)
+* [Daily Builds](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/references/daily_builds.md)
+* [Version String Formatting](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/references/version_string_formatting.md)
+* [PR review policy](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/references/pr_review_policy.md)
 
 ### Explanation
 
-* [How auto-attach works](./dev-docs/explanations/how_auto_attach_works.md)
+* [How auto-attach works](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/explanations/how_auto_attach_works.md)
 
 ### Documentation
 
-* [Documentation guide](./dev-docs/devdocs_styleguide.md)
+* [Documentation guide](https://github.com/canonical/ubuntu-pro-client/blob/docs/dev-docs/devdocs_styleguide.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1>
   <a href="https://ubuntu.com/pro" target="_blank">
-    <img src="./docs/_static/circle_of_friends.png" width="33"/>
+    <img src="https://raw.githubusercontent.com/canonical/ubuntu-pro-client/docs/docs/_static/circle_of_friends.png" width="33"/>
   </a>
   <br>
   Ubuntu Pro Client


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because the links are broken - the files they reference now live in a different branch.
It is not ideal that we use the /blob/ links, but the links in CONTRIBUTING should be updated again to point to readthedocs when the development documentation is published there.

## Test Steps
click all the links and make sure they are not broken (:

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
