### PR TITLE
i18n prep: logging: standardize logging callsite conventions (SC-1602)

### DIFF
--- a/lib/patch_status_json.py
+++ b/lib/patch_status_json.py
@@ -30,7 +30,7 @@ def patch_status_json_schema_0_1(status_file: str):
     try:
         status = json.loads(content, cls=util.DatetimeAwareJSONDecoder)
     except ValueError as e:
-        LOG.debug(
+        LOG.warning(
             "Unable to patch /var/lib/ubuntu-advantage/status.json: %s", str(e)
         )
         return
@@ -57,10 +57,8 @@ def patch_status_json_schema_0_1(status_file: str):
             new_status, cls=util.DatetimeAwareJSONEncoder
         )
     except ValueError as e:
-        LOG.debug(
-            "Unable to patch /var/lib/ubuntu-advantage/status.json: {}".format(
-                str(e)
-            )
+        LOG.warning(
+            "Unable to patch /var/lib/ubuntu-advantage/status.json: %s", str(e)
         )
     system.write_file(status_file, status_content)
 

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -24,7 +24,6 @@ from uaclient import (
     exceptions,
     http,
     lock,
-    messages,
     upgrade_lts_contract,
 )
 from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
@@ -60,11 +59,7 @@ def fix_pro_pkg_holds(cfg: config.UAConfig):
     try:
         fips.install_packages(cleanup_on_failure=False)
     except exceptions.UserFacingError:
-        LOG.warning(
-            "Failed to install packages at boot: {}".format(
-                ", ".join(fips.packages)
-            )
-        )
+        LOG.warning("Failed to install packages at boot: %r", fips.packages)
         raise
 
 
@@ -72,7 +67,7 @@ def refresh_contract(cfg: config.UAConfig):
     try:
         contract.refresh(cfg)
     except exceptions.UrlError:
-        LOG.warning(messages.REFRESH_CONTRACT_FAILURE)
+        LOG.warning("Failed to refresh contract")
         raise
 
 

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -64,11 +64,11 @@ class TimedJob:
         if configured_interval is None:
             return self._default_interval_seconds
         if not isinstance(configured_interval, int) or configured_interval < 0:
-            warning_msg = (
-                "Invalid value for {} interval found in config. "
-                "Default value will be used."
-            ).format(self.name)
-            LOG.warning(warning_msg)
+            LOG.warning(
+                "Invalid value for %s interval found in config. "
+                "Default value will be used.",
+                self.name,
+            )
             return self._default_interval_seconds
         return configured_interval
 
@@ -157,9 +157,10 @@ def run_jobs(cfg: UAConfig, current_time: datetime):
         try:
             timer_jobs_state_file.delete()
         except (OSError, PermissionError) as exception:
-            msg = "Error trying to delete invalid jobs-status.json file: {}"
-            msg = msg.format(str(exception))
-            LOG.warning(msg)
+            LOG.warning(
+                "Error trying to delete invalid jobs-status.json file: %s",
+                str(exception),
+            )
             return
 
     if jobs_status_obj is None:

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -417,7 +417,7 @@ def add_auth_apt_repo(
             continue  # Only enable suites matching this current series
         maybe_comment = ""
         if "-updates" in suite and not updates_enabled:
-            LOG.debug(
+            LOG.warning(
                 'Not enabling apt suite "%s" because "%s-updates" is not'
                 " enabled",
                 suite,

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -48,13 +48,11 @@ class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
             try:
                 headers = self._get_imds_v2_token_headers(ip_address=address)
             except Exception as e:
-                msg = (
-                    "Could not reach AWS IMDS at http://{endpoint}:"
-                    " {reason}\n".format(
-                        endpoint=address, reason=getattr(e, "reason", "")
-                    )
+                LOG.warning(
+                    "Could not reach AWS IMDS at http://%s: %s\n",
+                    address,
+                    getattr(e, "reason", ""),
                 )
-                LOG.debug(msg)
             else:
                 self._ip_address = address
                 break

--- a/uaclient/clouds/tests/test_aws.py
+++ b/uaclient/clouds/tests/test_aws.py
@@ -112,9 +112,9 @@ class TestUAAutoAttachAWSInstance:
         expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
         assert expected_sleep_calls == sleep.call_args_list
         expected_logs = [
-            "(701, 'funky error msg') Retrying 3 more times.",
-            "(702, 'funky error msg') Retrying 2 more times.",
-            "(703, 'funky error msg') Retrying 1 more times.",
+            "(701, 'funky error msg'): Retrying 3 more times.",
+            "(702, 'funky error msg'): Retrying 2 more times.",
+            "(703, 'funky error msg'): Retrying 1 more times.",
         ]
         logs = caplog_text()
         for log in expected_logs:
@@ -193,9 +193,9 @@ class TestUAAutoAttachAWSInstance:
         expected_sleep_calls = [mock.call(0.5), mock.call(1), mock.call(1)]
         assert expected_sleep_calls == sleep.call_args_list
         expected_logs = [
-            "(702, 'funky error msg') Retrying 3 more times.",
-            "(703, 'funky error msg') Retrying 2 more times.",
-            "(704, 'funky error msg') Retrying 1 more times.",
+            "(702, 'funky error msg'): Retrying 3 more times.",
+            "(703, 'funky error msg'): Retrying 2 more times.",
+            "(704, 'funky error msg'): Retrying 1 more times.",
         ]
         logs = caplog_text()
         for log in expected_logs:

--- a/uaclient/clouds/tests/test_azure.py
+++ b/uaclient/clouds/tests/test_azure.py
@@ -102,9 +102,9 @@ class TestUAAutoAttachAzureInstance:
         expected_sleep_calls = [mock.call(1), mock.call(1), mock.call(1)]
         assert expected_sleep_calls == sleep.call_args_list
         expected_logs = [
-            "(701, 'funky error msg') Retrying 3 more times.",
-            "(702, 'funky error msg') Retrying 2 more times.",
-            "(703, 'funky error msg') Retrying 1 more times.",
+            "(701, 'funky error msg'): Retrying 3 more times.",
+            "(702, 'funky error msg'): Retrying 2 more times.",
+            "(703, 'funky error msg'): Retrying 1 more times.",
         ]
         logs = caplog_text()
         for log in expected_logs:

--- a/uaclient/clouds/tests/test_gcp.py
+++ b/uaclient/clouds/tests/test_gcp.py
@@ -83,11 +83,11 @@ class TestUAAutoAttachGCPInstance:
 
         expected_logs = [
             "GCPProServiceAccount Error 701: "
-            + "funky error msg Retrying 3 more times.",
+            + "funky error msg: Retrying 3 more times.",
             "GCPProServiceAccount Error 702: "
-            + "funky error msg Retrying 2 more times.",
+            + "funky error msg: Retrying 2 more times.",
             "GCPProServiceAccount Error 703: "
-            + "funky error msg Retrying 1 more times.",
+            + "funky error msg: Retrying 1 more times.",
         ]
         logs = caplog_text()
         for log in expected_logs:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -128,7 +128,7 @@ class UAConfig:
                     or state_files.UserConfigData()
                 )
             except Exception as e:
-                LOG.warning("Error loading user config: {}".format(e))
+                LOG.warning("Error loading user config", exc_info=e)
                 LOG.warning("Using default config values")
                 self.user_config = state_files.UserConfigData()
 
@@ -491,7 +491,9 @@ class UAConfig:
         ):
             value = getattr(self, prop)
             if value is None:
-                LOG.debug("No config set for {}, default value will be used.")
+                LOG.debug(
+                    "No config set for %s, default value will be used.", prop
+                )
             elif not isinstance(value, int) or value < 0:
                 error_msg = (
                     "Value for the {} interval must be a positive integer. "

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -264,7 +264,7 @@ class UAContractClient(serviceclient.UAServiceClient):
                 API_V1_GET_MAGIC_ATTACH_TOKEN_INFO, headers=headers
             )
         except exceptions.UrlError as e:
-            LOG.exception(str(e))
+            LOG.exception(e)
             raise exceptions.ConnectivityError()
         if response.code == 401:
             raise exceptions.MagicAttachTokenError()
@@ -290,7 +290,7 @@ class UAContractClient(serviceclient.UAServiceClient):
                 method="POST",
             )
         except exceptions.UrlError as e:
-            LOG.exception(str(e))
+            LOG.exception(e)
             raise exceptions.ConnectivityError()
         if response.code == 503:
             raise exceptions.MagicAttachUnavailable()
@@ -313,7 +313,7 @@ class UAContractClient(serviceclient.UAServiceClient):
                 method="DELETE",
             )
         except exceptions.UrlError as e:
-            LOG.exception(str(e))
+            LOG.exception(e)
             raise exceptions.ConnectivityError()
         if response.code == 400:
             raise exceptions.MagicAttachTokenAlreadyActivated()
@@ -514,19 +514,23 @@ def process_entitlements_delta(
                 allow_enable=allow_enable,
                 series_overrides=series_overrides,
             )
-        except exceptions.UserFacingError:
+        except exceptions.UserFacingError as e:
+            LOG.exception(e)
             delta_error = True
             failed_services.append(name)
             LOG.error(
-                "Failed to process contract delta for {name}:"
-                " {delta}".format(name=name, delta=new_entitlement)
+                "Failed to process contract delta for %s: %r",
+                name,
+                new_entitlement,
             )
-        except Exception:
+        except Exception as e:
+            LOG.exception(e)
             unexpected_error = True
             failed_services.append(name)
             LOG.exception(
-                "Unexpected error processing contract delta for {name}:"
-                " {delta}".format(name=name, delta=new_entitlement)
+                "Unexpected error processing contract delta for %s: %r",
+                name,
+                new_entitlement,
             )
         else:
             # If we have any deltas to process and we were able to process

--- a/uaclient/daemon/__init__.py
+++ b/uaclient/daemon/__init__.py
@@ -23,7 +23,7 @@ def start():
             ["systemctl", "start", "ubuntu-advantage.service"], timeout=2.0
         )
     except (exceptions.ProcessExecutionError, TimeoutExpired) as e:
