### PR TITLE
release 30: add integration tests and fixes for the disable --purge functionality 

### DIFF
--- a/debian/po/pt_BR.po
+++ b/debian/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-03 17:43-0300\n"
+"POT-Creation-Date: 2023-10-11 09:31-0300\n"
 "PO-Revision-Date: 2023-09-25 12:29-0400\n"
 "Last-Translator: Lucas Moura <lucas.moura@canonical.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -2321,7 +2321,7 @@ msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1301
-#: ../../uaclient/messages/__init__.py:1727
+#: ../../uaclient/messages/__init__.py:1732
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
@@ -2613,187 +2613,192 @@ msgstr ""
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1585
+#: ../../uaclient/messages/__init__.py:1584
+#, python-brace-format
+msgid "{title} does not support being disabled with --purge"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1590
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1592
+#: ../../uaclient/messages/__init__.py:1597
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1600
+#: ../../uaclient/messages/__init__.py:1605
 #, python-brace-format
 msgid "Cannot disable {entitlement_name} with purge: no origin value defined"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1607
+#: ../../uaclient/messages/__init__.py:1612
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1612
+#: ../../uaclient/messages/__init__.py:1617
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1620
+#: ../../uaclient/messages/__init__.py:1625
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1628
+#: ../../uaclient/messages/__init__.py:1633
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1631
+#: ../../uaclient/messages/__init__.py:1636
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1636
+#: ../../uaclient/messages/__init__.py:1641
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1642
+#: ../../uaclient/messages/__init__.py:1647
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1646
+#: ../../uaclient/messages/__init__.py:1651
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1651
+#: ../../uaclient/messages/__init__.py:1656
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1658
+#: ../../uaclient/messages/__init__.py:1663
 #, python-brace-format
 msgid ""
 "{title} is already enabled.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1665
+#: ../../uaclient/messages/__init__.py:1670
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1671
+#: ../../uaclient/messages/__init__.py:1676
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1677
+#: ../../uaclient/messages/__init__.py:1682
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1685
+#: ../../uaclient/messages/__init__.py:1690
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1693
+#: ../../uaclient/messages/__init__.py:1698
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1700
+#: ../../uaclient/messages/__init__.py:1705
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1708
+#: ../../uaclient/messages/__init__.py:1713
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1715
+#: ../../uaclient/messages/__init__.py:1720
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1721
+#: ../../uaclient/messages/__init__.py:1726
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1731
+#: ../../uaclient/messages/__init__.py:1736
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1734
+#: ../../uaclient/messages/__init__.py:1739
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1738
+#: ../../uaclient/messages/__init__.py:1743
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1743
+#: ../../uaclient/messages/__init__.py:1748
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1751
+#: ../../uaclient/messages/__init__.py:1756
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1760
+#: ../../uaclient/messages/__init__.py:1765
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1768
+#: ../../uaclient/messages/__init__.py:1773
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1772
+#: ../../uaclient/messages/__init__.py:1777
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1777
+#: ../../uaclient/messages/__init__.py:1782
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1785
+#: ../../uaclient/messages/__init__.py:1790
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2803,7 +2808,7 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1794
+#: ../../uaclient/messages/__init__.py:1799
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2812,76 +2817,76 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1804
+#: ../../uaclient/messages/__init__.py:1809
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1810
+#: ../../uaclient/messages/__init__.py:1815
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1817
+#: ../../uaclient/messages/__init__.py:1822
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1824
+#: ../../uaclient/messages/__init__.py:1829
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1829
+#: ../../uaclient/messages/__init__.py:1834
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1833
+#: ../../uaclient/messages/__init__.py:1838
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1838
+#: ../../uaclient/messages/__init__.py:1843
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1842
+#: ../../uaclient/messages/__init__.py:1847
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1846
+#: ../../uaclient/messages/__init__.py:1851
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1851
+#: ../../uaclient/messages/__init__.py:1856
 msgid "lanscape-client is not installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1856
+#: ../../uaclient/messages/__init__.py:1861
 msgid ""
 "Landscape is installed but not configured.\n"
 "Run `sudo landscape-config` to set it up, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1865
+#: ../../uaclient/messages/__init__.py:1870
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1874
+#: ../../uaclient/messages/__init__.py:1879
 msgid ""
 "Landscape is installed and configured and registered but not running.\n"
 "Run `sudo landscape-config` to start it, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1882
+#: ../../uaclient/messages/__init__.py:1887
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1888
+#: ../../uaclient/messages/__init__.py:1893
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2891,28 +2896,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1902
+#: ../../uaclient/messages/__init__.py:1907
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1908
+#: ../../uaclient/messages/__init__.py:1913
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1938
+#: ../../uaclient/messages/__init__.py:1943
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1943
+#: ../../uaclient/messages/__init__.py:1948
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1949
+#: ../../uaclient/messages/__init__.py:1954
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2920,96 +2925,96 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1959
+#: ../../uaclient/messages/__init__.py:1964
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1966
+#: ../../uaclient/messages/__init__.py:1971
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1971
+#: ../../uaclient/messages/__init__.py:1976
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1975
+#: ../../uaclient/messages/__init__.py:1980
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1979
+#: ../../uaclient/messages/__init__.py:1984
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1984
+#: ../../uaclient/messages/__init__.py:1989
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2000
+#: ../../uaclient/messages/__init__.py:2005
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2006
+#: ../../uaclient/messages/__init__.py:2011
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2010
+#: ../../uaclient/messages/__init__.py:2015
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2016
+#: ../../uaclient/messages/__init__.py:2021
 msgid ""
 "Failed to connect to authentication server\n"
 "Check your Internet connection and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2023
