### PR TITLE
github: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Report a bug
+about: Create a report to help us fix or improve the Pro Client
+title: 'Bug: '
+labels: 'bug'
+
+---
+
+**Description of the bug**
+
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Current behavior**
+
+A clear and concise description of what is happening now
+Feel free to include screenshots or quoted output if relevant.
+
+**To Reproduce**
+
+Please include details on how to reproduce the bug.
+1. Launch a VM/Container
+2. Run ...
+
+**System information:**
+
+- Ubuntu release: <!-- $ grep 'VERSION=' /etc/os-release -->
+- Pro Client version: <!-- $ pro version -->
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Suggest a new feature
+about: Suggest an idea for the Pro Client
+title: 'Feature: '
+labels: 'feature'
+
+---
+
+**Please describe the scenario where the new feature would be useful**
+
+What is the situation that made you realize this feature is necessary?
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Current behavior**
+
+Is this partially implemented somehow? Is there any alternative way to solve the problem?
+
+**Additional context**
+
+Add any other context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,18 @@
+---
+name: Ask for guidance / documentation
+about: Ask questions, and potentially help us improve our docs
+title: 'Question: '
+labels: 'docs'
+
+---
+
+**What is the subject you need more information on?**
+
+Let us know how can we help.
+
+**Did you check the documentation first?**
+
+After looking for guidance in [the Pro Client documentation](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/), mark one of the following checkboxes:
+
+ - [ ] There is documentation about this, but it needs improvement
+ - [ ] There is no documentation about this


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it adds issue templates to guide users when opening an issue.

And it 
Fixes: #2646

## Test Steps
- Merge this PR
- Try to open an issue against the `ubuntu-pro-client` repository
- If something is odd/wrong, please open an issue against the `ubuntu-pro-client` repository

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: 

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
