### PR TITLE
esm: pin repositories to a higher priority using a static file

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -41,6 +41,8 @@ ESM_APT_PREF_FILE_TRUSTY="$APT_PREFERENCES_DIR/ubuntu-esm-trusty"
 ESM_INFRA_OLD_APT_PREF_FILE_TRUSTY="$APT_PREFERENCES_DIR/ubuntu-esm-infra-trusty"
 ESM_INFRA_APT_PREF_FILE="$APT_PREFERENCES_DIR/ubuntu-esm-infra"
 ESM_APPS_APT_PREF_FILE="$APT_PREFERENCES_DIR/ubuntu-esm-apps"
+FIPS_APT_PREF_FILE="$APT_PREFERENCES_DIR/ubuntu-fips"
+FIPS_UPDATES_APT_PREF_FILE="$APT_PREFERENCES_DIR/ubuntu-fips-updates"
 
 SYSTEMD_WANTS_AUTO_ATTACH_LINK="/etc/systemd/system/multi-user.target.wants/ua-auto-attach.service"
 SYSTEMD_HELPER_ENABLED_AUTO_ATTACH_DSH="/var/lib/systemd/deb-systemd-helper-enabled/ua-auto-attach.service.dsh-also"
@@ -395,6 +397,15 @@ rename_gpg_keys() {
     fi
 }
 
+remove_old_fips_preferences() {
+    if check_service_is_enabled fips; then
+        rm -f $FIPS_APT_PREF_FILE
+    fi
+    if check_service_is_enabled fips-updates; then
+        rm -f $FIPS_UPDATES_APT_PREF_FILE
+    fi
+}
+
 case "$1" in
     configure)
       PREVIOUS_PKG_VER=$2
@@ -491,6 +502,7 @@ case "$1" in
       # Rename the gpg keys to -pro-
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "29~"; then
           rename_gpg_keys
+          remove_old_fips_preferences
       fi
 
       if grep -q "^ua_config:" /etc/ubuntu-advantage/uaclient.conf; then

--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -3,7 +3,7 @@ Feature: Performing attach using ua-airgapped
 
     @series.jammy
     @uses.config.machine_type.lxd-container
-    Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
+    Scenario Outline: Attached enable of airgapped services in an ubuntu lxd container
         Given a `<release>` machine with ubuntu-advantage-tools installed
         # set up the apt mirror configuration
         Given a `jammy` machine named `mirror`
@@ -41,11 +41,11 @@ Feature: Performing attach using ua-airgapped
         When I run `apt-cache policy hello` with sudo
         Then stdout matches regexp:
         """
-        500 .*:9000/ubuntu jammy-apps-security/main
+        510 .*:9000/ubuntu jammy-apps-security/main
         """
         And stdout matches regexp:
         """
-        500 .*:8000/ubuntu jammy-infra-security/main
+        510 .*:8000/ubuntu jammy-infra-security/main
         """
 
         Examples: ubuntu release

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -233,16 +233,24 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         See: sudo pro status
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         <esm-infra-url> <release>-infra-updates/main amd64 Packages
+        """
+        And apt-cache policy for the following url has permission `510`
+        """
+        <esm-infra-url> <release>-infra-security/main amd64 Packages
         """
         And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt install -y <infra-pkg>` with sudo, retrying exit [100]
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 <esm-infra-url> <release>-infra-security/main amd64 Packages
+        \s*510 <esm-infra-url> <release>-infra-security/main amd64 Packages
+        """
+        And stdout matches regexp:
+        """
+        \s*510 <esm-infra-url> <release>-infra-updates/main amd64 Packages
         """
 
         Examples: ubuntu release
