### PR TITLE
fips-preview: add service support

### DIFF
--- a/debian/po/pt_BR.po
+++ b/debian/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-03 17:05-0300\n"
+"POT-Creation-Date: 2023-10-03 17:15-0300\n"
 "PO-Revision-Date: 2023-09-25 12:29-0400\n"
 "Last-Translator: Lucas Moura <lucas.moura@canonical.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -2203,33 +2203,32 @@ msgid "FIPS"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1199
-msgid "NIST-certified core packages"
+msgid "NIST-certified FIPS crypto packages"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1201
 #, python-brace-format
 msgid ""
-"FIPS 140-2 is a set of publicly announced cryptographic standards developed "
-"by\n"
-"the National Institute of Standards and Technology applicable for FedRAMP,\n"
-"HIPAA, PCI and ISO compliance use cases. Note that \"fips\" does not "
-"provide\n"
-"security patching. For FIPS certified modules with security patches please\n"
-"see \"fips-updates\". You can find out more at {url}"
+"Installs FIPS 140 crypto packages for FedRAMP, FISMA and compliance use "
+"cases.\n"
+"Note that \"fips\" does not provide security patching. For FIPS certified\n"
+"modules with security patches please see \"fips-updates\". If you are "
+"unsure,\n"
+"choose \"fips-updates\" for maximum security. Find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1209
+#: ../../uaclient/messages/__init__.py:1208
 msgid "Could not determine cloud, defaulting to generic FIPS package."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1212
+#: ../../uaclient/messages/__init__.py:1211
 #, python-brace-format
 msgid ""
 "FIPS kernel is running in a disabled state.\n"
 "  To manually remove fips kernel: {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1218
+#: ../../uaclient/messages/__init__.py:1217
 msgid ""
 "Warning: FIPS kernel is not optimized for your specific cloud.\n"
 "To fix it, run the following commands:\n"
@@ -2240,20 +2239,20 @@ msgid ""
 "    4. sudo reboot\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1230
+#: ../../uaclient/messages/__init__.py:1229
 msgid ""
 "This will install the FIPS packages. The Livepatch service will be "
 "unavailable.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1239
+#: ../../uaclient/messages/__init__.py:1238
 msgid ""
 "This will install the FIPS packages including security updates.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1248
+#: ../../uaclient/messages/__init__.py:1247
 #, python-brace-format
 msgid ""
 "Warning: Enabling {title} in a container.\n"
@@ -2263,67 +2262,95 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1260
+#: ../../uaclient/messages/__init__.py:1259
+#, python-brace-format
 msgid ""
-"This will disable the FIPS entitlement but the FIPS packages will remain "
-"installed.\n"
+"This will disable the {title} entitlement but the {title} packages will "
+"remain installed.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1267
+#: ../../uaclient/messages/__init__.py:1266
 msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1269
-#: ../../uaclient/messages/__init__.py:1667
+#: ../../uaclient/messages/__init__.py:1268
+#: ../../uaclient/messages/__init__.py:1686
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1271
+#: ../../uaclient/messages/__init__.py:1270
 msgid "This FIPS install is out of date, run: sudo pro enable fips"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1274
+#: ../../uaclient/messages/__init__.py:1273
 msgid "Disabling FIPS requires system reboot to complete operation."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1277
+#: ../../uaclient/messages/__init__.py:1276
 #, python-brace-format
 msgid "{service} {pkg} package could not be installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1280
+#: ../../uaclient/messages/__init__.py:1279
 msgid ""
 "Please run `apt upgrade` to ensure all FIPS packages are updated to the "
 "correct\n"
 "version.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1287
+#: ../../uaclient/messages/__init__.py:1285
 msgid "FIPS Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1289
-msgid "NIST-certified core packages with priority security updates"
-msgstr ""
+#: ../../uaclient/messages/__init__.py:1287
+#, fuzzy
+msgid "FIPS compliant crypto packages with stable security updates"
+msgstr "Pacotes instalados com atualizações disponíveis por {service}:"
 
-#: ../../uaclient/messages/__init__.py:1292
+#: ../../uaclient/messages/__init__.py:1290
 #, python-brace-format
 msgid ""
-"fips-updates installs fips modules including all security patches for those\n"
-"modules that have been provided since their certification date. You can "
-"find\n"
-"out more at {url}"
+"fips-updates installs FIPS 140 crypto packages including all security "
+"patches\n"
+"for those modules that have been provided since their certification date.\n"
+"You can find out more at {url}"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1296
+msgid "FIPS Preview"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1298
+msgid "Preview of FIPS crypto packages undergoing certification with NIST"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1301
+msgid ""
+"Installs FIPS crypto packages that are under certification with NIST,\n"
+"for FedRAMP, FISMA and compliance use cases."
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1306
+msgid ""
+"This will install crypto packages that have been submitted to NIST for "
+"review\n"
+"but do not have FIPS certification yet. Use this for early access to the "
+"FIPS\n"
+"modules.\n"
+"Please note that the Livepatch service will be unavailable after\n"
+"this operation.\n"
+"Warning: This action can take some time and cannot be undone.\n"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1317
 msgid "Landscape"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1300
+#: ../../uaclient/messages/__init__.py:1319
 msgid "Management and administration tool for Ubuntu"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1303
+#: ../../uaclient/messages/__init__.py:1322
 #, python-brace-format
 msgid ""
 "Landscape Client can be installed on this machine and enrolled in "
@@ -2336,15 +2363,15 @@ msgid ""
 "more. Find out more about Landscape at {home_url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1316
+#: ../../uaclient/messages/__init__.py:1335
 msgid "Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1317
+#: ../../uaclient/messages/__init__.py:1336
 msgid "Canonical Livepatch service"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1319
+#: ../../uaclient/messages/__init__.py:1338
 #, python-brace-format
 msgid ""
 "Livepatch provides selected high and critical kernel CVE fixes and other\n"
@@ -2359,42 +2386,42 @@ msgid ""
 "service at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1328
+#: ../../uaclient/messages/__init__.py:1347
 msgid "Current kernel is not supported"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1331
+#: ../../uaclient/messages/__init__.py:1350
 #, python-brace-format
 msgid "Supported livepatch kernels are listed here: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1334
+#: ../../uaclient/messages/__init__.py:1353
 #, python-brace-format
 msgid "Unable to configure livepatch: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1336
+#: ../../uaclient/messages/__init__.py:1355
 msgid "Unable to enable Livepatch: "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1338
+#: ../../uaclient/messages/__init__.py:1357
 msgid "Disabling Livepatch prior to re-attach with new token"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1341
+#: ../../uaclient/messages/__init__.py:1360
 msgid "Livepatch support requires a system reboot across LTS upgrade."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1344
-#: ../../uaclient/messages/__init__.py:1357
+#: ../../uaclient/messages/__init__.py:1363
+#: ../../uaclient/messages/__init__.py:1376
 msgid "Real-time kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1346
+#: ../../uaclient/messages/__init__.py:1365
 msgid "Ubuntu kernel with PREEMPT_RT patches integrated"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1349
+#: ../../uaclient/messages/__init__.py:1368
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated. "
 "It\n"
@@ -2407,27 +2434,27 @@ msgid ""
 "Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1359
+#: ../../uaclient/messages/__init__.py:1378
 msgid "Generic version of the RT kernel (default)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1361
+#: ../../uaclient/messages/__init__.py:1380
 msgid "Real-time NVIDIA Tegra Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1363
+#: ../../uaclient/messages/__init__.py:1382
 msgid "RT kernel optimized for NVIDIA Tegra platform"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1365
+#: ../../uaclient/messages/__init__.py:1384
 msgid "Real-time Intel IOTG Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1367
+#: ../../uaclient/messages/__init__.py:1386
 msgid "RT kernel optimized for Intel IOTG platform"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1370
+#: ../../uaclient/messages/__init__.py:1389
 #, python-brace-format
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches "
@@ -2440,7 +2467,7 @@ msgid ""
 "Do you want to continue? [ default = Yes ]: (Y/n) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1381
+#: ../../uaclient/messages/__init__.py:1400
 msgid ""
 "This will remove the boot order preference for the Real-time kernel and\n"
 "disable updates to the Real-time kernel.\n"
@@ -2457,15 +2484,15 @@ msgid ""
 "Are you sure? (y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1397
+#: ../../uaclient/messages/__init__.py:1416
 msgid "ROS ESM Security Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1398
+#: ../../uaclient/messages/__init__.py:1417
 msgid "Security Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1400
+#: ../../uaclient/messages/__init__.py:1419
 #, python-brace-format
 msgid ""
 "ros provides access to a private PPA which includes security-related "
@@ -2478,15 +2505,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1409
+#: ../../uaclient/messages/__init__.py:1428
 msgid "ROS ESM All Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1411
+#: ../../uaclient/messages/__init__.py:1430
 msgid "All Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1414
+#: ../../uaclient/messages/__init__.py:1433
 #, python-brace-format
 msgid ""
 "ros-updates provides access to a private PPA that includes non-security-"
@@ -2499,14 +2526,14 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1485
+#: ../../uaclient/messages/__init__.py:1504
 msgid ""
 "Unexpected error(s) occurred.\n"
 "For more details, see the log: /var/log/ubuntu-advantage.log\n"
 "To file a bug run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1495
+#: ../../uaclient/messages/__init__.py:1514
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2514,7 +2541,7 @@ msgid ""
 "Please install \"ca-certificates\" and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1505
+#: ../../uaclient/messages/__init__.py:1524
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2522,199 +2549,199 @@ msgid ""
 "Please check your openssl configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1514
+#: ../../uaclient/messages/__init__.py:1533
 #, python-brace-format
 msgid "Ignoring unknown argument '{arg}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1520
+#: ../../uaclient/messages/__init__.py:1539
 #, python-brace-format
 msgid ""
 "A new version of the client is available: {version}. Please upgrade to the "
 "latest version to get the new features and bug fixes."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1527
+#: ../../uaclient/messages/__init__.py:1546
 #, python-brace-format
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1533
+#: ../../uaclient/messages/__init__.py:1552
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1540
+#: ../../uaclient/messages/__init__.py:1559
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1547
+#: ../../uaclient/messages/__init__.py:1566
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1552
+#: ../../uaclient/messages/__init__.py:1571
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1560
+#: ../../uaclient/messages/__init__.py:1579
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1568
+#: ../../uaclient/messages/__init__.py:1587
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1571
+#: ../../uaclient/messages/__init__.py:1590
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1576
+#: ../../uaclient/messages/__init__.py:1595
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1582
+#: ../../uaclient/messages/__init__.py:1601
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1586
+#: ../../uaclient/messages/__init__.py:1605
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1591
+#: ../../uaclient/messages/__init__.py:1610
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1598
+#: ../../uaclient/messages/__init__.py:1617
 #, python-brace-format
 msgid ""
 "{title} is already enabled.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1605