+#: ../../uaclient/messages/__init__.py:2028
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2029
+#: ../../uaclient/messages/__init__.py:2034
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2038
+#: ../../uaclient/messages/__init__.py:2043
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2045
+#: ../../uaclient/messages/__init__.py:2050
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2052
+#: ../../uaclient/messages/__init__.py:2057
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2057
+#: ../../uaclient/messages/__init__.py:2062
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2063
+#: ../../uaclient/messages/__init__.py:2068
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3017,7 +3022,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2073
+#: ../../uaclient/messages/__init__.py:2078
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3025,7 +3030,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2083
+#: ../../uaclient/messages/__init__.py:2088
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3033,41 +3038,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2093
+#: ../../uaclient/messages/__init__.py:2098
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2100
+#: ../../uaclient/messages/__init__.py:2105
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2106
+#: ../../uaclient/messages/__init__.py:2111
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2112
+#: ../../uaclient/messages/__init__.py:2117
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2117
+#: ../../uaclient/messages/__init__.py:2122
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2123
+#: ../../uaclient/messages/__init__.py:2128
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2131
+#: ../../uaclient/messages/__init__.py:2136
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2140
+#: ../../uaclient/messages/__init__.py:2145
 #, python-brace-format
 msgid ""
 "To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
@@ -3075,59 +3080,59 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2156
+#: ../../uaclient/messages/__init__.py:2161
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2161
+#: ../../uaclient/messages/__init__.py:2166
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2167
+#: ../../uaclient/messages/__init__.py:2172
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2175
+#: ../../uaclient/messages/__init__.py:2180
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2183
+#: ../../uaclient/messages/__init__.py:2188
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2190
+#: ../../uaclient/messages/__init__.py:2195
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2197
+#: ../../uaclient/messages/__init__.py:2202
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2206
+#: ../../uaclient/messages/__init__.py:2211
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2210
+#: ../../uaclient/messages/__init__.py:2215
 #, python-brace-format
 msgid ""
 "Error on Pro Image:\n"
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2216
+#: ../../uaclient/messages/__init__.py:2221
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2223
+#: ../../uaclient/messages/__init__.py:2228
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -3135,16 +3140,16 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2233
+#: ../../uaclient/messages/__init__.py:2238
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2240
+#: ../../uaclient/messages/__init__.py:2245
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2248
+#: ../../uaclient/messages/__init__.py:2253
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
@@ -3153,7 +3158,7 @@ msgstr ""
 "Suporte para auto-attach não está disponível para esta imagem\n"
 "Veja {url}"
 
-#: ../../uaclient/messages/__init__.py:2257
+#: ../../uaclient/messages/__init__.py:2262
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
@@ -3162,18 +3167,18 @@ msgstr ""
 "Suporte para auto-attach não está disponível para {{cloud_type}}\n"
 "Veja: {url}"
 
-#: ../../uaclient/messages/__init__.py:2265
+#: ../../uaclient/messages/__init__.py:2270
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2271
+#: ../../uaclient/messages/__init__.py:2276
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2279
+#: ../../uaclient/messages/__init__.py:2284
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -3184,7 +3189,7 @@ msgstr ""
 "o campo VERSION não tem a informação de versão: {version}\n"
 "e o campo VERSION_CODENAME não está presente"
 
-#: ../../uaclient/messages/__init__.py:2289
+#: ../../uaclient/messages/__init__.py:2294
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -3198,12 +3203,12 @@ msgstr ""
 "\n"
 "$ sudo rm {lock_file_path}"
 
-#: ../../uaclient/messages/__init__.py:2298
+#: ../../uaclient/messages/__init__.py:2303
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr "{source} retornou um json inválido: {out}"
 
-#: ../../uaclient/messages/__init__.py:2304
+#: ../../uaclient/messages/__init__.py:2309
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
@@ -3212,7 +3217,7 @@ msgstr ""
 "Valor inválido para {path_to_value} em /etc/ubuntu-advantage/uaclient.conf."
 "Esperava {expected_value}, mas {value} foi encontrado."
 
-#: ../../uaclient/messages/__init__.py:2313
+#: ../../uaclient/messages/__init__.py:2318
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
@@ -3220,17 +3225,17 @@ msgstr ""
 "Não foi possível associar {key} a {value}: <value> precisa ser um inteiro "
 "positivo."
 
-#: ../../uaclient/messages/__init__.py:2320
+#: ../../uaclient/messages/__init__.py:2325
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr "url inválida no arquivo de configuração. {key}: {value}"
 
-#: ../../uaclient/messages/__init__.py:2325
+#: ../../uaclient/messages/__init__.py:2330
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr "Não foi possível encontrar o arquivo yaml: {filepath}"
 
-#: ../../uaclient/messages/__init__.py:2331
+#: ../../uaclient/messages/__init__.py:2336
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
@@ -3241,27 +3246,27 @@ msgstr ""
 "pro de apt ao mesmo tempo não é suportado.\n"
 "Cancelando o processo de configuração.\n"
 
-#: ../../uaclient/messages/__init__.py:2341
+#: ../../uaclient/messages/__init__.py:2346
 msgid "Can't load the distro-info database."
 msgstr "Não foi possível carregar o banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2346
