### PR TITLE
docs: skip PR builds on PRs to main

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+  jobs:
+    post_checkout:
+      # Always skip on main branch.
+      # Docs are kept in separate docs and docs-devel branches.
+      - exit 183
+


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR will skip the RTD build on dev PRs.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

RTD job on this PR should get skipped :crossed_fingers: 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [n/a] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
