### PR TITLE
Pin esm but only esm

### DIFF
--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -41,11 +41,11 @@ Feature: Performing attach using ua-airgapped
         When I run `apt-cache policy hello` with sudo
         Then stdout matches regexp:
         """
-        500 .*:9000/ubuntu jammy-apps-security/main
+        510 .*:9000/ubuntu jammy-apps-security/main
         """
         And stdout matches regexp:
         """
-        500 .*:8000/ubuntu jammy-infra-security/main
+        510 .*:8000/ubuntu jammy-infra-security/main
         """
         Then I verify that running `pro refresh` `with sudo` exits `0`
 

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -233,16 +233,20 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         See: sudo pro status
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         <esm-infra-url> <release>-infra-updates/main amd64 Packages
+        """
+        And apt-cache policy for the following url has permission `510`
+        """
+        <esm-infra-url> <release>-infra-security/main amd64 Packages
         """
         And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt install -y <infra-pkg>` with sudo, retrying exit [100]
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 <esm-infra-url> <release>-infra-security/main amd64 Packages
+        \s*510 <esm-infra-url> <release>-infra-security/main amd64 Packages
         """
 
         Examples: ubuntu release
@@ -1124,11 +1128,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt-cache policy` as non-root
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -1138,8 +1142,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I verify that running `pro enable esm-apps` `with sudo` exits `1`
         Then stdout matches regexp

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -289,19 +289,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -310,7 +310,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -321,8 +321,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
         """
@@ -416,19 +416,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -437,7 +437,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -448,8 +448,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
         """
@@ -542,19 +542,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -563,7 +563,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -574,8 +574,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
         """

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -60,19 +60,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -85,11 +85,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -100,8 +100,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
@@ -280,19 +280,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -305,11 +305,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -320,8 +320,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
@@ -553,19 +553,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `500`
+        And apt-cache policy for the following url has permission `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -578,11 +578,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -593,8 +593,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:

--- a/preferences.d/ubuntu-pro-esm-apps
+++ b/preferences.d/ubuntu-pro-esm-apps
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=UbuntuESMApps
+Pin-Priority: 510

--- a/preferences.d/ubuntu-pro-esm-infra
+++ b/preferences.d/ubuntu-pro-esm-infra
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=UbuntuESM
+Pin-Priority: 510

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ def _get_data_files():
             "/etc/update-manager/release-upgrades.d/",
             ["release-upgrades.d/ubuntu-advantage-upgrades.cfg"],
         ),
