### PR TITLE
config: pass cfg object to Livepatch

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -562,7 +562,7 @@ class UAConfig:
         from uaclient.entitlements.entitlement_status import ApplicationStatus
         from uaclient.entitlements.livepatch import LivepatchEntitlement
 
-        livepatch_ent = LivepatchEntitlement()
+        livepatch_ent = LivepatchEntitlement(self)
         livepatch_status, _ = livepatch_ent.application_status()
 
         if livepatch_status == ApplicationStatus.ENABLED:


### PR DESCRIPTION
In Livepatch UAConfig is called directly, when it should actually receive the current cfg as an argument.

## Why is this needed?
Solves some mocking issues when we have config files on our machines, i.e. user-config.json

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->
- Create the file `/var/lib/ubuntu-advantage/user-config.json` with the following content:
 ```
 {"metering_timer": "notanumber", "update_messaging_timer":-10}
 ```
- run `tox -e test`
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
