### PR TITLE
Reinsert pinning of the ESM services

### DIFF
--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -41,11 +41,11 @@ Feature: Performing attach using ua-airgapped
         When I run `apt-cache policy hello` with sudo
         Then stdout matches regexp:
         """
-        500 .*:9000/ubuntu jammy-apps-security/main
+        510 .*:9000/ubuntu jammy-apps-security/main
         """
         And stdout matches regexp:
         """
-        500 .*:8000/ubuntu jammy-infra-security/main
+        510 .*:8000/ubuntu jammy-infra-security/main
         """
         Then I verify that running `pro refresh` `with sudo` exits `0`
 

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -233,16 +233,20 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         See: sudo pro status
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `500`
+        Then apt-cache policy for the following url has priority `510`
         """
         <esm-infra-url> <release>-infra-updates/main amd64 Packages
+        """
+        And apt-cache policy for the following url has priority `510`
+        """
+        <esm-infra-url> <release>-infra-security/main amd64 Packages
         """
         And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt install -y <infra-pkg>` with sudo, retrying exit [100]
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 <esm-infra-url> <release>-infra-security/main amd64 Packages
+        \s*510 <esm-infra-url> <release>-infra-security/main amd64 Packages
         """
 
         Examples: ubuntu release
@@ -1127,11 +1131,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt-cache policy` as non-root
-        Then apt-cache policy for the following url has priority `500`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -1141,8 +1145,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I verify that running `pro enable esm-apps` `with sudo` exits `1`
         Then stdout matches regexp

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -289,19 +289,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `500`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -310,7 +310,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -321,8 +321,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
         """
@@ -416,19 +416,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `500`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -437,7 +437,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -448,8 +448,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
         """
@@ -542,19 +542,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `500`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -563,7 +563,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -574,8 +574,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
         """

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -60,19 +60,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `500`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -85,11 +85,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -100,8 +100,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
@@ -280,19 +280,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `500`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -305,11 +305,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -320,8 +320,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:
@@ -554,19 +554,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         To use a different subscription first run: sudo pro detach.
         """
         When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `500`
+        Then apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
         """
-        And apt-cache policy for the following url has priority `500`
+        And apt-cache policy for the following url has priority `510`
         """
         https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
@@ -579,11 +579,11 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I run `apt-cache policy <infra-pkg>` as non-root
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
         """
         Then stdout matches regexp:
         """
-        \s*500 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
+        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
         """
         And stdout matches regexp:
         """
@@ -594,8 +594,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Then stdout matches regexp:
         """
         Version table:
-        \s*\*\*\* .* 500
-        \s*500 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
+        \s*\*\*\* .* 510
+        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then I will see the following on stdout:

--- a/preferences.d/ubuntu-pro-esm-apps
+++ b/preferences.d/ubuntu-pro-esm-apps
@@ -1,7 +1,10 @@
-# This file was created by ubuntu-advantage-tools
-
-# Pin esm-apps packages to a slightly higher value than the archive,
-# so those are preferred when the service is enabled
+# This file is used by Ubuntu Pro and supplied by the ubuntu-advantage-tools
+# package. It has no effect if Ubuntu Pro services are not in use since no
+# other apt repositories are expected to match o=UbuntuESMApps.
+#
+# Pin esm-apps packages to a slightly higher value than the default,
+# so those are preferred over a non-ESM package from the archive when the
+# service is enabled.
 
 Package: *
 Pin: release o=UbuntuESMApps

--- a/preferences.d/ubuntu-pro-esm-apps
+++ b/preferences.d/ubuntu-pro-esm-apps
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=UbuntuESMApps
+Pin-Priority: 510

--- a/preferences.d/ubuntu-pro-esm-apps
+++ b/preferences.d/ubuntu-pro-esm-apps
@@ -1,3 +1,8 @@
+# This file was created by ubuntu-advantage-tools
+
+# Pin esm-apps packages to a slightly higher value than the archive,
+# so those are preferred when the service is enabled
+
 Package: *
 Pin: release o=UbuntuESMApps
 Pin-Priority: 510

--- a/preferences.d/ubuntu-pro-esm-infra
+++ b/preferences.d/ubuntu-pro-esm-infra
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=UbuntuESM
+Pin-Priority: 510

--- a/preferences.d/ubuntu-pro-esm-infra
+++ b/preferences.d/ubuntu-pro-esm-infra
@@ -1,8 +1,10 @@
-# This file was created by ubuntu-advantage-tools
-
-# Pin esm-infra packages to a slightly higher value than the archive,
-# so those are preferred when the service is enabled
-
+# This file is used by Ubuntu Pro and supplied by the ubuntu-advantage-tools
+# package. It has no effect if Ubuntu Pro services are not in use since no
+# other apt repositories are expected to match o=UbuntuESM.
+#
+# Pin esm-infra packages to a slightly higher value than the default,
+# so those are preferred over a non-ESM package from the archive when the
+# service is enabled.
 Package: *
 Pin: release o=UbuntuESM
 Pin-Priority: 510

--- a/preferences.d/ubuntu-pro-esm-infra
+++ b/preferences.d/ubuntu-pro-esm-infra
@@ -1,3 +1,8 @@
+# This file was created by ubuntu-advantage-tools
+
+# Pin esm-infra packages to a slightly higher value than the archive,
+# so those are preferred when the service is enabled
+
 Package: *
 Pin: release o=UbuntuESM
 Pin-Priority: 510

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ def _get_data_files():
             "/etc/update-manager/release-upgrades.d/",
             ["release-upgrades.d/ubuntu-advantage-upgrades.cfg"],
         ),
+        ("/etc/apt/preferences.d", glob.glob("preferences.d/*")),
         (defaults.CONFIG_DEFAULTS["data_dir"], []),
         ("/lib/systemd/system", glob.glob("systemd/*")),
         (


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we had merged this before, but needed to revert due to unforeseen image build time circumstances. Now we are bringing those changes back.

## Test Steps
Updated integration tests show it all.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] Changes here need to be documented, and this was done in: #2691 

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
