### PR TITLE
systemd: change u-a.service type from notify to exec

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -2,8 +2,6 @@ import logging
 import os
 import sys
 
-from systemd.daemon import notify  # type: ignore
-
 from uaclient import http
 from uaclient.config import UAConfig
 from uaclient.daemon import poll_for_pro_license, retry_auto_attach
@@ -23,8 +21,6 @@ def main() -> int:
     http.configure_web_proxy(cfg.http_proxy, cfg.https_proxy)
 
     LOG.debug("daemon starting")
-
-    notify("READY=1")
 
     is_correct_cloud = any(
         os.path.exists("/run/cloud-init/cloud-id-{}".format(cloud))

--- a/systemd/ubuntu-advantage.service
+++ b/systemd/ubuntu-advantage.service
@@ -24,8 +24,7 @@ ConditionPathExists=|/run/cloud-init/cloud-id-azure
 ConditionPathExists=|/run/ubuntu-advantage/flags/auto-attach-failed
 
 [Service]
-Type=notify
-NotifyAccess=main
+Type=exec
 ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/daemon.py
 WorkingDirectory=/var/lib/ubuntu-advantage/
 


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because we have a dependency on python3-systemd to use the 'notify' function, which cannot be satisfied as the package is not part of ubuntu-minimal. This dependency was never declared in the debian/control file anyway, and we are removing it.

We don't lose much in the change anyway, as we are only configuring logging before notifying.

Fixes: #2692

## Test Steps
Execute all behave features which involve the `ubuntu-advantage.service` and see them all passing

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: 

## Does this PR require extra reviews?
 - [x] Yes - basak or panlinux
 - [ ] No
