### PR TITLE
tests: use prod environment for magic-attach test

### DIFF
--- a/features/magic_attach.feature
+++ b/features/magic_attach.feature
@@ -4,11 +4,10 @@ Feature: Magic attach flow related tests
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach using the magic attach flow
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I change contract to staging with sudo
-        And I create the file `/tmp/response-overlay.json` with the following:
+        When I create the file `/tmp/response-overlay.json` with the following:
         """
         {
-            "https://contracts.staging.canonical.com/v1/magic-attach": [
+            "https://contracts.canonical.com/v1/magic-attach": [
             {
               "code": 200,
               "response": {
@@ -26,7 +25,7 @@ Feature: Magic attach flow related tests
                     "expires": "expire-date",
                     "expiresIn": 2000,
                     "contractID": "test-contract-id",
-                    "contractToken": "$behave_var{contract_token_staging}"
+                    "contractToken": "$behave_var{contract_token}"
                 }
             }]
         }

--- a/features/util.py
+++ b/features/util.py
@@ -368,6 +368,13 @@ def process_template_vars(
                 context.pro_config.contract_token_staging,
                 logger_fn,
             )
+        elif function_name == "contract_token":
+            processed_template = _replace_and_log(
+                processed_template,
+                match.group(0),
+                context.pro_config.contract_token,
+                logger_fn,
+            )
         elif function_name == "config":
             item = args[1]
             if not shown or item not in context.pro_config.redact_options:


### PR DESCRIPTION
## Why is this needed?
The staging esm environment is presenting some problems when the apt-helper command tries to verify the credential for some services. We are now switching for the production environment to mitigate that issue

## Test Steps
Run the modified integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