-        LOG.warning(e)
+        LOG.warning(e, exc_info=e)
 
 
 def stop():
@@ -32,7 +32,7 @@ def stop():
             ["systemctl", "stop", "ubuntu-advantage.service"], timeout=2.0
         )
     except (exceptions.ProcessExecutionError, TimeoutExpired) as e:
-        LOG.warning(e)
+        LOG.warning(e, exc_info=e)
 
 
 def cleanup(cfg: UAConfig):

--- a/uaclient/daemon/poll_for_pro_license.py
+++ b/uaclient/daemon/poll_for_pro_license.py
@@ -106,9 +106,8 @@ def poll_for_pro_license(cfg: UAConfig):
             if end - start < 10:
                 LOG.debug(
                     "wait_for_change returned quickly and no pro license"
-                    " present. Waiting {} seconds before polling again".format(
-                        cfg.polling_error_retry_delay
-                    )
+                    " present. Waiting %d seconds before polling again",
+                    cfg.polling_error_retry_delay,
                 )
                 time.sleep(cfg.polling_error_retry_delay)
                 continue

--- a/uaclient/daemon/retry_auto_attach.py
+++ b/uaclient/daemon/retry_auto_attach.py
@@ -58,7 +58,7 @@ def full_auto_attach_exception_to_failure_reason(e: Exception) -> str:
     elif isinstance(e, api_exceptions.UserFacingError):
         return '"{}"'.format(e.msg)
     else:
