### PR TITLE
PRO security isolation: apt_news

### DIFF
--- a/apport/source_ubuntu-advantage-tools.py
+++ b/apport/source_ubuntu-advantage-tools.py
@@ -3,7 +3,7 @@ import tempfile
 
 from apport.hookutils import attach_file_if_exists
 from uaclient import defaults
-from uaclient.actions import collect_logs
+from uaclient.actions import collect_logs, APPARMOR_PROFILES
 from uaclient.config import UAConfig
 
 
@@ -11,6 +11,7 @@ def add_info(report, ui=None):
     report["LaunchpadPrivate"] = "1"
     report["LaunchpadSubscribe"] = "ua-client"
     cfg = UAConfig()
+    apparmor_files = [os.path.basename(f) for f in APPARMOR_PROFILES]
     with tempfile.TemporaryDirectory() as output_dir:
         collect_logs(cfg, output_dir)
         auto_include_log_files = {
@@ -21,6 +22,8 @@ def add_info(report, ui=None):
             "livepatch-status.txt",
             "livepatch-status.txt-error",
             "pro-journal.txt",
+            "apparmor_logs.txt",
+            *apparmor_files,
             os.path.basename(cfg.cfg_path),
             os.path.basename(cfg.log_file),
             os.path.basename(cfg.data_path("jobs-status")),

--- a/debian/apparmor/ubuntu_advantage_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_advantage_apt_news.jinja2
@@ -1,0 +1,51 @@
+{% if ubuntu_codename not in ["xenial", "bionic", "focal"] %}
+abi <abi/3.0>,
+{% endif %}
+include <tunables/global>
+
+profile ubuntu_advantage_apt_news flags=(attach_disconnected) {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+  include <abstractions/openssl>
+  include <abstractions/python>
+
+  # Needed because apt-news calls apt_pkg.init() which tries to
+  # switch to the _apt system user/group.
+  capability setgid,
+  capability setuid,
+  capability dac_read_search,
+
+  /etc/apt/** r,
+  /etc/default/apport r,
+  /etc/ubuntu-advantage/* r,
+  /usr/bin/python3.{1,}[0-9] mrix,
+{% if ubuntu_codename in ["focal"] %}
+  # "import uuid" in focal triggers an uname call
+  /usr/bin/uname mrix,
+{% endif %}
+  /usr/lib/apt/methods/http mrix,
+  /usr/lib/apt/methods/https mrix,
+  /usr/lib/ubuntu-advantage/apt_news.py r,
+  /usr/share/dpkg/* r,
+  /var/log/ubuntu-advantage.log rw,
+  /var/lib/ubuntu-advantage/** r,
+  /var/lib/ubuntu-advantage/messages/ rw,
+  /var/lib/ubuntu-advantage/messages/* rw,
+  /run/ubuntu-advantage/ rw,
+  /run/ubuntu-advantage/* rw,
+
+  /tmp/** r,
+
+  owner @{PROC}/@{pid}/fd/ r,
+  @{PROC}/@{pid}/cgroup r,
+{% if ubuntu_codename in ["bionic", "xenial"] %}
+  # see https://bugs.python.org/issue40501
+  /sbin/ldconfig rix,
+  /sbin/ldconfig.real rix,
+  @{PROC}/@{pid}/mounts r,
+  /usr/bin/@{multiarch}-gcc-* rix,
+  /usr/bin/@{multiarch}-ld.bfd rix,
+  /usr/lib/gcc/@{multiarch}/*/collect2 rix,
+  /usr/bin/@{multiarch}-objdump rix,
+{% endif %}
+}

--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -48,5 +48,16 @@ profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   /usr/bin/@{multiarch}-ld.bfd rix,
   /usr/lib/gcc/@{multiarch}/*/collect2 rix,
   /usr/bin/@{multiarch}-objdump rix,
+
+  # for some reason, these are not needed in later ubuntu releases
+  capability chown,
+  capability fowner,
+  capability dac_override,
+
+  /etc/apt/auth.conf.d/90ubuntu-advantage rw,
+  /var/lib/apt/lists/partial/ rw,
+  /var/lib/apt/lists/partial/* rw,
+  /var/cache/apt/archives/partial/ rw,
+  /var/cache/apt/archives/partial/* rw,
 {% endif %}
 }

--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -43,6 +43,7 @@ profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   /sbin/ldconfig rix,
   /sbin/ldconfig.real rix,
   @{PROC}/@{pid}/mounts r,
+  @{PROC}/@{pid}/status r,
   /usr/bin/@{multiarch}-gcc-* rix,
   /usr/bin/@{multiarch}-ld.bfd rix,
   /usr/lib/gcc/@{multiarch}/*/collect2 rix,

--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -48,8 +48,9 @@ profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   /usr/bin/@{multiarch}-ld.bfd rix,
   /usr/lib/gcc/@{multiarch}/*/collect2 rix,
   /usr/bin/@{multiarch}-objdump rix,
-
-  # for some reason, these are not needed in later ubuntu releases
+{% endif %}
+{% if ubuntu_codename in ["xenial"] %}
+  # for some reason, these were just needed in xenial
   capability chown,
   capability fowner,
   capability dac_override,

--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -3,7 +3,7 @@ abi <abi/3.0>,
 {% endif %}
 include <tunables/global>
 
-profile ubuntu_advantage_apt_news flags=(attach_disconnected) {
+profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   include <abstractions/base>
   include <abstractions/nameservice>
   include <abstractions/openssl>

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends: bash-completion,
                debianutils (>= 4.7),
                dh-python,
                dh-apparmor,
+               apparmor,
 # After debhelper 13.3 we no longer need dh-systemd.
 # On hirsute and later, dh-systemd doesn't even exist.
 # On recent releases, the first alternative will be used.

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends: bash-completion,
                debhelper (>=9),
                debianutils (>= 4.7),
                dh-python,
+               dh-apparmor,
 # After debhelper 13.3 we no longer need dh-systemd.
 # On hirsute and later, dh-systemd doesn't even exist.
 # On recent releases, the first alternative will be used.
@@ -21,6 +22,7 @@ Build-Depends: bash-completion,
                po-debconf,
                python3 (>= 3.4),
                python3-flake8,
+               python3-jinja2,
                python3-mock,
                python3-pytest,
                python3-setuptools,

--- a/debian/jinja2_render
+++ b/debian/jinja2_render
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+import sys
+
+from jinja2 import Template
+
+input_file = sys.argv[1]
+output_file = sys.argv[2]
+kwargs = {}
+
+# key=value pairs in the command-line
+if len(sys.argv) > 3:
+    kwargs = {arg.split("=")[0]:arg.split("=")[1] for arg in sys.argv[3:]}
+
+t = Template(open(input_file, "r").read())
+output = t.render(**kwargs)
+
+with open(output_file, "w") as f:
+    f.write(output)
+

--- a/debian/rules
+++ b/debian/rules
@@ -63,6 +63,10 @@ override_dh_systemd_start:
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
+	debian/jinja2_render debian/apparmor/ubuntu_advantage_apt_news.jinja2 debian/apparmor/ubuntu_advantage_apt_news ubuntu_codename=${UBUNTU_CODENAME}
+	install -D -m 644 $(CURDIR)/debian/apparmor/ubuntu_advantage_apt_news $(CURDIR)/debian/ubuntu-advantage-tools/etc/apparmor.d/ubuntu_advantage_apt_news
+	dh_apparmor -pubuntu-advantage-tools --profile-name=ubuntu_advantage_apt_news
+
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}
 
 	# We install the conf file even on non-LTS version to avoid issues on upgrade scenarios
@@ -86,3 +90,4 @@ endif
 override_dh_auto_clean:
 	dh_auto_clean
 	make clean
+	rm -f debian/apparmor/ubuntu_advantage_apt_news

--- a/debian/rules
+++ b/debian/rules
@@ -64,6 +64,8 @@ override_dh_systemd_start:
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
 	debian/jinja2_render debian/apparmor/ubuntu_advantage_apt_news.jinja2 debian/apparmor/ubuntu_advantage_apt_news ubuntu_codename=${UBUNTU_CODENAME}
+	# quick syntax check on the generated profile
+	apparmor_parser -K -T -Q debian/apparmor/ubuntu_advantage_apt_news
 	install -D -m 644 $(CURDIR)/debian/apparmor/ubuntu_advantage_apt_news $(CURDIR)/debian/ubuntu-advantage-tools/etc/apparmor.d/ubuntu_advantage_apt_news
 	dh_apparmor -pubuntu-advantage-tools --profile-name=ubuntu_advantage_apt_news
 

--- a/debian/rules
+++ b/debian/rules
@@ -63,11 +63,11 @@ override_dh_systemd_start:
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
-	debian/jinja2_render debian/apparmor/ubuntu_advantage_apt_news.jinja2 debian/apparmor/ubuntu_advantage_apt_news ubuntu_codename=${UBUNTU_CODENAME}
+	debian/jinja2_render debian/apparmor/ubuntu_pro_apt_news.jinja2 debian/apparmor/ubuntu_pro_apt_news ubuntu_codename=${UBUNTU_CODENAME}
 	# quick syntax check on the generated profile
-	apparmor_parser -K -T -Q debian/apparmor/ubuntu_advantage_apt_news
-	install -D -m 644 $(CURDIR)/debian/apparmor/ubuntu_advantage_apt_news $(CURDIR)/debian/ubuntu-advantage-tools/etc/apparmor.d/ubuntu_advantage_apt_news
-	dh_apparmor -pubuntu-advantage-tools --profile-name=ubuntu_advantage_apt_news
+	apparmor_parser -K -T -Q debian/apparmor/ubuntu_pro_apt_news
+	install -D -m 644 $(CURDIR)/debian/apparmor/ubuntu_pro_apt_news $(CURDIR)/debian/ubuntu-advantage-tools/etc/apparmor.d/ubuntu_pro_apt_news
+	dh_apparmor -pubuntu-advantage-tools --profile-name=ubuntu_pro_apt_news
 
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}
 
@@ -92,4 +92,4 @@ endif
 override_dh_auto_clean:
 	dh_auto_clean
 	make clean
-	rm -f debian/apparmor/ubuntu_advantage_apt_news
+	rm -f debian/apparmor/ubuntu_pro_apt_news

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -335,6 +335,8 @@ Feature: APT Messages
         When I run `rm -rf /var/lib/ubuntu-advantage/messages` with sudo
         When I run `rm /var/lib/apt/periodic/update-success-stamp` with sudo
         When I run `apt-get update` with sudo
+        # the apt-news.service unit runs in the background, give it some time to fetch the json file
+        When I wait `5` seconds
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """
@@ -567,6 +569,8 @@ Feature: APT Messages
         # test that apt update will trigger hook to update apt_news for local override
         When I run `rm -f /var/lib/apt/periodic/update-success-stamp` with sudo
         When I run `apt-get update` with sudo
+        # the apt-news.service unit runs in the background, give it some time to fetch the json file
+        When I wait `5` seconds
         When I run `apt upgrade` with sudo
         Then I will see the following on stdout
         """

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -638,7 +638,7 @@ Feature: APT Messages
         """
         "*Your Ubuntu Pro subscription has EXPIRED*\nRenew your subscription at https://ubuntu.com/pro/dashboard"
         """
-        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        When I create the file `/var/lib/ubuntu-advantage/machine-token-overlay.json` with the following:
         """
         {
             "machineTokenInfo": {

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -298,7 +298,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
     Scenario Outline: Attached status in a ubuntu machine with feature overrides
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        When I create the file `/var/lib/ubuntu-advantage/machine-token-overlay.json` with the following:
         """
         {
             "machineTokenInfo": {
@@ -316,7 +316,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         And I append the following on uaclient config:
         """
         features:
-          machine_token_overlay: "/tmp/machine-token-overlay.json"
+          machine_token_overlay: "/var/lib/ubuntu-advantage/machine-token-overlay.json"
           disable_auto_attach: true
           other: false
         """
@@ -332,7 +332,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
         FEATURES
         disable_auto_attach: True
-        machine_token_overlay: /tmp/machine-token-overlay.json
+        machine_token_overlay: /var/lib/ubuntu-advantage/machine-token-overlay.json
         other: False
         """
         When I run `pro status --all` as non-root
@@ -346,7 +346,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
         FEATURES
         disable_auto_attach: True
-        machine_token_overlay: /tmp/machine-token-overlay.json
+        machine_token_overlay: /var/lib/ubuntu-advantage/machine-token-overlay.json
         other: False
         """
         When I run `pro detach --assume-yes` with sudo
@@ -745,7 +745,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         Then I verify that `activityInfo.activityToken` value has been updated on the contract
         And I verify that `activityInfo.activityID` value has been updated on the contract
         # We are keeping this test to guarantee that the activityPingInterval is also updated
-        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        When I create the file `/var/lib/ubuntu-advantage/machine-token-overlay.json` with the following:
         """
         {
             "machineTokenInfo": {
@@ -756,7 +756,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
             }
         }
         """
-        And I create the file `/tmp/response-overlay.json` with the following:
+        And I create the file `/var/lib/ubuntu-advantage/response-overlay.json` with the following:
         """
         {
             "https://contracts.canonical.com/v1/contracts/testCID/machine-activity/testMID": [
@@ -773,8 +773,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         And I append the following on uaclient config:
         """
         features:
-          machine_token_overlay: "/tmp/machine-token-overlay.json"
-          serviceclient_url_responses: "/tmp/response-overlay.json"
+          machine_token_overlay: "/var/lib/ubuntu-advantage/machine-token-overlay.json"
+          serviceclient_url_responses: "/var/lib/ubuntu-advantage/response-overlay.json"
         """
         When I delete the file `/var/lib/ubuntu-advantage/jobs-status.json`
         And I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -81,7 +81,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         One moment, checking your subscription first
         Ubuntu Pro: ESM Infra is not available for Ubuntu .*
         """
-        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        When I create the file `/var/lib/ubuntu-advantage/machine-token-overlay.json` with the following:
         """
         {
             "machineTokenInfo": {

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -9,7 +9,7 @@ Feature: Attached status
         When I run `pro status --format yaml` as non-root
         Then stdout is a yaml matching the `ua_status` schema
 
-        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        When I create the file `/var/lib/ubuntu-advantage/machine-token-overlay.json` with the following:
         """
         {
             "machineTokenInfo": {
@@ -22,7 +22,7 @@ Feature: Attached status
         And I append the following on uaclient config:
         """
         features:
-          machine_token_overlay: "/tmp/machine-token-overlay.json"
+          machine_token_overlay: "/var/lib/ubuntu-advantage/machine-token-overlay.json"
         """
         And I run `pro status` with sudo
         Then stdout contains substring:

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -160,7 +160,7 @@ Feature: Pro supports multiple languages
         Then stdout is a json matching the `ua_status` schema
         When I run `pro status --format yaml` as non-root
         Then stdout is a yaml matching the `ua_status` schema
-        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        When I create the file `/var/lib/ubuntu-advantage/machine-token-overlay.json` with the following:
         """
         {
             "machineTokenInfo": {
@@ -173,7 +173,7 @@ Feature: Pro supports multiple languages
         And I append the following on uaclient config:
         """
         features:
-          machine_token_overlay: "/tmp/machine-token-overlay.json"
+          machine_token_overlay: "/var/lib/ubuntu-advantage/machine-token-overlay.json"
         """
         And I run `pro status` with sudo
         Then stdout contains substring:

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -119,7 +119,7 @@ Feature: MOTD Messages
         Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard
 
         """
-        When I create the file `/tmp/machine-token-overlay.json` with the following:
+        When I create the file `/var/lib/ubuntu-advantage/machine-token-overlay.json` with the following:
         """
         {
             "machineTokenInfo": {

--- a/features/steps/contract.py
+++ b/features/steps/contract.py
@@ -124,10 +124,13 @@ def when_i_set_the_machine_token_overlay(context):
         yaml.safe_load(context.text), cls=util.DatetimeAwareJSONEncoder
     )
     when_i_create_file_with_content(
-        context, "/tmp/machine-token-overlay.json", text=json_text
+        context,
+        "/var/lib/ubuntu-advantage/machine-token-overlay.json",
+        text=json_text,
     )
     change_config_key_to_use_value(
         context,
         "features",
-        "{ machine_token_overlay: /tmp/machine-token-overlay.json}",
+        "{ machine_token_overlay: "
+        "/var/lib/ubuntu-advantage/machine-token-overlay.json}",
     )

--- a/systemd/apt-news.service
+++ b/systemd/apt-news.service
@@ -14,3 +14,29 @@ Description=Update APT News
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/apt_news.py
+AppArmorProfile=ubuntu_advantage_apt_news
+CapabilityBoundingSet=~CAP_SYS_ADMIN
+CapabilityBoundingSet=~CAP_NET_ADMIN
+CapabilityBoundingSet=~CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=~CAP_SYS_PTRACE
+CapabilityBoundingSet=~CAP_NET_RAW
+PrivateTmp=true
+RestrictAddressFamilies=~AF_NETLINK
+RestrictAddressFamilies=~AF_PACKET
+# These may break some tests, and should be enabled carefully
+#NoNewPrivileges=true
+#PrivateDevices=true
+#ProtectControlGroups=true
+# ProtectHome=true seems to reliably break the GH integration test with a lunar lxd on jammy host
+#ProtectHome=true
+#ProtectKernelModules=true
+#ProtectKernelTunables=true
+#ProtectSystem=full
+#RestrictSUIDSGID=true
+# Unsupported in bionic
+# Suggestion from systemd.exec(5) manpage on SystemCallFilter
+#SystemCallFilter=@system-service
+#SystemCallFilter=~@mount
+#SystemCallErrorNumber=EPERM
+#ProtectClock=true
+#ProtectKernelLogs=true

--- a/systemd/apt-news.service
+++ b/systemd/apt-news.service
@@ -14,7 +14,7 @@ Description=Update APT News
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/apt_news.py
-AppArmorProfile=ubuntu_advantage_apt_news
+AppArmorProfile=ubuntu_pro_apt_news
 CapabilityBoundingSet=~CAP_SYS_ADMIN
 CapabilityBoundingSet=~CAP_NET_ADMIN
 CapabilityBoundingSet=~CAP_NET_BIND_SERVICE

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -20,10 +20,10 @@ from uaclient import system, timer, util
 from uaclient.clouds import AutoAttachCloudInstance  # noqa: F401
 from uaclient.clouds import identity
 from uaclient.defaults import (
+    APPARMOR_PROFILES,
     CLOUD_BUILD_INFO,
     DEFAULT_CONFIG_FILE,
     DEFAULT_LOG_PREFIX,
-    APPARMOR_PROFILES,
 )
 from uaclient.files.state_files import (
     AttachmentData,

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -23,6 +23,7 @@ from uaclient.defaults import (
     CLOUD_BUILD_INFO,
     DEFAULT_CONFIG_FILE,
     DEFAULT_LOG_PREFIX,
+    APPARMOR_PROFILES,
 )
 from uaclient.files.state_files import (
     AttachmentData,
@@ -45,11 +46,6 @@ UA_SERVICES = (
 )
 
 USER_LOG_COLLECTED_LIMIT = 10
-
-# XXX handle /etc/apparmor.d/local/<name>, which has the local admin overrides
-APPARMOR_PROFILES = [
-    "/etc/apparmor.d/ubuntu_pro_apt_news",
-]
 
 
 def attach_with_token(

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -295,9 +295,13 @@ def collect_logs(cfg: config.UAConfig, output_dir: str):
 
     # get apparmor logs
     # can't use journalctl's --grep, because xenial doesn't support it :/
-    kernel_logs, _ = system.subp(
-        ["journalctl", "-b", "-k", "--since=1 day ago"]
-    )
+    try:
+        kernel_logs, _ = system.subp(
+            ["journalctl", "-b", "-k", "--since=1 day ago"]
+        )
+    except exceptions.ProcessExecutionError as e:
+        LOG.warning("Failed to collect kernel logs:\n%s", str(e))
+        kernel_logs = None
     apparmor_logs = []
     if kernel_logs:
         # filter out only what interests us

--- a/uaclient/cli/tests/test_cli_collect_logs.py
+++ b/uaclient/cli/tests/test_cli_collect_logs.py
@@ -4,13 +4,13 @@ import textwrap
 import mock
 import pytest
 
-from uaclient.actions import APPARMOR_PROFILES
 from uaclient.cli import (
     action_collect_logs,
     collect_logs_parser,
     get_parser,
     main,
 )
+from uaclient.defaults import APPARMOR_PROFILES
 
 M_PATH = "uaclient.cli."
 

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -60,3 +60,8 @@ NOTICES_TEMPORARY_DIRECTORY = UAC_RUN_PATH + "notices/"
 USER_CACHE_SUBDIR = "ubuntu-pro"
 
 SSL_CERTS_PATH = "/etc/ssl/certs/ca-certificates.crt"
+
+# used by apport, collect-logs, and tests
+APPARMOR_PROFILES = [
+    "/etc/apparmor.d/ubuntu_pro_apt_news",
+]


### PR DESCRIPTION
## Why is this needed?
This is part of [JIRA SD-1277](https://warthogs.atlassian.net/browse/SD-1277) which aims to enable security features to existing Pro systemd services. The goal is to provide reasonable AppAmor and systemd security isolation configuration for the Pro systemd services.

There are multiple services to be tackled, and this PR is about apt-news.service, and tracked via [JIRA SD-1450](https://warthogs.atlassian.net/browse/SD-1450)

## Test Steps
This change relies mostly on the integration tests, but it can also be superficially tested manually.

Install `ubuntu-advantage-tools`, and run `apt-get update`.. Observe `dmesg -wT` and confirm there are no apparmor DENIED messages tied to the profile `ubuntu_advantage_apt_news`, and that the apt-news service performs normally.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: https://github.com/canonical/ubuntu-pro-client/pull/2906

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No

Unsure, thinking.