+#: ../../uaclient/messages/__init__.py:2351
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 "Não foi possível encontrar a série {series} na banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2351
+#: ../../uaclient/messages/__init__.py:2356
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr "Erro: não é possível usar {option1} junto com {option2}"
 
-#: ../../uaclient/messages/__init__.py:2355
+#: ../../uaclient/messages/__init__.py:2360
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr "Ajuda não disponível para '{name}'"
 
-#: ../../uaclient/messages/__init__.py:2361
+#: ../../uaclient/messages/__init__.py:2366
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
@@ -3270,34 +3275,34 @@ msgstr ""
 "Erro: problema de segurnça \"{issue}\" não foi reconhecido.\n"
 "Use: \"pro fix CVE-yyyy-nnnn\" ou \"pro fix USN-nnnn\""
 
-#: ../../uaclient/messages/__init__.py:2367
+#: ../../uaclient/messages/__init__.py:2372
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr "{arg} precisa ser um de: {choices}"
 
-#: ../../uaclient/messages/__init__.py:2372
+#: ../../uaclient/messages/__init__.py:2377
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr "Esperava {expected} mas encontrou: {actual}"
 
-#: ../../uaclient/messages/__init__.py:2376
+#: ../../uaclient/messages/__init__.py:2381
 msgid "Unable to process uaclient.conf"
 msgstr "Falha ao processar uaclient.conf"
 
-#: ../../uaclient/messages/__init__.py:2381
+#: ../../uaclient/messages/__init__.py:2386
 msgid "Unable to refresh your subscription"
 msgstr "Falha ao atualizar sua assinatura"
 
-#: ../../uaclient/messages/__init__.py:2386
+#: ../../uaclient/messages/__init__.py:2391
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 "Falha ao atualizar as mensagens de APT e MOTD relacioandas ao Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:2392
+#: ../../uaclient/messages/__init__.py:2397
 msgid "json formatted response requires --assume-yes flag."
 msgstr "resposta formatada em json necessita do paramêtro --assume-yes"
 
-#: ../../uaclient/messages/__init__.py:2400
+#: ../../uaclient/messages/__init__.py:2405
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
@@ -3307,50 +3312,50 @@ msgstr ""
 "Ao invés disso, inclua o token no arquivo de attach-config.\n"
 "    "
 
-#: ../../uaclient/messages/__init__.py:2409
+#: ../../uaclient/messages/__init__.py:2414
 msgid "Cannot provide both --args and --data at the same time"
 msgstr "Não é possível usar --args e --data ao mesmo tempo"
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2420
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr "Falha ao executar: {lock_request}.\n"
 
-#: ../../uaclient/messages/__init__.py:2424
+#: ../../uaclient/messages/__init__.py:2429
 msgid "This command must be run as root (try using sudo)."
 msgstr "Esse comando precisa ser executado como root (tente usando sudo)."
 
-#: ../../uaclient/messages/__init__.py:2429
+#: ../../uaclient/messages/__init__.py:2434
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr "Metadados para {issue} não são válidos. Erro: {error_msg}."
 
-#: ../../uaclient/messages/__init__.py:2436
+#: ../../uaclient/messages/__init__.py:2441
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr "Erro: {issue_id} não encontrada."
 
-#: ../../uaclient/messages/__init__.py:2440
+#: ../../uaclient/messages/__init__.py:2445
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr "chave GPG '{keyfile}' não foi encontrada"
 
-#: ../../uaclient/messages/__init__.py:2445
+#: ../../uaclient/messages/__init__.py:2450
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr "'{endpoint}' não é um endpoint válido"
 
-#: ../../uaclient/messages/__init__.py:2450
+#: ../../uaclient/messages/__init__.py:2455
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr "'{arg}' está faltando para endpoint {endpoint}"
 
-#: ../../uaclient/messages/__init__.py:2455
+#: ../../uaclient/messages/__init__.py:2460
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr "{endpoint} não aceita paramêtros"
 
-#: ../../uaclient/messages/__init__.py:2460
+#: ../../uaclient/messages/__init__.py:2465
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
@@ -3359,32 +3364,32 @@ msgstr ""
 "Error ao analisar paramêtro data para API json:\n"
 "{data}"
 
-#: ../../uaclient/messages/__init__.py:2465
+#: ../../uaclient/messages/__init__.py:2470
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr "'{arg}' não está formatado como 'chave=valor'"
 
-#: ../../uaclient/messages/__init__.py:2470
+#: ../../uaclient/messages/__init__.py:2475
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr "Não foi possível determinar a versão: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2475
+#: ../../uaclient/messages/__init__.py:2480
 msgid "features.disable_auto_attach set in config"
 msgstr "features.disable_auto_attach definida na configuração"
 
-#: ../../uaclient/messages/__init__.py:2480
+#: ../../uaclient/messages/__init__.py:2485
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 "Não foi possível determinar o status do unattended-upgrades: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2486
+#: ../../uaclient/messages/__init__.py:2491
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr "Esperava valor com tipo {expected_type}, mas recebeu tipo {got_type}"
 
-#: ../../uaclient/messages/__init__.py:2492
+#: ../../uaclient/messages/__init__.py:2497
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
@@ -3393,7 +3398,7 @@ msgstr ""
 "Valor com tipo incorreto na posição {index}:\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2498
