### PR TITLE
tests: fix ros status on Focal

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -220,7 +220,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
        livepatch     +(yes|no)   +(Canonical Livepatch service|Current kernel is not supported)
        realtime-kernel +<realtime-kernel> +Ubuntu kernel with PREEMPT_RT patches integrated
        ros           +<ros>      +Security Updates for the Robot Operating System
-       ros-updates   +<ros>      +All Updates for the Robot Operating System
+       ros-updates   +<ros-updates>      +All Updates for the Robot Operating System
        """
        Then stdout matches regexp:
        """
@@ -258,11 +258,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
        """
 
        Examples: ubuntu release
-           | release | anbox | esm-apps | cc-eal | cis | fips | fips-update | ros | cis_or_usg | realtime-kernel |
-           | xenial  | no    | yes      | yes    | yes | yes  | yes         | yes | cis        | no              |
-           | bionic  | no    | yes      | yes    | yes | yes  | yes         | yes | cis        | no              |
-           | focal   | yes   | yes      | no     | yes | yes  | yes         | no  | usg        | no              |
-           | jammy   | yes   | yes      | no     | yes | no   | no          | no  | usg        | yes             |
+           | release | anbox | esm-apps | cc-eal | cis | fips | fips-update | ros | ros-updates | cis_or_usg | realtime-kernel |
+           | xenial  | no    | yes      | yes    | yes | yes  | yes         | yes | yes         | cis        | no              |
+           | bionic  | no    | yes      | yes    | yes | yes  | yes         | yes | yes         | cis        | no              |
+           | focal   | yes   | yes      | no     | yes | yes  | yes         | yes | no          | usg        | no              |
+           | jammy   | yes   | yes      | no     | yes | no   | no          | no  | no          | usg        | yes             |
 
     @series.all
     @uses.config.machine_type.lxd-container

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -145,6 +145,7 @@ Feature: Attached status
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
         fips            +yes      +disabled +NIST-certified core packages
         fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        ros             +yes      +disabled +Security Updates for the Robot Operating System
         usg             +yes      +disabled +Security compliance and audit tools
 
         For a list of all Ubuntu Pro services, run 'pro status --all'
@@ -164,7 +165,7 @@ Feature: Attached status
         landscape       +yes      +n/a      +Management and administration tool for Ubuntu
         livepatch       +yes      +n/a      +Canonical Livepatch service
         realtime-kernel +yes      +n/a      +Ubuntu kernel with PREEMPT_RT patches integrated
-        ros             +yes      +n/a      +Security Updates for the Robot Operating System
+        ros             +yes      +disabled +Security Updates for the Robot Operating System
         ros-updates     +yes      +n/a      +All Updates for the Robot Operating System
         usg             +yes      +disabled +Security compliance and audit tools
 

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -138,6 +138,7 @@ Feature: Unattached status
         fips            +yes       +NIST-certified core packages
         fips-updates    +yes       +NIST-certified core packages with priority security updates
         livepatch       +yes       +Canonical Livepatch service
+        ros             +yes       +Security Updates for the Robot Operating System
         usg             +yes       +Security compliance and audit tools
 
         For a list of all Ubuntu Pro services, run 'pro status --all'
@@ -159,7 +160,7 @@ Feature: Unattached status
         landscape       +no        +Management and administration tool for Ubuntu
         livepatch       +yes       +Canonical Livepatch service
         realtime-kernel +no        +Ubuntu kernel with PREEMPT_RT patches integrated
-        ros             +no        +Security Updates for the Robot Operating System
+        ros             +yes       +Security Updates for the Robot Operating System
         ros-updates     +no        +All Updates for the Robot Operating System
         usg             +yes       +Security compliance and audit tools
 
@@ -182,6 +183,7 @@ Feature: Unattached status
         fips            +yes       +NIST-certified core packages
         fips-updates    +yes       +NIST-certified core packages with priority security updates
         livepatch       +yes       +Canonical Livepatch service
+        ros             +yes       +Security Updates for the Robot Operating System
         usg             +yes       +Security compliance and audit tools
 
         FEATURES
@@ -349,6 +351,7 @@ Feature: Unattached status
         fips            +yes       +yes       +no           +NIST-certified core packages
         fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        ros             +yes       +yes       +no           +Security Updates for the Robot Operating System
         usg             +yes       +yes       +no           +Security compliance and audit tools
         """
         When I do a preflight check for `contract_token` with the all flag
@@ -364,7 +367,7 @@ Feature: Unattached status
         landscape       +no        +yes       +no           +Management and administration tool for Ubuntu
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         realtime-kernel +no        +yes       +no           +Ubuntu kernel with PREEMPT_RT patches integrated
-        ros             +no        +yes       +no           +Security Updates for the Robot Operating System
+        ros             +yes       +yes       +no           +Security Updates for the Robot Operating System
         ros-updates     +no        +yes       +no           +All Updates for the Robot Operating System
         usg             +yes       +yes       +no           +Security compliance and audit tools
         """
@@ -552,6 +555,7 @@ Feature: Unattached status
         fips            +yes       +yes       +no           +NIST-certified core packages
         fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
+        ros             +yes       +no        +no           +Security Updates for the Robot Operating System
         usg             +yes       +yes       +no           +Security compliance and audit tools
         """
 


### PR DESCRIPTION
## Why is this needed?
Now that ros is supported on Focal, we are updating the Focal test that show the ros status in the output

## Test Steps
Run the modified tests and guarantee they are working as expected

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
