### PR TITLE
apt_news: allow current_news api to be called as non-root

### DIFF
--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -271,7 +271,7 @@ Feature: APT Messages
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         "one"
@@ -317,7 +317,7 @@ Feature: APT Messages
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         "one"
@@ -339,7 +339,7 @@ Feature: APT Messages
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         "one\ntwo\nthree"
@@ -364,7 +364,7 @@ Feature: APT Messages
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         "one\ntwo\nthree"
@@ -397,7 +397,7 @@ Feature: APT Messages
         Calculating upgrade...
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         null
@@ -427,7 +427,7 @@ Feature: APT Messages
         Calculating upgrade...
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         null
@@ -458,7 +458,7 @@ Feature: APT Messages
         Calculating upgrade...
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         null
@@ -490,7 +490,7 @@ Feature: APT Messages
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         "one"
@@ -521,7 +521,7 @@ Feature: APT Messages
         Calculating upgrade...
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         null
@@ -551,7 +551,7 @@ Feature: APT Messages
         Calculating upgrade...
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         null
@@ -596,7 +596,7 @@ Feature: APT Messages
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         "CAUTION: Your Ubuntu Pro subscription will expire in 2 days.\nRenew your subscription at https://ubuntu.com/pro to ensure continued\nsecurity coverage for your applications."
@@ -623,7 +623,7 @@ Feature: APT Messages
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then stdout matches regexp:
         """
         "CAUTION: Your Ubuntu Pro subscription expired on \d+ \w+ \d+.\\nRenew your subscription at https:\/\/ubuntu.com\/pro to ensure continued\\nsecurity coverage for your applications.\\nYour grace period will expire in 11 days."
@@ -648,7 +648,7 @@ Feature: APT Messages
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         "*Your Ubuntu Pro subscription has EXPIRED*\nRenew your service at https://ubuntu.com/pro"
@@ -677,7 +677,7 @@ Feature: APT Messages
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
-        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` with sudo
+        When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
         "*Your Ubuntu Pro subscription has EXPIRED*\nRenew your service at https://ubuntu.com/pro"

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -136,7 +136,9 @@ timer_jobs_state_file = DataObjectFile(
 
 
 apt_news_contents_file = UAFile("apt-news", directory=defaults.MESSAGES_DIR)
-apt_news_raw_file = UAFile("apt-news-raw", directory=defaults.MESSAGES_DIR)
+apt_news_raw_file = UAFile(
+    "apt-news-raw", private=False, directory=defaults.MESSAGES_DIR
+)
 
 
 class LivepatchSupportCacheData(DataObject):


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because...

update-manager will be the consumer of this api and is usually not running as root

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
env ./tools/test-in-lxd.sh xenial
pro api u.apt_news.current_news.v1
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [n/a] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