+#: ../../uaclient/messages/__init__.py:2503
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
@@ -3402,7 +3407,7 @@ msgstr ""
 "Valor com tipo incorreto para o campo \"{key}\":\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2505
+#: ../../uaclient/messages/__init__.py:2510
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""

--- a/debian/po/ubuntu-pro.pot
+++ b/debian/po/ubuntu-pro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-03 17:43-0300\n"
+"POT-Creation-Date: 2023-10-11 09:31-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1985,7 +1985,7 @@ msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1301
-#: ../../uaclient/messages/__init__.py:1727
+#: ../../uaclient/messages/__init__.py:1732
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
@@ -2276,187 +2276,192 @@ msgstr ""
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1585
+#: ../../uaclient/messages/__init__.py:1584
+#, python-brace-format
+msgid "{title} does not support being disabled with --purge"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1590
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1592
+#: ../../uaclient/messages/__init__.py:1597
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1600
+#: ../../uaclient/messages/__init__.py:1605
 #, python-brace-format
 msgid "Cannot disable {entitlement_name} with purge: no origin value defined"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1607
+#: ../../uaclient/messages/__init__.py:1612
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1612
+#: ../../uaclient/messages/__init__.py:1617
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1620
+#: ../../uaclient/messages/__init__.py:1625
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1628
+#: ../../uaclient/messages/__init__.py:1633
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1631
+#: ../../uaclient/messages/__init__.py:1636
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1636
+#: ../../uaclient/messages/__init__.py:1641
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1642
+#: ../../uaclient/messages/__init__.py:1647
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1646
+#: ../../uaclient/messages/__init__.py:1651
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1651
+#: ../../uaclient/messages/__init__.py:1656
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1658
+#: ../../uaclient/messages/__init__.py:1663
 #, python-brace-format
 msgid ""
 "{title} is already enabled.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1665
+#: ../../uaclient/messages/__init__.py:1670
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1671
+#: ../../uaclient/messages/__init__.py:1676
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1677
+#: ../../uaclient/messages/__init__.py:1682
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1685
+#: ../../uaclient/messages/__init__.py:1690
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1693
+#: ../../uaclient/messages/__init__.py:1698
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1700
+#: ../../uaclient/messages/__init__.py:1705
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1708
+#: ../../uaclient/messages/__init__.py:1713
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1715
+#: ../../uaclient/messages/__init__.py:1720
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1721
+#: ../../uaclient/messages/__init__.py:1726
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1731
+#: ../../uaclient/messages/__init__.py:1736
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1734
+#: ../../uaclient/messages/__init__.py:1739
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1738
+#: ../../uaclient/messages/__init__.py:1743
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1743
+#: ../../uaclient/messages/__init__.py:1748
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1751
+#: ../../uaclient/messages/__init__.py:1756
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1760
+#: ../../uaclient/messages/__init__.py:1765
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1768
+#: ../../uaclient/messages/__init__.py:1773
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1772
+#: ../../uaclient/messages/__init__.py:1777
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1777
+#: ../../uaclient/messages/__init__.py:1782
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1785
+#: ../../uaclient/messages/__init__.py:1790
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2466,7 +2471,7 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1794
+#: ../../uaclient/messages/__init__.py:1799
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2475,76 +2480,76 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1804
+#: ../../uaclient/messages/__init__.py:1809
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1810
+#: ../../uaclient/messages/__init__.py:1815
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1817
+#: ../../uaclient/messages/__init__.py:1822
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1824
+#: ../../uaclient/messages/__init__.py:1829
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1829
+#: ../../uaclient/messages/__init__.py:1834
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1833
+#: ../../uaclient/messages/__init__.py:1838
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1838
+#: ../../uaclient/messages/__init__.py:1843
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1842
+#: ../../uaclient/messages/__init__.py:1847
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1846
+#: ../../uaclient/messages/__init__.py:1851
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1851
+#: ../../uaclient/messages/__init__.py:1856
 msgid "lanscape-client is not installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1856
+#: ../../uaclient/messages/__init__.py:1861
 msgid ""
 "Landscape is installed but not configured.\n"
 "Run `sudo landscape-config` to set it up, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1865
+#: ../../uaclient/messages/__init__.py:1870
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1874
+#: ../../uaclient/messages/__init__.py:1879
 msgid ""
 "Landscape is installed and configured and registered but not running.\n"
 "Run `sudo landscape-config` to start it, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1882
+#: ../../uaclient/messages/__init__.py:1887
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1888
+#: ../../uaclient/messages/__init__.py:1893
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2554,28 +2559,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1902
+#: ../../uaclient/messages/__init__.py:1907
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1908
+#: ../../uaclient/messages/__init__.py:1913
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1938
+#: ../../uaclient/messages/__init__.py:1943
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1943
+#: ../../uaclient/messages/__init__.py:1948
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1949
+#: ../../uaclient/messages/__init__.py:1954
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2583,96 +2588,96 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1959
+#: ../../uaclient/messages/__init__.py:1964
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1966
+#: ../../uaclient/messages/__init__.py:1971
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1971
+#: ../../uaclient/messages/__init__.py:1976
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1975
+#: ../../uaclient/messages/__init__.py:1980
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1979
+#: ../../uaclient/messages/__init__.py:1984
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1984
+#: ../../uaclient/messages/__init__.py:1989
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2000
+#: ../../uaclient/messages/__init__.py:2005
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2006
+#: ../../uaclient/messages/__init__.py:2011
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2010
+#: ../../uaclient/messages/__init__.py:2015
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2016
+#: ../../uaclient/messages/__init__.py:2021
 msgid ""
 "Failed to connect to authentication server\n"
 "Check your Internet connection and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2023