+        ("/etc/apt/preferences.d", glob.glob("preferences.d/*")),
         (defaults.CONFIG_DEFAULTS["data_dir"], []),
         ("/lib/systemd/system", glob.glob("systemd/*")),
         (

--- a/sru/release-29/test-esm-pinning.sh
+++ b/sru/release-29/test-esm-pinning.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+set -e
+
+series=$1
+token=$2
+install_from=$3 # either path to a .deb, or 'staging', or 'proposed'
+
+name=$series-dev
+
+function cleanup {
+  lxc delete $name --force
+}
+
+function on_err {
+  echo -e "Test Failed"
+  cleanup
+  exit 1
+}
+trap on_err ERR
+
+function check_esm_pin {
+    service=$1
+    pin=$2
+    apt_policy=$(lxc exec $name -- apt-cache policy)
+    if grep -q "$pin https://esm.ubuntu.com/$service/ubuntu $series-$service-updates" <<< "$apt_policy"; then
+        echo "SUCCESS: esm-$service is pinned to $pin"
+    else
+        echo "ERROR: esm-$service is pinned to a different value than $pin"
+    fi
+}
+
+function disable_esm_services {
+    # Disable esm-apps and esm-infra
+    # ----------------------------------------------------------------
+    echo -e "\n* Disabling esm-infra and esm-apps"
+    lxc exec $name -- sudo pro disable esm-infra esm-apps --assume-yes
+    echo "###########################################"
+    lxc exec $name -- pro status --wait
+    echo -e "###########################################\n"
+    apt_policy=$(lxc exec $name -- apt-cache policy)
+    if grep -q "510 https://esm.ubuntu.com/infra/ubuntu $series-infra-updates" <<< "$apt_policy"; then
+        echo "ERROR: esm-infra is still enabled"
+    else
+        echo "SUCCESS: esm-infra not enabled"
+    fi
+
+    if grep -q "510 https://esm.ubuntu.com/apps/ubuntu $series-apps-updates" <<< "$apt_policy"; then
+        echo "ERROR: esm-apps is still enabled"
+    else
+        echo "SUCCESS: esm-apps not enabled"
+    fi
+}
+
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+
+# Install latest ubuntu-advantage-tools
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get install  -y ubuntu-advantage-tools > /dev/null
+echo -e "\n* Latest u-a-t is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Attach with the current ubuntu-advantage-tools package
+lxc exec $name -- pro attach $token &> /dev/null
+echo -e "\n* Pro is attached, esm-infra is enabled"
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Verify that esm-apps and esm-infra are not pinned
+echo -e "\n* Check esm pins"
+echo "###########################################"
+check_esm_pin "infra" 500
+check_esm_pin "apps" 500
+echo -e "###########################################\n"
+
+# Upgrade u-a-t to new version
+# ----------------------------------------------------------------
+if [ $install_from == 'staging' ]; then
+  lxc exec $name -- sudo add-apt-repository ppa:ua-client/staging -y > /dev/null
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+elif [ $install_from == 'proposed' ]; then
+  lxc exec $name -- sh -c "echo \"deb http://archive.ubuntu.com/ubuntu $series-proposed main\" | tee /etc/apt/sources.list.d/proposed.list"
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+else
+  lxc file push $install_from $name/new-ua.deb
+  lxc exec $name -- dpkg -i /new-ua.deb > /dev/null
+fi
+# ----------------------------------------------------------------
+echo -e "\n* u-a-t now has the change"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Check esm-pins again
+echo -e "\n* Check esm pins after upgrading the package"
+echo "###########################################"
+check_esm_pin "infra" 510
+check_esm_pin "apps" 510
+echo -e "###########################################\n"
+
+# Disable esm-apps and esm-infra
+# ----------------------------------------------------------------
+disable_esm_services
+
+# enable esm-apps and esm-infra
+# ----------------------------------------------------------------
+echo -e "\n* Enabling esm-infra and esm-apps"
+lxc exec $name -- sudo pro enable esm-infra esm-apps --assume-yes
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Check esm-pins again
+echo -e "\n* Check esm pins after enable"
+echo "###########################################"
+check_esm_pin "infra" 510
+check_esm_pin "apps" 510
+echo -e "###########################################\n"
+
+# Disable esm-apps and esm-infra
+# ----------------------------------------------------------------
+echo -e "\n* Disabling esm-infra and esm-apps"
+disable_esm_services
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+
+echo -e "\n* Create custom pin files with alphabetical name lower than the Pro pin file"
+lxc exec $name -- sudo sh -c 'echo "Package: *\nPin: release o=UbuntuESM\nPin-Priority: 450" > /etc/apt/preferences.d/custom-esm-infra'
+lxc exec $name -- sudo sh -c 'echo "Package: *\nPin: release o=UbuntuESMApps\nPin-Priority: 450" > /etc/apt/preferences.d/custom-esm-apps'
+echo -e "\n* Enabling esm-infra and esm-apps"
+lxc exec $name -- sudo pro enable esm-infra esm-apps --assume-yes
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Check esm-pins again
+echo -e "\n* Check esm pins after enable"
+echo "###########################################"
+check_esm_pin "infra" 450
+check_esm_pin "apps" 450
+echo -e "###########################################\n"
+
+#  Disable esm-apps and esm-infra
+# ----------------------------------------------------------------
+echo -e "\n* Disabling esm-infra and esm-apps"
+disable_esm_services
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+echo -e "\n* Create custom pin files with alphabetical name higher than the Pro pin file"
+lxc exec $name -- sudo rm /etc/apt/preferences.d/custom-esm-infra
+lxc exec $name -- sudo rm /etc/apt/preferences.d/custom-esm-apps
+lxc exec $name -- sudo sh -c 'echo "Package: *\nPin: release o=UbuntuESM\nPin-Priority: 450" > /etc/apt/preferences.d/zcustom-esm-infra'
+lxc exec $name -- sudo sh -c 'echo "Package: *\nPin: release o=UbuntuESMApps\nPin-Priority: 450" > /etc/apt/preferences.d/zcustom-esm-apps'
+echo -e "\n* Enabling esm-infra and esm-apps"
+lxc exec $name -- sudo pro enable esm-infra esm-apps --assume-yes
+echo "###########################################"
+lxc exec $name -- pro status --wait
+echo -e "###########################################\n"
+
+# Check esm-pins again
+echo -e "\n* Check esm pins after enable"
+echo "###########################################"
+check_esm_pin "infra" 510
+check_esm_pin "apps" 510
+echo -e "###########################################\n"
+
+cleanup


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it 
Fixes: #2580
context is provided in the issue and the internal spec

This is a version of #2664 which does not change the existing FIPS logic - thus, we have both ways to pin repositories (static and dynamic) at the same time. #2680 was created to reflect the next steps of this work.

## Test Steps
Run CI and the new `sru/` test.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] Changes here need to be documented, and this was done in: 

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