@@ -1124,11 +1132,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt-cache policy` as non-root
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -1138,8 +1146,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I verify that running `pro enable esm-apps` `with sudo` exits `1`
         Then stdout matches regexp

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -22,13 +22,12 @@ Feature: Pro Install and Uninstall related tests
     Scenario Outline: Purge package after attaching it to a machine
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `touch /etc/apt/preferences.d/ubuntu-esm-infra` with sudo
         Then I verify that files exist matching `/var/log/ubuntu-advantage.log`
         And I verify that running `test -d /var/lib/ubuntu-advantage` `with sudo` exits `0`
         And I verify that files exist matching `/etc/apt/auth.conf.d/90ubuntu-advantage`
         And I verify that files exist matching `/etc/apt/trusted.gpg.d/ubuntu-pro-esm-infra.gpg`
         And I verify that files exist matching `/etc/apt/sources.list.d/ubuntu-esm-infra.list`
-        And I verify that files exist matching `/etc/apt/preferences.d/ubuntu-esm-infra`
+        And I verify that files exist matching `/etc/apt/preferences.d/ubuntu-pro-preferences`
         When I run `apt-get purge ubuntu-advantage-tools -y` with sudo, retrying exit [100]
         Then stdout matches regexp:
         """

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -289,19 +289,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -310,7 +310,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -321,8 +321,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
         """
@@ -416,19 +416,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -437,7 +437,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -448,8 +448,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
         """
@@ -542,19 +542,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -563,7 +563,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -574,8 +574,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
         """

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -60,19 +60,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -85,11 +85,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -100,8 +100,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
@@ -280,19 +280,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -305,11 +305,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -320,8 +320,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
@@ -553,19 +553,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -578,11 +578,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -593,8 +593,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:

--- a/preferences.d/ubuntu-pro-preferences
+++ b/preferences.d/ubuntu-pro-preferences
@@ -1,0 +1,15 @@
+Package: *
+Pin: release o=UbuntuESM
+Pin-Priority: 510
+
+Package: *
+Pin: release o=UbuntuESMApps
+Pin-Priority: 510
+
+Package: *
+Pin: release o=UbuntuFIPS
+Pin-Priority: 1001
+
+Package: *
+Pin: release o=UbuntuFIPSUpdates
+Pin-Priority: 1001

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ def _get_data_files():
             "/etc/update-manager/release-upgrades.d/",
             ["release-upgrades.d/ubuntu-advantage-upgrades.cfg"],
         ),
+        ("/etc/apt/preferences.d/", ["preferences.d/ubuntu-pro-preferences"]),
         (defaults.CONFIG_DEFAULTS["data_dir"], []),
         ("/lib/systemd/system", glob.glob("systemd/*")),
         (

--- a/sru/release-29/test-esm-pinning.sh
+++ b/sru/release-29/test-esm-pinning.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+set -e
+
+series=$1
+token=$2
+install_from=$3 # either path to a .deb, or 'staging', or 'proposed'
+
+name=$series-dev
+
+function cleanup {
+  lxc delete $name --force
+}
+
+function on_err {
+  echo -e "Test Failed"
+  cleanup
+  exit 1
+}
+trap on_err ERR
+
+function check_esm_pin {
+    service=$1
+    pin=$2
+    apt_policy=$(lxc exec $name -- apt-cache policy)
+    if grep -q "$pin https://esm.ubuntu.com/$service/ubuntu $series-$service-updates" <<< "$apt_policy"; then
+        echo "SUCCESS: esm-$service is pinned to $pin"
+    else
+        echo "ERROR: esm-$service is pinned to a different value than $pin"
+    fi
+}
+
+function disable_esm_services {
+    # Disable esm-apps and esm-infra
+    # ----------------------------------------------------------------
+    echo -e "\n* Disabling esm-infra and esm-apps"
+    lxc exec $name -- sudo pro disable esm-infra esm-apps --assume-yes
+    echo "###########################################"
+    lxc exec $name -- pro status --wait
+    echo -e "###########################################\n"
+    apt_policy=$(lxc exec $name -- apt-cache policy)
+    if grep -q "510 https://esm.ubuntu.com/infra/ubuntu $series-infra-updates" <<< "$apt_policy"; then
+        echo "ERROR: esm-infra is still enabled"
+    else
+        echo "SUCCESS: esm-infra not enabled"
+    fi
+
+    if grep -q "510 https://esm.ubuntu.com/apps/ubuntu $series-apps-updates" <<< "$apt_policy"; then
+        echo "ERROR: esm-apps is still enabled"
+    else
+        echo "SUCCESS: esm-apps not enabled"
+    fi
+}
+
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+
+# Install latest ubuntu-advantage-tools
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get install  -y ubuntu-advantage-tools > /dev/null
+echo -e "\n* Latest u-a-t is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Attach with the current ubuntu-advantage-tools package
+lxc exec $name -- pro attach $token &> /dev/null
+echo -e "\n* Pro is attached, esm-infra is enabled"
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Verify that esm-apps and esm-infra are not pinned
+echo -e "\n* Check esm pins"
+echo "###########################################"
+check_esm_pin "infra" 500
+check_esm_pin "apps" 500
+echo -e "###########################################\n"
+
+# Upgrade u-a-t to new version
+# ----------------------------------------------------------------
+if [ $install_from == 'staging' ]; then
+  lxc exec $name -- sudo add-apt-repository ppa:ua-client/staging -y > /dev/null
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+elif [ $install_from == 'proposed' ]; then
+  lxc exec $name -- sh -c "echo \"deb http://archive.ubuntu.com/ubuntu $series-proposed main\" | tee /etc/apt/sources.list.d/proposed.list"
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+else
+  lxc file push $install_from $name/new-ua.deb
+  lxc exec $name -- dpkg -i /new-ua.deb > /dev/null
+fi
+# ----------------------------------------------------------------
+echo -e "\n* u-a-t now has the change"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Check esm-pins again
+echo -e "\n* Check esm pins after upgrading the package"
+echo "###########################################"
+check_esm_pin "infra" 510
+check_esm_pin "apps" 510
+echo -e "###########################################\n"
+
+# Disable esm-apps and esm-infra
+# ----------------------------------------------------------------
+disable_esm_services
+
+# enable esm-apps and esm-infra
+# ----------------------------------------------------------------
+echo -e "\n* Enabling esm-infra and esm-apps"
+lxc exec $name -- sudo pro enable esm-infra esm-apps --assume-yes
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Check esm-pins again
+echo -e "\n* Check esm pins after enable"
+echo "###########################################"
+check_esm_pin "infra" 510
+check_esm_pin "apps" 510
+echo -e "###########################################\n"
+
+# Disable esm-apps and esm-infra
+# ----------------------------------------------------------------
+echo -e "\n* Disabling esm-infra and esm-apps"
+disable_esm_services
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+
+echo -e "\n* Create custom pin files with alphabetical name lower than the Pro pin file"
+lxc exec $name -- sudo sh -c 'echo "Package: *\nPin: release o=UbuntuESM\nPin-Priority: 450" > /etc/apt/preferences.d/custom-esm-infra'
+lxc exec $name -- sudo sh -c 'echo "Package: *\nPin: release o=UbuntuESMApps\nPin-Priority: 450" > /etc/apt/preferences.d/custom-esm-apps'
+echo -e "\n* Enabling esm-infra and esm-apps"
+lxc exec $name -- sudo pro enable esm-infra esm-apps --assume-yes
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Check esm-pins again
+echo -e "\n* Check esm pins after enable"
+echo "###########################################"
+check_esm_pin "infra" 450
+check_esm_pin "apps" 450
+echo -e "###########################################\n"
+
+#  Disable esm-apps and esm-infra
+# ----------------------------------------------------------------
+echo -e "\n* Disabling esm-infra and esm-apps"
+disable_esm_services
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+echo -e "\n* Create custom pin files with alphabetical name higher than the Pro pin file"
+lxc exec $name -- sudo rm /etc/apt/preferences.d/custom-esm-infra
+lxc exec $name -- sudo rm /etc/apt/preferences.d/custom-esm-apps
+lxc exec $name -- sudo sh -c 'echo "Package: *\nPin: release o=UbuntuESM\nPin-Priority: 450" > /etc/apt/preferences.d/zcustom-esm-infra'
+lxc exec $name -- sudo sh -c 'echo "Package: *\nPin: release o=UbuntuESMApps\nPin-Priority: 450" > /etc/apt/preferences.d/zcustom-esm-apps'
+echo -e "\n* Enabling esm-infra and esm-apps"
+lxc exec $name -- sudo pro enable esm-infra esm-apps --assume-yes
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Check esm-pins again
+echo -e "\n* Check esm pins after enable"
+echo "###########################################"
+check_esm_pin "infra" 510
+check_esm_pin "apps" 510
+echo -e "###########################################\n"
+
+cleanup

--- a/sru/release-29/test-fips-pinning.sh
+++ b/sru/release-29/test-fips-pinning.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -e
+
+series=$1
+token=$2
+service_to_test=$3 # either fips or fips-updates
+install_from=$4 # either path to a .deb, or 'staging', or 'proposed'
+
+name=$series-dev-$service_to_test
+
+function cleanup {
+  lxc delete $name --force
+}
+
+function on_err {
+  echo -e "Test Failed"
+  cleanup
+  exit 1
+}
+trap on_err ERR
+
+function check_fips_pin {
+    service=$1
+    pin=$2
+    apt_policy=$(lxc exec $name -- apt-cache policy)
+    if grep -q "$pin https://esm.ubuntu.com/$service/ubuntu $series" <<< "$apt_policy"; then
+        echo "SUCCESS: $service is pinned to $pin"
+    else
+        echo "ERROR: $service is pinned to a different value than $pin"
+    fi
+}
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+
+# Install latest ubuntu-advantage-tools
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get install  -y ubuntu-advantage-tools > /dev/null
+echo -e "\n* Latest u-a-t is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Attach with the current ubuntu-advantage-tools package
+lxc exec $name -- pro attach $token &> /dev/null
+echo -e "\n* Pro is attached"
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Enable FIPS
+lxc exec $name -- pro enable $service_to_test --assume-yes &> /dev/null
+echo -e "\n* FIPS is enabled"
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Verify that FIPS is pinned to 1001
+echo -e "\n* Check FIPS pins"
+echo "###########################################"
+check_fips_pin "$service_to_test" 1001
+echo -e "###########################################\n"
+
+# Check the contents of the preferences dir
+echo -e "\n* APT preferences directory content"
+echo "###########################################"
+lxc exec $name -- ls -l /etc/apt/preferences.d/
+echo -e "###########################################\n"
+
+# Upgrade u-a-t to new version
+# ----------------------------------------------------------------
+if [ $install_from == 'staging' ]; then
+  lxc exec $name -- sudo add-apt-repository ppa:ua-client/staging -y > /dev/null
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+elif [ $install_from == 'proposed' ]; then
+  lxc exec $name -- sh -c "echo \"deb http://archive.ubuntu.com/ubuntu $series-proposed main\" | tee /etc/apt/sources.list.d/proposed.list"
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+else
+  lxc file push $install_from $name/new-ua.deb
+  lxc exec $name -- dpkg -i /new-ua.deb > /dev/null
+fi
+# ----------------------------------------------------------------
+echo -e "\n* u-a-t now has the change"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Check FIPS pins again
+echo -e "\n* Check esm pins after upgrading the package"
+echo "###########################################"
+check_fips_pin "$service_to_test" 1001
+echo -e "###########################################\n"
+
+# Check the contents of the preferences dir again
+echo -e "\n* APT preferences directory content"
+echo "###########################################"
+lxc exec $name -- ls -l /etc/apt/preferences.d/
+echo -e "###########################################\n"
+
+cleanup

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -508,19 +508,6 @@ def remove_auth_apt_repo(
     remove_repo_from_apt_auth_file(repo_url)
 
 
-def add_ppa_pinning(apt_preference_file, repo_url, origin, priority):
-    """Add an apt preferences file and pin for a PPA."""
-    _protocol, repo_path = repo_url.split("://")
-    if repo_path.endswith("/"):  # strip trailing slash
-        repo_path = repo_path[:-1]
-    content = (
-        "Package: *\n"
-        "Pin: release o={origin}\n"
-        "Pin-Priority: {priority}\n".format(origin=origin, priority=priority)
-    )
-    system.write_file(apt_preference_file, content)
-
-
 def get_apt_auth_file_from_apt_config():
     """Return to patch to the system configured APT auth file."""
     out, _err = system.subp(
@@ -583,19 +570,12 @@ def clean_apt_files(*, _entitlements=None):
         if not issubclass(ent_cls, RepoEntitlement):
             continue
         repo_file = ent_cls.repo_list_file_tmpl.format(name=ent_cls.name)
-        pref_file = ent_cls.repo_pref_file_tmpl.format(name=ent_cls.name)
         if os.path.exists(repo_file):
             event.info(
                 "Removing apt source file: {}".format(repo_file),
                 file_type=sys.stderr,
             )
             system.ensure_file_absent(repo_file)
-        if os.path.exists(pref_file):
-            event.info(
-                "Removing apt preferences file: {}".format(pref_file),
-                file_type=sys.stderr,
-            )
-            system.ensure_file_absent(pref_file)
 
 
 def is_installed(pkg: str) -> bool:

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -82,8 +82,6 @@ FIPS_CONTAINER_CONDITIONAL_PACKAGES = {
 
 
 class FIPSCommonEntitlement(repo.RepoEntitlement):
-
-    repo_pin_priority = 1001
     repo_key_file = "ubuntu-pro-fips.gpg"  # Same for fips & fips-updates
     FIPS_PROC_FILE = "/proc/sys/crypto/fips_enabled"
 

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -156,9 +156,8 @@ class TestCommonCriteriaEntitlementEnable:
         entitlement = CommonCriteriaEntitlement(cfg, allow_beta=True)
 
         with mock.patch("uaclient.apt.add_auth_apt_repo") as m_add_apt:
-            with mock.patch("uaclient.apt.add_ppa_pinning") as m_add_pin:
-                with mock.patch(M_REPOPATH + "exists", side_effect=exists):
-                    assert (True, None) == entitlement.enable()
+            with mock.patch(M_REPOPATH + "exists", side_effect=exists):
+                assert (True, None) == entitlement.enable()
 
         add_apt_calls = [
             mock.call(
@@ -224,8 +223,6 @@ class TestCommonCriteriaEntitlementEnable:
         )
 
         assert add_apt_calls == m_add_apt.call_args_list
-        # No apt pinning for cc
-        assert [] == m_add_pin.call_args_list
         assert 1 == m_setup_apt_proxy.call_count
         assert 1 == m_should_reboot.call_count
         assert 1 == m_apt_cache_policy.call_count

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -82,8 +82,7 @@ class TestCISEntitlementEnable:
 
         with mock.patch(M_REPOPATH + "exists", mock.Mock(return_value=True)):
             with mock.patch("uaclient.apt.add_auth_apt_repo") as m_add_apt:
-                with mock.patch("uaclient.apt.add_ppa_pinning") as m_add_pin:
-                    assert entitlement.enable()
+                assert entitlement.enable()
 
         add_apt_calls = [
             mock.call(
@@ -125,8 +124,6 @@ class TestCISEntitlementEnable:
         ]
 
         assert add_apt_calls == m_add_apt.call_args_list
-        # No apt pinning for cis
-        assert [] == m_add_pin.call_args_list
         assert 1 == m_setup_apt_proxy.call_count
         assert subp_apt_cmds == m_subp.call_args_list
         assert 1 == m_apt_policy.call_count


### PR DESCRIPTION
note: this PR is one of the alternatives to pinning ESM. The other alternative is #2663 . Please merge one of them and discard the other.

## Why is this needed?
This PR solves all of our problems because it 
Fixes: #2580
context is provided in the issue and the internal spec

## Test Steps
Run CI

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] Changes here need to be documented, and this was done in: 

## Does this PR require extra reviews?
 - [x] Yes - basak or panlinux
 - [ ] No