+#: ../../uaclient/messages/__init__.py:1624
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1611
+#: ../../uaclient/messages/__init__.py:1630
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1617
+#: ../../uaclient/messages/__init__.py:1636
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1625
+#: ../../uaclient/messages/__init__.py:1644
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1633
+#: ../../uaclient/messages/__init__.py:1652
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1640
+#: ../../uaclient/messages/__init__.py:1659
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1648
+#: ../../uaclient/messages/__init__.py:1667
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1655
+#: ../../uaclient/messages/__init__.py:1674
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1661
+#: ../../uaclient/messages/__init__.py:1680
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1671
+#: ../../uaclient/messages/__init__.py:1690
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1674
+#: ../../uaclient/messages/__init__.py:1693
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1678
+#: ../../uaclient/messages/__init__.py:1697
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1683
+#: ../../uaclient/messages/__init__.py:1702
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1691
+#: ../../uaclient/messages/__init__.py:1710
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1700
+#: ../../uaclient/messages/__init__.py:1719
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1708
+#: ../../uaclient/messages/__init__.py:1727
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1712
+#: ../../uaclient/messages/__init__.py:1731
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1717
+#: ../../uaclient/messages/__init__.py:1736
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1725
+#: ../../uaclient/messages/__init__.py:1744
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2724,7 +2751,7 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1734
+#: ../../uaclient/messages/__init__.py:1753
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2733,76 +2760,76 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1744
+#: ../../uaclient/messages/__init__.py:1763
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1750
+#: ../../uaclient/messages/__init__.py:1769
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1757
+#: ../../uaclient/messages/__init__.py:1776
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1764
+#: ../../uaclient/messages/__init__.py:1783
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1769
+#: ../../uaclient/messages/__init__.py:1788
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1773
+#: ../../uaclient/messages/__init__.py:1792
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1778
+#: ../../uaclient/messages/__init__.py:1797
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1782
+#: ../../uaclient/messages/__init__.py:1801
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1786
+#: ../../uaclient/messages/__init__.py:1805
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1791
+#: ../../uaclient/messages/__init__.py:1810
 msgid "lanscape-client is not installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1796
+#: ../../uaclient/messages/__init__.py:1815
 msgid ""
 "Landscape is installed but not configured.\n"
 "Run `sudo landscape-config` to set it up, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1805
+#: ../../uaclient/messages/__init__.py:1824
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1814
+#: ../../uaclient/messages/__init__.py:1833
 msgid ""
 "Landscape is installed and configured and registered but not running.\n"
 "Run `sudo landscape-config` to start it, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1822
+#: ../../uaclient/messages/__init__.py:1841
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1828
+#: ../../uaclient/messages/__init__.py:1847
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2812,28 +2839,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1842
+#: ../../uaclient/messages/__init__.py:1861
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1848
+#: ../../uaclient/messages/__init__.py:1867
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1878
+#: ../../uaclient/messages/__init__.py:1897
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1883
+#: ../../uaclient/messages/__init__.py:1902
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1889
+#: ../../uaclient/messages/__init__.py:1908
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2841,96 +2868,96 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1899
+#: ../../uaclient/messages/__init__.py:1918
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1906
+#: ../../uaclient/messages/__init__.py:1925
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1911
+#: ../../uaclient/messages/__init__.py:1930
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1915
+#: ../../uaclient/messages/__init__.py:1934
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1919
+#: ../../uaclient/messages/__init__.py:1938
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1924
+#: ../../uaclient/messages/__init__.py:1943
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1940
+#: ../../uaclient/messages/__init__.py:1959
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1946
+#: ../../uaclient/messages/__init__.py:1965
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1950
+#: ../../uaclient/messages/__init__.py:1969
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1956
+#: ../../uaclient/messages/__init__.py:1975
 msgid ""
 "Failed to connect to authentication server\n"
 "Check your Internet connection and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1963
+#: ../../uaclient/messages/__init__.py:1982
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1969
+#: ../../uaclient/messages/__init__.py:1988
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1978
+#: ../../uaclient/messages/__init__.py:1997
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1985
+#: ../../uaclient/messages/__init__.py:2004
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1992
+#: ../../uaclient/messages/__init__.py:2011
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1997
+#: ../../uaclient/messages/__init__.py:2016
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2003
+#: ../../uaclient/messages/__init__.py:2022
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2938,7 +2965,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2013
+#: ../../uaclient/messages/__init__.py:2032
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2946,7 +2973,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2023
+#: ../../uaclient/messages/__init__.py:2042
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2954,41 +2981,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2033
+#: ../../uaclient/messages/__init__.py:2052
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2040
+#: ../../uaclient/messages/__init__.py:2059
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2046
+#: ../../uaclient/messages/__init__.py:2065
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2052
+#: ../../uaclient/messages/__init__.py:2071
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2057
+#: ../../uaclient/messages/__init__.py:2076
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2063
+#: ../../uaclient/messages/__init__.py:2082
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2071
+#: ../../uaclient/messages/__init__.py:2090
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2080
+#: ../../uaclient/messages/__init__.py:2099
 #, python-brace-format
 msgid ""
 "To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
@@ -2996,59 +3023,59 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2096
+#: ../../uaclient/messages/__init__.py:2115
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2101
+#: ../../uaclient/messages/__init__.py:2120
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2107
+#: ../../uaclient/messages/__init__.py:2126
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2115
+#: ../../uaclient/messages/__init__.py:2134
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2123
+#: ../../uaclient/messages/__init__.py:2142
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2130
+#: ../../uaclient/messages/__init__.py:2149
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2137
+#: ../../uaclient/messages/__init__.py:2156
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2146
+#: ../../uaclient/messages/__init__.py:2165
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2150
+#: ../../uaclient/messages/__init__.py:2169
 #, python-brace-format
 msgid ""
 "Error on Pro Image:\n"
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2156
+#: ../../uaclient/messages/__init__.py:2175
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2163
+#: ../../uaclient/messages/__init__.py:2182
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -3056,16 +3083,16 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2173
+#: ../../uaclient/messages/__init__.py:2192
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2180
+#: ../../uaclient/messages/__init__.py:2199
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2188
+#: ../../uaclient/messages/__init__.py:2207
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
@@ -3074,7 +3101,7 @@ msgstr ""
 "Suporte para auto-attach não está disponível para esta imagem\n"
 "Veja {url}"
 
-#: ../../uaclient/messages/__init__.py:2197
+#: ../../uaclient/messages/__init__.py:2216
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
@@ -3083,18 +3110,18 @@ msgstr ""
 "Suporte para auto-attach não está disponível para {{cloud_type}}\n"
 "Veja: {url}"
 
-#: ../../uaclient/messages/__init__.py:2205
+#: ../../uaclient/messages/__init__.py:2224
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2211
+#: ../../uaclient/messages/__init__.py:2230
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2219
+#: ../../uaclient/messages/__init__.py:2238
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -3105,7 +3132,7 @@ msgstr ""
 "o campo VERSION não tem a informação de versão: {version}\n"
 "e o campo VERSION_CODENAME não está presente"
 
-#: ../../uaclient/messages/__init__.py:2229
+#: ../../uaclient/messages/__init__.py:2248
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -3119,12 +3146,12 @@ msgstr ""
 "\n"
 "$ sudo rm {lock_file_path}"
 
-#: ../../uaclient/messages/__init__.py:2238
+#: ../../uaclient/messages/__init__.py:2257
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr "{source} retornou um json inválido: {out}"
 
-#: ../../uaclient/messages/__init__.py:2244
+#: ../../uaclient/messages/__init__.py:2263
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
@@ -3133,7 +3160,7 @@ msgstr ""
 "Valor inválido para {path_to_value} em /etc/ubuntu-advantage/uaclient.conf."
 "Esperava {expected_value}, mas {value} foi encontrado."
 
-#: ../../uaclient/messages/__init__.py:2253
+#: ../../uaclient/messages/__init__.py:2272
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
@@ -3141,17 +3168,17 @@ msgstr ""
 "Não foi possível associar {key} a {value}: <value> precisa ser um inteiro "
 "positivo."
 
-#: ../../uaclient/messages/__init__.py:2260
+#: ../../uaclient/messages/__init__.py:2279
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr "url inválida no arquivo de configuração. {key}: {value}"
 
-#: ../../uaclient/messages/__init__.py:2265
+#: ../../uaclient/messages/__init__.py:2284
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr "Não foi possível encontrar o arquivo yaml: {filepath}"
 
-#: ../../uaclient/messages/__init__.py:2271
+#: ../../uaclient/messages/__init__.py:2290
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
@@ -3162,27 +3189,27 @@ msgstr ""
 "pro de apt ao mesmo tempo não é suportado.\n"
 "Cancelando o processo de configuração.\n"
 
-#: ../../uaclient/messages/__init__.py:2281
+#: ../../uaclient/messages/__init__.py:2300
 msgid "Can't load the distro-info database."
 msgstr "Não foi possível carregar o banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2286
+#: ../../uaclient/messages/__init__.py:2305
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 "Não foi possível encontrar a série {series} na banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2291
+#: ../../uaclient/messages/__init__.py:2310
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr "Erro: não é possível usar {option1} junto com {option2}"
 
-#: ../../uaclient/messages/__init__.py:2295
+#: ../../uaclient/messages/__init__.py:2314
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr "Ajuda não disponível para '{name}'"
 
-#: ../../uaclient/messages/__init__.py:2301
+#: ../../uaclient/messages/__init__.py:2320
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
@@ -3191,34 +3218,34 @@ msgstr ""
 "Erro: problema de segurnça \"{issue}\" não foi reconhecido.\n"
 "Use: \"pro fix CVE-yyyy-nnnn\" ou \"pro fix USN-nnnn\""
 
-#: ../../uaclient/messages/__init__.py:2307
+#: ../../uaclient/messages/__init__.py:2326
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr "{arg} precisa ser um de: {choices}"
 
-#: ../../uaclient/messages/__init__.py:2312
+#: ../../uaclient/messages/__init__.py:2331
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr "Esperava {expected} mas encontrou: {actual}"
 
-#: ../../uaclient/messages/__init__.py:2316
+#: ../../uaclient/messages/__init__.py:2335
 msgid "Unable to process uaclient.conf"
 msgstr "Falha ao processar uaclient.conf"
 
-#: ../../uaclient/messages/__init__.py:2321
+#: ../../uaclient/messages/__init__.py:2340
 msgid "Unable to refresh your subscription"
 msgstr "Falha ao atualizar sua assinatura"
 
-#: ../../uaclient/messages/__init__.py:2326
+#: ../../uaclient/messages/__init__.py:2345
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 "Falha ao atualizar as mensagens de APT e MOTD relacioandas ao Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:2332
+#: ../../uaclient/messages/__init__.py:2351
 msgid "json formatted response requires --assume-yes flag."
 msgstr "resposta formatada em json necessita do paramêtro --assume-yes"
 
-#: ../../uaclient/messages/__init__.py:2340
+#: ../../uaclient/messages/__init__.py:2359
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
@@ -3228,50 +3255,50 @@ msgstr ""
 "Ao invés disso, inclua o token no arquivo de attach-config.\n"
 "    "
 
-#: ../../uaclient/messages/__init__.py:2349
+#: ../../uaclient/messages/__init__.py:2368
 msgid "Cannot provide both --args and --data at the same time"
 msgstr "Não é possível usar --args e --data ao mesmo tempo"
 
-#: ../../uaclient/messages/__init__.py:2355
+#: ../../uaclient/messages/__init__.py:2374
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr "Falha ao executar: {lock_request}.\n"
 
-#: ../../uaclient/messages/__init__.py:2364
+#: ../../uaclient/messages/__init__.py:2383
 msgid "This command must be run as root (try using sudo)."
 msgstr "Esse comando precisa ser executado como root (tente usando sudo)."
 
-#: ../../uaclient/messages/__init__.py:2369
+#: ../../uaclient/messages/__init__.py:2388
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr "Metadados para {issue} não são válidos. Erro: {error_msg}."
 
-#: ../../uaclient/messages/__init__.py:2376
+#: ../../uaclient/messages/__init__.py:2395
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr "Erro: {issue_id} não encontrada."
 
-#: ../../uaclient/messages/__init__.py:2380
+#: ../../uaclient/messages/__init__.py:2399
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr "chave GPG '{keyfile}' não foi encontrada"
 
-#: ../../uaclient/messages/__init__.py:2385
+#: ../../uaclient/messages/__init__.py:2404
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr "'{endpoint}' não é um endpoint válido"
 
