### PR TITLE
tests: mask iscsi service to avoid intermittent errors on github runners

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -263,7 +263,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
        Examples: ubuntu release
            | release | anbox | esm-apps | cc-eal | cis | fips | fips-update | ros | cis_or_usg | realtime-kernel |
            | xenial  | no    | yes      | yes    | yes | yes  | yes         | yes | cis        | no              |
-           | bionic  | yes   | yes      | yes    | yes | yes  | yes         | yes | cis        | no              |
+           | bionic  | no    | yes      | yes    | yes | yes  | yes         | yes | cis        | no              |
            | focal   | yes   | yes      | no     | yes | yes  | yes         | no  | usg        | no              |
            | jammy   | yes   | yes      | no     | yes | no   | no          | no  | usg        | yes             |
 

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -6,6 +6,7 @@ from typing import Dict, NamedTuple
 from behave import given, when
 from pycloudlib.instance import BaseInstance  # type: ignore
 
+from features.steps.shell import when_i_run_command
 from features.steps.ubuntu_advantage_tools import when_i_install_uat
 from features.util import (
     SUT,
@@ -87,6 +88,16 @@ def given_a_machine(
     context.machines[machine_name] = MachineTuple(
         series=series, instance=instance
     )
+
+    if series == "xenial":
+        # Upgrading open-iscsi to esm version on xenial restarts this service
+        # This sometimes causes resource errors on github action runners
+        when_i_run_command(
+            context,
+            "systemctl mask iscsid.service",
+            "with sudo",
+            machine_name=machine_name,
+        )
 
     if cleanup:
 


### PR DESCRIPTION
## Why is this needed?
iscsid.service has been getting intermittent resource errors when restarted as part of a full apt upgrade to ESM on xenial containers. This only seems to happen on our github runners and I haven't been able to reproduce it locally. Since this service isn't necessary for testing pro-client, we can mask it to let the tests continue.

## Test Steps
All I want is for CI to be green

