### PR TITLE
logging: fix calls to cli.setup_logging

### DIFF
--- a/lib/patch_status_json.py
+++ b/lib/patch_status_json.py
@@ -66,7 +66,7 @@ def patch_status_json_schema_0_1(status_file: str):
 
 
 if __name__ == "__main__":
-    setup_logging(logging.INFO, logging.DEBUG)
+    setup_logging(logging.DEBUG)
     patch_status_json_schema_0_1(
         status_file="/var/lib/ubuntu-advantage/status.json"
     )

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -12,7 +12,7 @@ from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
 
 if __name__ == "__main__":
-    setup_logging(logging.INFO, logging.DEBUG)
+    setup_logging(logging.DEBUG)
     cfg = UAConfig()
     http.configure_web_proxy(cfg.http_proxy, cfg.https_proxy)
     upgrade_lts_contract.process_contract_delta_after_apt_lock(cfg)


### PR DESCRIPTION
## Why is this needed?
During the refactor that changed cli.setup_logging to no longer setup a console logger, not all callsites were updated. This should fix the last of them.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Search for all callsites of cli.setup_logging. Make sure they are all correct.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [n/a] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
