### PR TITLE
tests: add scenario where cloud-init is disabled

### DIFF
--- a/features/cloud.py
+++ b/features/cloud.py
@@ -327,9 +327,9 @@ class EC2(Cloud):
             An AWS cloud provider instance
         """
         if not image_name:
-            if series == "xenial" and "pro" not in machine_type:
+            if series in ("xenial", "bionic") and "pro" not in machine_type:
                 logging.debug(
-                    "defaulting to non-daily image for awsgeneric-16.04"
+                    "defaulting to non-daily image for awsgeneric-[16|18].04"
                 )
                 daily = False
             else:


### PR DESCRIPTION
## Why is this needed?
Add a scenario where cloud-init is disabled after boot. In that situation there is no cloud-id command anymore. To test that the Pro client doesn't break, we will enable FIPS on a cloud instance to show that service is indeed enabled even though the cloud metapackage is not installed

This is also needed because there is a Launchpad [bug](https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/1938208) that address the lack of this test

## Test Steps
Run the new integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
