### PR TITLE
logging: use journald logging for all systemd services

### DIFF
--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -340,19 +340,18 @@ Feature: Command behaviour when unattached
       esm-cache\.service
       """
     When I run `journalctl -o cat -u esm-cache.service` with sudo
-    Then stdout does not match regexp:
+    Then stdout does not contain substring:
       """
-      raise FetchFailedException\(\)
+      raise FetchFailedException()
       """
-    When I run `ls /var/crash/` with sudo
-    Then stdout does not match regexp:
-      """
-      _usr_lib_ubuntu-advantage_esm_cache
-      """
-    When I run `cat /var/log/ubuntu-advantage.log` with sudo
     Then stdout matches regexp:
       """
-      Failed to fetch ESM Apt Cache item:
+      "WARNING", "ubuntupro.apt", "fail", \d+, "Failed to fetch ESM Apt Cache item: https://esm.ubuntu.com/apps/ubuntu/dists/<release>-apps-security/InRelease", {}]
+      """
+    When I run `ls /var/crash/` with sudo
+    Then stdout does not contain substring:
+      """
+      _usr_lib_ubuntu-advantage_esm_cache
       """
 
     Examples: ubuntu release

--- a/lib/apt_news.py
+++ b/lib/apt_news.py
@@ -1,12 +1,10 @@
 #!/usr/bin/python3
 
-import logging
 from datetime import datetime, timedelta, timezone
 
-from uaclient import apt, defaults
+from uaclient import apt, log
 from uaclient.apt_news import update_apt_news
 from uaclient.config import UAConfig
-from uaclient.daemon import setup_logging
 
 
 def main(cfg: UAConfig):
@@ -22,15 +20,6 @@ def main(cfg: UAConfig):
 
 
 if __name__ == "__main__":
-    setup_logging(
-        logging.INFO,
-        logging.DEBUG,
-        defaults.CONFIG_DEFAULTS["log_file"],
-    )
+    log.setup_journald_logging()
     cfg = UAConfig()
-    setup_logging(
-        logging.INFO,
-        logging.DEBUG,
-        cfg.log_file,
-    )
     main(cfg)

--- a/lib/auto_attach.py
+++ b/lib/auto_attach.py
@@ -13,7 +13,7 @@ their side.
 import logging
 import sys
 
-from uaclient import defaults, http, messages, system
+from uaclient import http, log, messages, system
 from uaclient.api.exceptions import (
     AlreadyAttachedError,
     AutoAttachDisabledError,
@@ -24,11 +24,7 @@ from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
     full_auto_attach,
 )
 from uaclient.config import UAConfig
-from uaclient.daemon import (
-    AUTO_ATTACH_STATUS_MOTD_FILE,
-    retry_auto_attach,
-    setup_logging,
-)
+from uaclient.daemon import AUTO_ATTACH_STATUS_MOTD_FILE, retry_auto_attach
 from uaclient.files import state_files
 
 LOG = logging.getLogger("ubuntupro.lib.auto_attach")
@@ -105,16 +101,7 @@ def main(cfg: UAConfig):
 
 
 if __name__ == "__main__":
-    setup_logging(
-        logging.INFO,
-        logging.DEBUG,
-        defaults.CONFIG_DEFAULTS["log_file"],
-    )
+    log.setup_journald_logging()
     cfg = UAConfig()
-    setup_logging(
-        logging.INFO,
-        logging.DEBUG,
-        cfg.log_file,
-    )
     http.configure_web_proxy(cfg.http_proxy, cfg.https_proxy)
     sys.exit(main(cfg))

--- a/lib/convert_list_to_deb822.py
+++ b/lib/convert_list_to_deb822.py
@@ -11,10 +11,10 @@ import sys
 
 from aptsources.sourceslist import SourceEntry  # type: ignore
 
-from uaclient import entitlements
+from uaclient import defaults, entitlements
 from uaclient.apt import _get_sources_file_content
-from uaclient.cli import setup_logging
 from uaclient.config import UAConfig
+from uaclient.log import setup_cli_logging
 from uaclient.system import (
     ensure_file_absent,
     get_release_info,
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     if series != "noble":
         sys.exit(0)
 
-    setup_logging(logging.DEBUG)
+    setup_cli_logging(logging.DEBUG, defaults.CONFIG_DEFAULTS["log_file"])
     cfg = UAConfig()
 
     for entitlement_class in entitlements.ENTITLEMENT_CLASSES:

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -3,10 +3,9 @@ import os
 import sys
 import time
 
-from uaclient import http, system
+from uaclient import http, log, system
 from uaclient.config import UAConfig
 from uaclient.daemon import poll_for_pro_license, retry_auto_attach
-from uaclient.log import setup_journald_logging
 
 LOG = logging.getLogger("ubuntupro.daemon")
 
@@ -40,16 +39,13 @@ def _wait_for_cloud_config():
 
 
 def main() -> int:
-    setup_journald_logging(logging.DEBUG, LOG)
-    # Make sure the ubuntupro.daemon logger does not generate double logging
-    LOG.propagate = False
-    setup_journald_logging(logging.ERROR, logging.getLogger("ubuntupro"))
+    log.setup_journald_logging()
 
     cfg = UAConfig()
 
     http.configure_web_proxy(cfg.http_proxy, cfg.https_proxy)
 
-    LOG.debug("daemon starting")
+    LOG.info("daemon starting")
 
     _wait_for_cloud_config()
 
@@ -70,7 +66,7 @@ def main() -> int:
         LOG.info("mode: retry auto attach")
         retry_auto_attach.retry_auto_attach(cfg)
 
-    LOG.debug("daemon ending")
+    LOG.info("daemon ending")
     return 0
 
 

--- a/lib/esm_cache.py
+++ b/lib/esm_cache.py
@@ -2,10 +2,9 @@
 
 import logging
 
-from uaclient import defaults
+from uaclient import log
 from uaclient.apt import update_esm_caches
 from uaclient.config import UAConfig
-from uaclient.daemon import setup_logging
 
 LOG = logging.getLogger("ubuntupro.lib.esm_cache")
 
@@ -19,15 +18,6 @@ def main(cfg: UAConfig) -> None:
 
 
 if __name__ == "__main__":
-    setup_logging(
-        logging.INFO,
-        logging.DEBUG,
-        defaults.CONFIG_DEFAULTS["log_file"],
-    )
+    log.setup_journald_logging()
     cfg = UAConfig()
-    setup_logging(
-        logging.INFO,
-        logging.DEBUG,
-        cfg.log_file,
-    )
     main(cfg)

--- a/lib/patch_status_json.py
+++ b/lib/patch_status_json.py
@@ -18,8 +18,7 @@ import copy
 import json
 import logging
 
-from uaclient import system, util
-from uaclient.cli import setup_logging
+from uaclient import config, defaults, log, system, util
 
 LOG = logging.getLogger("ubuntupro.lib.patch_status_json")
 
@@ -64,7 +63,9 @@ def patch_status_json_schema_0_1(status_file: str):
 
 
 if __name__ == "__main__":
-    setup_logging(logging.DEBUG)
+    log.setup_cli_logging(logging.DEBUG, defaults.CONFIG_DEFAULTS["log_level"])
+    cfg = config.UAConfig()
+    log.setup_cli_logging(cfg.log_level, cfg.log_file)
     patch_status_json_schema_0_1(
         status_file="/var/lib/ubuntu-advantage/status.json"
     )

--- a/lib/timer.py
+++ b/lib/timer.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional
 
-from uaclient import http
+from uaclient import http, log
 from uaclient.config import UAConfig
 from uaclient.exceptions import InvalidFileFormatError
 from uaclient.files.state_files import (
@@ -14,7 +14,6 @@ from uaclient.files.state_files import (
     TimerJobState,
     timer_jobs_state_file,
 )
-from uaclient.log import setup_journald_logging
 from uaclient.timer.metering import metering_enabled_resources
 from uaclient.timer.update_contract_info import update_contract_info
 from uaclient.timer.update_messaging import update_motd_messages
@@ -49,9 +48,9 @@ class TimedJob:
             return False
 
         try:
-            LOG.debug("Running job: %s", self.name)
+            LOG.info("Running job: %s", self.name)
             if self._job_func(cfg=cfg):
-                LOG.debug("Executed job: %s", self.name)
+                LOG.info("Executed job: %s", self.name)
         except Exception as e:
             LOG.error("Error executing job %s: %s", self.name, str(e))
             return False
@@ -180,10 +179,7 @@ def run_jobs(cfg: UAConfig, current_time: datetime):
 
 
 if __name__ == "__main__":
-    setup_journald_logging(logging.DEBUG, LOG)
-    # Make sure the ubuntupro.timer logger does not generate double logging
-    LOG.propagate = False
-    setup_journald_logging(logging.ERROR, logging.getLogger("ubuntupro"))
+    log.setup_journald_logging()
 
     cfg = UAConfig()
     current_time = datetime.now(timezone.utc)

--- a/lib/upgrade_lts_contract.py
+++ b/lib/upgrade_lts_contract.py
@@ -7,13 +7,12 @@ See uaclient/upgrade_lts_contract.py for more details.
 
 import logging
 
-from uaclient import http, upgrade_lts_contract
-from uaclient.cli import setup_logging
-from uaclient.config import UAConfig
+from uaclient import config, defaults, http, log, upgrade_lts_contract
 
 if __name__ == "__main__":
-    setup_logging(logging.DEBUG)
-    cfg = UAConfig()
+    log.setup_cli_logging(logging.DEBUG, defaults.CONFIG_DEFAULTS["log_level"])
+    cfg = config.UAConfig()
+    log.setup_cli_logging(cfg.log_level, cfg.log_file)
     http.configure_web_proxy(cfg.http_proxy, cfg.https_proxy)
     upgrade_lts_contract.process_contract_delta_after_apt_lock(cfg)
     upgrade_lts_contract.remove_private_esm_apt_cache()

--- a/uaclient/cli/tests/test_cli_api.py
+++ b/uaclient/cli/tests/test_cli_api.py
@@ -27,7 +27,7 @@ positional arguments:
 
 class TestActionAPI:
     @mock.patch("uaclient.cli.entitlements.valid_services", return_value=[])
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     def test_api_help(self, _m_setup_logging, valid_services, capsys):
         with pytest.raises(SystemExit):
             with mock.patch("sys.argv", ["/usr/bin/ua", "api", "--help"]):

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -714,7 +714,7 @@ class TestActionAttach:
 
 @mock.patch(M_PATH + "contract.get_available_resources")
 class TestParser:
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     def test_attach_help(
         self, _m_resources, _m_setup_logging, capsys, FakeConfig
     ):

--- a/uaclient/cli/tests/test_cli_auto_attach.py
+++ b/uaclient/cli/tests/test_cli_auto_attach.py
@@ -43,7 +43,7 @@ def test_non_root_users_are_rejected(we_are_currently_root, FakeConfig):
 
 
 class TestActionAutoAttach:
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     @mock.patch(M_PATH + "contract.get_available_resources")
     def test_auto_attach_help(
         self, _m_resources, _m_setup_logging, capsys, FakeConfig

--- a/uaclient/cli/tests/test_cli_collect_logs.py
+++ b/uaclient/cli/tests/test_cli_collect_logs.py
@@ -30,7 +30,7 @@ Collect logs and relevant system information into a tarball.
 
 
 class TestActionCollectLogs:
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     @mock.patch(M_PATH + "contract.get_available_resources")
     def test_collect_logs_help(
         self, _m_resources, _m_setup_logging, capsys, FakeConfig

--- a/uaclient/cli/tests/test_cli_config.py
+++ b/uaclient/cli/tests/test_cli_config.py
@@ -22,7 +22,7 @@ Available Commands:
 
 
 @mock.patch("uaclient.cli.LOG.error")
-@mock.patch("uaclient.cli.setup_logging")
+@mock.patch("uaclient.log.setup_cli_logging")
 @mock.patch(M_PATH + "contract.get_available_resources")
 class TestMainConfig:
     @pytest.mark.parametrize("additional_params", ([], ["--help"]))

--- a/uaclient/cli/tests/test_cli_config_set.py
+++ b/uaclient/cli/tests/test_cli_config_set.py
@@ -25,7 +25,7 @@ Flags:
 M_LIVEPATCH = "uaclient.entitlements.livepatch."
 
 
-@mock.patch("uaclient.cli.setup_logging")
+@mock.patch("uaclient.log.setup_cli_logging")
 class TestMainConfigSet:
     @pytest.mark.parametrize(
         "kv_pair,err_msg",

--- a/uaclient/cli/tests/test_cli_config_show.py
+++ b/uaclient/cli/tests/test_cli_config_show.py
@@ -17,7 +17,7 @@ positional arguments:
 
 
 @mock.patch("uaclient.cli.logging.error")
-@mock.patch("uaclient.cli.setup_logging")
+@mock.patch("uaclient.log.setup_cli_logging")
 @mock.patch(M_PATH + "contract.get_available_resources")
 class TestMainConfigShow:
     def test_config_show_help(

--- a/uaclient/cli/tests/test_cli_config_unset.py
+++ b/uaclient/cli/tests/test_cli_config_unset.py
@@ -24,7 +24,7 @@ Flags:
 M_LIVEPATCH = "uaclient.entitlements.livepatch."
 
 
-@mock.patch("uaclient.cli.setup_logging")
+@mock.patch("uaclient.log.setup_cli_logging")
 @mock.patch("uaclient.cli.contract.get_available_resources")
 class TestMainConfigUnSet:
     @pytest.mark.parametrize(

--- a/uaclient/cli/tests/test_cli_disable.py
+++ b/uaclient/cli/tests/test_cli_disable.py
@@ -55,7 +55,7 @@ Flags:
 
 
 class TestDisable:
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     @mock.patch("uaclient.cli.contract.get_available_resources")
     def test_disable_help(
         self, _m_resources, _m_setup_logging, capsys, FakeConfig

--- a/uaclient/cli/tests/test_cli_enable.py
+++ b/uaclient/cli/tests/test_cli_enable.py
@@ -46,7 +46,7 @@ Flags:
 )
 @mock.patch("uaclient.contract.refresh")
 class TestActionEnable:
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     @mock.patch("uaclient.cli.contract.get_available_resources")
     def test_enable_help(
         self,
@@ -67,7 +67,7 @@ class TestActionEnable:
         out, _err = capsys.readouterr()
         assert HELP_OUTPUT == out
 
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     @mock.patch("uaclient.util.we_are_currently_root", return_value=False)
     @mock.patch("uaclient.cli.contract.get_available_resources")
     def test_non_root_users_are_rejected(

--- a/uaclient/cli/tests/test_cli_fix.py
+++ b/uaclient/cli/tests/test_cli_fix.py
@@ -82,7 +82,7 @@ Flags:
 
 
 class TestActionFix:
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     @mock.patch("uaclient.cli.contract.get_available_resources")
     def test_fix_help(
         self, _m_resources, _m_setup_logging, capsys, FakeConfig

--- a/uaclient/cli/tests/test_cli_reboot_required.py
+++ b/uaclient/cli/tests/test_cli_reboot_required.py
@@ -22,7 +22,7 @@ for the machine regarding reboot:
 
 
 class TestActionRebootRequired:
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     def test_enable_help(self, _m_setup_logging, capsys, FakeConfig):
         with pytest.raises(SystemExit):
             with mock.patch(

--- a/uaclient/cli/tests/test_cli_refresh.py
+++ b/uaclient/cli/tests/test_cli_refresh.py
@@ -28,7 +28,7 @@ Flags:
 
 
 class TestActionRefresh:
-    @mock.patch("uaclient.cli.setup_logging")
+    @mock.patch("uaclient.log.setup_cli_logging")
     @mock.patch("uaclient.cli.contract.get_available_resources")
     def test_refresh_help(
         self, _m_resources, _m_setup_logging, capsys, FakeConfig

--- a/uaclient/cli/tests/test_cli_security_status.py
+++ b/uaclient/cli/tests/test_cli_security_status.py
@@ -54,7 +54,7 @@ complete status on Ubuntu Pro services, run 'pro status'.
 @mock.patch(M_PATH + "security_status.security_status_dict")
 @mock.patch(M_PATH + "contract.get_available_resources")
 class TestActionSecurityStatus:
-    @mock.patch(M_PATH + "setup_logging")
+    @mock.patch(M_PATH + "log.setup_cli_logging")
     def test_security_status_help(
         self,
         _m_setup_logging,
@@ -121,7 +121,7 @@ class TestActionSecurityStatus:
             assert m_security_status.call_args_list == [mock.call(cfg)]
             assert m_security_status.call_count == 1
 
-    @mock.patch(M_PATH + "setup_logging")
+    @mock.patch(M_PATH + "log.setup_cli_logging")
     def test_error_on_wrong_format(
         self,
         _m_setup_logging,

--- a/uaclient/cli/tests/test_cli_status.py
+++ b/uaclient/cli/tests/test_cli_status.py
@@ -348,7 +348,7 @@ Flags:
     return_value=UserConfigData(),
 )
 class TestActionStatus:
-    @mock.patch(M_PATH + "setup_logging")
+    @mock.patch(M_PATH + "log.setup_cli_logging")
     def test_status_help(
         self,
         _m_setup_logging,

--- a/uaclient/daemon/__init__.py
+++ b/uaclient/daemon/__init__.py
@@ -1,14 +1,10 @@
 import logging
 import os
-import sys
 from subprocess import TimeoutExpired
 
-from uaclient import exceptions
-from uaclient import log as pro_log
-from uaclient import system, util
+from uaclient import exceptions, system, util
 from uaclient.config import UAConfig
 from uaclient.defaults import DEFAULT_DATA_DIR
-from uaclient.log import JsonArrayFormatter
 
 LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
 
@@ -39,25 +35,3 @@ def cleanup(cfg: UAConfig):
     from uaclient.daemon import retry_auto_attach
 
     retry_auto_attach.cleanup(cfg)
-
-
-def setup_logging(console_level, log_level, log_file, logger=None):
-    if logger is None:
-        logger = logging.getLogger("ubuntupro")
-
-    logger.setLevel(log_level)
-
-    logger.handlers = []
-    logger.addFilter(pro_log.RedactionFilter())
-
-    console_handler = logging.StreamHandler(sys.stderr)
-    console_handler.setFormatter(logging.Formatter("%(message)s"))
-    console_handler.setLevel(console_level)
-    console_handler.set_name("upro-console")
-    logger.addHandler(console_handler)
-
-    file_handler = logging.FileHandler(log_file)
-    file_handler.setFormatter(JsonArrayFormatter())
-    file_handler.setLevel(log_level)
-    file_handler.set_name("upro-file")
-    logger.addHandler(file_handler)

--- a/uaclient/daemon/tests/test_poll_for_pro_license.py
+++ b/uaclient/daemon/tests/test_poll_for_pro_license.py
@@ -24,13 +24,11 @@ def time_mock_side_effect_increment_by(increment):
     return _time_mock_side_effect
 
 
-@mock.patch(M_PATH + "LOG.debug")
+@mock.patch(M_PATH + "LOG.info")
 @mock.patch(M_PATH + "actions.auto_attach")
 @mock.patch(M_PATH + "lock.RetryLock")
 class TestAttemptAutoAttach:
-    def test_success(
-        self, m_spin_lock, m_auto_attach, m_log_debug, FakeConfig
-    ):
+    def test_success(self, m_spin_lock, m_auto_attach, m_log_info, FakeConfig):
         cfg = FakeConfig()
         cloud = mock.MagicMock()
 
@@ -43,21 +41,19 @@ class TestAttemptAutoAttach:
         assert [mock.call(cfg, cloud)] == m_auto_attach.call_args_list
         assert [
             mock.call("Successful auto attach")
-        ] == m_log_debug.call_args_list
+        ] == m_log_info.call_args_list
 
     @mock.patch(M_PATH + "system.create_file")
     @mock.patch(M_PATH + "lock.clear_lock_file_if_present")
     @mock.patch(M_PATH + "LOG.error")
-    @mock.patch(M_PATH + "LOG.info")
     def test_exception(
         self,
-        m_log_info,
         m_log_error,
         m_clear_lock,
         m_create_file,
         m_spin_lock,
         m_auto_attach,
-        m_log_debug,
+        m_log_info,
         FakeConfig,
     ):
         err = Exception()
@@ -81,7 +77,7 @@ class TestAttemptAutoAttach:
         ] == m_create_file.call_args_list
 
 
-@mock.patch(M_PATH + "LOG.debug")
+@mock.patch(M_PATH + "LOG.info")
 @mock.patch(M_PATH + "time.sleep")
 @mock.patch(M_PATH + "time.time")
 @mock.patch(M_PATH + "attempt_auto_attach")
@@ -99,7 +95,7 @@ class TestPollForProLicense:
         "should_poll,"
         "is_pro_license_present,"
         "cfg_poll_for_pro_licenses,"
-        "expected_log_debug_calls,"
+        "expected_log_info_calls,"
         "expected_is_pro_license_present_calls,"
         "expected_attempt_auto_attach_calls",
         [
@@ -243,7 +239,7 @@ class TestPollForProLicense:
         m_attempt_auto_attach,
         m_time,
         m_sleep,
-        m_log_debug,
+        m_log_info,
         is_config_value_true,
         is_attached,
         is_current_series_lts,
@@ -251,7 +247,7 @@ class TestPollForProLicense:
         should_poll,
         is_pro_license_present,
         cfg_poll_for_pro_licenses,
-        expected_log_debug_calls,
+        expected_log_info_calls,
         expected_is_pro_license_present_calls,
         expected_attempt_auto_attach_calls,
         FakeConfig,
@@ -270,7 +266,7 @@ class TestPollForProLicense:
 
         poll_for_pro_license(cfg)
 
-        assert expected_log_debug_calls == m_log_debug.call_args_list
+        assert expected_log_info_calls == m_log_info.call_args_list
         assert (
             expected_is_pro_license_present_calls
             == m_is_pro_license_present.call_args_list
@@ -285,7 +281,7 @@ class TestPollForProLicense:
         "time_side_effect,"
         "expected_is_pro_license_present_calls,"
         "expected_attempt_auto_attach_calls,"
-        "expected_log_debug_calls,"
+        "expected_log_info_calls,"
         "expected_sleep_calls",
         [
             (
@@ -403,12 +399,12 @@ class TestPollForProLicense:
         m_attempt_auto_attach,
         m_time,
         m_sleep,
-        m_log_debug,
+        m_log_info,
         is_pro_license_present_side_effect,
         time_side_effect,
         expected_is_pro_license_present_calls,
         expected_attempt_auto_attach_calls,
-        expected_log_debug_calls,
+        expected_log_info_calls,
         expected_sleep_calls,
         FakeConfig,
     ):
@@ -428,7 +424,7 @@ class TestPollForProLicense:
         poll_for_pro_license(cfg)
 
         assert expected_sleep_calls == m_sleep.call_args_list
-        assert expected_log_debug_calls == m_log_debug.call_args_list
+        assert expected_log_info_calls == m_log_info.call_args_list
         assert (
             expected_is_pro_license_present_calls
             == m_is_pro_license_present.call_args_list

--- a/uaclient/log.py
+++ b/uaclient/log.py
@@ -98,10 +98,11 @@ def get_all_user_log_files() -> List[str]:
     return log_files
 
 
-def setup_journald_logging(log_level, logger):
-    logger.setLevel(log_level)
+def setup_journald_logging():
+    logger = logging.getLogger("ubuntupro")
+    logger.setLevel(logging.INFO)
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(JsonArrayFormatter())
-    console_handler.setLevel(log_level)
+    console_handler.setLevel(logging.INFO)
     console_handler.addFilter(RedactionFilter())
     logger.addHandler(console_handler)

--- a/uaclient/timer/update_messaging.py
+++ b/uaclient/timer/update_messaging.py
@@ -65,7 +65,7 @@ def update_motd_messages(cfg: UAConfig) -> bool:
     if not is_attached_info.is_attached:
         return False
 
-    LOG.debug("Updating Ubuntu Pro messages for MOTD.")
+    LOG.info("Updating Ubuntu Pro messages for MOTD.")
     motd_contract_status_msg_path = os.path.join(
         cfg.data_dir, "messages", MOTD_CONTRACT_STATUS_FILE_NAME
     )


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR brings journald logging to all systemd services, plus a few small related refactors.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
./tools/test-in-lxd.sh xenial
apt update
# ensure logs of esm_cache end up in journald
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
