### PR TITLE
fix: update message for cloud advertisement

### DIFF
--- a/uaclient/cli/fix.py
+++ b/uaclient/cli/fix.py
@@ -364,7 +364,8 @@ def _inform_ubuntu_pro_existence_if_applicable() -> None:
     if cloud_type in PRO_CLOUD_URLS.keys():
         print(
             messages.SECURITY_USE_PRO_TMPL.format(
-                title=CLOUD_TYPE_TO_TITLE.get(cloud_type), cloud=cloud_type
+                title=CLOUD_TYPE_TO_TITLE.get(cloud_type),
+                cloud_specific_url=PRO_CLOUD_URLS.get(cloud_type),
             )
         )
 


### PR DESCRIPTION
## Why is this needed?
The attribute of a message for Ubuntu Pro cloud advertisement need to be update, since it is no longer matching the definition on the messages module

## Test Steps
Guarantee that the message attributes are being correctly used

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