-#: ../../uaclient/messages/__init__.py:2390
+#: ../../uaclient/messages/__init__.py:2409
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr "'{arg}' está faltando para endpoint {endpoint}"
 
-#: ../../uaclient/messages/__init__.py:2395
+#: ../../uaclient/messages/__init__.py:2414
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr "{endpoint} não aceita paramêtros"
 
-#: ../../uaclient/messages/__init__.py:2400
+#: ../../uaclient/messages/__init__.py:2419
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
@@ -3280,32 +3307,32 @@ msgstr ""
 "Error ao analisar paramêtro data para API json:\n"
 "{data}"
 
-#: ../../uaclient/messages/__init__.py:2405
+#: ../../uaclient/messages/__init__.py:2424
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr "'{arg}' não está formatado como 'chave=valor'"
 
-#: ../../uaclient/messages/__init__.py:2410
+#: ../../uaclient/messages/__init__.py:2429
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr "Não foi possível determinar a versão: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2434
 msgid "features.disable_auto_attach set in config"
 msgstr "features.disable_auto_attach definida na configuração"
 
-#: ../../uaclient/messages/__init__.py:2420
+#: ../../uaclient/messages/__init__.py:2439
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 "Não foi possível determinar o status do unattended-upgrades: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2426
+#: ../../uaclient/messages/__init__.py:2445
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr "Esperava valor com tipo {expected_type}, mas recebeu tipo {got_type}"
 
-#: ../../uaclient/messages/__init__.py:2432
+#: ../../uaclient/messages/__init__.py:2451
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
@@ -3314,7 +3341,7 @@ msgstr ""
 "Valor com tipo incorreto na posição {index}:\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2438
+#: ../../uaclient/messages/__init__.py:2457
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
@@ -3323,7 +3350,7 @@ msgstr ""
 "Valor com tipo incorreto para o campo \"{key}\":\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2445
+#: ../../uaclient/messages/__init__.py:2464
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""

--- a/debian/po/ubuntu-pro.pot
+++ b/debian/po/ubuntu-pro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-03 17:05-0300\n"
+"POT-Creation-Date: 2023-10-03 17:15-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1869,33 +1869,32 @@ msgid "FIPS"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1199
-msgid "NIST-certified core packages"
+msgid "NIST-certified FIPS crypto packages"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1201
 #, python-brace-format
 msgid ""
-"FIPS 140-2 is a set of publicly announced cryptographic standards developed "
-"by\n"
-"the National Institute of Standards and Technology applicable for FedRAMP,\n"
-"HIPAA, PCI and ISO compliance use cases. Note that \"fips\" does not "
-"provide\n"
-"security patching. For FIPS certified modules with security patches please\n"
-"see \"fips-updates\". You can find out more at {url}"
+"Installs FIPS 140 crypto packages for FedRAMP, FISMA and compliance use "
+"cases.\n"
+"Note that \"fips\" does not provide security patching. For FIPS certified\n"
+"modules with security patches please see \"fips-updates\". If you are "
+"unsure,\n"
+"choose \"fips-updates\" for maximum security. Find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1209
+#: ../../uaclient/messages/__init__.py:1208
 msgid "Could not determine cloud, defaulting to generic FIPS package."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1212
+#: ../../uaclient/messages/__init__.py:1211
 #, python-brace-format
 msgid ""
 "FIPS kernel is running in a disabled state.\n"
 "  To manually remove fips kernel: {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1218
+#: ../../uaclient/messages/__init__.py:1217
 msgid ""
 "Warning: FIPS kernel is not optimized for your specific cloud.\n"
 "To fix it, run the following commands:\n"
@@ -1906,20 +1905,20 @@ msgid ""
 "    4. sudo reboot\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1230
+#: ../../uaclient/messages/__init__.py:1229
 msgid ""
 "This will install the FIPS packages. The Livepatch service will be "
 "unavailable.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1239
+#: ../../uaclient/messages/__init__.py:1238
 msgid ""
 "This will install the FIPS packages including security updates.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1248
+#: ../../uaclient/messages/__init__.py:1247
 #, python-brace-format
 msgid ""
 "Warning: Enabling {title} in a container.\n"
@@ -1929,67 +1928,94 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1260
+#: ../../uaclient/messages/__init__.py:1259
+#, python-brace-format
 msgid ""
-"This will disable the FIPS entitlement but the FIPS packages will remain "
-"installed.\n"
+"This will disable the {title} entitlement but the {title} packages will "
+"remain installed.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1267
+#: ../../uaclient/messages/__init__.py:1266
 msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1269
-#: ../../uaclient/messages/__init__.py:1667
+#: ../../uaclient/messages/__init__.py:1268
+#: ../../uaclient/messages/__init__.py:1686
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1271
+#: ../../uaclient/messages/__init__.py:1270
 msgid "This FIPS install is out of date, run: sudo pro enable fips"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1274
+#: ../../uaclient/messages/__init__.py:1273
 msgid "Disabling FIPS requires system reboot to complete operation."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1277
+#: ../../uaclient/messages/__init__.py:1276
 #, python-brace-format
 msgid "{service} {pkg} package could not be installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1280
+#: ../../uaclient/messages/__init__.py:1279
 msgid ""
 "Please run `apt upgrade` to ensure all FIPS packages are updated to the "
 "correct\n"
 "version.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1287
+#: ../../uaclient/messages/__init__.py:1285
 msgid "FIPS Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1289
-msgid "NIST-certified core packages with priority security updates"
+#: ../../uaclient/messages/__init__.py:1287
+msgid "FIPS compliant crypto packages with stable security updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1292
+#: ../../uaclient/messages/__init__.py:1290
 #, python-brace-format
 msgid ""
-"fips-updates installs fips modules including all security patches for those\n"
-"modules that have been provided since their certification date. You can "
-"find\n"
-"out more at {url}"
+"fips-updates installs FIPS 140 crypto packages including all security "
+"patches\n"
+"for those modules that have been provided since their certification date.\n"
+"You can find out more at {url}"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1296
+msgid "FIPS Preview"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1298
+msgid "Preview of FIPS crypto packages undergoing certification with NIST"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1301
+msgid ""
+"Installs FIPS crypto packages that are under certification with NIST,\n"
+"for FedRAMP, FISMA and compliance use cases."
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1306
+msgid ""
+"This will install crypto packages that have been submitted to NIST for "
+"review\n"
+"but do not have FIPS certification yet. Use this for early access to the "
+"FIPS\n"
+"modules.\n"
+"Please note that the Livepatch service will be unavailable after\n"
+"this operation.\n"
+"Warning: This action can take some time and cannot be undone.\n"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1317
 msgid "Landscape"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1300
+#: ../../uaclient/messages/__init__.py:1319
 msgid "Management and administration tool for Ubuntu"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1303
+#: ../../uaclient/messages/__init__.py:1322
 #, python-brace-format
 msgid ""
 "Landscape Client can be installed on this machine and enrolled in "
@@ -2002,15 +2028,15 @@ msgid ""
 "more. Find out more about Landscape at {home_url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1316
+#: ../../uaclient/messages/__init__.py:1335
 msgid "Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1317
+#: ../../uaclient/messages/__init__.py:1336
 msgid "Canonical Livepatch service"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1319
+#: ../../uaclient/messages/__init__.py:1338
 #, python-brace-format
 msgid ""
 "Livepatch provides selected high and critical kernel CVE fixes and other\n"
@@ -2025,42 +2051,42 @@ msgid ""
 "service at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1328
+#: ../../uaclient/messages/__init__.py:1347
 msgid "Current kernel is not supported"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1331
+#: ../../uaclient/messages/__init__.py:1350
 #, python-brace-format
 msgid "Supported livepatch kernels are listed here: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1334
+#: ../../uaclient/messages/__init__.py:1353
 #, python-brace-format
 msgid "Unable to configure livepatch: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1336
+#: ../../uaclient/messages/__init__.py:1355
 msgid "Unable to enable Livepatch: "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1338
+#: ../../uaclient/messages/__init__.py:1357
 msgid "Disabling Livepatch prior to re-attach with new token"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1341
+#: ../../uaclient/messages/__init__.py:1360
 msgid "Livepatch support requires a system reboot across LTS upgrade."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1344
-#: ../../uaclient/messages/__init__.py:1357
+#: ../../uaclient/messages/__init__.py:1363
+#: ../../uaclient/messages/__init__.py:1376
 msgid "Real-time kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1346
+#: ../../uaclient/messages/__init__.py:1365
 msgid "Ubuntu kernel with PREEMPT_RT patches integrated"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1349
+#: ../../uaclient/messages/__init__.py:1368
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated. "
 "It\n"
@@ -2073,27 +2099,27 @@ msgid ""
 "Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1359
+#: ../../uaclient/messages/__init__.py:1378
 msgid "Generic version of the RT kernel (default)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1361
+#: ../../uaclient/messages/__init__.py:1380
 msgid "Real-time NVIDIA Tegra Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1363
+#: ../../uaclient/messages/__init__.py:1382
 msgid "RT kernel optimized for NVIDIA Tegra platform"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1365
+#: ../../uaclient/messages/__init__.py:1384
 msgid "Real-time Intel IOTG Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1367
+#: ../../uaclient/messages/__init__.py:1386
 msgid "RT kernel optimized for Intel IOTG platform"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1370
+#: ../../uaclient/messages/__init__.py:1389
 #, python-brace-format
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches "
@@ -2106,7 +2132,7 @@ msgid ""
 "Do you want to continue? [ default = Yes ]: (Y/n) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1381
+#: ../../uaclient/messages/__init__.py:1400
 msgid ""
 "This will remove the boot order preference for the Real-time kernel and\n"
 "disable updates to the Real-time kernel.\n"
@@ -2123,15 +2149,15 @@ msgid ""
 "Are you sure? (y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1397
+#: ../../uaclient/messages/__init__.py:1416
 msgid "ROS ESM Security Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1398
+#: ../../uaclient/messages/__init__.py:1417
 msgid "Security Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1400
+#: ../../uaclient/messages/__init__.py:1419
 #, python-brace-format
 msgid ""
 "ros provides access to a private PPA which includes security-related "
@@ -2144,15 +2170,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1409
+#: ../../uaclient/messages/__init__.py:1428
 msgid "ROS ESM All Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1411
+#: ../../uaclient/messages/__init__.py:1430
 msgid "All Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1414
+#: ../../uaclient/messages/__init__.py:1433
 #, python-brace-format
 msgid ""
 "ros-updates provides access to a private PPA that includes non-security-"
@@ -2165,14 +2191,14 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1485
+#: ../../uaclient/messages/__init__.py:1504
 msgid ""
 "Unexpected error(s) occurred.\n"
 "For more details, see the log: /var/log/ubuntu-advantage.log\n"
 "To file a bug run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1495
+#: ../../uaclient/messages/__init__.py:1514
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2180,7 +2206,7 @@ msgid ""
 "Please install \"ca-certificates\" and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1505
+#: ../../uaclient/messages/__init__.py:1524
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2188,199 +2214,199 @@ msgid ""
 "Please check your openssl configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1514
+#: ../../uaclient/messages/__init__.py:1533
 #, python-brace-format
 msgid "Ignoring unknown argument '{arg}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1520
+#: ../../uaclient/messages/__init__.py:1539
 #, python-brace-format
 msgid ""
 "A new version of the client is available: {version}. Please upgrade to the "
 "latest version to get the new features and bug fixes."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1527
