### PR TITLE
docs: update network requirements with fix endpoint info

### DIFF
--- a/docs/references/network_requirements.md
+++ b/docs/references/network_requirements.md
@@ -39,3 +39,9 @@ Necessary endpoints for `snap`:
 
 Necessary endpoints for `livepatch`:
 - `livepatch.canonical.com:443`
+
+## Fix
+`pro fix` needs to fetch information about USNs and/or CVEs from the Ubuntu Security APIs.
+
+Necessary endpoints:
+- `ubuntu.com/security:443`


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it adds the security URL to the network requirements.