### PR TITLE
[draft] feat: warn/confirm with user if enabling fips downgrades the kernel

### DIFF
--- a/features/enable_fips_pro.feature
+++ b/features/enable_fips_pro.feature
@@ -118,7 +118,7 @@ Feature: FIPS enablement in PRO cloud based machines
            | focal   | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
            | focal   | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
-
+    @wip
     @slow
     @series.bionic
     @series.focal
@@ -142,6 +142,10 @@ Feature: FIPS enablement in PRO cloud based machines
         When I run `pro enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
             """
+            This will downgrade the kernel from X to new_version.
+            Warning: Downgrading the kernel may cause hardware failures.  Please ensure the
+            hardware is compatible with the new kernel version before proceeding.
+            Are you sure? (y/N)
             Updating <fips-name> package lists
             Installing <fips-name> packages
             <fips-name> enabled

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -405,6 +405,12 @@ class TestFIPSEntitlementEnable:
                 retry_sleeps=apt.APT_RETRIES,
                 override_env_vars=None,
             ),
+            mock.call(
+                ["apt-cache", "policy", "linux-fips"],
+                capture=True,
+                retry_sleeps=apt.APT_RETRIES,
+                override_env_vars=None,
+            ),
         ]
         subp_calls += install_cmd
 
@@ -1104,7 +1110,6 @@ class TestFipsEntitlementInstallPackages:
         fips_entitlement_factory,
         event,
     ):
-
         conditional_pkgs = ["b", "c"]
         m_installed_pkgs.return_value = conditional_pkgs
         packages = ["a"]

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1295,6 +1295,16 @@ This will disable the {title} entitlement but the {title} packages will remain i
     )
     + PROMPT_YES_NO
 )
+PROMPT_KERNEL_DOWNGRADE = (
+    t.gettext(
+    """\
+This will downgrade the kernel from {current_version} to {new_version}.
+Warning: Downgrading the kernel may cause hardware failures.  Please ensure the
+         hardware is compatible with the new kernel version before proceeding.
+"""
+    + PROMPT_YES_NO
+    )
+)
 FIPS_SYSTEM_REBOOT_REQUIRED = t.gettext(
     "FIPS support requires system reboot to complete configuration."
 )


### PR DESCRIPTION
This change adds a new message prompting the user to confirm if enabling fips downgrades the kernel.

## Why is this needed?
There have been reports of people enabling FIPS (not realizing it will downgrade their kernel), and having their hardware fail as it needed the new kernel.  This change adds an additional warning/prompt if a FIPS enablement is determined to downgrade the kernel.

Jira card: https://warthogs.atlassian.net/browse/SC-1534

## Test Steps
TODO: create integration tests
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
