### PR TITLE
contract: change default value of lastAttachment so server doesn't try to parse empty string

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -417,7 +417,7 @@ class UAContractClient(serviceclient.UAServiceClient):
                 "resources": [service.name for service in enabled_services],
                 "lastAttachment": attachment_data.attached_at.isoformat()
                 if attachment_data
-                else "",
+                else None,
             }
         else:
             activity_info = {}


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
Machines attached with a pro version <=28.1 don't have a lastAttachment time. The fallback value of "" was trying to be parsed by the contract server, which resulted in errors. The new fallback value of `None` is treated as nil by the backend and isn't parsed.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
apt update
apt install ubuntu-advantage-tools
pro attach $token
exit # new version gets installed after exit and lxc shell is re-started
sudo pro disable esm-infra
# Before this PR: you'd get an error here
# With this PR: this should succeed
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [n/a] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
