### PR TITLE
Add Ubuntu-themed header

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -6,3 +6,4 @@ sphinx_autobuild
 sphinx_copybutton
 sphinx_design
 sphinxcontrib-mermaid
+sphinxcontrib-jquery

--- a/docs/_static/css/header.css
+++ b/docs/_static/css/header.css
@@ -1,0 +1,167 @@
+.p-navigation {
+  border-bottom: 1px solid var(--color-sidebar-background-border);
+}
+
+.p-navigation__nav {
+  background: #333333;
+  display: flex;
+}
+
+.p-logo {
+  display: flex !important;
+  padding-top: 0 !important;
+  text-decoration: none;
+}
+
+.p-logo-image {
+  height: 44px;
+  padding-right: 10px;
+}
+
+.p-logo-text {
+  margin-top: 18px;
+  color: white;
+  text-decoration: none;
+}
+
+ul.p-navigation__links {
+  display: flex;
+  list-style: none;
+  margin-left: 0;
+  margin-top: auto;
+  margin-bottom: auto;
+  max-width: 800px;
+  width: 100%;
+}
+
+ul.p-navigation__links li {
+  margin: 0 auto;
+  text-align: center;
+  width: 100%;
+}
+
+ul.p-navigation__links li a {
+  background-color: rgba(0, 0, 0, 0);
+  border: none;
+  border-radius: 0;
+  color: var(--color-sidebar-link-text);
+  display: block;
+  font-weight: 400;
+  line-height: 1.5rem;
+  margin: 0;
+  overflow: hidden;
+  padding: 1rem 0;
+  position: relative;
+  text-align: left;
+  text-overflow: ellipsis;
+  transition-duration: .1s;
+  transition-property: background-color, color, opacity;
+  transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+  white-space: nowrap;
+  width: 100%;
+}
+
+ul.p-navigation__links .p-navigation__link {
+  color: #ffffff;
+  font-weight: 300;
+  text-align: center;
+  text-decoration: none;
+}
+
+ul.p-navigation__links .p-navigation__link:hover {
+  background-color: #2b2b2b;
+}
+
+ul.p-navigation__links .p-dropdown__link:hover {
+  background-color: var(--color-sidebar-item-background--hover);
+}
+
+ul.p-navigation__links .p-navigation__sub-link {
+  background: var(--color-background-primary);
+  padding: .5rem 0 .5rem .5rem;
+  font-weight: 300;
+}
+
+ul.p-navigation__links .more-links-dropdown li a {
+  border-left: 1px solid var(--color-sidebar-background-border);
+  border-right: 1px solid var(--color-sidebar-background-border);
+}
+
+ul.p-navigation__links .more-links-dropdown li:first-child a {
+  border-top: 1px solid var(--color-sidebar-background-border);
+}
+
+ul.p-navigation__links .more-links-dropdown li:last-child a {
+  border-bottom: 1px solid var(--color-sidebar-background-border);
+}
+
+ul.p-navigation__links .p-navigation__logo {
+  padding: 0.5rem;
+}
+
+ul.p-navigation__links .p-navigation__logo img {
+  width: 40px;
+}
+
+ul.more-links-dropdown {
+  display: none;
+  overflow-x: visible;
+  height: 0;
+  z-index: 55;
+  padding: 0;
+  position: relative;
+  list-style: none;
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.nav-more-links::after {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='%23111' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  content: "";
+  display: block;
+  filter: invert(100%);
+  height: 1rem;
+  pointer-events: none;
+  position: absolute;
+  right: 1rem;
+  text-indent: calc(100% + 10rem);
+  top: calc(1rem + 0.25rem);
+  width: 1rem;
+}
+
+.nav-ubuntu-com {
+  display: none;
+}
+
+@media only screen and (min-width: 480px) {
+  ul.p-navigation__links li {
+    width: 100%;
+  }
+
+  .nav-ubuntu-com {
+    display: inherit;
+  }
+}
+
+@media only screen and (max-width: 800px) {
+  .nav-more-links {
+    margin-left: auto !important;
+    padding-right: 2rem !important;
+    width: 8rem !important;
+  }
+}
+
+@media only screen and (min-width: 800px) {
+  ul.p-navigation__links li {
+    width: 100% !important;
+  }
+}
+
+@media only screen and (min-width: 1310px) {
+  ul.p-navigation__links {
+    margin-left: calc(50% - 41em);
+  }
+}

--- a/docs/_static/js/header-nav.js
+++ b/docs/_static/js/header-nav.js
@@ -1,0 +1,10 @@
+$(document).ready(function() {
+    $(document).on("click", function () {
+        $(".more-links-dropdown").hide();
+    });
+
+    $('.nav-more-links').click(function(event) {
+        $('.more-links-dropdown').toggle();
+        event.stopPropagation();
+    });
+})

--- a/docs/_templates/header.html
+++ b/docs/_templates/header.html
@@ -1,0 +1,40 @@
+<header id="header" class="p-navigation">
+
+  <div class="p-navigation__nav" role="menubar">
+
+    <ul class="p-navigation__links" role="menu">
+
+      <li>
+        <a class="p-logo" href="https://{{ product_page }}" aria-current="page">
+          <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
+          <div class="p-logo-text p-heading--4">{{ project }}
+          </div>
+        </a>
+      </li>
+
+      <li class="nav-ubuntu-com">
+        <a href="https://{{ product_page }}" class="p-navigation__link">{{ product_page }}</a>
+      </li>
+
+      <li>
+        <a href="#" class="p-navigation__link nav-more-links">More resources</a>
+        <ul class="more-links-dropdown">
+
+          <li>
+            <a href="https://discourse.ubuntu.com/c/ubuntu-pro/116" class="p-navigation__sub-link p-dropdown__link">Forum</a>
+          </li>
+
+          <li>
+            <a href="https://discourse.ubuntu.com/t/ubuntu-pro-faq/34042" class="p-navigation__sub-link p-dropdown__link">FAQ</a>
+          </li>
+
+          <li>
+            <a href="https://github.com/canonical/ubuntu-pro-client" class="p-navigation__sub-link p-dropdown__link">GitHub</a>
+          </li>
+
+        </ul>
+      </li>
+
+    </ul>
+  </div>
+</header>

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,6 @@
+{% extends "furo/page.html" %}
+
+{% block body -%}
+   {% include "header.html" %}
+   {{ super() }}
+{%- endblock body %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx_design",
     "sphinxcontrib.mermaid",
     "sphinx.ext.autosectionlabel",
+    "sphinxcontrib.jquery",
 ]
 autosectionlabel_prefix_document = True
 
@@ -63,7 +64,7 @@ myst_heading_anchors = 3
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "furo"
-html_logo = "_static/circle_of_friends.png"
+# html_logo = "_static/circle_of_friends.png"
 html_theme_options = {
     "light_css_variables": {
         "color-sidebar-background-border": "none",
@@ -96,6 +97,13 @@ html_theme_options = {
         "color-sidebar-item-background--hover": "#333",
     },
 }
+html_context = {
+    "product_page": "ubuntu.com/pro",
+    "product_tag": "_static/circle_of_friends.png",
+    "github_version": "docs",
+    "github_folder": "/docs/",
+    "github_issues": "enabled"
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -107,8 +115,10 @@ html_css_files = [
     "css/github_issue_links.css",
     "css/custom.css",
     "css/mermaid.css",
+    "css/header.css",
 ]
 html_js_files = [
     "js/github_issue_links.js",
+    "js/header-nav.js",
     "js/synced_tab_links.js",
 ]


### PR DESCRIPTION
```
This change will further align us with Ubuntu branding.

I haven't changed much past the default in the starter pack
so I can tailor it to our needs. Let me know what other links
we should add to the "more resources" menu, or any other changes
you'd like me to make. When I uprate the devdocs, they will be
added to this header (so they align with ubuntu.com docs)
```

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [X] No