-        LOG.error("Unexpected exception: {}".format(e))
+        LOG.error("Unexpected exception", exc_info=e)
         return str(e) or messages.RETRY_ERROR_DETAIL_UNKNOWN
 
 

--- a/uaclient/daemon/tests/test_daemon.py
+++ b/uaclient/daemon/tests/test_daemon.py
@@ -35,7 +35,7 @@ class TestStart:
                 ["systemctl", "start", "ubuntu-advantage.service"], timeout=2.0
             )
         ] == m_subp.call_args_list
-        assert [mock.call(err)] == m_log_warning.call_args_list
+        assert [mock.call(err, exc_info=err)] == m_log_warning.call_args_list
 
 
 @mock.patch(M_PATH + "system.subp")
@@ -64,4 +64,4 @@ class TestStop:
                 ["systemctl", "stop", "ubuntu-advantage.service"], timeout=2.0
             )
         ] == m_subp.call_args_list
-        assert [mock.call(err)] == m_log_warning.call_args_list
+        assert [mock.call(err, exc_info=err)] == m_log_warning.call_args_list

--- a/uaclient/daemon/tests/test_poll_for_pro_license.py
+++ b/uaclient/daemon/tests/test_poll_for_pro_license.py
@@ -325,7 +325,8 @@ class TestPollForProLicense:
                 [
                     mock.call(
                         "wait_for_change returned quickly and no pro license"
-                        " present. Waiting 123 seconds before polling again"
+                        " present. Waiting %d seconds before polling again",
+                        123,
                     )
                 ],
                 [mock.call(123)],
