### PR TITLE
refactor: simplify prerm to not import python

### DIFF
--- a/debian/ubuntu-advantage-tools.prerm
+++ b/debian/ubuntu-advantage-tools.prerm
@@ -3,12 +3,14 @@
 set -e
 
 remove_apt_files() {
-    /usr/bin/python3 -c '
-from uaclient.apt import clean_apt_files
-
-clean_apt_files()
-'
-
+    # This list should be kept up to date with the list of available apt-repo-based services
+    for service in anbox cc-eal cis esm-apps esm-infra fips fips-preview fips-updates realtime-kernel ros ros-updates; do
+        rm -f /etc/apt/sources.list.d/ubuntu-${service}.list
+    done
+    # preferences are only dynamically created for fips services
+    for fips_service in fips fips-preview fips-updates; do
+        rm -f /etc/apt/preferences.d/ubuntu-${fips_service}
+    done
 }
 
 case "$1" in

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 import subprocess
-import sys
 import tempfile
 from functools import lru_cache, wraps
 from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Union
@@ -659,43 +658,6 @@ def remove_apt_list_files(repo_url, series):
     """Remove any apt list files present for this repo_url and series."""
     for path in find_apt_list_files(repo_url, series):
         system.ensure_file_absent(path)
-
-
-def clean_apt_files(*, _entitlements=None):
-    """
-    Clean apt files written by uaclient
-
-    :param _entitlements:
-        The uaclient.entitlements module to use, defaults to
-        uaclient.entitlements. (This is only present for testing, because the
-        import happens within the function to avoid circular imports.)
-    """
-    from uaclient.entitlements.repo import RepoEntitlement
-
-    if _entitlements is None:
-        from uaclient import entitlements as __entitlements
-
-        _entitlements = __entitlements
-
-    for ent_cls in _entitlements.ENTITLEMENT_CLASSES:
-        if not issubclass(ent_cls, RepoEntitlement):
-            continue
-        repo_file = ent_cls.repo_list_file_tmpl.format(name=ent_cls.name)
-        pref_file = ent_cls.repo_pref_file_tmpl.format(name=ent_cls.name)
-        if os.path.exists(repo_file):
-            event.info(
-                messages.APT_REMOVING_SOURCE_FILE.format(filename=repo_file),
-                file_type=sys.stderr,
-            )
-            system.ensure_file_absent(repo_file)
-        if os.path.exists(pref_file):
-            event.info(
-                messages.APT_REMOVING_PREFERENCES_FILE.format(
-                    filename=pref_file
-                ),
-                file_type=sys.stderr,
-            )
-            system.ensure_file_absent(pref_file)
 
 
 def is_installed(pkg: str) -> bool:

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -26,7 +26,6 @@ from uaclient.apt import (
     add_auth_apt_repo,
     add_ppa_pinning,
     assert_valid_apt_credentials,
-    clean_apt_files,
     find_apt_list_files,
     get_alternative_versions_for_package,
     get_apt_cache_policy,
@@ -46,7 +45,6 @@ from uaclient.apt import (
 from uaclient.entitlements.base import UAEntitlement
 from uaclient.entitlements.entitlement_status import ApplicationStatus
 from uaclient.entitlements.repo import RepoEntitlement
-from uaclient.entitlements.tests.test_repo import RepoTestEntitlement
 from uaclient.testing import fakes
 
 POST_INSTALL_APT_CACHE_NO_UPDATES = """
@@ -654,51 +652,6 @@ class TestCleanAptFiles:
                 f.write("")
 
         return TestRepo
-
-    @mock.patch("os.path.exists", return_value=True)
-    @mock.patch("uaclient.system.ensure_file_absent")
-    def test_removals_for_repo_entitlements(
-        self, m_ensure_file_absent, _m_path_exists
-    ):
-        m_entitlements = mock.Mock()
-        m_entitlements.ENTITLEMENT_CLASSES = [RepoTestEntitlement]
-
-        clean_apt_files(_entitlements=m_entitlements)
-
-        assert 2 == m_ensure_file_absent.call_count
-
-    def test_files_for_all_series_removed(self, mock_apt_entitlement, tmpdir):
-        m_entitlements = mock.Mock()
-        m_entitlements.ENTITLEMENT_CLASSES = [mock_apt_entitlement]
-
-        clean_apt_files(_entitlements=m_entitlements)
-
-        if mock_apt_entitlement.is_repo:
-            assert [] == tmpdir.listdir()
-        else:
-            assert sorted(
-                [tmpdir.join("source-test_ent"), tmpdir.join("pref-test_ent")]
-            ) == sorted(tmpdir.listdir())
-
-    def test_other_files_not_removed(self, mock_apt_entitlement, tmpdir):
-        other_filename = "other_file-acidic"
-        tmpdir.join(other_filename).ensure()
-
-        m_entitlements = mock.Mock()
-        m_entitlements.ENTITLEMENT_CLASSES = [mock_apt_entitlement]
-
-        clean_apt_files(_entitlements=m_entitlements)
-
-        if mock_apt_entitlement.is_repo:
-            assert [tmpdir.join(other_filename)] == tmpdir.listdir()
-        else:
-            assert sorted(
-                [
-                    tmpdir.join("source-test_ent"),
-                    tmpdir.join("pref-test_ent"),
-                    tmpdir.join(other_filename),
-                ]
-            ) == sorted(tmpdir.listdir())
 
 
 @pytest.fixture(params=(mock.sentinel.default, None, "some_string"))


### PR DESCRIPTION
LP: #2021988

## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
Importing our python module in prerm exposes the packaing script to all the complexity of our python and the risk that a seemingly unrelated change in the python could affect the prerm script.

This happened when we started relying on python3-apt and resulted in LP: #2021988

This PR removes the python import entirely and instead hardcodes the files that need to be removed.

## Test Steps
```
./tools/test-in-lxd.sh xenial
pro attach
apt remove ubuntu-advantage-tools
ls /etc/apt/sources.list.d
# pro sources files should be gone
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
