### PR TITLE
logging: no more cli console logging

### DIFF
--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -119,11 +119,10 @@ def main(cfg: config.UAConfig) -> int:
 
 if __name__ == "__main__":
     setup_logging(
-        logging.INFO,
         logging.DEBUG,
         defaults.CONFIG_DEFAULTS["log_file"],
     )
     cfg = config.UAConfig()
-    setup_logging(logging.INFO, logging.DEBUG, log_file=cfg.log_file)
+    setup_logging(logging.DEBUG, log_file=cfg.log_file)
     http.configure_web_proxy(cfg.http_proxy, cfg.https_proxy)
     sys.exit(main(cfg=cfg))

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -180,7 +180,6 @@ def run_jobs(cfg: UAConfig, current_time: datetime):
 
 if __name__ == "__main__":
     setup_logging(
-        logging.CRITICAL,
         logging.DEBUG,
         defaults.CONFIG_DEFAULTS["timer_log_file"],
         logger=LOG,
@@ -190,7 +189,6 @@ if __name__ == "__main__":
 
     # The ua-timer logger should log everything to its file
     setup_logging(
-        logging.CRITICAL,
         logging.DEBUG,
         log_file=cfg.timer_log_file,
         logger=LOG,
@@ -198,7 +196,7 @@ if __name__ == "__main__":
     # Make sure the ua-timer logger does not generate double logging
     LOG.propagate = False
     # The root logger should log any error to the timer log file
-    setup_logging(logging.CRITICAL, logging.ERROR, log_file=cfg.timer_log_file)
+    setup_logging(logging.ERROR, log_file=cfg.timer_log_file)
     http.configure_web_proxy(cfg.http_proxy, cfg.https_proxy)
 
     run_jobs(cfg=cfg, current_time=current_time)

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -64,8 +64,7 @@ def attach_with_token(
             contract_token=token, attachment_dt=attached_at
         )
     except exceptions.UrlError as e:
-        with util.disable_log_to_console():
-            LOG.exception(str(e))
+        LOG.exception(str(e))
         raise exceptions.ConnectivityError()
 
     cfg.machine_token_file.write(new_machine_token)

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -128,9 +128,8 @@ class UAConfig:
                     or state_files.UserConfigData()
                 )
             except Exception as e:
-                with util.disable_log_to_console():
-                    LOG.warning("Error loading user config: {}".format(e))
-                    LOG.warning("Using default config values")
+                LOG.warning("Error loading user config: {}".format(e))
+                LOG.warning("Using default config values")
                 self.user_config = state_files.UserConfigData()
 
         # support old ua_config values in uaclient.conf as user-config.json

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -517,19 +517,17 @@ def process_entitlements_delta(
         except exceptions.UserFacingError:
             delta_error = True
             failed_services.append(name)
-            with util.disable_log_to_console():
-                LOG.error(
-                    "Failed to process contract delta for {name}:"
-                    " {delta}".format(name=name, delta=new_entitlement)
-                )
+            LOG.error(
+                "Failed to process contract delta for {name}:"
+                " {delta}".format(name=name, delta=new_entitlement)
+            )
         except Exception:
             unexpected_error = True
             failed_services.append(name)
-            with util.disable_log_to_console():
-                LOG.exception(
-                    "Unexpected error processing contract delta for {name}:"
-                    " {delta}".format(name=name, delta=new_entitlement)
-                )
+            LOG.exception(
+                "Unexpected error processing contract delta for {name}:"
+                " {delta}".format(name=name, delta=new_entitlement)
+            )
         else:
             # If we have any deltas to process and we were able to process
             # them, then we will mark that service as successfully enabled

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -1179,17 +1179,19 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             if application_status != ApplicationStatus.DISABLED:
                 if self.can_disable():
                     self.disable()
-                    LOG.info(
-                        "Due to contract refresh, '%s' is now disabled.",
-                        self.name,
-                    )
+                    msg = (
+                        "Due to contract refresh, " "'{}' is now disabled."
+                    ).format(self.name)
+                    LOG.info(msg)
+                    event.info(msg)
                 else:
-                    LOG.warning(
-                        "Unable to disable '%s' as recommended during contract"
+                    msg = (
+                        "Unable to disable '{}' as recommended during contract"
                         " refresh. Service is still active. See"
-                        " `pro status`",
-                        self.name,
-                    )
+                        " `pro status`"
+                    ).format(self.name)
+                    LOG.warning(msg)
+                    event.info(msg)
             # Clean up former entitled machine-access-<name> response cache
             # file because uaclient doesn't access machine-access-* routes or
             # responses on unentitled services.

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -450,10 +450,12 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     def _perform_enable(self, silent: bool = False) -> bool:
         cloud_type, error = get_cloud_type()
         if cloud_type is None and error == NoCloudTypeReason.CLOUD_ID_ERROR:
-            LOG.warning(
+            msg = (
                 "Could not determine cloud, "
                 "defaulting to generic FIPS package."
             )
+            LOG.warning(msg)
+            event.info(msg)
         if super()._perform_enable(silent=silent):
             notices.remove(
                 Notice.FIPS_INSTALL_OUT_OF_DATE,

--- a/uaclient/entitlements/landscape.py
+++ b/uaclient/entitlements/landscape.py
@@ -65,8 +65,7 @@ class LandscapeEntitlement(UAEntitlement):
         try:
             system.subp(cmd)
         except exceptions.ProcessExecutionError as e:
-            with util.disable_log_to_console():
-                LOG.error(e)
+            LOG.error(e)
             event.info(str(e).strip())
             event.warning(str(e), self.name)
 
@@ -82,8 +81,7 @@ class LandscapeEntitlement(UAEntitlement):
                 LANDSCAPE_CLIENT_CONFIG_PATH_DISABLE_BACKUP,
             )
         except FileNotFoundError as e:
-            with util.disable_log_to_console():
-                LOG.error(e)
+            LOG.error(e)
             event.info(str(e))
             event.warning(str(e), self.name)
 

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -147,10 +147,11 @@ class LivepatchEntitlement(UAEntitlement):
                 livepatch_token = self.cfg.machine_token["machineToken"]
             application_status, _details = self.application_status()
             if application_status != ApplicationStatus.DISABLED:
-                LOG.info(
-                    "Disabling %s prior to re-attach with new token",
-                    self.title,
+                msg = "Disabling {} prior to re-attach with new token".format(
+                    self.title
                 )
+                LOG.info(msg)
+                event.info(msg)
                 try:
                     system.subp([livepatch.LIVEPATCH_CMD, "disable"])
                 except exceptions.ProcessExecutionError as e:
@@ -280,7 +281,9 @@ class LivepatchEntitlement(UAEntitlement):
         )
         process_token = bool(deltas.get("resourceToken", False))
         if any([process_directives, process_token]):
-            LOG.info("Updating '%s' on changed directives.", self.name)
+            msg = "Updating '{}' on changed directives.".format(self.name)
+            LOG.info(msg)
+            event.info(msg)
             return self.setup_livepatch_config(
                 process_directives=process_directives,
                 process_token=process_token,

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -202,10 +202,14 @@ class RepoEntitlement(base.UAEntitlement):
             return False
 
         if not self._check_apt_url_is_applied(delta_apt_url):
-            LOG.info(
-                "Updating '%s' apt sources list on changed directives.",
-                self.name,
+
+            msg = (
+                "Updating '{}' apt sources list on changed directives.".format(
+                    self.name
+                )
             )
+            LOG.info(msg)
+            event.info(msg)
 
             orig_entitlement = orig_access.get("entitlement", {})
             old_url = orig_entitlement.get("directives", {}).get("aptURL")
@@ -218,11 +222,11 @@ class RepoEntitlement(base.UAEntitlement):
             self.setup_apt_config()
 
         if delta_packages:
-            LOG.info(
-                "Installing packages on changed directives: {}".format(
-                    ", ".join(delta_packages)
-                )
+            msg = "Installing packages on changed directives: {}".format(
+                ", ".join(delta_packages)
             )
+            LOG.info(msg)
+            event.info(msg)
             self.install_packages(package_list=delta_packages)
 
         return True

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -466,6 +466,7 @@ class TestLivepatchEntitlementEnable:
             "Installing snapd\n"
             "Updating package lists\n"
             "Installing canonical-livepatch snap\n"
+            "Disabling Livepatch prior to re-attach with new token\n"
             "Canonical livepatch enabled.\n"
         )
         assert (msg, "") == capsys.readouterr()
@@ -520,6 +521,7 @@ class TestLivepatchEntitlementEnable:
         )
         msg = (
             "Installing canonical-livepatch snap\n"
+            "Disabling Livepatch prior to re-attach with new token\n"
             "Canonical livepatch enabled.\n"
         )
         assert (msg, "") == capsys.readouterr()
@@ -579,7 +581,11 @@ class TestLivepatchEntitlementEnable:
             ),
         ]
         assert subp_calls == m_subp.call_args_list
-        assert ("Canonical livepatch enabled.\n", "") == capsys.readouterr()
+        assert (
+            "Disabling Livepatch prior to re-attach with new token\n"
+            "Canonical livepatch enabled.\n",
+            "",
+        ) == capsys.readouterr()
         assert m_validate_proxy.call_count == 2
         assert m_snap_proxy.call_count == 1
         assert m_livepatch_proxy.call_count == 1

--- a/uaclient/files/notices.py
+++ b/uaclient/files/notices.py
@@ -119,8 +119,7 @@ class NoticesManager:
         :param description: The content to be written to the notice file.
         """
         if not util.we_are_currently_root():
-            with util.disable_log_to_console():
-                LOG.warning("Trying to add a notice as non-root user")
+            LOG.warning("Trying to add a notice as non-root user")
             return
 
         directory = (
@@ -142,8 +141,7 @@ class NoticesManager:
         :param notice_details: Holds details concerning the notice file.
         """
         if not util.we_are_currently_root():
-            with util.disable_log_to_console():
-                LOG.warning("Trying to remove a notice as non-root user")
+            LOG.warning("Trying to remove a notice as non-root user")
             return
 
         directory = (
@@ -193,13 +191,12 @@ class NoticesManager:
                             raise Exception()
                         notices.append(notice.value.message)
                     except Exception:
-                        with util.disable_log_to_console():
-                            LOG.warning(
-                                "Something went wrong while processing"
-                                " notice: {}.".format(
-                                    notice_file_name,
-                                )
+                        LOG.warning(
+                            "Something went wrong while processing"
+                            " notice: {}.".format(
+                                notice_file_name,
                             )
+                        )
         notices.sort()
         return notices
 

--- a/uaclient/http/__init__.py
+++ b/uaclient/http/__init__.py
@@ -73,13 +73,12 @@ def validate_proxy(
         except exceptions.ProxyAuthenticationFailed:
             raise
         except Exception as e:
-            with util.disable_log_to_console():
-                msg = getattr(e, "reason", str(e))
-                LOG.error(
-                    messages.ERROR_USING_PROXY.format(
-                        proxy=proxy, test_url=test_url, error=msg
-                    )
+            msg = getattr(e, "reason", str(e))
+            LOG.error(
+                messages.ERROR_USING_PROXY.format(
+                    proxy=proxy, test_url=test_url, error=msg
                 )
+            )
             raise exceptions.ProxyNotWorkingError(proxy)
 
         if response.code == 200:
@@ -94,13 +93,12 @@ def validate_proxy(
         opener.open(req)
         return proxy
     except (socket.timeout, error.URLError) as e:
-        with util.disable_log_to_console():
-            msg = getattr(e, "reason", str(e))
-            LOG.error(
-                messages.ERROR_USING_PROXY.format(
-                    proxy=proxy, test_url=test_url, error=msg
-                )
+        msg = getattr(e, "reason", str(e))
+        LOG.error(
+            messages.ERROR_USING_PROXY.format(
+                proxy=proxy, test_url=test_url, error=msg
             )
+        )
         raise exceptions.ProxyNotWorkingError(proxy)
 
 
@@ -279,8 +277,7 @@ def _readurl_pycurl_https_in_https(
         c.setopt(pycurl.PROXY, https_proxy)
         c.setopt(pycurl.PROXYTYPE, 2)  # 2 == HTTPS
     else:
-        with util.disable_log_to_console():
-            LOG.warning("in pycurl request function without an https proxy")
+        LOG.warning("in pycurl request function without an https proxy")
 
     # Response handling
     body_output = io.BytesIO()

--- a/uaclient/livepatch.py
+++ b/uaclient/livepatch.py
@@ -131,31 +131,26 @@ def status() -> Optional[LivepatchStatusStatus]:
             [LIVEPATCH_CMD, "status", "--verbose", "--format", "json"]
         )
     except exceptions.ProcessExecutionError:
-        with util.disable_log_to_console():
-            LOG.warning(
-                "canonical-livepatch returned error when checking status"
-            )
+        LOG.warning("canonical-livepatch returned error when checking status")
         return None
 
     try:
         status_json = json.loads(out)
     except json.JSONDecodeError:
-        with util.disable_log_to_console():
-            LOG.warning(
-                messages.JSON_PARSER_ERROR.format(
-                    source="canonical-livepatch status", out=out
-                ).msg
-            )
+        LOG.warning(
+            messages.JSON_PARSER_ERROR.format(
+                source="canonical-livepatch status", out=out
+            ).msg
+        )
         return None
 
     try:
         status_root = LivepatchStatus.from_dict(status_json)
     except IncorrectTypeError:
-        with util.disable_log_to_console():
-            LOG.warning(
-                "canonical-livepatch status returned unexpected "
-                "structure: {}".format(out)
-            )
+        LOG.warning(
+            "canonical-livepatch status returned unexpected "
+            "structure: {}".format(out)
+        )
         return None
 
     if status_root.status is None or len(status_root.status) < 1:
@@ -209,17 +204,13 @@ class UALivepatchClient(serviceclient.UAServiceClient):
                 headers=headers,
             )
         except Exception as e:
-            with util.disable_log_to_console():
-                LOG.warning(
-                    "error while checking livepatch supported kernels API"
-                )
-                LOG.warning(e)
+            LOG.warning("error while checking livepatch supported kernels API")
+            LOG.warning(e)
             return None
 
         if response.code != 200:
-            with util.disable_log_to_console():
-                LOG.warning("livepatch supported kernels API was unsuccessful")
-                LOG.warning(response.body)
+            LOG.warning("livepatch supported kernels API was unsuccessful")
+            LOG.warning(response.body)
             return None
 
         api_supported_val = response.json_dict.get("Supported")
@@ -265,10 +256,7 @@ def _on_supported_kernel_cache(
             ]
         ):
             if cache_data.supported is None:
-                with util.disable_log_to_console():
-                    LOG.warning(
-                        "livepatch kernel support cache has None value"
-                    )
+                LOG.warning("livepatch kernel support cache has None value")
             return (True, cache_data.supported)
     return (False, None)
 
@@ -306,8 +294,7 @@ def _on_supported_kernel_api(
     )
 
     if supported is None:
-        with util.disable_log_to_console():
-            LOG.warning("livepatch kernel support API response was ambiguous")
+        LOG.warning("livepatch kernel support API response was ambiguous")
     return supported
 
 

--- a/uaclient/snap.py
+++ b/uaclient/snap.py
@@ -184,13 +184,12 @@ def get_snap_info(snap: str) -> SnapPackage:
         try:
             data = json.loads(out)
         except json.JSONDecodeError:
-            with util.disable_log_to_console():
-                LOG.warning(
-                    messages.JSON_PARSER_ERROR.format(
-                        source="SNAPD API {}".format(url),
-                        out=out,
-                    ).msg
-                )
+            LOG.warning(
+                messages.JSON_PARSER_ERROR.format(
+                    source="SNAPD API {}".format(url),
+                    out=out,
+                ).msg
+            )
             raise exceptions.SnapdInvalidJson(url=url, out=out)
 
         # This means that the snap doesn't exist or is not installed

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -95,14 +95,12 @@ def _get_kernel_changelog_timestamp(
     uname: os.uname_result,
 ) -> Optional[datetime.datetime]:
     if is_container():
-        with util.disable_log_to_console():
-            LOG.warning(
-                "Not attempting to use timestamp of kernel changelog because we're in a container"  # noqa: E501
-            )
+        LOG.warning(
+            "Not attempting to use timestamp of kernel changelog because we're in a container"  # noqa: E501
+        )
         return None
 
-    with util.disable_log_to_console():
-        LOG.warning("Falling back to using timestamp of kernel changelog")
+    LOG.warning("Falling back to using timestamp of kernel changelog")
 
     try:
         stat_result = os.stat(
@@ -114,8 +112,7 @@ def _get_kernel_changelog_timestamp(
             stat_result.st_mtime, datetime.timezone.utc
         )
     except Exception:
-        with util.disable_log_to_console():
-            LOG.warning("Unable to stat kernel changelog")
+        LOG.warning("Unable to stat kernel changelog")
         return None
 
 
@@ -124,15 +121,13 @@ def _get_kernel_build_date(
 ) -> Optional[datetime.datetime]:
     date_match = re.search(RE_KERNEL_EXTRACT_BUILD_DATE, uname.version)
     if date_match is None:
-        with util.disable_log_to_console():
-            LOG.warning("Unable to find build date in uname version")
+        LOG.warning("Unable to find build date in uname version")
         return _get_kernel_changelog_timestamp(uname)
     date_str = date_match.group(0)
     try:
         dt = datetime.datetime.strptime(date_str, "%a %b %d %H:%M:%S %Z %Y")
     except ValueError:
-        with util.disable_log_to_console():
-            LOG.warning("Unable to parse build date from uname version")
+        LOG.warning("Unable to parse build date from uname version")
         return _get_kernel_changelog_timestamp(uname)
     if dt.tzinfo is None:
         # Give it a default timezone if it didn't get one from strptime

--- a/uaclient/tests/test_esm_cache.py
+++ b/uaclient/tests/test_esm_cache.py
@@ -28,11 +28,11 @@ class TestUpdateEsmCaches:
 
         assert expected_log_args == m_esm_cache_log_err.call_args_list
 
-    def test_log_exception(self, m_update_caches, capsys, FakeConfig):
+    def test_log_exception(self, m_update_caches, caplog_text, FakeConfig):
         expected_msg = "unexpected exception"
         expected_exception = Exception(expected_msg)
         m_update_caches.side_effect = expected_exception
         main(cfg=FakeConfig())
-        _, err = capsys.readouterr()
+        log = caplog_text()
 
-        assert expected_msg in err
+        assert expected_msg in log

--- a/uaclient/timer/update_contract_info.py
+++ b/uaclient/timer/update_contract_info.py
@@ -21,10 +21,9 @@ def update_contract_info(cfg: UAConfig) -> bool:
                     Notice.CONTRACT_REFRESH_WARNING,
                 )
         except Exception as e:
-            with util.disable_log_to_console():
-                err_msg = messages.UPDATE_CHECK_CONTRACT_FAILURE.format(
-                    reason=str(e)
-                )
-                LOG.warning(err_msg)
+            err_msg = messages.UPDATE_CHECK_CONTRACT_FAILURE.format(
+                reason=str(e)
+            )
+            LOG.warning(err_msg)
             return False
     return True

--- a/uaclient/yaml.py
+++ b/uaclient/yaml.py
@@ -10,6 +10,7 @@ try:
     import yaml
 except ImportError:
     LOG.error(MISSING_YAML_MODULE.msg)
+    print(MISSING_YAML_MODULE.msg, file=sys.stderr)
     sys.exit(1)
 
 
@@ -17,7 +18,9 @@ def safe_load(stream):
     try:
         return yaml.safe_load(stream)
     except AttributeError:
-        LOG.error(BROKEN_YAML_MODULE.format(path=yaml.__path__).msg)
+        msg = BROKEN_YAML_MODULE.format(path=yaml.__path__).msg
+        LOG.error(msg)
+        print(msg, file=sys.stderr)
         sys.exit(1)
 
 
@@ -25,7 +28,9 @@ def safe_dump(data, stream=None, **kwargs):
     try:
         return yaml.safe_dump(data, stream, **kwargs)
     except AttributeError:
-        LOG.error(BROKEN_YAML_MODULE.format(path=yaml.__path__).msg)
+        msg = BROKEN_YAML_MODULE.format(path=yaml.__path__).msg
+        LOG.error(msg)
+        print(msg, file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This removes some old code around conditionally logging messages to the console. In most cases, that is what we do, and in some of the few cases where we didn't disable the console logger, that was a bug.

We should treat the console as our cli UX and treat the logs as logs. There should be no instance where a log message is also part of our UX. In the rare case where we want to print the same message to the User and our logs, then that can be two separate statements.

The exception is the `--debug` flag which is useful to include log statements in the middle of the console output - that functionality is kept and enhanced by removing the formatter that stripped a lot of useful information from those logs.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
CI should pass.

Please review all instances of logging.info, logging.warn, logging.error, and logging.exception. Please double check that, where necessary, the messages are also printed/event.infoed properly. This includes statements that are not a part of the diff.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
