### PR TITLE
WIP: Reduce race window between mkdir and chmod

### DIFF
--- a/uaclient/files/files.py
+++ b/uaclient/files/files.py
@@ -42,9 +42,10 @@ class UAFile:
             else defaults.WORLD_READABLE_MODE
         )
         if not os.path.exists(self._directory):
-            os.makedirs(self._directory)
             if os.path.basename(self._directory) == defaults.PRIVATE_SUBDIR:
-                os.chmod(self._directory, 0o700)
+                os.makedirs(self._directory)
+            else:
+                os.makedirs(self._directory, mode=0o700)
         system.write_file(self.path, content, file_mode)
 
     def read(self) -> Optional[str]:


### PR DESCRIPTION
Careful review by Seth (thanks) revealed a potential race where an attacker could exchange the element we chmod to gain benefit. In this case to potentially gain execute rights.

Reduce the race by setting the permissions correctly in the mkdir() call right away.

LP: #2024204

## Why is this needed?

While the discussion didn't lead to a panic "Oh no this is super-bad" we still would want to mitigate any weakness we can.

## Test Steps

```
# Set up a system to be ready for pro attached
# ensure there is no old private dir
$ rm -rf /var/lib/ubuntu-advantage/private
strace -o verify-access.strace -rTf pro attach <redacted>
```

The resulting file will have the following entries

```
06:56:17.120305 mkdir("/var/lib/ubuntu-advantage/private", 0777) = 0 <0.000108>
...
```

Hmm, I wanted to show the chmod to the `private` dir here (which I see for files) and use the timing to show how much shorter it would get (or even better directly on creation).

But what I found was that with the above steps we actually create `private` it with lower permissions.

```
$ ll /var/lib/ubuntu-advantage/
drwxr-xr-x  2 root root     5 Aug 29 06:56 private/
```

This needs a discussion why this latter permission issue happens.
And then we can revisit testing this

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in

## Does this PR require extra reviews?
 - [x] Yes
 - [ ] No
