### PR TITLE
logging: fix calls to logging to use correct logger

### DIFF
--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -65,7 +65,7 @@ def attach_with_token(
         )
     except exceptions.UrlError as e:
         with util.disable_log_to_console():
-            logging.exception(str(e))
+            LOG.exception(str(e))
         raise exceptions.ConnectivityError()
 
     cfg.machine_token_file.write(new_machine_token)

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -555,7 +555,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         package_names = [package["name"] for package in required_packages]
         msg = messages.INSTALLING_PACKAGES.format(" ".join(package_names))
-        logging.debug(msg)
+        LOG.debug(msg)
         event.info(msg)
         apt.run_apt_install_command(package_names)
 
@@ -581,7 +581,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         ]
         package_names_str = " ".join(package_names)
         msg = messages.UNINSTALLING_PACKAGES.format(package_names_str)
-        logging.debug(msg)
+        LOG.debug(msg)
         event.info(msg)
         apt.remove_packages(
             package_names,

--- a/uaclient/entitlements/landscape.py
+++ b/uaclient/entitlements/landscape.py
@@ -6,6 +6,7 @@ from uaclient import apt, event_logger, exceptions, messages, system, util
 from uaclient.entitlements.base import UAEntitlement
 from uaclient.entitlements.entitlement_status import ApplicationStatus
 
+LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
 event = event_logger.get_event_logger()
 
 LANDSCAPE_CLIENT_PACKAGE_NAME = "landscape-client"
@@ -26,7 +27,7 @@ class LandscapeEntitlement(UAEntitlement):
         if self.assume_yes and "--silent" not in cmd:
             cmd += ["--silent"]
 
-        logging.debug(messages.EXECUTING_COMMAND.format(" ".join(cmd)))
+        LOG.debug(messages.EXECUTING_COMMAND.format(" ".join(cmd)))
         event.info(
             util.redact_sensitive_logs(
                 messages.EXECUTING_COMMAND.format(" ".join(cmd))
@@ -65,7 +66,7 @@ class LandscapeEntitlement(UAEntitlement):
             system.subp(cmd)
         except exceptions.ProcessExecutionError as e:
             with util.disable_log_to_console():
-                logging.error(e)
+                LOG.error(e)
             event.info(str(e).strip())
             event.warning(str(e), self.name)
 
@@ -73,7 +74,7 @@ class LandscapeEntitlement(UAEntitlement):
             original=LANDSCAPE_CLIENT_CONFIG_PATH,
             backup=LANDSCAPE_CLIENT_CONFIG_PATH_DISABLE_BACKUP,
         )
-        logging.debug(msg)
+        LOG.debug(msg)
         event.info(msg)
         try:
             os.rename(
@@ -82,7 +83,7 @@ class LandscapeEntitlement(UAEntitlement):
             )
         except FileNotFoundError as e:
             with util.disable_log_to_console():
-                logging.error(e)
+                LOG.error(e)
             event.info(str(e))
             event.warning(str(e), self.name)
 


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because I forgot to change my `logging.*` calls to use the new logging setup when rebasing on the new logging implementation.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Before:
```
./tools/test-in-lxd.sh mantic
sudo pro attach $TOKEN
sudo pro enable landscape
# See tons of logging to the console
```
After: you wont see the logging to the console


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [n/a] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