+#: ../../uaclient/messages/__init__.py:1546
 #, python-brace-format
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1533
+#: ../../uaclient/messages/__init__.py:1552
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1540
+#: ../../uaclient/messages/__init__.py:1559
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1547
+#: ../../uaclient/messages/__init__.py:1566
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1552
+#: ../../uaclient/messages/__init__.py:1571
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1560
+#: ../../uaclient/messages/__init__.py:1579
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1568
+#: ../../uaclient/messages/__init__.py:1587
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1571
+#: ../../uaclient/messages/__init__.py:1590
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1576
+#: ../../uaclient/messages/__init__.py:1595
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1582
+#: ../../uaclient/messages/__init__.py:1601
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1586
+#: ../../uaclient/messages/__init__.py:1605
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1591
+#: ../../uaclient/messages/__init__.py:1610
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1598
+#: ../../uaclient/messages/__init__.py:1617
 #, python-brace-format
 msgid ""
 "{title} is already enabled.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1605
+#: ../../uaclient/messages/__init__.py:1624
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1611
+#: ../../uaclient/messages/__init__.py:1630
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1617
+#: ../../uaclient/messages/__init__.py:1636
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1625
+#: ../../uaclient/messages/__init__.py:1644
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1633
+#: ../../uaclient/messages/__init__.py:1652
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1640
+#: ../../uaclient/messages/__init__.py:1659
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1648
+#: ../../uaclient/messages/__init__.py:1667
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1655
+#: ../../uaclient/messages/__init__.py:1674
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1661
+#: ../../uaclient/messages/__init__.py:1680
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1671
+#: ../../uaclient/messages/__init__.py:1690
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1674
+#: ../../uaclient/messages/__init__.py:1693
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1678
+#: ../../uaclient/messages/__init__.py:1697
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1683
+#: ../../uaclient/messages/__init__.py:1702
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1691
+#: ../../uaclient/messages/__init__.py:1710
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1700
+#: ../../uaclient/messages/__init__.py:1719
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1708
+#: ../../uaclient/messages/__init__.py:1727
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1712
+#: ../../uaclient/messages/__init__.py:1731
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1717
+#: ../../uaclient/messages/__init__.py:1736
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1725
+#: ../../uaclient/messages/__init__.py:1744
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2390,7 +2416,7 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1734
+#: ../../uaclient/messages/__init__.py:1753
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2399,76 +2425,76 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1744
+#: ../../uaclient/messages/__init__.py:1763
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1750
+#: ../../uaclient/messages/__init__.py:1769
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1757
+#: ../../uaclient/messages/__init__.py:1776
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1764
+#: ../../uaclient/messages/__init__.py:1783
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1769
+#: ../../uaclient/messages/__init__.py:1788
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1773
+#: ../../uaclient/messages/__init__.py:1792
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1778
+#: ../../uaclient/messages/__init__.py:1797
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1782
+#: ../../uaclient/messages/__init__.py:1801
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1786
+#: ../../uaclient/messages/__init__.py:1805
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1791
+#: ../../uaclient/messages/__init__.py:1810
 msgid "lanscape-client is not installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1796
+#: ../../uaclient/messages/__init__.py:1815
 msgid ""
 "Landscape is installed but not configured.\n"
 "Run `sudo landscape-config` to set it up, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1805
+#: ../../uaclient/messages/__init__.py:1824
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1814
+#: ../../uaclient/messages/__init__.py:1833
 msgid ""
 "Landscape is installed and configured and registered but not running.\n"
 "Run `sudo landscape-config` to start it, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1822
+#: ../../uaclient/messages/__init__.py:1841
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1828
+#: ../../uaclient/messages/__init__.py:1847
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2478,28 +2504,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1842
+#: ../../uaclient/messages/__init__.py:1861
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1848
+#: ../../uaclient/messages/__init__.py:1867
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1878
+#: ../../uaclient/messages/__init__.py:1897
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1883
+#: ../../uaclient/messages/__init__.py:1902
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1889
+#: ../../uaclient/messages/__init__.py:1908
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2507,96 +2533,96 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1899
+#: ../../uaclient/messages/__init__.py:1918
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1906
+#: ../../uaclient/messages/__init__.py:1925
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1911
+#: ../../uaclient/messages/__init__.py:1930
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1915
+#: ../../uaclient/messages/__init__.py:1934
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1919
+#: ../../uaclient/messages/__init__.py:1938
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1924
+#: ../../uaclient/messages/__init__.py:1943
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1940
+#: ../../uaclient/messages/__init__.py:1959
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1946
+#: ../../uaclient/messages/__init__.py:1965
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1950
+#: ../../uaclient/messages/__init__.py:1969
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1956
+#: ../../uaclient/messages/__init__.py:1975
 msgid ""
 "Failed to connect to authentication server\n"
 "Check your Internet connection and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1963
+#: ../../uaclient/messages/__init__.py:1982
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1969
+#: ../../uaclient/messages/__init__.py:1988
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1978
+#: ../../uaclient/messages/__init__.py:1997
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1985
+#: ../../uaclient/messages/__init__.py:2004
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1992
+#: ../../uaclient/messages/__init__.py:2011
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1997
+#: ../../uaclient/messages/__init__.py:2016
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2003
+#: ../../uaclient/messages/__init__.py:2022
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2604,7 +2630,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2013
+#: ../../uaclient/messages/__init__.py:2032
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2612,7 +2638,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2023
+#: ../../uaclient/messages/__init__.py:2042
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2620,41 +2646,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2033
+#: ../../uaclient/messages/__init__.py:2052
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2040
+#: ../../uaclient/messages/__init__.py:2059
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2046
+#: ../../uaclient/messages/__init__.py:2065
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2052
+#: ../../uaclient/messages/__init__.py:2071
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2057
+#: ../../uaclient/messages/__init__.py:2076
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2063
+#: ../../uaclient/messages/__init__.py:2082
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2071
+#: ../../uaclient/messages/__init__.py:2090
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2080
+#: ../../uaclient/messages/__init__.py:2099
 #, python-brace-format
 msgid ""
 "To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
@@ -2662,59 +2688,59 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2096
+#: ../../uaclient/messages/__init__.py:2115
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2101
+#: ../../uaclient/messages/__init__.py:2120
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2107
+#: ../../uaclient/messages/__init__.py:2126
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2115
+#: ../../uaclient/messages/__init__.py:2134
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2123
+#: ../../uaclient/messages/__init__.py:2142
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2130
+#: ../../uaclient/messages/__init__.py:2149
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2137
+#: ../../uaclient/messages/__init__.py:2156
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2146
+#: ../../uaclient/messages/__init__.py:2165
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2150
+#: ../../uaclient/messages/__init__.py:2169
 #, python-brace-format
 msgid ""
 "Error on Pro Image:\n"
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2156
+#: ../../uaclient/messages/__init__.py:2175
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2163
+#: ../../uaclient/messages/__init__.py:2182
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -2722,41 +2748,41 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2173
+#: ../../uaclient/messages/__init__.py:2192
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2180
+#: ../../uaclient/messages/__init__.py:2199
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2188
+#: ../../uaclient/messages/__init__.py:2207
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2197
+#: ../../uaclient/messages/__init__.py:2216
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2205
+#: ../../uaclient/messages/__init__.py:2224
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2211
+#: ../../uaclient/messages/__init__.py:2230
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2219
+#: ../../uaclient/messages/__init__.py:2238
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -2764,7 +2790,7 @@ msgid ""
 "and the VERSION_CODENAME information is not present"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2229
+#: ../../uaclient/messages/__init__.py:2248
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -2773,189 +2799,189 @@ msgid ""
 "$ sudo rm {lock_file_path}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2238
+#: ../../uaclient/messages/__init__.py:2257
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2244
+#: ../../uaclient/messages/__init__.py:2263
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
 "Expected {expected_value}, found {value}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2253
+#: ../../uaclient/messages/__init__.py:2272
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2260
+#: ../../uaclient/messages/__init__.py:2279
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2265
+#: ../../uaclient/messages/__init__.py:2284
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2271
+#: ../../uaclient/messages/__init__.py:2290
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
 "Cancelling config process operation.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2281
+#: ../../uaclient/messages/__init__.py:2300
 msgid "Can't load the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2286
+#: ../../uaclient/messages/__init__.py:2305
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2291
+#: ../../uaclient/messages/__init__.py:2310
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2295
+#: ../../uaclient/messages/__init__.py:2314
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2301
+#: ../../uaclient/messages/__init__.py:2320
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
 "Usage: \"pro fix CVE-yyyy-nnnn\" or \"pro fix USN-nnnn\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2307
+#: ../../uaclient/messages/__init__.py:2326
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2312
+#: ../../uaclient/messages/__init__.py:2331
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2316
+#: ../../uaclient/messages/__init__.py:2335
 msgid "Unable to process uaclient.conf"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2321
+#: ../../uaclient/messages/__init__.py:2340
 msgid "Unable to refresh your subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2326
+#: ../../uaclient/messages/__init__.py:2345
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2332
+#: ../../uaclient/messages/__init__.py:2351
 msgid "json formatted response requires --assume-yes flag."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2340
+#: ../../uaclient/messages/__init__.py:2359
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
 "    "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2349
+#: ../../uaclient/messages/__init__.py:2368
 msgid "Cannot provide both --args and --data at the same time"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2355
+#: ../../uaclient/messages/__init__.py:2374
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2364
+#: ../../uaclient/messages/__init__.py:2383
 msgid "This command must be run as root (try using sudo)."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2369
+#: ../../uaclient/messages/__init__.py:2388
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2376
+#: ../../uaclient/messages/__init__.py:2395
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2380
+#: ../../uaclient/messages/__init__.py:2399
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2385
+#: ../../uaclient/messages/__init__.py:2404
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2390
+#: ../../uaclient/messages/__init__.py:2409
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2395
+#: ../../uaclient/messages/__init__.py:2414
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2400
+#: ../../uaclient/messages/__init__.py:2419
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
 "{data}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2405
+#: ../../uaclient/messages/__init__.py:2424
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2410
+#: ../../uaclient/messages/__init__.py:2429
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2434
 msgid "features.disable_auto_attach set in config"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2420
+#: ../../uaclient/messages/__init__.py:2439
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2426
+#: ../../uaclient/messages/__init__.py:2445
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2432
+#: ../../uaclient/messages/__init__.py:2451
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2438
+#: ../../uaclient/messages/__init__.py:2457
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2445
+#: ../../uaclient/messages/__init__.py:2464
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -26,8 +26,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         cis           +yes      +n/a      +Security compliance and audit tools
         esm-apps      +yes      +n/a      +Expanded Security Maintenance for Applications
         esm-infra     +yes      +n/a      +Expanded Security Maintenance for Infrastructure
-        fips          +yes      +n/a      +NIST-certified core packages
-        fips-updates  +yes      +n/a      +NIST-certified core packages with priority security updates
+        fips          +yes      +n/a      +NIST-certified FIPS crypto packages
+        fips-updates  +yes      +n/a      +FIPS compliant crypto packages with stable security updates
         landscape     +yes      +<landscape>      +Management and administration tool for Ubuntu
         livepatch     +yes      +n/a      +Canonical Livepatch service
         """

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -214,9 +214,9 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
        """
        esm-apps      +<esm-apps> +Expanded Security Maintenance for Applications
        esm-infra     +yes        +Expanded Security Maintenance for Infrastructure
-       fips          +<fips>     +NIST-certified core packages
+       fips          +<fips>     +NIST-certified FIPS crypto packages
        fips-preview  +.* +.*
-       fips-updates  +<fips>     +NIST-certified core packages with priority security updates
+       fips-updates  +<fips>     +FIPS compliant crypto packages with stable security updates
        landscape     +(yes|no)   +Management and administration tool for Ubuntu
        livepatch     +(yes|no)   +(Canonical Livepatch service|Current kernel is not supported)
        realtime-kernel +<realtime-kernel> +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -484,10 +484,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
          - fips-preview: .*
