### PR TITLE
Look for the snapd package instead of looking for the snap command

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -486,13 +486,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         if required_snaps is None:
             return True
 
-        if not system.which(snap.SNAP_CMD):
+        if not snap.is_snapd_installed():
             event.info("Installing snapd")
             snap.install_snapd()
-        elif not snap.is_snapd_installed():
-            raise exceptions.SnapdNotProperlyInstalledError(
-                snap_cmd=snap.SNAP_CMD, service=self.title
-            )
 
         snap.run_snapd_wait_cmd()
 

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -84,14 +84,9 @@ class LivepatchEntitlement(UAEntitlement):
 
         @return: True on success, False otherwise.
         """
-        if not system.which(snap.SNAP_CMD):
+        if not snap.is_snapd_installed():
             event.info("Installing snapd")
             snap.install_snapd()
-
-        elif not snap.is_snapd_installed():
-            raise exceptions.SnapdNotProperlyInstalledError(
-                snap_cmd=snap.SNAP_CMD, service=self.title
-            )
 
         snap.run_snapd_wait_cmd()
 

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -1255,7 +1255,6 @@ class TestHandleRequiredSnaps:
     @mock.patch(
         "uaclient.entitlements.base.UAEntitlement._base_entitlement_cfg"
     )
-    @mock.patch("uaclient.system.which", return_value=True)
     @mock.patch("uaclient.snap.is_snapd_installed", return_value=True)
     @mock.patch("uaclient.snap.run_snapd_wait_cmd")
     @mock.patch("uaclient.snap.get_snap_info")
@@ -1270,7 +1269,6 @@ class TestHandleRequiredSnaps:
         m_get_snap_info,
         m_run_snapd_wait_cmd,
         m_is_snapd_installed,
-        m_which,
         m_base_ent_cfg,
         entitlement_cfg,
         concrete_entitlement_factory,
@@ -1286,13 +1284,11 @@ class TestHandleRequiredSnaps:
         assert entitlement.handle_required_snaps()
 
         if not entitlement_cfg:
-            assert 0 == m_which.call_count
             assert 0 == m_is_snapd_installed.call_count
             assert 0 == m_run_snapd_wait_cmd.call_count
             assert 0 == m_validate_proxy.call_count
             assert 0 == m_configure_snap_proxy.call_count
         else:
-            assert 1 == m_which.call_count
             assert 1 == m_is_snapd_installed.call_count
             assert 1 == m_run_snapd_wait_cmd.call_count
             assert 2 == m_validate_proxy.call_count

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -1229,7 +1229,7 @@ class TestGetContractVariant:
         assert 1 == m_base_ent_cfg.call_count
 
 
-class TestHandleAdditionalSnaps:
+class TestHandleRequiredSnaps:
     @pytest.mark.parametrize(
         "entitlement_cfg",
         (
@@ -1262,7 +1262,7 @@ class TestHandleAdditionalSnaps:
     @mock.patch("uaclient.snap.install_snap")
     @mock.patch("uaclient.http.validate_proxy")
     @mock.patch("uaclient.snap.configure_snap_proxy")
-    def test_get_contract_variant(
+    def test_handle_required_snaps(
         self,
         m_configure_snap_proxy,
         m_validate_proxy,

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -87,15 +87,6 @@ class APTInstallInvalidRepoError(UserFacingError):
         super().__init__(msg=msg.msg, msg_code=msg.name)
 
 
-class SnapdNotProperlyInstalledError(UserFacingError):
-    def __init__(self, snap_cmd: str, service: str) -> None:
-        msg = messages.SNAPD_NOT_PROPERLY_INSTALLED.format(
-            snap_cmd=snap_cmd, service=service
-        )
-
-        super().__init__(msg=msg.msg, msg_code=msg.name)
-
-
 class CannotInstallSnapdError(UserFacingError):
     def __init__(self) -> None:
         msg = messages.CANNOT_INSTALL_SNAPD

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -611,14 +611,6 @@ APT_INSTALL_INVALID_REPO = FormattedNamedMessage(
     "apt-install-invalid-repo", "{header_msg}APT install failed.{repo_msg}"
 )
 
-SNAPD_NOT_PROPERLY_INSTALLED = FormattedNamedMessage(
-    "snapd-not-properly-installed-for-livepatch",
-    (
-        "{snap_cmd} is present but snapd is not installed;"
-        " cannot enable {service}"
-    ),
-)
-
 CANNOT_INSTALL_SNAPD = NamedMessage(
     "cannot-install-snapd", "Failed to install snapd on the system"
 )

--- a/uaclient/snap.py
+++ b/uaclient/snap.py
@@ -51,12 +51,8 @@ def configure_snap_proxy(
         on failure; sleeping half a second before the first retry and 1 second
         before the second retry.
     """
-    if not system.which(SNAP_CMD):
-        logging.debug(
-            "Skipping configure snap proxy. {} does not exist.".format(
-                SNAP_CMD
-            )
-        )
+    if not is_snapd_installed():
+        logging.debug("Skipping configure snap proxy. snapd is not installed.")
         return
 
     if http_proxy or https_proxy:
@@ -87,11 +83,9 @@ def unconfigure_snap_proxy(
         on failure; sleeping half a second before the first retry and 1 second
         before the second retry.
     """
-    if not system.which(SNAP_CMD):
+    if not is_snapd_installed():
         logging.debug(
-            "Skipping unconfigure snap proxy. {} does not exist.".format(
-                SNAP_CMD
-            )
+            "Skipping unconfigure snap proxy. snapd is not installed."
         )
         return
     system.subp(


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we don't need two ways to check if snapd is there. If the package is installed, then the command exists. Otherwise, we install it and it creates the binary. Weird combinations (overriding the binary??) is not supported, so we don't need to check for that.

## Test Steps
It is refactor-ish, so CI should take care of this.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