+#: ../../uaclient/messages/__init__.py:2028
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2029
+#: ../../uaclient/messages/__init__.py:2034
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2038
+#: ../../uaclient/messages/__init__.py:2043
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2045
+#: ../../uaclient/messages/__init__.py:2050
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2052
+#: ../../uaclient/messages/__init__.py:2057
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2057
+#: ../../uaclient/messages/__init__.py:2062
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2063
+#: ../../uaclient/messages/__init__.py:2068
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2680,7 +2685,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2073
+#: ../../uaclient/messages/__init__.py:2078
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2688,7 +2693,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2083
+#: ../../uaclient/messages/__init__.py:2088
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2696,41 +2701,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2093
+#: ../../uaclient/messages/__init__.py:2098
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2100
+#: ../../uaclient/messages/__init__.py:2105
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2106
+#: ../../uaclient/messages/__init__.py:2111
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2112
+#: ../../uaclient/messages/__init__.py:2117
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2117
+#: ../../uaclient/messages/__init__.py:2122
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2123
+#: ../../uaclient/messages/__init__.py:2128
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2131
+#: ../../uaclient/messages/__init__.py:2136
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2140
+#: ../../uaclient/messages/__init__.py:2145
 #, python-brace-format
 msgid ""
 "To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
@@ -2738,59 +2743,59 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2156
+#: ../../uaclient/messages/__init__.py:2161
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2161
+#: ../../uaclient/messages/__init__.py:2166
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2167
+#: ../../uaclient/messages/__init__.py:2172
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2175
+#: ../../uaclient/messages/__init__.py:2180
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2183
+#: ../../uaclient/messages/__init__.py:2188
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2190
+#: ../../uaclient/messages/__init__.py:2195
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2197
+#: ../../uaclient/messages/__init__.py:2202
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2206
+#: ../../uaclient/messages/__init__.py:2211
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2210
+#: ../../uaclient/messages/__init__.py:2215
 #, python-brace-format
 msgid ""
 "Error on Pro Image:\n"
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2216
+#: ../../uaclient/messages/__init__.py:2221
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2223
+#: ../../uaclient/messages/__init__.py:2228
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -2798,41 +2803,41 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2233
+#: ../../uaclient/messages/__init__.py:2238
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2240
+#: ../../uaclient/messages/__init__.py:2245
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2248
+#: ../../uaclient/messages/__init__.py:2253
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2257
+#: ../../uaclient/messages/__init__.py:2262
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2265
+#: ../../uaclient/messages/__init__.py:2270
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2271
+#: ../../uaclient/messages/__init__.py:2276
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2279
+#: ../../uaclient/messages/__init__.py:2284
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -2840,7 +2845,7 @@ msgid ""
 "and the VERSION_CODENAME information is not present"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2289
+#: ../../uaclient/messages/__init__.py:2294
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -2849,189 +2854,189 @@ msgid ""
 "$ sudo rm {lock_file_path}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2298
+#: ../../uaclient/messages/__init__.py:2303
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2304
+#: ../../uaclient/messages/__init__.py:2309
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
 "Expected {expected_value}, found {value}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2313
+#: ../../uaclient/messages/__init__.py:2318
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2320
+#: ../../uaclient/messages/__init__.py:2325
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2325
+#: ../../uaclient/messages/__init__.py:2330
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2331
+#: ../../uaclient/messages/__init__.py:2336
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
 "Cancelling config process operation.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2341
-msgid "Can't load the distro-info database."
-msgstr ""
-
 #: ../../uaclient/messages/__init__.py:2346
-#, python-brace-format
-msgid "Can't find series {series} in the distro-info database."
+msgid "Can't load the distro-info database."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:2351
 #, python-brace-format
+msgid "Can't find series {series} in the distro-info database."
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:2356
+#, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2355
+#: ../../uaclient/messages/__init__.py:2360
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2361
+#: ../../uaclient/messages/__init__.py:2366
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
 "Usage: \"pro fix CVE-yyyy-nnnn\" or \"pro fix USN-nnnn\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2367
+#: ../../uaclient/messages/__init__.py:2372
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2372
+#: ../../uaclient/messages/__init__.py:2377
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2376
+#: ../../uaclient/messages/__init__.py:2381
 msgid "Unable to process uaclient.conf"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2381
+#: ../../uaclient/messages/__init__.py:2386
 msgid "Unable to refresh your subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2386
+#: ../../uaclient/messages/__init__.py:2391
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2392
+#: ../../uaclient/messages/__init__.py:2397
 msgid "json formatted response requires --assume-yes flag."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2400
+#: ../../uaclient/messages/__init__.py:2405
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
 "    "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2409
+#: ../../uaclient/messages/__init__.py:2414
 msgid "Cannot provide both --args and --data at the same time"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2420
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2424
+#: ../../uaclient/messages/__init__.py:2429
 msgid "This command must be run as root (try using sudo)."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2429