+           .*\(https://ubuntu.com/security/fips\)
+         - fips-updates: FIPS compliant crypto packages with stable security updates
            \(https://ubuntu.com/security/fips\)
-         - fips-updates: NIST-certified core packages with priority security updates
-           \(https://ubuntu.com/security/fips\)
-         - fips: NIST-certified core packages \(https://ubuntu.com/security/fips\)
+         - fips: NIST-certified FIPS crypto packages \(https://ubuntu.com/security/fips\)
          - landscape: Management and administration tool for Ubuntu
            \(https://ubuntu.com/landscape\)
          - livepatch: Canonical Livepatch service
@@ -507,10 +507,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
          - fips-preview: .*
+           .*\(https://ubuntu.com/security/fips\)
+         - fips-updates: FIPS compliant crypto packages with stable security updates
            \(https://ubuntu.com/security/fips\)
-         - fips-updates: NIST-certified core packages with priority security updates
-           \(https://ubuntu.com/security/fips\)
-         - fips: NIST-certified core packages \(https://ubuntu.com/security/fips\)
+         - fips: NIST-certified FIPS crypto packages \(https://ubuntu.com/security/fips\)
          - landscape: Management and administration tool for Ubuntu
            \(https://ubuntu.com/landscape\)
          - livepatch: Canonical Livepatch service
@@ -530,10 +530,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
          - fips-preview: .*
+           .*\(https://ubuntu.com/security/fips\)
+         - fips-updates: FIPS compliant crypto packages with stable security updates
            \(https://ubuntu.com/security/fips\)
-         - fips-updates: NIST-certified core packages with priority security updates
-           \(https://ubuntu.com/security/fips\)
-         - fips: NIST-certified core packages \(https://ubuntu.com/security/fips\)
+         - fips: NIST-certified FIPS crypto packages \(https://ubuntu.com/security/fips\)
          - landscape: Management and administration tool for Ubuntu
            \(https://ubuntu.com/landscape\)
          - livepatch: Canonical Livepatch service
@@ -600,9 +600,9 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
-         - fips-updates: NIST-certified core packages with priority security updates
-           \(https://ubuntu.com/security/fips\)
-         - fips: NIST-certified core packages \(https://ubuntu.com/security/fips\)
+         - fips-updates: NIST-certified FIPS crypto packages with priority security
+           updates \(https://ubuntu.com/security/fips\)
+         - fips: NIST-certified FIPS crypto packages \(https://ubuntu.com/security/fips\)
          - landscape: Management and administration tool for Ubuntu
            \(https://ubuntu.com/landscape\)
          - livepatch: Canonical Livepatch service
@@ -627,9 +627,9 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
-         - fips-updates: NIST-certified core packages with priority security updates
-           \(https://ubuntu.com/security/fips\)
-         - fips: NIST-certified core packages \(https://ubuntu.com/security/fips\)
+         - fips-updates: NIST-certified FIPS crypto packages with priority security
+           updates \(https://ubuntu.com/security/fips\)
+         - fips: NIST-certified FIPS crypto packages \(https://ubuntu.com/security/fips\)
          - landscape: Management and administration tool for Ubuntu
            \(https://ubuntu.com/landscape\)
          - livepatch: Canonical Livepatch service
@@ -654,9 +654,9 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
-         - fips-updates: NIST-certified core packages with priority security updates
-           \(https://ubuntu.com/security/fips\)
-         - fips: NIST-certified core packages \(https://ubuntu.com/security/fips\)
+         - fips-updates: NIST-certified FIPS crypto packages with priority security
+           updates \(https://ubuntu.com/security/fips\)
+         - fips: NIST-certified FIPS crypto packages \(https://ubuntu.com/security/fips\)
          - landscape: Management and administration tool for Ubuntu
            \(https://ubuntu.com/landscape\)
          - livepatch: Canonical Livepatch service

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -132,11 +132,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | valid_services                                                                                                    |
-           | xenial  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-updates, landscape,\nlivepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-updates, landscape,\nlivepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | valid_services                                                                                                                             |
+           | xenial  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | jammy   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.lts
     @uses.config.machine_type.lxd-container
@@ -172,11 +172,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         And I verify that running `apt update` `with sudo` exits `0`
 
         Examples: ubuntu release
-           | release | msg                                                                                                                   |
-           | xenial  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-updates, landscape,\nlivepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-updates, landscape,\nlivepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | msg                                                                                                                                            |
+           | xenial  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | jammy   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.lts
     @uses.config.machine_type.lxd-container
@@ -215,6 +215,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
        esm-apps      +<esm-apps> +Expanded Security Maintenance for Applications
        esm-infra     +yes        +Expanded Security Maintenance for Infrastructure
        fips          +<fips>     +NIST-certified core packages
+       fips-preview  +.* +.*
        fips-updates  +<fips>     +NIST-certified core packages with priority security updates
        landscape     +(yes|no)   +Management and administration tool for Ubuntu
        livepatch     +(yes|no)   +(Canonical Livepatch service|Current kernel is not supported)
@@ -425,11 +426,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | msg                                                                                                                   |
-           | xenial  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-updates, landscape,\nlivepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-updates, landscape,\nlivepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | msg                                                                                                                                            |
+           | xenial  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | jammy   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.xenial
     @series.bionic
@@ -482,6 +483,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
+         - fips-preview: .*
+           \(https://ubuntu.com/security/fips\)
          - fips-updates: NIST-certified core packages with priority security updates
            \(https://ubuntu.com/security/fips\)
          - fips: NIST-certified core packages \(https://ubuntu.com/security/fips\)
@@ -503,6 +506,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
+         - fips-preview: .*
+           \(https://ubuntu.com/security/fips\)
          - fips-updates: NIST-certified core packages with priority security updates
            \(https://ubuntu.com/security/fips\)
          - fips: NIST-certified core packages \(https://ubuntu.com/security/fips\)
@@ -524,6 +529,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            \(https://ubuntu.com/security/esm\)
          - esm-infra: Expanded Security Maintenance for Infrastructure
            \(https://ubuntu.com/security/esm\)
+         - fips-preview: .*
+           \(https://ubuntu.com/security/fips\)
          - fips-updates: NIST-certified core packages with priority security updates
            \(https://ubuntu.com/security/fips\)
          - fips: NIST-certified core packages \(https://ubuntu.com/security/fips\)

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -189,11 +189,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | valid_services                                                                                                    |
-           | xenial  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-updates, landscape,\nlivepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-updates, landscape,\nlivepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | valid_services                                                                                                                             |
+           | xenial  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | jammy   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.lts
     @uses.config.machine_type.lxd-container
@@ -247,9 +247,9 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
         Examples: ubuntu release
            | release | infra-pkg | esm-infra-url                       | msg                                                                                                                   |
-           | xenial  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | hello     | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-updates, landscape,\nlivepatch, realtime-kernel, ros, ros-updates, usg. |
+           | xenial  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | hello     | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.all
     @uses.config.machine_type.lxd-container
@@ -490,7 +490,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         And stderr matches regexp:
         """
         Cannot enable unknown service 'usg'.
-        Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates\.
+        Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates\.
         """
 
         Examples: cis service

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -570,8 +570,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         esm-apps     +yes      +enabled  +Expanded Security Maintenance for Applications
         esm-infra    +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        fips         +yes      +disabled +NIST-certified core packages
-        fips-updates +yes      +disabled +NIST-certified core packages with priority security updates
+        fips         +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-updates +yes      +disabled +FIPS compliant crypto packages with stable security updates
         livepatch    +yes      +<livepatch_status>  +Canonical Livepatch service
         """
         When I run `pro disable livepatch` with sudo
@@ -586,8 +586,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         esm-apps     +yes      +enabled  +Expanded Security Maintenance for Applications
         esm-infra    +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        fips         +yes      +disabled +NIST-certified core packages
-        fips-updates +yes      +disabled +NIST-certified core packages with priority security updates
+        fips         +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-updates +yes      +disabled +FIPS compliant crypto packages with stable security updates
         livepatch    +yes      +disabled +Canonical Livepatch service
         """
         When I verify that running `pro enable livepatch --access-only` `with sudo` exits `1`

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -97,8 +97,8 @@ Feature: Attached status
         cis             +yes      +disabled +Security compliance and audit tools
         esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        fips            +yes      +disabled +NIST-certified core packages
-        fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
         ros             +yes      +disabled +Security Updates for the Robot Operating System
         ros-updates     +yes      +disabled +All Updates for the Robot Operating System
 
@@ -115,8 +115,8 @@ Feature: Attached status
         cis             +yes      +disabled +Security compliance and audit tools
         esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        fips            +yes      +disabled +NIST-certified core packages
-        fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
         landscape       +yes      +n/a      +Management and administration tool for Ubuntu
         livepatch       +yes      +n/a      +Canonical Livepatch service
         realtime-kernel +yes      +n/a      +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -144,8 +144,8 @@ Feature: Attached status
         anbox-cloud     +yes      +disabled +.*
         esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        fips            +yes      +disabled +NIST-certified core packages
-        fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
         ros             +yes      +disabled +Security Updates for the Robot Operating System
         usg             +yes      +disabled +Security compliance and audit tools
 
@@ -161,8 +161,8 @@ Feature: Attached status
         cc-eal          +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
         esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        fips            +yes      +disabled +NIST-certified core packages
-        fips-updates    +yes      +disabled +NIST-certified core packages with priority security updates
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
         landscape       +yes      +n/a      +Management and administration tool for Ubuntu
         livepatch       +yes      +n/a      +Canonical Livepatch service
         realtime-kernel +yes      +n/a      +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -204,8 +204,8 @@ Feature: Attached status
         cc-eal          +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
         esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        fips            +yes      +n/a      +NIST-certified core packages
-        fips-updates    +yes      +n/a      +NIST-certified core packages with priority security updates
+        fips            +yes      +n/a      +NIST-certified FIPS crypto packages
+        fips-updates    +yes      +n/a      +FIPS compliant crypto packages with stable security updates
         landscape       +yes      +n/a      +Management and administration tool for Ubuntu
         livepatch       +yes      +n/a      +Canonical Livepatch service
         realtime-kernel +yes      +n/a      +Ubuntu kernel with PREEMPT_RT patches integrated

--- a/features/enable_fips_container.feature
+++ b/features/enable_fips_container.feature
@@ -56,7 +56,7 @@ Feature: FIPS enablement in lxd containers
         When I run `pro disable fips<updates>` `with sudo` and stdin `y`
         Then stdout matches regexp:
             """
-            This will disable the FIPS entitlement but the FIPS packages will remain installed.
+            This will disable the <fips-name> entitlement but the <fips-name> packages will remain installed.
             """
         And stdout matches regexp:
             """
@@ -73,7 +73,7 @@ Feature: FIPS enablement in lxd containers
             """
         Then stdout does not match regexp:
             """
-            Disabling FIPS requires system reboot to complete operation
+            Disabling <fips-name> requires system reboot to complete operation
             """
         When I run `apt-cache policy ubuntu-fips` as non-root
         Then stdout does not match regexp:

--- a/features/enable_fips_pro.feature
+++ b/features/enable_fips_pro.feature
@@ -17,8 +17,8 @@ Feature: FIPS enablement in PRO cloud based machines
         And I run `pro status --wait` with sudo
         Then stdout matches regexp:
             """
-            fips          +yes +disabled +NIST-certified core packages
-            fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+            fips          +yes +disabled +NIST-certified FIPS crypto packages
+            fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
             """
             When I run `pro enable <fips-service> --assume-yes` with sudo
             Then stdout matches regexp:
@@ -76,8 +76,8 @@ Feature: FIPS enablement in PRO cloud based machines
         And I run `pro status --wait` with sudo
         Then stdout matches regexp:
             """
-            fips          +yes +disabled +NIST-certified core packages
-            fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+            fips          +yes +disabled +NIST-certified FIPS crypto packages
+            fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
             """
             When I run `pro enable <fips-service> --assume-yes` with sudo
             Then stdout matches regexp:
@@ -136,8 +136,8 @@ Feature: FIPS enablement in PRO cloud based machines
         And I run `pro status --wait` with sudo
         Then stdout matches regexp:
             """
-            fips          +yes +disabled +NIST-certified core packages
-            fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+            fips          +yes +disabled +NIST-certified FIPS crypto packages
+            fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
             """
         When I run `pro enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -11,7 +11,7 @@ Feature: FIPS enablement in lxd VMs
         When I run `pro status --format json` with sudo
         Then stdout contains substring
         """
-        {"available": "yes", "blocked_by": [{"name": "livepatch", "reason": "Livepatch cannot be enabled while running the official FIPS certified kernel. If you would like a FIPS compliant kernel with additional bug fixes and security updates, you can use the FIPS Updates service with Livepatch.", "reason_code": "livepatch-invalidates-fips"}], "description": "NIST-certified core packages", "description_override": null, "entitled": "yes", "name": "fips", "status": "disabled", "status_details": "FIPS is not configured", "warning": null}
+        {"available": "yes", "blocked_by": [{"name": "livepatch", "reason": "Livepatch cannot be enabled while running the official FIPS certified kernel. If you would like a FIPS compliant kernel with additional bug fixes and security updates, you can use the FIPS Updates service with Livepatch.", "reason_code": "livepatch-invalidates-fips"}], "description": "NIST-certified FIPS crypto packages", "description_override": null, "entitled": "yes", "name": "fips", "status": "disabled", "status_details": "FIPS is not configured", "warning": null}
         """
         When I run `pro disable livepatch` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
@@ -170,7 +170,7 @@ Feature: FIPS enablement in lxd VMs
         When I run `pro status --all --format json` with sudo
         Then stdout contains substring:
         """
-        {"available": "no", "blocked_by": [{"name": "fips-updates", "reason": "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS Updates installs security patches that aren't officially certified.", "reason_code": "fips-updates-invalidates-fips"}], "description": "NIST-certified core packages", "description_override": null, "entitled": "yes", "name": "fips", "status": "n/a", "status_details": "Cannot enable FIPS when FIPS Updates is enabled.", "warning": null}
+        {"available": "no", "blocked_by": [{"name": "fips-updates", "reason": "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS Updates installs security patches that aren't officially certified.", "reason_code": "fips-updates-invalidates-fips"}], "description": "NIST-certified FIPS crypto packages", "description_override": null, "entitled": "yes", "name": "fips", "status": "n/a", "status_details": "Cannot enable FIPS when FIPS Updates is enabled.", "warning": null}
         """
 
         When I reboot the machine
@@ -244,7 +244,7 @@ Feature: FIPS enablement in lxd VMs
         When I run `pro status --all --format json` with sudo
         Then stdout contains substring:
         """
-        {"available": "no", "blocked_by": [{"name": "livepatch", "reason": "Livepatch cannot be enabled while running the official FIPS certified kernel. If you would like a FIPS compliant kernel with additional bug fixes and security updates, you can use the FIPS Updates service with Livepatch.", "reason_code": "livepatch-invalidates-fips"}, {"name": "fips-updates", "reason": "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS Updates installs security patches that aren't officially certified.", "reason_code": "fips-updates-invalidates-fips"}], "description": "NIST-certified core packages", "description_override": null, "entitled": "yes", "name": "fips", "status": "n/a", "status_details": "Cannot enable FIPS when FIPS Updates is enabled.", "warning": null}
+        {"available": "no", "blocked_by": [{"name": "livepatch", "reason": "Livepatch cannot be enabled while running the official FIPS certified kernel. If you would like a FIPS compliant kernel with additional bug fixes and security updates, you can use the FIPS Updates service with Livepatch.", "reason_code": "livepatch-invalidates-fips"}, {"name": "fips-updates", "reason": "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS Updates installs security patches that aren't officially certified.", "reason_code": "fips-updates-invalidates-fips"}], "description": "NIST-certified FIPS crypto packages", "description_override": null, "entitled": "yes", "name": "fips", "status": "n/a", "status_details": "Cannot enable FIPS when FIPS Updates is enabled.", "warning": null}
         """
         When I run `pro disable <fips-service> --assume-yes` with sudo
         And I run `pro enable <fips-service> --assume-yes --format json --assume-yes` with sudo

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -35,8 +35,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             """
             esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
             esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-            fips          +yes +<fips-s> +NIST-certified core packages
-            fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
+            fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
+            fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
             livepatch     +yes +enabled  +Canonical Livepatch service
             """
         Then stdout matches regexp:
@@ -108,8 +108,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             """
             esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
             esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-            fips          +yes +<fips-s> +NIST-certified core packages
-            fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
+            fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
+            fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
             livepatch     +yes +<livepatch-s>  +Canonical Livepatch service
             """
         Then stdout matches regexp:
@@ -181,8 +181,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
             """
             esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
             esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-            fips          +yes +<fips-s> +NIST-certified core packages
-            fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
+            fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
+            fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
             livepatch     +yes +<livepatch-s> +<lp-desc>
             """
         Then stdout matches regexp:
@@ -243,8 +243,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified core packages
-        fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
+        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
+        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
         livepatch     +yes +<livepatch-s>  +(Canonical Livepatch service|Current kernel is not supported)
         """
         Then stdout matches regexp:
@@ -262,8 +262,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified core packages
-        fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
+        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
+        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
         livepatch     +yes +<livepatch-s>  +(Canonical Livepatch service|Current kernel is not supported)
         """
         Then stdout matches regexp:
@@ -370,8 +370,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified core packages
-        fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
+        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
+        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
         livepatch     +yes +<livepatch>  +Canonical Livepatch service
         """
         Then stdout matches regexp:
@@ -389,8 +389,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified core packages
-        fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
+        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
+        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
         livepatch     +yes +<livepatch>  +Canonical Livepatch service
         """
         Then stdout matches regexp:
@@ -496,8 +496,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified core packages
-        fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
+        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
+        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
         livepatch     +yes +<livepatch>  +<lp-desc>
         """
         Then stdout matches regexp:
@@ -515,8 +515,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified core packages
-        fips-updates  +yes +<fips-s> +NIST-certified core packages with priority security updates
+        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
+        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
         livepatch     +yes +<livepatch>  +<lp-desc>
         """
         Then stdout matches regexp:

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -20,8 +20,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
@@ -116,7 +116,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         When I run `pro status` with sudo
         Then stdout matches regexp:
         """
-        fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+        fips-updates  +yes +enabled +FIPS compliant crypto packages with stable security updates
         """
         And stdout matches regexp:
         """
@@ -170,8 +170,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
@@ -205,8 +205,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
@@ -240,8 +240,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
@@ -337,7 +337,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         When I run `pro status` with sudo
         Then stdout matches regexp:
         """
-        fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+        fips-updates  +yes +enabled +FIPS compliant crypto packages with stable security updates
         """
         And stdout matches regexp:
         """
@@ -391,8 +391,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
@@ -426,8 +426,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
@@ -461,8 +461,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `pro status` as non-root
         Then stdout matches regexp:
         """
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then stdout matches regexp:
@@ -477,7 +477,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         When I run `pro status` with sudo
         Then stdout matches regexp:
         """
-        fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+        fips-updates  +yes +enabled +FIPS compliant crypto packages with stable security updates
         """
         When I reboot the machine
         And  I run `uname -r` as non-root
@@ -514,8 +514,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
@@ -610,7 +610,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         When I run `pro status` with sudo
         Then stdout matches regexp:
         """
-        fips-updates  +yes +enabled +NIST-certified core packages with priority security updates
+        fips-updates  +yes +enabled +FIPS compliant crypto packages with stable security updates
         """
         And stdout matches regexp:
         """
@@ -663,8 +663,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
@@ -695,8 +695,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
         esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified core packages
-        fips-updates  +yes +disabled +NIST-certified core packages with priority security updates
+        fips          +yes +enabled +NIST-certified FIPS crypto packages
+        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -56,8 +56,8 @@ Feature: Unattached status
         cis             +yes       +Security compliance and audit tools
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +NIST-certified core packages
-        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        fips            +yes       +NIST-certified FIPS crypto packages
+        fips-updates    +yes       +FIPS compliant crypto packages with stable security updates
         livepatch       +yes      +(Canonical Livepatch service|Current kernel is not supported)
         ros             +yes       +Security Updates for the Robot Operating System
         ros-updates     +yes       +All Updates for the Robot Operating System
@@ -77,9 +77,9 @@ Feature: Unattached status
         cis             +yes       +Security compliance and audit tools
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +NIST-certified core packages
+        fips            +yes       +NIST-certified FIPS crypto packages
         fips-preview  +.* +.*
-        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        fips-updates    +yes       +FIPS compliant crypto packages with stable security updates
         landscape       +no        +Management and administration tool for Ubuntu
         livepatch       +yes      +(Canonical Livepatch service|Current kernel is not supported)
         realtime-kernel +no        +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -104,8 +104,8 @@ Feature: Unattached status
         cis             +yes       +Security compliance and audit tools
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +NIST-certified core packages
-        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        fips            +yes       +NIST-certified FIPS crypto packages
+        fips-updates    +yes       +FIPS compliant crypto packages with stable security updates
         livepatch       +yes      +(Canonical Livepatch service|Current kernel is not supported)
         ros             +yes       +Security Updates for the Robot Operating System
         ros-updates     +yes       +All Updates for the Robot Operating System
@@ -136,9 +136,9 @@ Feature: Unattached status
         anbox-cloud     +yes       +.*
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +NIST-certified core packages
+        fips            +yes       +NIST-certified FIPS crypto packages
         fips-preview    +.* +.*
-        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        fips-updates    +yes       +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +Canonical Livepatch service
         ros             +yes       +Security Updates for the Robot Operating System
         usg             +yes       +Security compliance and audit tools
@@ -157,9 +157,9 @@ Feature: Unattached status
         cc-eal          +no        +Common Criteria EAL2 Provisioning Packages
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +NIST-certified core packages
+        fips            +yes       +NIST-certified FIPS crypto packages
         fips-preview    +.* +.*
-        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        fips-updates    +yes       +FIPS compliant crypto packages with stable security updates
         landscape       +no        +Management and administration tool for Ubuntu
         livepatch       +yes       +Canonical Livepatch service
         realtime-kernel +no        +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -183,9 +183,9 @@ Feature: Unattached status
         anbox-cloud     +yes       +.*
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +NIST-certified core packages
+        fips            +yes       +NIST-certified FIPS crypto packages
         fips-preview    +.* +.*
-        fips-updates    +yes       +NIST-certified core packages with priority security updates
+        fips-updates    +yes       +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +Canonical Livepatch service
         ros             +yes       +Security Updates for the Robot Operating System
         usg             +yes       +Security compliance and audit tools
@@ -233,9 +233,9 @@ Feature: Unattached status
         cc-eal          +no        +Common Criteria EAL2 Provisioning Packages
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
-        fips            +no        +NIST-certified core packages
+        fips            +no        +NIST-certified FIPS crypto packages
         fips-preview    +.* +.*
-        fips-updates    +no        +NIST-certified core packages with priority security updates
+        fips-updates    +no        +FIPS compliant crypto packages with stable security updates
         landscape       +no        +Management and administration tool for Ubuntu
         livepatch       +yes       +Canonical Livepatch service
         realtime-kernel +yes       +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -291,8 +291,8 @@ Feature: Unattached status
         cis             +yes       +yes       +no           +Security compliance and audit tools
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +yes       +no           +NIST-certified core packages
-        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        fips            +yes       +yes       +no           +NIST-certified FIPS crypto packages
+        fips-updates    +yes       +yes       +no           +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         """
         When I do a preflight check for `contract_token` with the all flag
@@ -304,9 +304,9 @@ Feature: Unattached status
         cis             +yes       +yes       +no           +Security compliance and audit tools
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips            +yes       +yes       +no           +NIST-certified FIPS crypto packages
         fips-preview    +.* +.* +.*
-        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        fips-updates    +yes       +yes       +no           +FIPS compliant crypto packages with stable security updates
         landscape       +no        +yes       +no           +Management and administration tool for Ubuntu
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         realtime-kernel +no        +yes       +no           +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -354,9 +354,9 @@ Feature: Unattached status
         anbox-cloud     +yes       +.*
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips            +yes       +yes       +no           +NIST-certified FIPS crypto packages
         fips-preview    +.* +.* +.*
-        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        fips-updates    +yes       +yes       +no           +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         ros             +yes       +yes       +no           +Security Updates for the Robot Operating System
         usg             +yes       +yes       +no           +Security compliance and audit tools
@@ -369,9 +369,9 @@ Feature: Unattached status
         cc-eal          +no        +yes       +no           +Common Criteria EAL2 Provisioning Packages
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips            +yes       +yes       +no           +NIST-certified FIPS crypto packages
         fips-preview    +.* +.* +.*
-        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        fips-updates    +yes       +yes       +no           +FIPS compliant crypto packages with stable security updates
         landscape       +no        +yes       +no           +Management and administration tool for Ubuntu
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         realtime-kernel +no        +yes       +no           +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -432,9 +432,9 @@ Feature: Unattached status
         cc-eal          +no        +yes       +no           +Common Criteria EAL2 Provisioning Packages
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
-        fips            +no        +yes       +no           +NIST-certified core packages
+        fips            +no        +yes       +no           +NIST-certified FIPS crypto packages
         fips-preview    +.* +.* +.*
-        fips-updates    +no        +yes       +no           +NIST-certified core packages with priority security updates
+        fips-updates    +no        +yes       +no           +FIPS compliant crypto packages with stable security updates
         landscape       +no        +yes       +no           +Management and administration tool for Ubuntu
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         realtime-kernel +yes       +yes       +no           +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -512,8 +512,8 @@ Feature: Unattached status
         cis             +yes       +yes       +no           +Security compliance and audit tools
         esm-apps        +yes       +no        +no           +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +yes       +no           +NIST-certified core packages
-        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        fips            +yes       +yes       +no           +NIST-certified FIPS crypto packages
+        fips-updates    +yes       +yes       +no           +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         ros             +yes       +no        +no           +Security Updates for the Robot Operating System
         ros-updates     +yes       +no        +no           +All Updates for the Robot Operating System
@@ -561,8 +561,8 @@ Feature: Unattached status
         anbox-cloud     +yes       +.*
         esm-apps        +yes       +no        +no           +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +yes       +no           +NIST-certified core packages
-        fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
+        fips            +yes       +yes       +no           +NIST-certified FIPS crypto packages
+        fips-updates    +yes       +yes       +no           +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         ros             +yes       +no        +no           +Security Updates for the Robot Operating System
         usg             +yes       +yes       +no           +Security compliance and audit tools
@@ -609,7 +609,7 @@ Feature: Unattached status
         anbox-cloud     +yes       +.*
         esm-apps        +yes       +no        +no           +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
-        fips            +yes       +yes       +no           +NIST-certified core packages
+        fips            +yes       +yes       +no           +NIST-certified FIPS crypto packages
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         """
 

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -78,6 +78,7 @@ Feature: Unattached status
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips            +yes       +NIST-certified core packages
+        fips-preview  +.* +.*
         fips-updates    +yes       +NIST-certified core packages with priority security updates
         landscape       +no        +Management and administration tool for Ubuntu
         livepatch       +yes      +(Canonical Livepatch service|Current kernel is not supported)
@@ -136,6 +137,7 @@ Feature: Unattached status
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips            +yes       +NIST-certified core packages
+        fips-preview    +.* +.*
         fips-updates    +yes       +NIST-certified core packages with priority security updates
         livepatch       +yes       +Canonical Livepatch service
         ros             +yes       +Security Updates for the Robot Operating System
@@ -156,6 +158,7 @@ Feature: Unattached status
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips            +yes       +NIST-certified core packages
+        fips-preview    +.* +.*
         fips-updates    +yes       +NIST-certified core packages with priority security updates
         landscape       +no        +Management and administration tool for Ubuntu
         livepatch       +yes       +Canonical Livepatch service
@@ -181,6 +184,7 @@ Feature: Unattached status
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips            +yes       +NIST-certified core packages
+        fips-preview    +.* +.*
         fips-updates    +yes       +NIST-certified core packages with priority security updates
         livepatch       +yes       +Canonical Livepatch service
         ros             +yes       +Security Updates for the Robot Operating System
@@ -230,6 +234,7 @@ Feature: Unattached status
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips            +no        +NIST-certified core packages
+        fips-preview    +.* +.*
         fips-updates    +no        +NIST-certified core packages with priority security updates
         landscape       +no        +Management and administration tool for Ubuntu
         livepatch       +yes       +Canonical Livepatch service
@@ -300,6 +305,7 @@ Feature: Unattached status
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips            +yes       +yes       +no           +NIST-certified core packages
+        fips-preview    +.* +.* +.*
         fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
         landscape       +no        +yes       +no           +Management and administration tool for Ubuntu
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
@@ -349,6 +355,7 @@ Feature: Unattached status
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips            +yes       +yes       +no           +NIST-certified core packages
+        fips-preview    +.* +.* +.*
         fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         ros             +yes       +yes       +no           +Security Updates for the Robot Operating System
@@ -363,6 +370,7 @@ Feature: Unattached status
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips            +yes       +yes       +no           +NIST-certified core packages
+        fips-preview    +.* +.* +.*
         fips-updates    +yes       +yes       +no           +NIST-certified core packages with priority security updates
         landscape       +no        +yes       +no           +Management and administration tool for Ubuntu
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
@@ -425,6 +433,7 @@ Feature: Unattached status
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips            +no        +yes       +no           +NIST-certified core packages
+        fips-preview    +.* +.* +.*
         fips-updates    +no        +yes       +no           +NIST-certified core packages with priority security updates
         landscape       +no        +yes       +no           +Management and administration tool for Ubuntu
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service

--- a/uaclient/cli/tests/test_cli.py
+++ b/uaclient/cli/tests/test_cli.py
@@ -55,9 +55,9 @@ Client to manage Ubuntu Pro services on a machine.
    (https://ubuntu.com/security/esm)
  - esm-infra: Expanded Security Maintenance for Infrastructure
    (https://ubuntu.com/security/esm)
- - fips-updates: NIST-certified core packages with priority security updates
+ - fips-updates: FIPS compliant crypto packages with stable security updates
    (https://ubuntu.com/security/fips)
- - fips: NIST-certified core packages (https://ubuntu.com/security/fips)
+ - fips: NIST-certified FIPS crypto packages (https://ubuntu.com/security/fips)
  - livepatch: Canonical Livepatch service
    (https://ubuntu.com/security/livepatch)
  - ros-updates: All Updates for the Robot Operating System

--- a/uaclient/cli/tests/test_cli_collect_logs.py
+++ b/uaclient/cli/tests/test_cli_collect_logs.py
@@ -92,7 +92,7 @@ class TestActionCollectLogs:
             tmpdir.join("user1-log").strpath,
             tmpdir.join("user2-log").strpath,
         ]
-        is_file_calls = 16
+        is_file_calls = 17
         user_log_files = [mock.call(m_get_user())]
         if util_we_are_currently_root():
             user_log_files = [
@@ -168,6 +168,7 @@ class TestActionCollectLogs:
             mock.call("/etc/apt/sources.list.d/ubuntu-esm-infra.list"),
             mock.call("/etc/apt/sources.list.d/ubuntu-fips.list"),
             mock.call("/etc/apt/sources.list.d/ubuntu-fips-updates.list"),
+            mock.call("/etc/apt/sources.list.d/ubuntu-fips-preview.list"),
             mock.call("/etc/apt/sources.list.d/ubuntu-realtime-kernel.list"),
             mock.call("/etc/apt/sources.list.d/ubuntu-ros.list"),
             mock.call("/etc/apt/sources.list.d/ubuntu-ros-updates.list"),

--- a/uaclient/cli/tests/test_cli_disable.py
+++ b/uaclient/cli/tests/test_cli_disable.py
@@ -40,8 +40,8 @@ Disable an Ubuntu Pro service.
 Arguments:
   service              the name(s) of the Ubuntu Pro services to disable. One
                        of: anbox-cloud, cc-eal, cis, esm-apps, esm-infra,
-                       fips, fips-updates, landscape, livepatch, realtime-
-                       kernel, ros, ros-updates
+                       fips, fips-preview, fips-updates, landscape, livepatch,
+                       realtime-kernel, ros, ros-updates
 
 Flags:
   -h, --help           show this help message and exit

--- a/uaclient/cli/tests/test_cli_enable.py
+++ b/uaclient/cli/tests/test_cli_enable.py
@@ -21,8 +21,8 @@ Enable an Ubuntu Pro service.
 Arguments:
   service              the name(s) of the Ubuntu Pro services to enable. One
                        of: anbox-cloud, cc-eal, cis, esm-apps, esm-infra,
-                       fips, fips-updates, landscape, livepatch, realtime-
-                       kernel, ros, ros-updates
+                       fips, fips-preview, fips-updates, landscape, livepatch,
+                       realtime-kernel, ros, ros-updates
 
 Flags:
   -h, --help           show this help message and exit

--- a/uaclient/cli/tests/test_cli_status.py
+++ b/uaclient/cli/tests/test_cli_status.py
@@ -74,8 +74,8 @@ SIMULATED_STATUS_ALL = """\
 SERVICE          AVAILABLE  ENTITLED   AUTO_ENABLED  DESCRIPTION
 esm-apps         yes        no         yes           Expanded Security Maintenance for Applications
 esm-infra        yes        yes        yes           Expanded Security Maintenance for Infrastructure
-fips             no         no         no            NIST-certified core packages
-fips-updates     no         no         no            NIST-certified core packages with priority security updates
+fips             no         no         no            NIST-certified FIPS crypto packages
+fips-updates     no         no         no            FIPS compliant crypto packages with stable security updates
 livepatch        yes        yes        no            Canonical Livepatch service
 realtime-kernel  no         no         no            Ubuntu kernel with PREEMPT_RT patches integrated
 ros              no         no         no            Security Updates for the Robot Operating System
@@ -93,8 +93,8 @@ UNATTACHED_STATUS_ALL = """\
 SERVICE          AVAILABLE  DESCRIPTION
 esm-apps         yes        Expanded Security Maintenance for Applications
 esm-infra        yes        Expanded Security Maintenance for Infrastructure
-fips             no         NIST-certified core packages
-fips-updates     no         NIST-certified core packages with priority security updates
+fips             no         NIST-certified FIPS crypto packages
+fips-updates     no         FIPS compliant crypto packages with stable security updates
 livepatch        yes        Canonical Livepatch service
 realtime-kernel  no         Ubuntu kernel with PREEMPT_RT patches integrated
 ros              no         Security Updates for the Robot Operating System
@@ -120,8 +120,8 @@ ATTACHED_STATUS_ALL = """\
 SERVICE          ENTITLED  STATUS    DESCRIPTION
 esm-apps         no        {dash}         Expanded Security Maintenance for Applications
 esm-infra        no        {dash}         Expanded Security Maintenance for Infrastructure
-fips             no        {dash}         NIST-certified core packages
-fips-updates     no        {dash}         NIST-certified core packages with priority security updates
+fips             no        {dash}         NIST-certified FIPS crypto packages
+fips-updates     no        {dash}         FIPS compliant crypto packages with stable security updates
 livepatch        no        {dash}         Canonical Livepatch service
 realtime-kernel  no        {dash}         Ubuntu kernel with PREEMPT_RT patches integrated
 ros              no        {dash}         Security Updates for the Robot Operating System
@@ -176,7 +176,7 @@ SERVICES_JSON_ALL = [
         "warning": None,
     },
     {
-        "description": "NIST-certified core packages",
+        "description": "NIST-certified FIPS crypto packages",
         "description_override": None,
         "entitled": "no",
         "name": "fips",
@@ -188,7 +188,7 @@ SERVICES_JSON_ALL = [
     },
     {
         "description": (
-            "NIST-certified core packages with priority security updates"
+            "FIPS compliant crypto packages with stable security updates"  # noqa
         ),
         "description_override": None,
         "entitled": "no",
@@ -842,15 +842,15 @@ class TestActionStatus:
             {
                 "auto_enabled": "no",
                 "available": "no",
-                "description": "NIST-certified core packages",
+                "description": "NIST-certified FIPS crypto packages",
                 "entitled": "no",
                 "name": "fips",
             },
             {
                 "auto_enabled": "no",
                 "available": "no",
-                "description": "NIST-certified core packages with priority"
-                " security updates",
+                "description": "FIPS compliant crypto packages "
+                "with stable security updates",
                 "entitled": "no",
                 "name": "fips-updates",
             },

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -25,6 +25,7 @@ ENTITLEMENT_CLASSES = [
     ESMInfraEntitlement,
     fips.FIPSEntitlement,
     fips.FIPSUpdatesEntitlement,
+    fips.FIPSPreviewEntitlement,
     LandscapeEntitlement,
     LivepatchEntitlement,
     RealtimeKernelEntitlement,

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -391,6 +391,7 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     description = messages.FIPS_DESCRIPTION
     help_text = messages.FIPS_HELP_TEXT
     origin = "UbuntuFIPS"
+    pre_enable_msg = messages.PROMPT_FIPS_PRE_ENABLE
 
     @property
     def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
@@ -454,7 +455,7 @@ class FIPSEntitlement(FIPSCommonEntitlement):
             )
             post_enable = [messages.FIPS_RUN_APT_UPGRADE]
         else:
-            pre_enable_prompt = messages.PROMPT_FIPS_PRE_ENABLE
+            pre_enable_prompt = self.pre_enable_msg
 
         return {
             "pre_enable": [
@@ -468,7 +469,9 @@ class FIPSEntitlement(FIPSCommonEntitlement):
                 (
                     util.prompt_for_confirmation,
                     {
-                        "msg": messages.PROMPT_FIPS_PRE_DISABLE,
+                        "msg": messages.PROMPT_FIPS_PRE_DISABLE.format(
+                            title=self.title
+                        ),
                         "assume_yes": self.assume_yes,
                     },
                 )
@@ -538,7 +541,9 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
                 (
                     util.prompt_for_confirmation,
                     {
-                        "msg": messages.PROMPT_FIPS_PRE_DISABLE,
+                        "msg": messages.PROMPT_FIPS_PRE_DISABLE.format(
+                            title=self.title
+                        ),
                         "assume_yes": self.assume_yes,
                     },
                 )
@@ -561,3 +566,20 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
             return True
 
         return False
+
+
+class FIPSPreviewEntitlement(FIPSEntitlement):
+    name = "fips-preview"
+    title = messages.FIPS_PREVIEW_TITLE
+    description = messages.FIPS_PREVIEW_DESCRIPTION
+    help_text = messages.FIPS_PREVIEW_HELP_TEXT
+    origin = "UbuntuFIPSPreview"
+    pre_enable_msg = messages.PROMPT_FIPS_PREVIEW_PRE_ENABLE
+
+    @property
+    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
+        return super().incompatible_services + (
+            IncompatibleService(
+                FIPSEntitlement, messages.FIPS_INVALIDATES_FIPS_UPDATES
+            ),
+        )

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -141,7 +141,9 @@ class TestFIPSEntitlementDefaults:
                         util.prompt_for_confirmation,
                         {
                             "assume_yes": assume_yes,
-                            "msg": messages.PROMPT_FIPS_PRE_DISABLE,
+                            "msg": messages.PROMPT_FIPS_PRE_DISABLE.format(
+                                title="FIPS"
+                            ),
                         },
                     )
                 ],
@@ -162,7 +164,9 @@ class TestFIPSEntitlementDefaults:
                         util.prompt_for_confirmation,
                         {
                             "assume_yes": assume_yes,
-                            "msg": messages.PROMPT_FIPS_PRE_DISABLE,
+                            "msg": messages.PROMPT_FIPS_PRE_DISABLE.format(
+                                title="FIPS Updates",
+                            ),
                         },
                     )
                 ],
@@ -200,7 +204,9 @@ class TestFIPSEntitlementDefaults:
                         util.prompt_for_confirmation,
                         {
                             "assume_yes": False,
-                            "msg": messages.PROMPT_FIPS_PRE_DISABLE,
+                            "msg": messages.PROMPT_FIPS_PRE_DISABLE.format(
+                                title="FIPS"
+                            ),
                         },
                     )
                 ],
@@ -223,7 +229,9 @@ class TestFIPSEntitlementDefaults:
                         util.prompt_for_confirmation,
                         {
                             "assume_yes": False,
-                            "msg": messages.PROMPT_FIPS_PRE_DISABLE,
+                            "msg": messages.PROMPT_FIPS_PRE_DISABLE.format(
+                                title="FIPS Updates"
+                            ),
                         },
                     )
                 ],

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1196,14 +1196,13 @@ Ubuntu Pro. You can find out more about the service at
 ).format(url=urls.ESM_HOME_PAGE)
 
 FIPS_TITLE = t.gettext("FIPS")
-FIPS_DESCRIPTION = t.gettext("NIST-certified core packages")
+FIPS_DESCRIPTION = t.gettext("NIST-certified FIPS crypto packages")
 FIPS_HELP_TEXT = t.gettext(
     """\
-FIPS 140-2 is a set of publicly announced cryptographic standards developed by
-the National Institute of Standards and Technology applicable for FedRAMP,
-HIPAA, PCI and ISO compliance use cases. Note that "fips" does not provide
-security patching. For FIPS certified modules with security patches please
-see "fips-updates". You can find out more at {url}"""
+Installs FIPS 140 crypto packages for FedRAMP, FISMA and compliance use cases.
+Note that "fips" does not provide security patching. For FIPS certified
+modules with security patches please see "fips-updates". If you are unsure,
+choose "fips-updates" for maximum security. Find out more at {url}"""
 ).format(url=urls.FIPS_HOME_PAGE)
 FIPS_COULD_NOT_DETERMINE_CLOUD_DEFAULT_PACKAGE = t.gettext(
     "Could not determine cloud, defaulting to generic FIPS package."
@@ -1283,33 +1282,33 @@ version.
 """
 )
 
-
 FIPS_UPDATES_TITLE = t.gettext("FIPS Updates")
 FIPS_UPDATES_DESCRIPTION = t.gettext(
-    "NIST-certified core packages with priority security updates"
+    "FIPS compliant crypto packages with stable security updates"
 )
 FIPS_UPDATES_HELP_TEXT = t.gettext(
     """\
-fips-updates installs fips modules including all security patches for those
-modules that have been provided since their certification date. You can find
-out more at {url}"""
+fips-updates installs FIPS 140 crypto packages including all security patches
+for those modules that have been provided since their certification date.
+You can find out more at {url}"""
 ).format(url=urls.FIPS_HOME_PAGE)
 
 FIPS_PREVIEW_TITLE = t.gettext("FIPS Preview")
 FIPS_PREVIEW_DESCRIPTION = t.gettext(
-    "early access for not yet NIST-certified packages"
+    "Preview of FIPS crypto packages undergoing certification with NIST"  # noqa
 )
 FIPS_PREVIEW_HELP_TEXT = t.gettext(
     """\
-fips-preview install fips modules that are not yet fully certified by NIST.
-The main goal for the service is to provide early access to the fips packages
-for testing purposes."""
+Installs FIPS crypto packages that are under certification with NIST,
+for FedRAMP, FISMA and compliance use cases."""
 )
 PROMPT_FIPS_PREVIEW_PRE_ENABLE = t.gettext(
     """\
-This will install not NIST-certified FIPS packages.
-Please use this service only for test purposes.
-Additionally, the Livepatch service will be unavailable after the operation.
+This will install crypto packages that have been submitted to NIST for review
+but do not have FIPS certification yet. Use this for early access to the FIPS
+modules.
+Please note that the Livepatch service will be unavailable after
+this operation.
 Warning: This action can take some time and cannot be undone.
 """
     + PROMPT_YES_NO

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1258,7 +1258,7 @@ Warning: This action can take some time and cannot be undone.
 PROMPT_FIPS_PRE_DISABLE = (
     t.gettext(
         """\
-This will disable the FIPS entitlement but the FIPS packages will remain installed.
+This will disable the {title} entitlement but the {title} packages will remain installed.
 """  # noqa: E501
     )
     + PROMPT_YES_NO
@@ -1294,6 +1294,26 @@ fips-updates installs fips modules including all security patches for those
 modules that have been provided since their certification date. You can find
 out more at {url}"""
 ).format(url=urls.FIPS_HOME_PAGE)
+
+FIPS_PREVIEW_TITLE = t.gettext("FIPS Preview")
+FIPS_PREVIEW_DESCRIPTION = t.gettext(
+    "early access for not yet NIST-certified packages"
+)
+FIPS_PREVIEW_HELP_TEXT = t.gettext(
+    """\
+fips-preview install fips modules that are not yet fully certified by NIST.
+The main goal for the service is to provide early access to the fips packages
+for testing purposes."""
+)
+PROMPT_FIPS_PREVIEW_PRE_ENABLE = t.gettext(
+    """\
+This will install not NIST-certified FIPS packages.
+Please use this service only for test purposes.
+Additionally, the Livepatch service will be unavailable after the operation.
+Warning: This action can take some time and cannot be undone.
+"""
+    + PROMPT_YES_NO
+)
 
 LANDSCAPE_TITLE = t.gettext("Landscape")
 LANDSCAPE_DESCRIPTION = t.gettext(

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -513,6 +513,7 @@ class TestStatus:
             }
             for cls in ENTITLEMENT_CLASSES
         ]
+        expected_services.sort(key=lambda x: x.get("name", ""))
         expected = copy.deepcopy(DEFAULT_STATUS)
         expected.update(
             {
@@ -852,13 +853,12 @@ class TestStatus:
                     "variants": variants,
                 }
             )
-        print("expected")
-        print(repr(expected))
+        expected["services"].sort(key=lambda x: x.get("name", ""))
         with mock.patch(
             "uaclient.status._get_config_status"
         ) as m_get_cfg_status:
             m_get_cfg_status.return_value = DEFAULT_CFG_STATUS
-            expected_status_calls = 12 if variants_in_contract else 9
+            expected_status_calls = 13 if variants_in_contract else 10
             assert expected == status.status(cfg=cfg, show_all=show_all)
             assert expected_status_calls == m_repo_uf_status.call_count
             assert 1 == m_livepatch_uf_status.call_count


### PR DESCRIPTION
## Why is this needed?
This create the necessary structure for the Pro client to support the fips-preview service

## Test Steps
Guarantee that the new `fips-preview` test is working as expected

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