@@ -343,10 +344,10 @@ class TestPollForProLicense:
                 ],
                 [mock.call(mock.ANY, mock.ANY)],
                 [
-                    mock.call(mock.ANY),
-                    mock.call(mock.ANY),
-                    mock.call(mock.ANY),
-                    mock.call(mock.ANY),
+                    mock.call(mock.ANY, mock.ANY),
+                    mock.call(mock.ANY, mock.ANY),
+                    mock.call(mock.ANY, mock.ANY),
+                    mock.call(mock.ANY, mock.ANY),
                 ],
                 [
                     mock.call(123),

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -457,12 +457,11 @@ see "fips-updates". You can find out more at https://ubuntu.com/security/fips\
     def _perform_enable(self, silent: bool = False) -> bool:
         cloud_type, error = get_cloud_type()
         if cloud_type is None and error == NoCloudTypeReason.CLOUD_ID_ERROR:
-            msg = (
+            LOG.warning(
                 "Could not determine cloud, "
                 "defaulting to generic FIPS package."
             )
-            LOG.warning(msg)
-            event.info(msg)
+            event.info(messages.FIPS_COULD_NOT_DETERMINE_CLOUD_DEFAULT_PACKAGE)
         if super()._perform_enable(silent=silent):
             notices.remove(
                 Notice.FIPS_INSTALL_OUT_OF_DATE,

--- a/uaclient/entitlements/landscape.py
+++ b/uaclient/entitlements/landscape.py
@@ -34,7 +34,7 @@ more. Find out more about Landscape at https://ubuntu.com/landscape"""
         if self.assume_yes and "--silent" not in cmd:
             cmd += ["--silent"]
 
-        LOG.debug(messages.EXECUTING_COMMAND.format(" ".join(cmd)))
+        LOG.debug("Executing: %r", cmd)
         event.info(
             util.redact_sensitive_logs(
                 messages.EXECUTING_COMMAND.format(" ".join(cmd))
@@ -76,12 +76,17 @@ more. Find out more about Landscape at https://ubuntu.com/landscape"""
             event.info(str(e).strip())
             event.warning(str(e), self.name)
 
-        msg = messages.BACKING_UP_FILE.format(
-            original=LANDSCAPE_CLIENT_CONFIG_PATH,
-            backup=LANDSCAPE_CLIENT_CONFIG_PATH_DISABLE_BACKUP,
+        LOG.debug(
+            "Backing up %s as %s",
+            LANDSCAPE_CLIENT_CONFIG_PATH,
+            LANDSCAPE_CLIENT_CONFIG_PATH_DISABLE_BACKUP,
         )
-        LOG.debug(msg)
-        event.info(msg)
+        event.info(
+            messages.BACKING_UP_FILE.format(
+                original=LANDSCAPE_CLIENT_CONFIG_PATH,
+                backup=LANDSCAPE_CLIENT_CONFIG_PATH_DISABLE_BACKUP,
+            )
+        )
         try:
             os.rename(
                 LANDSCAPE_CLIENT_CONFIG_PATH,

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -202,14 +202,12 @@ class RepoEntitlement(base.UAEntitlement):
             return False
 
         if not self._check_apt_url_is_applied(delta_apt_url):
-
-            msg = (
-                "Updating '{}' apt sources list on changed directives.".format(
-                    self.name
-                )
+            LOG.info(
+                "New aptURL, updating %s apt sources list to %s",
+                self.name,
+                delta_apt_url,
             )
-            LOG.info(msg)
-            event.info(msg)
+            event.info(messages.REPO_UPDATING_APT_SOURCES.format(self.name))
 
             orig_entitlement = orig_access.get("entitlement", {})
             old_url = orig_entitlement.get("directives", {}).get("aptURL")
@@ -222,11 +220,12 @@ class RepoEntitlement(base.UAEntitlement):
             self.setup_apt_config()
 
         if delta_packages:
-            msg = "Installing packages on changed directives: {}".format(
-                ", ".join(delta_packages)
+            LOG.info("New additionalPackages, installing %r", delta_packages)
+            event.info(
+                messages.REPO_REFRESH_INSTALLING_PACKAGES.format(
+                    ", ".join(delta_packages)
+                )
             )
-            LOG.info(msg)
-            event.info(msg)
             self.install_packages(package_list=delta_packages)
 
         return True

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -734,8 +734,10 @@ class TestLivepatchEntitlementEnable:
             in fake_stdout.getvalue().strip()
         )
 
-        for msg in messages.SNAPD_DOES_NOT_HAVE_WAIT_CMD.split("\n"):
-            assert msg in caplog_text()
+        assert (
+            "Detected version of snapd that does not have wait command"
+            in caplog_text()
+        )
 
         assert m_validate_proxy.call_count == 2
         assert m_snap_proxy.call_count == 1

--- a/uaclient/files/files.py
+++ b/uaclient/files/files.py
@@ -52,7 +52,7 @@ class UAFile:
         try:
             content = system.load_file(self.path)
         except FileNotFoundError:
-            LOG.debug("File does not exist: {}".format(self.path))
+            LOG.debug("Tried to load %s but file does not exist", self.path)
         return content
 
     def delete(self):

--- a/uaclient/files/notices.py
+++ b/uaclient/files/notices.py
@@ -119,7 +119,10 @@ class NoticesManager:
         :param description: The content to be written to the notice file.
         """
         if not util.we_are_currently_root():
-            LOG.warning("Trying to add a notice as non-root user")
+            LOG.warning(
+                "NoticesManager.add(%s) called as non-root user",
+                notice_details.value.label,
+            )
             return
 
         directory = (
@@ -141,7 +144,10 @@ class NoticesManager:
         :param notice_details: Holds details concerning the notice file.
         """
         if not util.we_are_currently_root():
-            LOG.warning("Trying to remove a notice as non-root user")
+            LOG.warning(
+                "NoticesManager.remove(%s) called as non-root user",
+                notice_details.value.label,
+            )
             return
 
         directory = (
@@ -193,9 +199,8 @@ class NoticesManager:
                     except Exception:
                         LOG.warning(
                             "Something went wrong while processing"
-                            " notice: {}.".format(
-                                notice_file_name,
-                            )
+                            " notice: %s.",
+                            notice_file_name,
                         )
         notices.sort()
         return notices

--- a/uaclient/files/tests/test_notices.py
+++ b/uaclient/files/tests/test_notices.py
@@ -46,7 +46,7 @@ class TestNotices:
         notice = NoticesManager()
         notice.add(FakeNotice.a, "content")
         assert [] == m_sys_write_file.call_args_list
-        assert "Trying to add a notice as non-root user" in caplog_text()
+        assert "NoticesManager.add(a) called as non-root user" in caplog_text()
 
     @pytest.mark.parametrize(
         "label,content",
@@ -106,7 +106,9 @@ class TestNotices:
         notice = NoticesManager()
         notice.remove(FakeNotice.a)
         assert [] == m_sys_file_absent.call_args_list
-        assert "Trying to remove a notice as non-root user" in caplog_text()
+        assert (
+            "NoticesManager.remove(a) called as non-root user" in caplog_text()
+        )
 
     @mock.patch("uaclient.files.notices.NoticesManager.list")
     @mock.patch("uaclient.files.notices.NoticesManager.remove")

--- a/uaclient/http/__init__.py
+++ b/uaclient/http/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, NamedTuple, Optional
 from urllib import error, request
 from urllib.parse import ParseResult, urlparse
 
-from uaclient import defaults, exceptions, messages, util
+from uaclient import defaults, exceptions, util
 
 UA_NO_PROXY_URLS = ("169.254.169.254", "metadata", "[fd00:ec2::254]")
 PROXY_VALIDATION_APT_HTTP_URL = "http://archive.ubuntu.com"
@@ -73,11 +73,11 @@ def validate_proxy(
         except exceptions.ProxyAuthenticationFailed:
             raise
         except Exception as e:
-            msg = getattr(e, "reason", str(e))
             LOG.error(
-                messages.ERROR_USING_PROXY.format(
-                    proxy=proxy, test_url=test_url, error=msg
-                )
+                'Error trying to use "%s" as pycurl proxy to reach "%s": %s',
+                proxy,
+                test_url,
+                str(e),
             )
             raise exceptions.ProxyNotWorkingError(proxy)
 
@@ -93,11 +93,11 @@ def validate_proxy(
         opener.open(req)
         return proxy
     except (socket.timeout, error.URLError) as e:
-        msg = getattr(e, "reason", str(e))
         LOG.error(
-            messages.ERROR_USING_PROXY.format(
-                proxy=proxy, test_url=test_url, error=msg
-            )
+            'Error trying to use "%s" as urllib proxy to reach "%s": %s',
+            proxy,
+            test_url,
+            getattr(e, "reason", str(e)),
         )
         raise exceptions.ProxyNotWorkingError(proxy)
 

--- a/uaclient/http/tests/test_http.py
+++ b/uaclient/http/tests/test_http.py
@@ -120,13 +120,9 @@ class TestValidateProxy:
         )
 
         assert (
-            messages.ERROR_USING_PROXY.format(
-                proxy="http://localhost:1234",
-                test_url="http://example.com",
-                error=expected_message,
-            )
-            in caplog_text()
-        )
+            'Error trying to use "http://localhost:1234" as urllib proxy '
+            'to reach "http://example.com": {}'
+        ).format(expected_message) in caplog_text()
 
 
 class TestConfigureWebProxy:

--- a/uaclient/livepatch.py
+++ b/uaclient/livepatch.py
@@ -136,11 +136,12 @@ def status() -> Optional[LivepatchStatusStatus]:
 
     try:
         status_json = json.loads(out)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as e:
         LOG.warning(
-            messages.JSON_PARSER_ERROR.format(
-                source="canonical-livepatch status", out=out
-            ).msg
+            "JSONDecodeError while parsing livepatch status, returning None. "
+            'output was: "%s"',
+            out,
+            exc_info=e,
         )
         return None
 
@@ -148,8 +149,8 @@ def status() -> Optional[LivepatchStatusStatus]:
         status_root = LivepatchStatus.from_dict(status_json)
     except IncorrectTypeError:
         LOG.warning(
-            "canonical-livepatch status returned unexpected "
-            "structure: {}".format(out)
+            "canonical-livepatch status returned unexpected structure: %s",
+            out,
         )
         return None
 

--- a/uaclient/lock.py
+++ b/uaclient/lock.py
@@ -91,7 +91,7 @@ class SpinLock(SingleAttemptLock):
         self.max_retries = max_retries
 
     def __enter__(self):
-        LOG.debug("spin lock starting for {}".format(self.lock_holder))
+        LOG.debug("spin lock starting for %s", self.lock_holder)
         tries = 0
         while True:
             try:
@@ -99,9 +99,7 @@ class SpinLock(SingleAttemptLock):
                 break
             except exceptions.LockHeldError as e:
                 LOG.debug(
-                    "SpinLock Attempt {}. {}. Spinning...".format(
-                        tries + 1, e.msg
-                    )
+                    "SpinLock Attempt %d. %s. Spinning...", tries + 1, e.msg
                 )
                 tries += 1
                 if tries >= self.max_retries:

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -265,10 +265,6 @@ REFRESH_MESSAGES_FAILURE = (
     "Unable to update Ubuntu Pro related APT and MOTD messages."
 )
 
-UPDATE_CHECK_CONTRACT_FAILURE = (
-    """Failed to check for change in machine contract. Reason: {reason}"""
-)
-
 INCOMPATIBLE_SERVICE = """\
 {service_being_enabled} cannot be enabled with {incompatible_service}.
 Disable {incompatible_service} and proceed to enable {service_being_enabled}? \
@@ -352,9 +348,6 @@ APT_PROXY_CONFIG_HEADER = """\
 """
 
 SETTING_SERVICE_PROXY = "Setting {service} proxy"
-ERROR_USING_PROXY = (
-    'Error trying to use "{proxy}" as proxy to reach "{test_url}": {error}'
-)
 
 PROXY_DETECTED_BUT_NOT_CONFIGURED = """\
 No proxy set in config; however, proxy is configured for: {{services}}.
@@ -838,11 +831,6 @@ GCP_SERVICE_ACCT_NOT_ENABLED_ERROR = NamedMessage(
     "see https://cloud.google.com/iam/docs/service-accounts",
 )
 
-LOG_CONNECTIVITY_ERROR_TMPL = CONNECTIVITY_ERROR.msg + " {error}"
-LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL = (
-    CONNECTIVITY_ERROR.msg + " Failed to access URL: {url}. {error}"
-)
-
 SETTING_SERVICE_PROXY_SCOPE = "Setting {scope} APT proxy"
 WARNING_APT_PROXY_SETUP = """\
 Warning: apt_{protocol_type}_proxy has been renamed to global_apt_{protocol_type}_proxy."""  # noqa: E501
@@ -863,10 +851,6 @@ ERROR_PROXY_CONFIGURATION = """\
 Error: Setting global apt proxy and pro scoped apt proxy
 at the same time is unsupported.
 Cancelling config process operation.
-"""
-
-AVAILABILITY_FROM_UNKNOWN_SERVICE = """\
-Ignoring availability of unknown service {service} from contract server
 """
 
 NOTICE_FIPS_MANUAL_DISABLE_URL = """\
@@ -948,13 +932,20 @@ INVALID_FILE_FORMAT = FormattedNamedMessage(
     name="invalid-file-format", msg="{file_name} is not valid {file_format}"
 )
 
-KERNEL_PARSE_ERROR = "Failed to parse kernel: {kernel}"
-
 WARN_NEW_VERSION_AVAILABLE = FormattedNamedMessage(
     name="new-version-available",
     msg="A new version of the client is available: {version}. \
 Please upgrade to the latest version to get the new features \
 and bug fixes.",
+)
+WARN_NEW_VERSION_AVAILABLE_CLI = (
+    "\n"
+    + BLUE_INFO
+    + """\
+ A new version is available: {version}
+Please run:
+    sudo apt-get install ubuntu-advantage-tools
+to get the latest version with new features and bug fixes."""
 )
 
 INVALID_PRO_IMAGE = FormattedNamedMessage(
@@ -1379,4 +1370,36 @@ USNs should follow the pattern USN-nnnn.""",
 SECURITY_FIX_NOT_FOUND_ISSUE = FormattedNamedMessage(
     "security-fix-not-found-issue",
     "Error: {issue_id} not found.",
+)
+
+DISABLE_DURING_CONTRACT_REFRESH = (
+    "Due to contract refresh, " "'{}' is now disabled."
+)
+UNABLE_TO_DISABLE_DURING_CONTRACT_REFRESH = (
+    "Unable to disable '{}' as recommended during contract"
+    " refresh. Service is still active. See"
+    " `pro status`"
+)
+
+FIPS_COULD_NOT_DETERMINE_CLOUD_DEFAULT_PACKAGE = (
+    "Could not determine cloud, defaulting to generic FIPS package."
+)
+
+
+REPO_UPDATING_APT_SOURCES = (
+    "Updating '{}' apt sources list on changed directives."
+)
+REPO_REFRESH_INSTALLING_PACKAGES = (
+    "Installing packages on changed directives: {}"
+)
+
+RELEASE_UPGRADE_APT_LOCK_HELD_WILL_WAIT = (
+    "APT lock is held. Ubuntu Pro configuration will wait until it is released"
+)
+RELEASE_UPGRADE_NO_PAST_RELEASE = "Could not find past release for {}"
+RELEASE_UPGRADE_STARTING = (
+    "Starting upgrade of Ubuntu Pro service configuration"
+)
+RELEASE_UPGRADE_SUCCESS = (
+    "Finished upgrade of Ubuntu Pro service configuration"
 )

--- a/uaclient/snap.py
+++ b/uaclient/snap.py
@@ -143,7 +143,10 @@ def run_snapd_wait_cmd():
         system.subp([SNAP_CMD, "wait", "system", "seed.loaded"], capture=True)
     except exceptions.ProcessExecutionError as e:
         if re.search(r"unknown command .*wait", str(e).lower()):
-            LOG.warning(messages.SNAPD_DOES_NOT_HAVE_WAIT_CMD)
+            LOG.warning(
+                "Detected version of snapd that does not have wait command"
+            )
+            event.info(messages.SNAPD_DOES_NOT_HAVE_WAIT_CMD)
         else:
             raise
 
@@ -183,12 +186,13 @@ def get_snap_info(snap: str) -> SnapPackage:
 
         try:
             data = json.loads(out)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
             LOG.warning(
-                messages.JSON_PARSER_ERROR.format(
-                    source="SNAPD API {}".format(url),
-                    out=out,
-                ).msg
+                "JSONDecodeError while parsing result of snap api call to %s, "
+                'returning None. output was: "%s"',
+                url,
+                out,
+                exc_info=e,
             )
             raise exceptions.SnapdInvalidJson(url=url, out=out)
 

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -279,9 +279,9 @@ def _unattached_status(cfg: UAConfig) -> Dict[str, Any]:
 
         except exceptions.EntitlementNotFoundError:
             LOG.debug(
-                messages.AVAILABILITY_FROM_UNKNOWN_SERVICE.format(
-                    service=resource.get("name", "without a 'name' key")
-                )
+                "Ignoring availability of unknown service %s from contract "
+                "server",
+                resource.get("name", "without a 'name' key"),
             )
             continue
 

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -152,7 +152,7 @@ def get_kernel_info() -> KernelInfo:
     uname_release = uname.release.strip()
     uname_match = re.match(RE_KERNEL_UNAME, uname_release)
     if uname_match is None:
-        LOG.warning(messages.KERNEL_PARSE_ERROR.format(kernel=uname_release))
+        LOG.warning("Failed to parse kernel: %s", uname_release)
         return KernelInfo(
             uname_machine_arch=uname_machine_arch,
             uname_release=uname_release,
@@ -477,8 +477,8 @@ def is_exe(path: str) -> bool:
 
 def load_file(filename: str, decode: bool = True) -> str:
     """Read filename and decode content."""
-    LOG.debug("Reading file: %s", filename)
     with open(filename, "rb") as stream:
+        LOG.debug("Reading file: %s", filename)
         content = stream.read()
     return content.decode("utf-8")
 
@@ -536,10 +536,10 @@ def write_file(
 def ensure_file_absent(file_path: str) -> None:
     """Remove a file if it exists, logging a message about removal."""
     try:
-        LOG.debug("Removing file: %s", file_path)
         os.unlink(file_path)
+        LOG.debug("Removed file: %s", file_path)
     except FileNotFoundError:
-        LOG.debug("File does not exist: %s", file_path)
+        LOG.debug("Tried to remove %s but file does not exist", file_path)
 
 
 def _subp(
@@ -676,22 +676,21 @@ def subp(
         except exceptions.ProcessExecutionError as e:
             if capture:
                 LOG.debug(str(e))
-                msg = "Stderr: {}\nStdout: {}".format(e.stderr, e.stdout)
-                LOG.warning(msg)
+                LOG.warning("Stderr: %s\nStdout: %s", e.stderr, e.stdout)
             if not retry_sleeps:
                 raise
-            retry_msg = " Retrying %d more times." % len(retry_sleeps)
-            LOG.debug(str(e) + retry_msg)
+            LOG.debug(str(e))
+            LOG.debug("Retrying %d more times.", len(retry_sleeps))
             time.sleep(retry_sleeps.pop(0))
     return out, err
 
 
 def ensure_folder_absent(folder_path: str) -> None:
     try:
-        LOG.debug("Removing folder: %s", folder_path)
         rmtree(folder_path)
+        LOG.debug("Removed folder: %s", folder_path)
     except FileNotFoundError:
-        LOG.debug("Folder does not exist: %s", folder_path)
+        LOG.debug("Tried to remove %s but folder does not exist", folder_path)
 
 
 def is_systemd_unit_active(service_name: str) -> bool:

--- a/uaclient/tests/test_system.py
+++ b/uaclient/tests/test_system.py
@@ -1214,9 +1214,12 @@ class TestSubp:
 
         logs = caplog_text()
         expected_logs = [
-            "'Funky apt %d error'. Retrying 3 more times.",
-            "'Funky apt %d error'. Retrying 2 more times.",
-            "'Funky apt %d error'. Retrying 1 more times.",
+            "Invalid command specified 'Funky apt %d error'.",
+            "Retrying 3 more times.",
+            "Invalid command specified 'Funky apt %d error'.",
+            "Retrying 2 more times.",
+            "Invalid command specified 'Funky apt %d error'.",
+            "Retrying 1 more times.",
         ]
         for log in expected_logs:
             assert log in logs

--- a/uaclient/timer/__init__.py
+++ b/uaclient/timer/__init__.py
@@ -10,11 +10,11 @@ def start():
     try:
         system.subp(["systemctl", "start", "ua-timer.timer"], timeout=2.0)
     except (exceptions.ProcessExecutionError, TimeoutExpired) as e:
-        LOG.warning(e)
+        LOG.warning(e, exc_info=e)
 
 
 def stop():
     try:
         system.subp(["systemctl", "stop", "ua-timer.timer"], timeout=2.0)
     except (exceptions.ProcessExecutionError, TimeoutExpired) as e:
-        LOG.warning(e)
+        LOG.warning(e, exc_info=e)

--- a/uaclient/timer/update_contract_info.py
+++ b/uaclient/timer/update_contract_info.py
@@ -1,6 +1,6 @@
 import logging
 
-from uaclient import contract, messages, util
+from uaclient import contract, util
 from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UAConfig
 from uaclient.files import notices
@@ -21,9 +21,10 @@ def update_contract_info(cfg: UAConfig) -> bool:
                     Notice.CONTRACT_REFRESH_WARNING,
                 )
         except Exception as e:
-            err_msg = messages.UPDATE_CHECK_CONTRACT_FAILURE.format(
-                reason=str(e)
+            LOG.warning(
+                "Failed to check for change in machine contract. Reason: %s",
+                str(e),
+                exc_info=e,
             )
-            LOG.warning(err_msg)
             return False
     return True

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -92,8 +92,9 @@ def retry(exception, retry_sleeps):
                 except exception as e:
                     if not sleeps:
                         raise e
-                    retry_msg = " Retrying %d more times." % len(sleeps)
-                    LOG.debug(str(e) + retry_msg)
+                    LOG.debug(
+                        "%s: Retrying %d more times.", str(e), len(sleeps)
+                    )
                     time.sleep(sleeps.pop(0))
 
         return decorator
@@ -119,14 +120,11 @@ def get_dict_deltas(
             else:
                 deltas[key] = DROPPED_KEY
         elif value != new_value:
-            log = (
-                "Contract value for '"
-                + key_path
-                + "' changed to '"
-                + str(new_value)
-                + "'"
+            LOG.debug(
+                "Contract value for '%s' changed to '%s'",
+                key_path,
+                str(new_value),
             )
-            LOG.debug(log)
             deltas[key] = new_value
     for key, value in new_dict.items():
         if key not in orig_dict:

--- a/uaclient/yaml.py
+++ b/uaclient/yaml.py
@@ -8,8 +8,8 @@ LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
 
 try:
     import yaml
-except ImportError:
-    LOG.error(MISSING_YAML_MODULE.msg)
+except ImportError as e:
+    LOG.exception(e)
     print(MISSING_YAML_MODULE.msg, file=sys.stderr)
     sys.exit(1)
 
@@ -17,20 +17,22 @@ except ImportError:
 def safe_load(stream):
     try:
         return yaml.safe_load(stream)
-    except AttributeError:
-        msg = BROKEN_YAML_MODULE.format(path=yaml.__path__).msg
-        LOG.error(msg)
-        print(msg, file=sys.stderr)
+    except AttributeError as e:
+        LOG.exception(e)
+        print(
+            BROKEN_YAML_MODULE.format(path=yaml.__path__).msg, file=sys.stderr
+        )
         sys.exit(1)
 
 
 def safe_dump(data, stream=None, **kwargs):
     try:
         return yaml.safe_dump(data, stream, **kwargs)
-    except AttributeError:
-        msg = BROKEN_YAML_MODULE.format(path=yaml.__path__).msg
-        LOG.error(msg)
-        print(msg, file=sys.stderr)
+    except AttributeError as e:
+        LOG.exception(e)
+        print(
+            BROKEN_YAML_MODULE.format(path=yaml.__path__).msg, file=sys.stderr
+        )
         sys.exit(1)
 
 


### PR DESCRIPTION
## Why is this needed?
This commit standardizes our logging calls in a couple ways:
 - log messages should be inline strings at the callsite
 - log string formatting should use lazy % style
 - logs shouldn't share strings with printed messages

In the places where log and print calls shared a string, I separated
them and attempted to make the log string more "log-like" and the
printed string more user-friendly. I also moved the printed string
to the messages module.

## Test Steps
Please review every log call and make sure it follows these conventions now.
Please review the changes in messages.

CI should pass

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