+#: ../../uaclient/messages/__init__.py:2434
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2436
+#: ../../uaclient/messages/__init__.py:2441
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2440
+#: ../../uaclient/messages/__init__.py:2445
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2445
+#: ../../uaclient/messages/__init__.py:2450
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2450
+#: ../../uaclient/messages/__init__.py:2455
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2455
+#: ../../uaclient/messages/__init__.py:2460
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2460
+#: ../../uaclient/messages/__init__.py:2465
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
 "{data}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2465
+#: ../../uaclient/messages/__init__.py:2470
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2470
+#: ../../uaclient/messages/__init__.py:2475
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2475
+#: ../../uaclient/messages/__init__.py:2480
 msgid "features.disable_auto_attach set in config"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2480
+#: ../../uaclient/messages/__init__.py:2485
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2486
+#: ../../uaclient/messages/__init__.py:2491
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2492
+#: ../../uaclient/messages/__init__.py:2497
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2498
+#: ../../uaclient/messages/__init__.py:2503
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2505
+#: ../../uaclient/messages/__init__.py:2510
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -857,3 +857,164 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | bionic  |
            | focal   |
            | jammy   |
+
+    @series.lts
+    @uses.config.machine_type.lxd-container
+    Scenario Outline: Disable with purge does not work with assume-yes
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I verify that running `pro disable esm-apps --assume-yes --purge` `with sudo` exits `1`
+        Then stderr contains substring:
+        """
+        Error: Cannot use --purge together with --assume-yes.
+        """
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |
+           | jammy   |
+
+    @series.lts
+    @uses.config.machine_type.lxd-container
+    Scenario Outline: Disable with purge works and purges repo services not involving a kernel
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `apt update` with sudo
+        And I apt install `ansible`
+        And I run `pro disable esm-apps --purge` `with sudo` and stdin `y`
+        Then stdout matches regexp:
+        """
+        \(The --purge flag is still experimental - use at your own discretion\)
+
+        The following package\(s\) will be reinstalled from the archive:
+        .*ansible.*
+
+        Do you want to proceed\? \(y/N\)
+        """
+        When I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        esm-apps   +yes   +disabled   +Expanded Security Maintenance for Applications
+        """
+        And I verify that `ansible` is installed from apt source `http://archive.ubuntu.com/ubuntu <pocket>/universe`
+
+        Examples: ubuntu release
+           | release | pocket           |
+           # This ends up in GH #943 but maybe can be improved?
+           | xenial  | xenial-backports |
+           | bionic  | bionic-updates   |
+           | focal   | focal            |
+           | jammy   | jammy            |
+
+    @series.lts
+    @uses.config.machine_type.lxd-vm
+    Scenario Outline: Disable with purge unsupported services
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I verify that running `pro disable livepatch --purge` `with sudo` exits `1`
+        Then I will see the following on stdout:
+        """
+        Livepatch does not support being disabled with --purge
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |
+           | jammy   |
+
+    @slow
+    @series.lts
+    @uses.config.machine_type.lxd-vm
+    Scenario Outline: Disable and purge fips
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `apt update` with sudo
+        And I run `pro enable <fips-service> --assume-yes` with sudo
+        And I reboot the machine
+        And I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        <fips-service>   +yes   +enabled
+        """
+        When  I run `uname -r` as non-root
+        Then stdout matches regexp:
+        """
+        fips
+        """
+        And I verify that `openssh-server` is installed from apt source `<fips-source>`
+        And I verify that `linux-fips` is installed from apt source `<fips-source>`
+        When I run `pro disable <fips-service> --purge` `with sudo` and stdin `y\ny`
+        Then stdout matches regexp:
+        """
+        \(The --purge flag is still experimental - use at your own discretion\)
+
+        Purging the <fips-name> packages would uninstall the following kernel\(s\):
+        .*
+        .* is the current running kernel\.
+        If you cannot guarantee that other kernels in this system are bootable and
+        working properly, \*do not proceed\*\. You may end up with an unbootable system\.
+        Do you want to proceed\? \(y/N\)
+        """
+        And stdout matches regexp:
+        """
+        The following package\(s\) will be REMOVED:
+        (.|\n)+
+
+        The following package\(s\) will be reinstalled from the archive:
+        (.|\n)+
+
+        Do you want to proceed\? \(y/N\)
+        """
+        When I reboot the machine
+        And I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        <fips-service>   +yes   +disabled
+        """
+        When  I run `uname -r` as non-root
+        Then stdout does not match regexp:
+        """
+        fips
+        """
+        And I verify that `openssh-server` is installed from apt source `<archive-source>`
+        And I verify that `linux-fips` is not installed
+        Examples: ubuntu release
+           | release | fips-service | fips-name    | fips-source                                                    | archive-source                                                 |
+           | xenial  | fips         | FIPS         | https://esm.ubuntu.com/fips/ubuntu xenial/main                 | https://esm.ubuntu.com/infra/ubuntu xenial-infra-security/main |
+           | xenial  | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu xenial-updates/main | https://esm.ubuntu.com/infra/ubuntu xenial-infra-security/main |
+           | bionic  | fips         | FIPS         | https://esm.ubuntu.com/fips/ubuntu bionic/main                 | https://esm.ubuntu.com/infra/ubuntu bionic-infra-security/main |
+           | bionic  | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu bionic-updates/main | https://esm.ubuntu.com/infra/ubuntu bionic-infra-security/main |
+           | focal   | fips         | FIPS         | https://esm.ubuntu.com/fips/ubuntu focal/main                  | http://archive.ubuntu.com/ubuntu focal-updates/main            |
+           | focal   | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main  | http://archive.ubuntu.com/ubuntu focal-updates/main            |
+
+    @slow
+    @series.lts
+    @uses.config.machine_type.lxd-vm
+    Scenario Outline: Disable does not purge if no other kernel found
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `apt update` with sudo
+        And I run `pro enable fips --assume-yes` with sudo
+        And I reboot the machine
+        And I run shell command `rm -rf $(find /boot -name 'vmlinuz*[^fips]')` with sudo
+        And I verify that running `pro disable fips --purge` `with sudo` exits `1`
+        Then stdout matches regexp:
+        """
+        \(The --purge flag is still experimental - use at your own discretion\)
+
+        Purging the FIPS packages would uninstall the following kernel\(s\):
+        .*
+        .* is the current running kernel\.
+        No other valid Ubuntu kernel was found in the system\.
+        Removing the package would potentially make the system unbootable\.
+        Aborting\.
+        """
+
+        Examples: ubuntu release
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |

