### PR TITLE
tests: fix typo permission -> priority

### DIFF
--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -72,7 +72,7 @@ Feature: Enable anbox on Ubuntu
         anbox-cloud +yes +enabled
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has priority `500`
         """
         https://archive.anbox-cloud.io/stable <release>/main amd64 Packages
         """
@@ -113,7 +113,7 @@ Feature: Enable anbox on Ubuntu
         anbox-cloud +yes +enabled
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has priority `500`
         """
         https://archive.anbox-cloud.io/stable <release>/main amd64 Packages
         """

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -233,11 +233,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         See: sudo pro status
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `510`
+        Then apt-cache policy for the following url has priority `510`
         """
         <esm-infra-url> <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         <esm-infra-url> <release>-infra-security/main amd64 Packages
         """
@@ -970,7 +970,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         esm-infra     +yes                enabled            Expanded Security Maintenance for Infrastructure
         """
         When I run `apt-cache policy` as non-root
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has priority `500`
         """
         <ros-security-source> amd64 Packages
         """
@@ -984,7 +984,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         ros-updates   +yes                enabled            All Updates for the Robot Operating System
         """
         When I run `apt-cache policy` as non-root
-        Then apt-cache policy for the following url has permission `500`
+        Then apt-cache policy for the following url has priority `500`
         """
         <ros-updates-source> amd64 Packages
         """
@@ -1128,11 +1128,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt-cache policy` as non-root
-        Then apt-cache policy for the following url has permission `510`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """

--- a/features/steps/packages.py
+++ b/features/steps/packages.py
@@ -29,11 +29,11 @@ def when_i_apt_install(context, package_names, machine_name=SUT):
     )
 
 
-@then("apt-cache policy for the following url has permission `{perm_id}`")
-def then_apt_cache_policy_for_the_following_url_has_permission_perm_id(
-    context, perm_id
+@then("apt-cache policy for the following url has priority `{prio_id}`")
+def then_apt_cache_policy_for_the_following_url_has_priority_prio_id(
+    context, prio_id
 ):
-    full_url = "{} {}".format(perm_id, context.text)
+    full_url = "{} {}".format(prio_id, context.text)
     assert_that(context.process.stdout.strip(), matches_regexp(full_url))
 
 

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -289,19 +289,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `510`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -416,19 +416,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `510`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -542,19 +542,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `510`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -60,23 +60,23 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `510`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `1001`
+        And apt-cache policy for the following url has priority `1001`
         """
         <fips-apt-source> amd64 Packages
         """
@@ -280,23 +280,23 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `510`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `1001`
+        And apt-cache policy for the following url has priority `1001`
         """
         <fips-apt-source> amd64 Packages
         """
@@ -553,23 +553,23 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has permission `510`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `510`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has permission `1001`
+        And apt-cache policy for the following url has priority `1001`
         """
         <fips-apt-source> amd64 Packages
         """


### PR DESCRIPTION
This is an accidental wrong word, it is only used inside the tests and not bleeding to a user or any such. Hence it can be fixed, but has no urgency.

Fixes: #2719

## Why is this needed?

It resolves an accidental typo

## Test Steps

Run the tests and watch the output no more speaking of "url permission" but instead of "priority".
(This isn't in the code active on a Ubuntu system, only in the self tests)


## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No