### PR TITLE
Send variant information to cs

### DIFF
--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -47,7 +47,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Real-time kernel service
         Given a `<release>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token_staging` with sudo and options `--no-auto-enable`
+        When I attach `contract_token` with sudo and options `--no-auto-enable`
         Then I verify that running `pro enable realtime-kernel` `as non-root` exits `1`
         And I will see the following on stderr:
         """
@@ -63,6 +63,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         to make the change manually..*
 
         Do you want to continue\? \[ default = Yes \]: \(Y/n\) Updating Real-time kernel package lists
+        Updating standard Ubuntu package lists
         Installing Real-time kernel packages
         Real-time kernel enabled
         A reboot is required to complete install.
@@ -74,7 +75,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         And stdout matches regexp:
         """
-        \s* 500 https://esm.staging.ubuntu.com/realtime/ubuntu <release>/main amd64 Packages
+        \s* 500 https://esm.ubuntu.com/realtime/ubuntu <release>/main amd64 Packages
         """
         When I run `pro api u.pro.status.enabled_services.v1` as non-root
         Then stdout matches regexp:
@@ -217,7 +218,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         .*This will change your kernel. To revert to your original kernel, you will need
         to make the change manually..*
 
-        Do you want to continue\? \[ default = Yes \]: \(Y/n\) Updating Real-time NVIDIA Tegra kernel package lists
+        Do you want to continue\? \[ default = Yes \]: \(Y/n\) Updating Real-time NVIDIA Tegra Kernel package lists
+        Updating standard Ubuntu package lists
         Installing Real-time NVIDIA Tegra Kernel packages
         Real-time NVIDIA Tegra Kernel enabled
         """

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -435,6 +435,11 @@ class UAContractClient(serviceclient.UAServiceClient):
                 or system.get_machine_id(self.cfg),
                 "activityToken": self.cfg.machine_token_file.activity_token,
                 "resources": [service.name for service in enabled_services],
+                "resourceVariants": {
+                    service.name: service.variant_name
+                    for service in enabled_services
+                    if service.variant_enabled
+                },
                 "lastAttachment": attachment_data.attached_at.isoformat()
                 if attachment_data
                 else None,

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -738,7 +738,13 @@ class TestUAContractClient:
                 "8001",
                 IsAttachedResult(is_attached=True),
                 mock.MagicMock(
-                    enabled_services=[helpers.mock_with_name_attr(name="one")]
+                    enabled_services=[
+                        helpers.mock_with_name_attr(
+                            name="one",
+                            variant_enabled=False,
+                            variant_name=None,
+                        )
+                    ]
                 ),
                 AttachmentData(
                     attached_at=datetime.datetime(
@@ -759,6 +765,7 @@ class TestUAContractClient:
                     "activityID": "activity_id",
                     "activityToken": "activity_token",
                     "resources": ["one"],
+                    "resourceVariants": {},
                     "lastAttachment": "2000-01-02T03:04:05+00:00",
                 },
             ),
@@ -786,7 +793,18 @@ class TestUAContractClient:
                 "8001",
                 IsAttachedResult(is_attached=True),
                 mock.MagicMock(
-                    enabled_services=[helpers.mock_with_name_attr(name="one")]
+                    enabled_services=[
+                        helpers.mock_with_name_attr(
+                            name="one",
+                            variant_enabled=False,
+                            variant_name=None,
+                        ),
+                        helpers.mock_with_name_attr(
+                            name="two",
+                            variant_enabled=True,
+                            variant_name="test",
+                        ),
+                    ]
                 ),
                 AttachmentData(
                     attached_at=datetime.datetime(
@@ -806,7 +824,8 @@ class TestUAContractClient:
                     "clientVersion": "8001",
                     "activityID": "machine_id",
                     "activityToken": "activity_token",
-                    "resources": ["one"],
+                    "resources": ["one", "two"],
+                    "resourceVariants": {"two": "test"},
                     "lastAttachment": "2000-01-02T03:04:05+00:00",
                 },
             ),


### PR DESCRIPTION
## Why is this needed?
When reporting about the machine status, we are now also sending if a variant of a service is enabled. This will allow the
Contract Server to better track which services are being use

## Test Steps
Confirm that the `_get_activity_info` method is now correctly returning  `resourceVariants` if variants are enabled and it is empty when no variant related service is enabled


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