--- a/features/steps/packages.py
+++ b/features/steps/packages.py
@@ -57,6 +57,16 @@ def verify_installed_packages_match_version_regexp(context, packages, regex):
         )
 
 
+@then("I verify that `{package}` is not installed")
+def verify_package_not_installed(context, package):
+    when_i_run_command(
+        context, "apt-cache policy {}".format(package), "as non-root"
+    )
+    assert_that(
+        context.process.stdout.strip(), contains_string("Installed: (none)")
+    )
+
+
 @then("I verify that `{package}` is installed from apt source `{apt_source}`")
 def verify_package_is_installed_from_apt_source(context, package, apt_source):
     when_i_run_command(

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -453,22 +453,20 @@ def get_installed_packages_by_origin(origin: str) -> List[apt_pkg.Package]:
     return list(result)
 
 
-def get_alternative_versions_for_package(
+def get_remote_versions_for_package(
     package: apt_pkg.Package, exclude_origin: Optional[str] = None
 ) -> List[apt_pkg.Version]:
-    alternative_versions = [
-        version
-        for version in package.version_list
-        if version != package.current_ver
-    ]
-    if exclude_origin:
-        for version in alternative_versions:
-            for file, _ in version.file_list:
-                if file.origin == exclude_origin:
-                    alternative_versions.remove(version)
-                    break
+    valid_versions = []
+    for version in package.version_list:
+        valid_origins = [
+            file
+            for file, _ in version.file_list
+            if file.component != "now" and file.origin != exclude_origin
+        ]
+        if valid_origins:
+            valid_versions.append(version)
 
-    return alternative_versions
+    return valid_versions
 
 
 def add_auth_apt_repo(

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -407,7 +407,8 @@ def update_sources_list(sources_list_path: str):
         try:
             with lock:
                 cache.update(fetch_progress, sources_list, 0)
-        except apt_pkg.Error:
+        # No apt_pkg.Error on Xenial
+        except getattr(apt_pkg, "Error", ()):
             raise exceptions.APTProcessConflictError()
         except SystemError as e:
             raise exceptions.APTUpdateFailed(detail=str(e))
@@ -873,7 +874,7 @@ def update_esm_caches(cfg) -> None:
         fetch_progress = EsmAcquireProgress()
         try:
             cache.update(fetch_progress, sources_list, 0)
-        except (apt_pkg.Error, SystemError) as e:
+        except (SystemError) as e:
             LOG.warning("Failed to fetch the ESM Apt Cache: {}".format(str(e)))
 
 

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -58,6 +58,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     # Whether the entitlement supports the --access-only flag
     supports_access_only = False
 
+    # Whether the entitlement supports the --purge flag
+    supports_purge = False
+
     # Help text for the entitlement
     help_text = ""
 
@@ -789,6 +792,17 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                         CanDisableFailureReason.ACTIVE_DEPENDENT_SERVICES
                     ),
                 )
+
+        if not self.supports_purge and self.purge:
+            return (
+                False,
+                CanDisableFailure(
+                    CanDisableFailureReason.PURGE_NOT_SUPPORTED,
+                    messages.DISABLE_PURGE_NOT_SUPPORTED.format(
+                        title=self.title
+                    ),
+                ),
+            )
 
         return True, None
 

--- a/uaclient/entitlements/entitlement_status.py
+++ b/uaclient/entitlements/entitlement_status.py
@@ -117,6 +117,7 @@ class CanDisableFailureReason(enum.Enum):
 
     ALREADY_DISABLED = object()
     ACTIVE_DEPENDENT_SERVICES = object()
+    PURGE_NOT_SUPPORTED = object()
     NOT_FOUND_DEPENDENT_SERVICE = object()
     NO_PURGE_WITHOUT_ORIGIN = object()
 

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -21,6 +21,7 @@ class RealtimeKernelEntitlement(repo.RepoEntitlement):
     repo_key_file = "ubuntu-pro-realtime-kernel.gpg"
     apt_noninteractive = True
     supports_access_only = True
+    supports_purge = False
     origin = "UbuntuRealtimeKernel"
 
     def _check_for_reboot(self) -> bool:

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -43,6 +43,9 @@ class RepoEntitlement(base.UAEntitlement):
     # the service is enabled or not
     check_packages_are_installed = False
 
+    # RepoEntitlements can be purged, unless specifically stated
+    supports_purge = True
+
     # Optional repo pin priority in subclass
     @property
     def repo_pin_priority(self) -> Union[int, str, None]:

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -137,7 +137,7 @@ class RepoEntitlement(base.UAEntitlement):
             packages_to_reinstall = []
             packages_to_remove = []
             for package in repo_origin_packages:
-                alternatives = apt.get_alternative_versions_for_package(
+                alternatives = apt.get_remote_versions_for_package(
                     package, exclude_origin=self.origin
                 )
                 if alternatives:

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -650,7 +650,7 @@ class TestPerformEnable:
 class TestPerformDisable:
     @pytest.mark.parametrize("purge_value", (True, False))
     @mock.patch(M_PATH + "apt.get_installed_packages_by_origin")
-    @mock.patch(M_PATH + "apt.get_alternative_versions_for_package")
+    @mock.patch(M_PATH + "apt.get_remote_versions_for_package")
     @mock.patch(M_PATH + "RepoEntitlement.prompt_for_purge")
     @mock.patch(M_PATH + "RepoEntitlement.execute_purge")
     @mock.patch(M_PATH + "RepoEntitlement.remove_apt_config")
@@ -659,19 +659,19 @@ class TestPerformDisable:
         m_remove_apt_config,
         m_execute_purge,
         m_prompt_for_purge,
-        m_get_alternative_versions,
+        m_get_remote_versions,
         m_get_installed_packages,
         purge_value,
         entitlement_factory,
     ):
         m_get_installed_packages.return_value = [1, 2, 3, 4, 5]
 
-        def return_alternatives(p, exclude_origins):
+        def return_alternatives(p, _exclude_origins):
             if p % 2:
                 return [p]
             return []
 
-        m_get_alternative_versions.side_effect = return_alternatives
+        m_get_remote_versions.side_effect = return_alternatives
 
         with mock.patch.object(RepoTestEntitlement, "origin", "TestOrigin"):
             entitlement = entitlement_factory(
@@ -688,7 +688,7 @@ class TestPerformDisable:
                 m_get_installed_packages.call_args_list = [
                     mock.call("TestOrigin")
                 ]
-                m_get_alternative_versions.call_args_list = [
+                m_get_remote_versions.call_args_list = [
                     mock.call(1, exclude_origin="TestOrigin"),
                     mock.call(2, exclude_origin="TestOrigin"),
                     mock.call(3, exclude_origin="TestOrigin"),
@@ -703,7 +703,7 @@ class TestPerformDisable:
                 ]
             else:
                 m_get_installed_packages.call_args_list = []
-                m_get_alternative_versions.call_args_list = []
+                m_get_remote_versions.call_args_list = []
                 m_prompt_for_purge.call_args_list = []
                 m_execute_purge.call_args_list = []
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1579,6 +1579,11 @@ ENABLE_ACCESS_ONLY_NOT_SUPPORTED = FormattedNamedMessage(
     msg=t.gettext("{title} does not support being enabled with --access-only"),
 )
 
+DISABLE_PURGE_NOT_SUPPORTED = FormattedNamedMessage(
+    name="disable-purge-not-supported",
+    msg=t.gettext("{title} does not support being disabled with --purge"),
+)
+
 FAILED_DISABLING_DEPENDENT_SERVICE = FormattedNamedMessage(
     "failed-disabling-dependent-service",
     t.gettext(

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -28,13 +28,13 @@ from uaclient.apt import (
     assert_valid_apt_credentials,
     clean_apt_files,
     find_apt_list_files,
-    get_alternative_versions_for_package,
     get_apt_cache_policy,
     get_apt_cache_time,
     get_apt_config_values,
     get_installed_packages_by_origin,
     get_installed_packages_names,
     get_pkg_candidate_version,
+    get_remote_versions_for_package,
     is_installed,
     remove_apt_list_files,
     remove_auth_apt_repo,
@@ -1405,12 +1405,12 @@ class TestGetInstalledPackagesByOrigin:
         )
 
 
-class TestGetAlternativeVersionsForPackage:
-    def test_get_alternative_versions_for_package(self):
+class TestGetRemoteVersionsForPackage:
+    def test_get_remote_versions_for_package(self):
         assert ["0.9", "1.1"] == [
             v.ver_str
             for v in sorted(
-                get_alternative_versions_for_package(
+                get_remote_versions_for_package(
                     mock_package(
                         "name",
                         installed_version=mock_version("1.0"),
@@ -1427,16 +1427,16 @@ class TestGetAlternativeVersionsForPackage:
             )
         ]
 
-    def test_no_alternative_versions(self):
-        assert [] == get_alternative_versions_for_package(
+    def test_no_remote_versions(self):
+        assert [] == get_remote_versions_for_package(
             mock_package("name", installed_version=mock_version("1.0"))
         )
 
-    def test_get_alternative_versions_excluding_origin(self):
+    def test_get_remote_versions_excluding_origin(self):
         assert ["0.9"] == [
             v.ver_str
             for v in sorted(
-                get_alternative_versions_for_package(
+                get_remote_versions_for_package(
                     mock_package(
                         "name",
                         installed_version=mock_version("1.0"),


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it brings integration testing to the `disable --purge` feature, and fixes some things here and there which were not working out:
- improve on how to look for alternative package versions, considering multi-origin and keeping installed versions when feasible
- not relying on apt_pkg.Error all the time (thanks Xenial support we love it)
- defining that some services just can't be purged

## Test Steps
This is mainly about adding integration tests so it is straightforward - run the new behave stuff

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
