### PR TITLE
apt-hook: use arch-dependent int types for formatting

### DIFF
--- a/apt-hook/json-hook.hh
+++ b/apt-hook/json-hook.hh
@@ -9,9 +9,9 @@ struct jsonrpc_request {
     json_object *params;
 };
 struct security_package_counts {
-    int64_t standard;
-    int64_t esm_infra;
-    int64_t esm_apps;
+    long unsigned int standard;
+    long unsigned int esm_infra;
+    long unsigned int esm_apps;
 };
 
 enum ESMType {APPS, INFRA};


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR uses the int type that the format strings expect in the apt-hook.
This is important because on non-64-bit systems we'd get warnings and errors along the lines of:
```
  164 |                     gettext("%lu standard LTS security updates"),
      |                              ~~^
      |                                |
      |                                long unsigned int
      |                              %llu
  165 |                     counts.standard
      |                     ~~~~~~~~~~~~~~~
      |                            |
      |                            int64_t {aka long long int}
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

`make -C apt-hook test` on i386?

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
