### PR TITLE
tests: behave-any anywhere

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -66,21 +66,21 @@ jobs:
       fail-fast: false
       matrix:
         release: ['bionic', 'focal', 'jammy', 'lunar']
-        platform: ['lxd']
+        platform: ['lxd-container']
         host_os: ['ubuntu-22.04']
         include:
           # xenial lxd containers dont work on hosts >20.04
           - release: xenial
-            platform: lxd
+            platform: lxd-container
             host_os: ubuntu-20.04
           - release: bionic
-            platform: awspro
+            platform: aws.pro
             host_os: ubuntu-22.04
           - release: bionic
-            platform: gcppro
+            platform: gcp.pro
             host_os: ubuntu-22.04
           - release: bionic
-            platform: awspro-fips
+            platform: aws.pro-fips
             host_os: ubuntu-22.04
     steps:
       - name: Prepare test tools
@@ -93,14 +93,14 @@ jobs:
           # https://linuxcontainers.org/lxd/docs/master/howto/network_bridge_firewalld/#prevent-issues-with-lxd-and-docker
           sudo iptables -I DOCKER-USER -j ACCEPT
       - name: Refresh LXD
-        if: matrix.platform == 'lxd' || matrix.platform == 'vm'
+        if: matrix.platform == 'lxd-container' || matrix.platform == 'lxd-vm'
         run: sudo snap refresh --channel latest/stable lxd
       - name: Initialize LXD
-        if: matrix.platform == 'lxd' || matrix.platform == 'vm'
+        if: matrix.platform == 'lxd-container' || matrix.platform == 'lxd-vm'
         run: sudo lxd init --auto
       - name: Git checkout
         uses: actions/checkout@v3
-      - name: Retieve debs
+      - name: Retrieve debs
         uses: actions/download-artifact@v3
         with:
           name: 'ci-debs-${{ matrix.release }}'
@@ -144,8 +144,7 @@ jobs:
           sh -c 'printf "%s\n" "$SSH_PRIVATE_KEY" > ~/.ssh/cloudinit_id_rsa'
           sh -c 'printf "%s\n" "$SSH_PUBLIC_KEY" > ~/.ssh/cloudinit_id_rsa.pub'
 
-          uversion=$(ubuntu-distro-info --series='${{ matrix.release }}' --release | cut -d' ' -f1)
-          sg lxd -c "tox -e 'behave-${{ matrix.platform }}-$uversion' -- --tags=-slow"
+          sg lxd -c "tox -e behave -- -D machine_types=${{ matrix.platform }} -D releases=${{ matrix.release }} --tags=-slow --tags=-upgrade"
       - name: Archive test artifacts
         if: always()
         uses: actions/upload-artifact@v3

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -2,6 +2,7 @@ Feature: Pro is expected version
 
     @series.all
     @uses.config.check_version
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.machine_type.lxd-vm
     @uses.config.machine_type.aws.generic
@@ -14,7 +15,7 @@ Feature: Pro is expected version
     @uses.config.machine_type.gcp.pro
     @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check pro version
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `dpkg-query --showformat='${Version}' --show ubuntu-advantage-tools` with sudo
         Then I will see the following on stdout
         """
@@ -34,20 +35,81 @@ Feature: Pro is expected version
         THIS GETS REPLACED AT RUNTIME VIA A HACK IN steps/ubuntu_advantage_tools.py
         """
         Examples: version
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
-            | jammy   |
-            | lunar   |
-            | mantic  |
+            | release | machine_type   |
+            | xenial  | lxd-container  |
+            | xenial  | lxd-vm         |
+            | xenial  | aws.generic    |
+            | xenial  | aws.pro        |
+            | xenial  | aws.pro-fips   |
+            | xenial  | azure.generic  |
+            | xenial  | azure.pro      |
+            | xenial  | azure.pro-fips |
+            | xenial  | gcp.generic    |
+            | xenial  | gcp.pro        |
+            | xenial  | gcp.pro-fips   |
+            | bionic  | lxd-container  |
+            | bionic  | lxd-vm         |
+            | bionic  | aws.generic    |
+            | bionic  | aws.pro        |
+            | bionic  | aws.pro-fips   |
+            | bionic  | azure.generic  |
+            | bionic  | azure.pro      |
+            | bionic  | azure.pro-fips |
+            | bionic  | gcp.generic    |
+            | bionic  | gcp.pro        |
+            | bionic  | gcp.pro-fips   |
+            | focal   | lxd-container  |
+            | focal   | lxd-vm         |
+            | focal   | aws.generic    |
+            | focal   | aws.pro        |
+            | focal   | aws.pro-fips   |
+            | focal   | azure.generic  |
+            | focal   | azure.pro      |
+            | focal   | azure.pro-fips |
+            | focal   | gcp.generic    |
+            | focal   | gcp.pro        |
+            | focal   | gcp.pro-fips   |
+            | jammy   | lxd-container  |
+            | jammy   | lxd-vm         |
+            | jammy   | aws.generic    |
+            | jammy   | aws.pro        |
+            | jammy   | aws.pro-fips   |
+            | jammy   | azure.generic  |
+            | jammy   | azure.pro      |
+            | jammy   | azure.pro-fips |
+            | jammy   | gcp.generic    |
+            | jammy   | gcp.pro        |
+            | jammy   | gcp.pro-fips   |
+            | lunar   | lxd-container  |
+            | lunar   | lxd-vm         |
+            | lunar   | aws.generic    |
+            | lunar   | aws.pro        |
+            | lunar   | aws.pro-fips   |
+            | lunar   | azure.generic  |
+            | lunar   | azure.pro      |
+            | lunar   | azure.pro-fips |
+            | lunar   | gcp.generic    |
+            | lunar   | gcp.pro        |
+            | lunar   | gcp.pro-fips   |
+            | mantic  | lxd-container  |
+            | mantic  | lxd-vm         |
+            | mantic  | aws.generic    |
+            | mantic  | aws.pro        |
+            | mantic  | aws.pro-fips   |
+            | mantic  | azure.generic  |
+            | mantic  | azure.pro      |
+            | mantic  | azure.pro-fips |
+            | mantic  | gcp.generic    |
+            | mantic  | gcp.pro        |
+            | mantic  | gcp.pro-fips   |
 
     @series.all
     @uses.config.check_version
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @upgrade
     Scenario Outline: Check pro version
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `dpkg-query --showformat='${Version}' --show ubuntu-advantage-tools` with sudo
         Then I will see the following on stdout
         """
@@ -67,10 +129,10 @@ Feature: Pro is expected version
         THIS GETS REPLACED AT RUNTIME VIA A HACK IN steps/ubuntu_advantage_tools.py
         """
         Examples: version
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
-            | jammy   |
-            | lunar   |
-            | mantic  |
+            | release | machine_type  |
+            | xenial  | lxd-container |
+            | bionic  | lxd-container |
+            | focal   | lxd-container |
+            | jammy   | lxd-container |
+            | lunar   | lxd-container |
+            | mantic  | lxd-container |

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -1,6 +1,5 @@
 Feature: Pro is expected version
 
-    @series.all
     @uses.config.check_version
     Scenario Outline: Check pro version
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -91,7 +90,6 @@ Feature: Pro is expected version
             | mantic  | gcp.pro        |
             | mantic  | gcp.pro-fips   |
 
-    @series.all
     @uses.config.check_version
     @upgrade
     Scenario Outline: Check pro version

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -2,18 +2,6 @@ Feature: Pro is expected version
 
     @series.all
     @uses.config.check_version
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
-    @uses.config.machine_type.lxd-vm
-    @uses.config.machine_type.aws.generic
-    @uses.config.machine_type.aws.pro
-    @uses.config.machine_type.aws.pro-fips
-    @uses.config.machine_type.azure.generic
-    @uses.config.machine_type.azure.pro
-    @uses.config.machine_type.azure.pro-fips
-    @uses.config.machine_type.gcp.generic
-    @uses.config.machine_type.gcp.pro
-    @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check pro version
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `dpkg-query --showformat='${Version}' --show ubuntu-advantage-tools` with sudo
@@ -105,8 +93,6 @@ Feature: Pro is expected version
 
     @series.all
     @uses.config.check_version
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @upgrade
     Scenario Outline: Check pro version
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -2,11 +2,12 @@
 Feature: Performing attach using ua-airgapped
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
-    Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+    Scenario Outline: Pro works with the airgapped contract server
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # set up the apt mirror configuration
-        Given a `jammy` machine named `mirror`
+        Given a `jammy` `<machine_type>` machine named `mirror`
         When I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `mirror` machine
         And I run `apt-get update` `with sudo` on the `mirror` machine
         And I run `apt-get install apt-mirror get-resource-tokens ua-airgapped -yq` `with sudo` on the `mirror` machine
@@ -21,7 +22,7 @@ Feature: Performing attach using ua-airgapped
         And I create the contract config overrides file for `esm-infra,esm-apps` on the `mirror` machine
         And I generate the contracts-airgapped configuration on the `mirror` machine
         # set up the contracts-airgapped configuration
-        Given a `jammy` machine named `contracts`
+        Given a `jammy` `<machine_type>` machine named `contracts`
         When I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `contracts` machine
         And I run `apt-get update` `with sudo` on the `contracts` machine
         And I run `apt-get install contracts-airgapped -yq` `with sudo` on the `contracts` machine
@@ -50,5 +51,5 @@ Feature: Performing attach using ua-airgapped
         Then I verify that running `pro refresh` `with sudo` exits `0`
 
         Examples: ubuntu release
-            | release |
-            | jammy   |
+            | release | machine_type  |
+            | jammy   | lxd-container |

--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -2,8 +2,6 @@
 Feature: Performing attach using ua-airgapped
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Pro works with the airgapped contract server
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # set up the apt mirror configuration

--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Performing attach using ua-airgapped
 
-    @series.jammy
     Scenario Outline: Pro works with the airgapped contract server
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # set up the apt mirror configuration

--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -2,9 +2,10 @@
 Feature: Enable anbox on Ubuntu
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Enable Anbox cloud service in a container
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
         When I run `pro status` as non-root
         Then stdout matches regexp:
@@ -48,13 +49,14 @@ Feature: Enable anbox on Ubuntu
         """
 
         Examples: ubuntu release
-            | release |
-            | jammy   |
+            | release | machine_type  |
+            | jammy   | lxd-container |
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Anbox cloud service in an unsupported release
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
         And I verify that running `pro enable anbox-cloud` `with sudo` exits `1`
         Then I will see the following on stdout:
@@ -64,13 +66,14 @@ Feature: Enable anbox on Ubuntu
         """
 
         Examples: ubuntu release
-            | release |
-            | xenial  |
+            | release | machine_type |
+            | xenial  | lxd-vm       |
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Anbox cloud service in a VM
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
         And I run `snap remove lxd` with sudo
         And I run `pro enable anbox-cloud --access-only --assume-yes` with sudo
@@ -146,5 +149,5 @@ Feature: Enable anbox on Ubuntu
         And I verify that no files exist matching `/var/lib/ubuntu-advantage/private/anbox-cloud-credentials`
 
         Examples: ubuntu release
-            | release |
-            | jammy   |
+            | release | machine_type |
+            | jammy   | lxd-vm       |

--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Enable anbox on Ubuntu
 
-    @series.jammy
     Scenario Outline: Enable Anbox cloud service in a container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -50,7 +49,6 @@ Feature: Enable anbox on Ubuntu
             | release | machine_type  |
             | jammy   | lxd-container |
 
-    @series.xenial
     Scenario Outline: Enable Anbox cloud service in an unsupported release
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -65,7 +63,6 @@ Feature: Enable anbox on Ubuntu
             | release | machine_type |
             | xenial  | lxd-vm       |
 
-    @series.jammy
     Scenario Outline: Enable Anbox cloud service in a VM
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`

--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -2,8 +2,6 @@
 Feature: Enable anbox on Ubuntu
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Enable Anbox cloud service in a container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -53,8 +51,6 @@ Feature: Enable anbox on Ubuntu
             | jammy   | lxd-container |
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Anbox cloud service in an unsupported release
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -70,8 +66,6 @@ Feature: Enable anbox on Ubuntu
             | xenial  | lxd-vm       |
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Anbox cloud service in a VM
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`

--- a/features/api.feature
+++ b/features/api.feature
@@ -1,6 +1,5 @@
 Feature: Client behaviour for the API endpoints
 
-    @series.all
     Scenario Outline: all API endpoints can be imported individually
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `python3 -c "from uaclient.api.u.pro.attach.auto.configure_retry_service.v1 import configure_retry_service"` as non-root
@@ -31,7 +30,6 @@ Feature: Client behaviour for the API endpoints
         | lunar   | lxd-container |
         | mantic  | lxd-container |
 
-    @series.all
     Scenario Outline: API invalid endpoint or args
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I verify that running `pro api invalid.endpoint` `with sudo` exits `1`
@@ -54,7 +52,6 @@ Feature: Client behaviour for the API endpoints
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.all
     Scenario Outline: Basic endpoints
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `pro api u.pro.version.v1` with sudo

--- a/features/api.feature
+++ b/features/api.feature
@@ -1,8 +1,6 @@
 Feature: Client behaviour for the API endpoints
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: all API endpoints can be imported individually
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `python3 -c "from uaclient.api.u.pro.attach.auto.configure_retry_service.v1 import configure_retry_service"` as non-root
@@ -34,8 +32,6 @@ Feature: Client behaviour for the API endpoints
         | mantic  | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: API invalid endpoint or args
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I verify that running `pro api invalid.endpoint` `with sudo` exits `1`
@@ -59,8 +55,6 @@ Feature: Client behaviour for the API endpoints
            | mantic  | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Basic endpoints
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `pro api u.pro.version.v1` with sudo

--- a/features/api_configure_retry_service.feature
+++ b/features/api_configure_retry_service.feature
@@ -1,9 +1,10 @@
 Feature: api.u.pro.attach.auto.configure_retry_service
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: v1 successfully triggers retry service when run during startup
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change contract to staging with sudo
         When I create the file `/lib/systemd/system/apitest.service` with the following
         """
@@ -52,8 +53,8 @@ Feature: api.u.pro.attach.auto.configure_retry_service
         You can try manually with `sudo pro auto-attach`.
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |

--- a/features/api_configure_retry_service.feature
+++ b/features/api_configure_retry_service.feature
@@ -1,6 +1,5 @@
 Feature: api.u.pro.attach.auto.configure_retry_service
 
-    @series.lts
     Scenario Outline: v1 successfully triggers retry service when run during startup
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change contract to staging with sudo

--- a/features/api_configure_retry_service.feature
+++ b/features/api_configure_retry_service.feature
@@ -1,8 +1,6 @@
 Feature: api.u.pro.attach.auto.configure_retry_service
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: v1 successfully triggers retry service when run during startup
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change contract to staging with sudo

--- a/features/api_fix_execute.feature
+++ b/features/api_fix_execute.feature
@@ -1,6 +1,5 @@
 Feature: Fix execute API endpoints
 
-    @series.lts
     Scenario Outline: Fix execute command on invalid CVEs/USNs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-1800-123456"]}'` as non-root
@@ -39,7 +38,6 @@ Feature: Fix execute API endpoints
            | focal   | lxd-container |
            | jammy   | lxd-container |
 
-    @series.focal
     Scenario Outline: Fix execute on a Focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root
@@ -102,7 +100,6 @@ Feature: Fix execute API endpoints
            | release | machine_type  |
            | focal   | lxd-container |
 
-    @series.xenial
     Scenario Outline: Fix execute API command on a Xenial machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2020-15180"]}'` as non-root
@@ -204,7 +201,6 @@ Feature: Fix execute API endpoints
            | release | machine_type  |
            | xenial  | lxd-container |
 
-    @series.bionic
     Scenario Outline: Fix execute API command on a Bionic machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root

--- a/features/api_fix_execute.feature
+++ b/features/api_fix_execute.feature
@@ -1,8 +1,6 @@
 Feature: Fix execute API endpoints
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix execute command on invalid CVEs/USNs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-1800-123456"]}'` as non-root
@@ -42,8 +40,6 @@ Feature: Fix execute API endpoints
            | jammy   | lxd-container |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix execute on a Focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root
@@ -107,8 +103,6 @@ Feature: Fix execute API endpoints
            | focal   | lxd-container |
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix execute API command on a Xenial machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2020-15180"]}'` as non-root
@@ -211,8 +205,6 @@ Feature: Fix execute API endpoints
            | xenial  | lxd-container |
 
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix execute API command on a Bionic machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root

--- a/features/api_fix_execute.feature
+++ b/features/api_fix_execute.feature
@@ -1,9 +1,10 @@
 Feature: Fix execute API endpoints
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix execute command on invalid CVEs/USNs
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-1800-123456"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_execute` schema
@@ -34,16 +35,17 @@ Feature: Fix execute API endpoints
         """
 
         Examples: ubuntu release details
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix execute on a Focal machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_execute` schema
@@ -101,13 +103,14 @@ Feature: Fix execute API endpoints
         """
 
         Examples: ubuntu release details
-           | release |
-           | focal   |
+           | release | machine_type  |
+           | focal   | lxd-container |
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix execute API command on a Xenial machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2020-15180"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_execute` schema
@@ -204,13 +207,14 @@ Feature: Fix execute API endpoints
         """
 
         Examples: ubuntu release details
-           | release |
-           | xenial  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
 
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix execute API command on a Bionic machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_execute` schema
@@ -269,5 +273,5 @@ Feature: Fix execute API endpoints
         """
 
         Examples: ubuntu release details
-           | release |
-           | bionic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |

--- a/features/api_fix_plan.feature
+++ b/features/api_fix_plan.feature
@@ -1,6 +1,5 @@
 Feature: Fix plan API endpoints
 
-    @series.lts
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-1800-123456"]}'` as non-root
@@ -39,7 +38,6 @@ Feature: Fix plan API endpoints
            | focal   | lxd-container |
            | jammy   | lxd-container |
 
-    @series.focal
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root
@@ -93,7 +91,6 @@ Feature: Fix plan API endpoints
            | release | machine_type  |
            | focal   | lxd-container |
 
-    @series.xenial
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2020-15180"]}'` as non-root
@@ -179,7 +176,6 @@ Feature: Fix plan API endpoints
            | release | machine_type  |
            | xenial  | lxd-container |
 
-    @series.bionic
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root

--- a/features/api_fix_plan.feature
+++ b/features/api_fix_plan.feature
@@ -1,9 +1,10 @@
 Feature: Fix plan API endpoints
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-1800-123456"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_plan` schema
@@ -34,16 +35,17 @@ Feature: Fix plan API endpoints
         """
 
         Examples: ubuntu release details
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_plan` schema
@@ -92,13 +94,14 @@ Feature: Fix plan API endpoints
         """
 
         Examples: ubuntu release details
-           | release |
-           | focal   |
+           | release | machine_type  |
+           | focal   | lxd-container |
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2020-15180"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_plan` schema
@@ -179,13 +182,14 @@ Feature: Fix plan API endpoints
         """
 
         Examples: ubuntu release details
-           | release |
-           | xenial  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
 
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_plan` schema
@@ -235,5 +239,5 @@ Feature: Fix plan API endpoints
         """
 
         Examples: ubuntu release details
-           | release |
-           | bionic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |

--- a/features/api_fix_plan.feature
+++ b/features/api_fix_plan.feature
@@ -1,8 +1,6 @@
 Feature: Fix plan API endpoints
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-1800-123456"]}'` as non-root
@@ -42,8 +40,6 @@ Feature: Fix plan API endpoints
            | jammy   | lxd-container |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root
@@ -98,8 +94,6 @@ Feature: Fix plan API endpoints
            | focal   | lxd-container |
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2020-15180"]}'` as non-root
@@ -186,8 +180,6 @@ Feature: Fix plan API endpoints
            | xenial  | lxd-container |
 
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2020-28196"]}'` as non-root

--- a/features/api_full_auto_attach.feature
+++ b/features/api_full_auto_attach.feature
@@ -1,6 +1,5 @@
 Feature: Full Auto-Attach Endpoint
 
-    @series.lts
     Scenario Outline: Run auto-attach on cloud instance.
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/api_full_auto_attach.feature
+++ b/features/api_full_auto_attach.feature
@@ -1,11 +1,12 @@
 Feature: Full Auto-Attach Endpoint
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro
     @uses.config.machine_type.azure.pro
     @uses.config.machine_type.gcp.pro
     Scenario Outline: Run auto-attach on cloud instance.
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -30,9 +31,17 @@ Feature: Full Auto-Attach Endpoint
         livepatch     +yes +(disabled|n/a)  +(Canonical Livepatch service|Current kernel is not supported)
         """
         Examples:
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type |
+           | xenial  | aws.pro      |
+           | xenial  | azure.pro    |
+           | xenial  | gcp.pro      |
+           | bionic  | aws.pro      |
+           | bionic  | azure.pro    |
+           | bionic  | gcp.pro      |
+           | focal   | aws.pro      |
+           | focal   | azure.pro    |
+           | focal   | gcp.pro      |
+           | jammy   | aws.pro      |
+           | jammy   | azure.pro    |
+           | jammy   | gcp.pro      |
            

--- a/features/api_full_auto_attach.feature
+++ b/features/api_full_auto_attach.feature
@@ -1,10 +1,6 @@
 Feature: Full Auto-Attach Endpoint
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro
-    @uses.config.machine_type.azure.pro
-    @uses.config.machine_type.gcp.pro
     Scenario Outline: Run auto-attach on cloud instance.
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/api_magic_attach.feature
+++ b/features/api_magic_attach.feature
@@ -1,8 +1,6 @@
 Feature: Magic Attach endpoints
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Call magic attach endpoints
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change contract to staging with sudo

--- a/features/api_magic_attach.feature
+++ b/features/api_magic_attach.feature
@@ -1,9 +1,10 @@
 Feature: Magic Attach endpoints
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Call magic attach endpoints
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change contract to staging with sudo
         And I verify that running `pro api u.pro.attach.magic.revoke.v1` `as non-root` exits `1`
         Then stdout is a json matching the `api_response` schema
@@ -67,8 +68,8 @@ Feature: Magic Attach endpoints
         """
 
         Examples: ubuntu release
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
-            | jammy   |
+            | release | machine_type  |
+            | xenial  | lxd-container |
+            | bionic  | lxd-container |
+            | focal   | lxd-container |
+            | jammy   | lxd-container |

--- a/features/api_magic_attach.feature
+++ b/features/api_magic_attach.feature
@@ -1,6 +1,5 @@
 Feature: Magic Attach endpoints
 
-    @series.lts
     Scenario Outline: Call magic attach endpoints
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change contract to staging with sudo

--- a/features/api_packages.feature
+++ b/features/api_packages.feature
@@ -1,6 +1,5 @@
 Feature: Package related API endpoints
 
-    @series.all
     @uses.config.contract_token
     Scenario Outline: Call packages API endpoints to see information in a Ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/api_packages.feature
+++ b/features/api_packages.feature
@@ -1,8 +1,6 @@
 Feature: Package related API endpoints
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Call packages API endpoints to see information in a Ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/api_packages.feature
+++ b/features/api_packages.feature
@@ -1,10 +1,11 @@
 Feature: Package related API endpoints
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Call packages API endpoints to see information in a Ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.pro.packages.summary.v1` as non-root
         Then stdout matches regexp:
         """
@@ -30,9 +31,9 @@ Feature: Package related API endpoints
         """
 
         Examples: ubuntu release
-            | release | package         | outdated_version | provided_by       |
-            | xenial  | libcurl3-gnutls | 7.47.0-1ubuntu2  | esm-infra         |
-            | bionic  | libcurl4        | 7.58.0-2ubuntu3  | esm-infra         |
-            | focal   | libcurl4        | 7.68.0-1ubuntu2  | standard-security |
-            | jammy   | libcurl4        | 7.81.0-1         | standard-security |
-            | lunar   | libcurl4        | 7.88.1-8ubuntu1  | standard-security |
+            | release | machine_type  | package         | outdated_version | provided_by       |
+            | xenial  | lxd-container | libcurl3-gnutls | 7.47.0-1ubuntu2  | esm-infra         |
+            | bionic  | lxd-container | libcurl4        | 7.58.0-2ubuntu3  | esm-infra         |
+            | focal   | lxd-container | libcurl4        | 7.68.0-1ubuntu2  | standard-security |
+            | jammy   | lxd-container | libcurl4        | 7.81.0-1         | standard-security |
+            | lunar   | lxd-container | libcurl4        | 7.88.1-8ubuntu1  | standard-security |

--- a/features/api_security.feature
+++ b/features/api_security.feature
@@ -1,6 +1,5 @@
 Feature: API security/security status tests
 
-    @series.xenial
     @uses.config.contract_token
     Scenario: Call Livepatched CVEs endpoint
         Given a `xenial` `lxd-vm` machine with ubuntu-advantage-tools installed
@@ -15,7 +14,6 @@ Feature: API security/security status tests
          "type": "LivepatchCVEs"
          """
 
-    @series.lts
     @uses.config.contract_token
     Scenario Outline: Call package manifest endpoint for machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/api_security.feature
+++ b/features/api_security.feature
@@ -1,8 +1,6 @@
 Feature: API security/security status tests
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     @uses.config.contract_token
     Scenario: Call Livepatched CVEs endpoint
         Given a `xenial` `lxd-vm` machine with ubuntu-advantage-tools installed
@@ -18,8 +16,6 @@ Feature: API security/security status tests
          """
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Call package manifest endpoint for machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/api_security.feature
+++ b/features/api_security.feature
@@ -1,10 +1,11 @@
 Feature: API security/security status tests
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     @uses.config.contract_token
     Scenario: Call Livepatched CVEs endpoint
-        Given a `xenial` machine with ubuntu-advantage-tools installed
+        Given a `xenial` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro api u.pro.security.status.livepatch_cves.v1` as non-root
         Then stdout matches regexp:
@@ -17,10 +18,11 @@ Feature: API security/security status tests
          """
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Call package manifest endpoint for machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro status` as non-root
         Then stdout matches regexp:
@@ -71,11 +73,9 @@ Feature: API security/security status tests
         """
         oval:com.ubuntu.<release>:def:<CVE_ID>:\s+true
         """
-        
-
         Examples: ubuntu release
-            | release | base_version    | CVE_ID      |
-            | xenial  | 3.4.10-4ubuntu1 | 39991000000 |
-            | bionic  | 3.5.18-1ubuntu1 | 55501000000 |
-            | focal   | 3.6.13-2ubuntu1 | 55501000000 |
-            | jammy   | 3.7.3-4ubuntu1  | 55501000000 |
+            | release | machine_type  | base_version    | CVE_ID      |
+            | xenial  | lxd-container | 3.4.10-4ubuntu1 | 39991000000 |
+            | bionic  | lxd-container | 3.5.18-1ubuntu1 | 55501000000 |
+            | focal   | lxd-container | 3.6.13-2ubuntu1 | 55501000000 |
+            | jammy   | lxd-container | 3.7.3-4ubuntu1  | 55501000000 |

--- a/features/api_unattended_upgrades.feature
+++ b/features/api_unattended_upgrades.feature
@@ -1,8 +1,6 @@
 Feature: api.u.unattended_upgrades.status.v1
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: v1 unattended upgrades status
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.unattended_upgrades.status.v1` as non-root

--- a/features/api_unattended_upgrades.feature
+++ b/features/api_unattended_upgrades.feature
@@ -1,9 +1,10 @@
 Feature: api.u.unattended_upgrades.status.v1
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: v1 unattended upgrades status
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.unattended_upgrades.status.v1` as non-root
         Then stdout matches regexp:
         """
@@ -198,10 +199,10 @@ Feature: api.u.unattended_upgrades.status.v1
         """
 
         Examples: ubuntu release
-           | release | extra_field                               |
-           | xenial  |                                           |
-           | bionic  | "Unattended-Upgrade::DevRelease": "false" |
-           | focal   | "Unattended-Upgrade::DevRelease": "auto"  |
-           | jammy   | "Unattended-Upgrade::DevRelease": "auto"  |
-           | lunar   | "Unattended-Upgrade::DevRelease": "auto"  |
-           | mantic  | "Unattended-Upgrade::DevRelease": "auto"  |
+           | release | machine_type  | extra_field                               |
+           | xenial  | lxd-container |                                           |
+           | bionic  | lxd-container | "Unattended-Upgrade::DevRelease": "false" |
+           | focal   | lxd-container | "Unattended-Upgrade::DevRelease": "auto"  |
+           | jammy   | lxd-container | "Unattended-Upgrade::DevRelease": "auto"  |
+           | lunar   | lxd-container | "Unattended-Upgrade::DevRelease": "auto"  |
+           | mantic  | lxd-container | "Unattended-Upgrade::DevRelease": "auto"  |

--- a/features/api_unattended_upgrades.feature
+++ b/features/api_unattended_upgrades.feature
@@ -1,6 +1,5 @@
 Feature: api.u.unattended_upgrades.status.v1
 
-    @series.all
     Scenario Outline: v1 unattended upgrades status
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro api u.unattended_upgrades.status.v1` as non-root

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -208,7 +208,6 @@ Feature: APT Messages
         """
         Examples: ubuntu release
           | release | machine_type  | package | more_msg                | learn_more_msg                                                    |
-          | bionic  | lxd-container | ansible | more security updates   | Learn more about Ubuntu Pro for 18.04 at https://ubuntu.com/18-04 |
           | focal   | lxd-container | hello   | another security update | Learn more about Ubuntu Pro at https://ubuntu.com/pro             |
           | jammy   | lxd-container | hello   | another security update | Learn more about Ubuntu Pro at https://ubuntu.com/pro             |
 

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -1,8 +1,6 @@
 Feature: APT Messages
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: APT JSON Hook prints package counts correctly on xenial
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -102,8 +100,6 @@ Feature: APT Messages
 
     @series.bionic
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: APT Hook advertises esm-infra on upgrade
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -162,8 +158,6 @@ Feature: APT Messages
 
     @series.focal
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: APT Hook advertises esm-apps on upgrade
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -224,8 +218,6 @@ Feature: APT Messages
           | jammy   | lxd-container | hello   | another security update | Learn more about Ubuntu Pro at https://ubuntu.com/pro             |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: APT News
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -693,10 +685,6 @@ Feature: APT Messages
     @series.xenial
     @series.bionic
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
-    @uses.config.machine_type.azure.generic
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: Cloud and series-specific URLs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -720,8 +708,6 @@ Feature: APT Messages
           | focal   | gcp.generic   | Learn more about Ubuntu Pro on GCP at https://ubuntu.com/gcp/pro                 |
 
     @series.lunar
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: APT Hook do not advertises esm-apps on upgrade for interim releases
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -1,6 +1,5 @@
 Feature: APT Messages
 
-    @series.xenial
     @uses.config.contract_token
     Scenario Outline: APT JSON Hook prints package counts correctly on xenial
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -98,8 +97,6 @@ Feature: APT Messages
            | release | machine_type  | standard-pkg         | infra-pkg                                            | apps-pkg     |
            | xenial  | lxd-container | wget=1.17.1-1ubuntu1 | curl=7.47.0-1ubuntu2 libcurl3-gnutls=7.47.0-1ubuntu2 | hello=2.10-1 |
 
-    @series.bionic
-    @series.xenial
     @uses.config.contract_token
     Scenario Outline: APT Hook advertises esm-infra on upgrade
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -156,8 +153,6 @@ Feature: APT Messages
           | xenial  | lxd-container | 16      |
           | bionic  | lxd-container | 18      |
 
-    @series.focal
-    @series.jammy
     @uses.config.contract_token
     Scenario Outline: APT Hook advertises esm-apps on upgrade
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -217,7 +212,6 @@ Feature: APT Messages
           | focal   | lxd-container | hello   | another security update | Learn more about Ubuntu Pro at https://ubuntu.com/pro             |
           | jammy   | lxd-container | hello   | another security update | Learn more about Ubuntu Pro at https://ubuntu.com/pro             |
 
-    @series.all
     @uses.config.contract_token
     Scenario Outline: APT News
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -682,9 +676,6 @@ Feature: APT Messages
           | jammy   | lxd-container |
           | lunar   | lxd-container |
 
-    @series.xenial
-    @series.bionic
-    @series.focal
     Scenario Outline: Cloud and series-specific URLs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -707,7 +698,6 @@ Feature: APT Messages
           | focal   | azure.generic | Learn more about Ubuntu Pro on Azure at https://ubuntu.com/azure/pro             |
           | focal   | gcp.generic   | Learn more about Ubuntu Pro on GCP at https://ubuntu.com/gcp/pro                 |
 
-    @series.lunar
     @uses.config.contract_token
     Scenario Outline: APT Hook do not advertises esm-apps on upgrade for interim releases
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -2,8 +2,6 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
          Pro subscription using an invalid token
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command failure on invalid token
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro attach INVALID_TOKEN` `with sudo` exits `1`
@@ -33,8 +31,6 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
            | mantic  | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token_staging_expired
     Scenario Outline: Attach command failure on expired token
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -1,7 +1,6 @@
 Feature: Command behaviour when trying to attach a machine to an Ubuntu
          Pro subscription using an invalid token
 
-    @series.all
     Scenario Outline: Attach command failure on invalid token
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro attach INVALID_TOKEN` `with sudo` exits `1`
@@ -30,7 +29,6 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.all
     @uses.config.contract_token_staging_expired
     Scenario Outline: Attach command failure on expired token
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -4,8 +4,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
 
     @series.lunar
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached command in a non-lts ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -43,8 +41,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
             | mantic  | lxd-container | yes       |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command in a ubuntu lxd container
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo, retrying exit [100]
@@ -103,8 +99,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | jammy   | lxd-container | hello=2.10-2ubuntu4         | n/a       | usg        | n/a      | n/a      | Canonical Livepatch service   |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command with attach config
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # simplest happy path
@@ -215,8 +209,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | focal   | lxd-container | usg        |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
     Scenario Outline: Attach command in an generic AWS Ubuntu VM
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -253,8 +245,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | jammy   | aws.generic  | n/a         |enabled   | Canonical Livepatch service   | n/a       | usg        | n/a        |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.generic
     Scenario Outline: Attach command in an generic Azure Ubuntu VM
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -291,8 +281,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | jammy   | azure.generic | enabled   | n/a         | n/a       | usg        | n/a        |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: Attach command in an generic GCP Ubuntu VM
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -329,8 +317,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | jammy   | gcp.generic  | enabled   | n/a         | n/a       | usg        | n/a        |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command with json output
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running attach `as non-root` with json response exits `1`
@@ -358,8 +344,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
           | jammy   | lxd-container | n/a      |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach and Check for contract change in status checking
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
        When I attach `contract_token` with sudo

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -2,8 +2,6 @@
 Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         subscription using a valid token
 
-    @series.lunar
-    @series.mantic
     Scenario Outline: Attached command in a non-lts ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -40,7 +38,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
             | lunar   | lxd-container | n/a       |
             | mantic  | lxd-container | yes       |
 
-    @series.lts
     Scenario Outline: Attach command in a ubuntu lxd container
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo, retrying exit [100]
@@ -98,7 +95,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | focal   | lxd-container | hello=2.10-2ubuntu2         | n/a       | usg        | disabled | disabled | Canonical Livepatch service   |
            | jammy   | lxd-container | hello=2.10-2ubuntu4         | n/a       | usg        | n/a      | n/a      | Canonical Livepatch service   |
 
-    @series.lts
     Scenario Outline: Attach command with attach config
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # simplest happy path
@@ -208,7 +204,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | bionic  | lxd-container | cis        |
            | focal   | lxd-container | usg        |
 
-    @series.all
     Scenario Outline: Attach command in an generic AWS Ubuntu VM
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -244,7 +239,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | focal   | aws.generic  | disabled    |enabled   | Canonical Livepatch service   | n/a       | usg        | disabled   |
            | jammy   | aws.generic  | n/a         |enabled   | Canonical Livepatch service   | n/a       | usg        | n/a        |
 
-    @series.lts
     Scenario Outline: Attach command in an generic Azure Ubuntu VM
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -280,7 +274,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | focal   | azure.generic | enabled   | disabled    | n/a       | usg        | disabled   |
            | jammy   | azure.generic | enabled   | n/a         | n/a       | usg        | n/a        |
 
-    @series.all
     Scenario Outline: Attach command in an generic GCP Ubuntu VM
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -316,7 +309,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
            | focal   | gcp.generic  | enabled   | disabled    | n/a       | usg        | disabled   |
            | jammy   | gcp.generic  | enabled   | n/a         | n/a       | usg        | n/a        |
 
-    @series.all
     Scenario Outline: Attach command with json output
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running attach `as non-root` with json response exits `1`
@@ -343,7 +335,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
           | focal   | lxd-container | n/a      |
           | jammy   | lxd-container | n/a      |
 
-    @series.all
     Scenario Outline: Attach and Check for contract change in status checking
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
        When I attach `contract_token` with sudo

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -4,9 +4,10 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
 
     @series.lunar
     @series.mantic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached command in a non-lts ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro status` as non-root
         Then stdout matches regexp:
@@ -37,14 +38,15 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
 
         Examples: ubuntu release
-            | release | landscape |
-            | lunar   | n/a       |
-            | mantic  | yes       |
+            | release | machine_type  | landscape |
+            | lunar   | lxd-container | n/a       |
+            | mantic  | lxd-container | yes       |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command in a ubuntu lxd container
-       Given a `<release>` machine with ubuntu-advantage-tools installed
+       Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo, retrying exit [100]
         And I run `apt install update-motd` with sudo, retrying exit [100]
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y <downrev_pkg>` with sudo, retrying exit [100]
@@ -94,16 +96,17 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
 
         Examples: ubuntu release packages
-           | release | downrev_pkg                 | cc_status | cis_or_usg | cis      | fips     | livepatch_desc                |
-           | xenial  | libkrad0=1.13.2+dfsg-5      | disabled  | cis        | disabled | disabled | Canonical Livepatch service   |
-           | bionic  | libkrad0=1.16-2build1       | disabled  | cis        | disabled | disabled | Canonical Livepatch service   |
-           | focal   | hello=2.10-2ubuntu2         | n/a       | usg        | disabled | disabled | Canonical Livepatch service   |
-           | jammy   | hello=2.10-2ubuntu4         | n/a       | usg        | n/a      | n/a      | Canonical Livepatch service   |
+           | release | machine_type  | downrev_pkg                 | cc_status | cis_or_usg | cis      | fips     | livepatch_desc                |
+           | xenial  | lxd-container | libkrad0=1.13.2+dfsg-5      | disabled  | cis        | disabled | disabled | Canonical Livepatch service   |
+           | bionic  | lxd-container | libkrad0=1.16-2build1       | disabled  | cis        | disabled | disabled | Canonical Livepatch service   |
+           | focal   | lxd-container | hello=2.10-2ubuntu2         | n/a       | usg        | disabled | disabled | Canonical Livepatch service   |
+           | jammy   | lxd-container | hello=2.10-2ubuntu4         | n/a       | usg        | n/a      | n/a      | Canonical Livepatch service   |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command with attach config
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # simplest happy path
         When I create the file `/tmp/attach.yaml` with the following
         """
@@ -206,15 +209,16 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         Cannot enable unknown service 'nonexistent, nonexistent2'.
         """
         Examples: ubuntu
-           | release | cis_or_usg |
-           | xenial  | cis        |
-           | bionic  | cis        |
-           | focal   | usg        |
+           | release | machine_type  | cis_or_usg |
+           | xenial  | lxd-container | cis        |
+           | bionic  | lxd-container | cis        |
+           | focal   | lxd-container | usg        |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     Scenario Outline: Attach command in an generic AWS Ubuntu VM
-       Given a `<release>` machine with ubuntu-advantage-tools installed
+       Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
         """
         machineTokenInfo:
@@ -242,16 +246,17 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
 
         Examples: ubuntu release livepatch status
-           | release | fips_status |lp_status | lp_desc                       | cc_status | cis_or_usg | cis_status |
-           | xenial  | disabled    |enabled   | Canonical Livepatch service   | disabled  | cis        | disabled   |
-           | bionic  | disabled    |enabled   | Canonical Livepatch service   | disabled  | cis        | disabled   |
-           | focal   | disabled    |enabled   | Canonical Livepatch service   | n/a       | usg        | disabled   |
-           | jammy   | n/a         |enabled   | Canonical Livepatch service   | n/a       | usg        | n/a        |
+           | release | machine_type | fips_status |lp_status | lp_desc                       | cc_status | cis_or_usg | cis_status |
+           | xenial  | aws.generic  | disabled    |enabled   | Canonical Livepatch service   | disabled  | cis        | disabled   |
+           | bionic  | aws.generic  | disabled    |enabled   | Canonical Livepatch service   | disabled  | cis        | disabled   |
+           | focal   | aws.generic  | disabled    |enabled   | Canonical Livepatch service   | n/a       | usg        | disabled   |
+           | jammy   | aws.generic  | n/a         |enabled   | Canonical Livepatch service   | n/a       | usg        | n/a        |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.generic
     Scenario Outline: Attach command in an generic Azure Ubuntu VM
-       Given a `<release>` machine with ubuntu-advantage-tools installed
+       Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
         """
         machineTokenInfo:
@@ -279,16 +284,17 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
 
         Examples: ubuntu release livepatch status
-           | release | lp_status | fips_status | cc_status | cis_or_usg | cis_status |
-           | xenial  | enabled   | disabled    | disabled  | cis        | disabled   |
-           | bionic  | enabled   | disabled    | disabled  | cis        | disabled   |
-           | focal   | enabled   | disabled    | n/a       | usg        | disabled   |
-           | jammy   | enabled   | n/a         | n/a       | usg        | n/a        |
+           | release | machine_type  | lp_status | fips_status | cc_status | cis_or_usg | cis_status |
+           | xenial  | azure.generic | enabled   | disabled    | disabled  | cis        | disabled   |
+           | bionic  | azure.generic | enabled   | disabled    | disabled  | cis        | disabled   |
+           | focal   | azure.generic | enabled   | disabled    | n/a       | usg        | disabled   |
+           | jammy   | azure.generic | enabled   | n/a         | n/a       | usg        | n/a        |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.generic
     Scenario Outline: Attach command in an generic GCP Ubuntu VM
-       Given a `<release>` machine with ubuntu-advantage-tools installed
+       Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
         """
         machineTokenInfo:
@@ -316,16 +322,17 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
 
         Examples: ubuntu release livepatch status
-           | release | lp_status | fips_status | cc_status | cis_or_usg | cis_status |
-           | xenial  | n/a       | n/a         | disabled  | cis        | disabled   |
-           | bionic  | enabled   | disabled    | disabled  | cis        | disabled   |
-           | focal   | enabled   | disabled    | n/a       | usg        | disabled   |
-           | jammy   | enabled   | n/a         | n/a       | usg        | n/a        |
+           | release | machine_type | lp_status | fips_status | cc_status | cis_or_usg | cis_status |
+           | xenial  | gcp.generic  | n/a       | n/a         | disabled  | cis        | disabled   |
+           | bionic  | gcp.generic  | enabled   | disabled    | disabled  | cis        | disabled   |
+           | focal   | gcp.generic  | enabled   | disabled    | n/a       | usg        | disabled   |
+           | jammy   | gcp.generic  | enabled   | n/a         | n/a       | usg        | n/a        |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command with json output
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running attach `as non-root` with json response exits `1`
         Then I will see the following on stdout:
             """
@@ -344,16 +351,17 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
         """
 
         Examples: ubuntu release
-          | release | cc-eal   |
-          | xenial  | disabled |
-          | bionic  | disabled |
-          | focal   | n/a      |
-          | jammy   | n/a      |
+          | release | machine_type  | cc-eal   |
+          | xenial  | lxd-container | disabled |
+          | bionic  | lxd-container | disabled |
+          | focal   | lxd-container | n/a      |
+          | jammy   | lxd-container | n/a      |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach and Check for contract change in status checking
-       Given a `<release>` machine with ubuntu-advantage-tools installed
+       Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
        When I attach `contract_token` with sudo
        Then stdout matches regexp:
        """
@@ -396,8 +404,8 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
        """
 
         Examples: ubuntu release livepatch status
-           | release |
+           | release | machine_type  |
            # removing until we add this feature back in a way that doesn't hammer the server
-           #| xenial  |
-           #| bionic  |
-           #| focal   |
+           #| xenial  | lxd-container |
+           #| bionic  | lxd-container |
+           #| focal   | lxd-container |

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -2,8 +2,6 @@
 Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached refresh in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -58,8 +56,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | mantic  | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -85,8 +81,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | mantic  | lxd-container |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached disable with json format
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -142,8 +136,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | jammy   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached disable of a service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -183,8 +175,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | jammy   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached detach in an ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -271,8 +261,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | jammy   | lxd-container | yes   | yes      | no     | yes | no   | no          | no  | no          | usg        | yes             |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached auto-attach in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -298,8 +286,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | mantic  | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached show version in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -322,8 +308,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | mantic  | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in a ubuntu machine with feature overrides
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/tmp/machine-token-overlay.json` with the following:
@@ -394,8 +378,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | mantic  | lxd-container |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached disable of different services in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -445,8 +427,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
     @series.bionic
     @series.lunar
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Help command on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -565,8 +545,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
     @series.jammy
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Help command on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -694,8 +672,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | jammy   | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Run timer script on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `systemctl stop ua-timer.timer` with sudo
@@ -773,8 +749,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | mantic  | lxd-container |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Run timer script to valid machine activity endpoint
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -846,8 +820,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | jammy   | lxd-container |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Run timer script to valid machine activity endpoint
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
-    @series.all
     Scenario Outline: Attached refresh in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -55,7 +54,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.all
     Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -80,7 +78,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.lts
     Scenario Outline: Attached disable with json format
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -135,7 +132,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
            | jammy   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
-    @series.lts
     Scenario Outline: Attached disable of a service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -174,7 +170,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
            | jammy   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
-    @series.lts
     Scenario Outline: Attached detach in an ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -260,7 +255,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container | yes   | yes      | no     | yes | yes  | yes         | yes | no          | usg        | no              |
            | jammy   | lxd-container | yes   | yes      | no     | yes | no   | no          | no  | no          | usg        | yes             |
 
-    @series.all
     Scenario Outline: Attached auto-attach in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -285,7 +279,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.all
     Scenario Outline: Attached show version in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -307,7 +300,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.all
     Scenario Outline: Attached status in a ubuntu machine with feature overrides
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/tmp/machine-token-overlay.json` with the following:
@@ -377,7 +369,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.lts
     Scenario Outline: Attached disable of different services in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -423,10 +414,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
            | jammy   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
-    @series.xenial
-    @series.bionic
-    @series.lunar
-    @series.mantic
     Scenario Outline: Help command on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -543,8 +530,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | lunar   | lxd-container | n/a          |
            | mantic  | lxd-container | n/a          |
 
-    @series.jammy
-    @series.focal
     Scenario Outline: Help command on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -671,7 +656,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container |
            | jammy   | lxd-container |
 
-    @series.all
     Scenario Outline: Run timer script on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `systemctl stop ua-timer.timer` with sudo
@@ -748,7 +732,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.lts
     Scenario Outline: Run timer script to valid machine activity endpoint
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -819,7 +802,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container |
            | jammy   | lxd-container |
 
-    @series.lts
     Scenario Outline: Run timer script to valid machine activity endpoint
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -2,9 +2,10 @@
 Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached refresh in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro refresh` `as non-root` exits `1`
         And stderr matches regexp:
@@ -48,18 +49,19 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | xenial  | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro disable livepatch` `as non-root` exits `1`
         And stderr matches regexp:
@@ -74,18 +76,19 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
             """
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | xenial  | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached disable with json format
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro disable foobar --format json` `as non-root` exits `1`
         And stdout is a json matching the `ua_operation` schema
@@ -132,16 +135,17 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | valid_services                                                                                                                             |
-           | xenial  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | machine_type  | valid_services                                                                                                                             |
+           | xenial  | lxd-container | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | lxd-container | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | jammy   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached disable of a service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro disable foobar` `as non-root` exits `1`
         And stderr matches regexp:
@@ -172,16 +176,17 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         And I verify that running `apt update` `with sudo` exits `0`
 
         Examples: ubuntu release
-           | release | msg                                                                                                                                            |
-           | xenial  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | machine_type  | msg                                                                                                                                            |
+           | xenial  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | jammy   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached detach in an ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro api u.pro.status.enabled_services.v1` as non-root
         Then stdout matches regexp:
@@ -259,16 +264,17 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
        """
 
        Examples: ubuntu release
-           | release | anbox | esm-apps | cc-eal | cis | fips | fips-update | ros | ros-updates | cis_or_usg | realtime-kernel |
-           | xenial  | no    | yes      | yes    | yes | yes  | yes         | yes | yes         | cis        | no              |
-           | bionic  | no    | yes      | yes    | yes | yes  | yes         | yes | yes         | cis        | no              |
-           | focal   | yes   | yes      | no     | yes | yes  | yes         | yes | no          | usg        | no              |
-           | jammy   | yes   | yes      | no     | yes | no   | no          | no  | no          | usg        | yes             |
+           | release | machine_type  | anbox | esm-apps | cc-eal | cis | fips | fips-update | ros | ros-updates | cis_or_usg | realtime-kernel |
+           | xenial  | lxd-container | no    | yes      | yes    | yes | yes  | yes         | yes | yes         | cis        | no              |
+           | bionic  | lxd-container | no    | yes      | yes    | yes | yes  | yes         | yes | yes         | cis        | no              |
+           | focal   | lxd-container | yes   | yes      | no     | yes | yes  | yes         | yes | no          | usg        | no              |
+           | jammy   | lxd-container | yes   | yes      | no     | yes | no   | no          | no  | no          | usg        | yes             |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached auto-attach in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro auto-attach` `as non-root` exits `1`
         And stderr matches regexp:
@@ -283,18 +289,19 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
             """
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | xenial  | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached show version in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro version` as non-root
         Then I will see the uaclient version on stdout
@@ -306,18 +313,19 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         Then I will see the uaclient version on stdout
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | xenial  | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in a ubuntu machine with feature overrides
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/tmp/machine-token-overlay.json` with the following:
         """
         {
@@ -377,18 +385,19 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | xenial  | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached disable of different services in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro disable esm-infra livepatch foobar` `as non-root` exits `1`
         And stderr matches regexp:
@@ -426,19 +435,20 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | msg                                                                                                                                            |
-           | xenial  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | machine_type  | msg                                                                                                                                            |
+           | xenial  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | jammy   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.xenial
     @series.bionic
     @series.lunar
     @series.mantic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Help command on an attached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro help esm-infra` with sudo
         Then I will see the following on stdout:
@@ -547,17 +557,18 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | infra-status |
-           | bionic  | enabled      |
-           | xenial  | enabled      |
-           | lunar   | n/a          |
-           | mantic  | n/a          |
+           | release | machine_type  | infra-status |
+           | bionic  | lxd-container | enabled      |
+           | xenial  | lxd-container | enabled      |
+           | lunar   | lxd-container | n/a          |
+           | mantic  | lxd-container | n/a          |
 
     @series.jammy
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Help command on an attached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro help esm-infra` with sudo
         Then I will see the following on stdout:
@@ -678,14 +689,15 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Run timer script on an attached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `systemctl stop ua-timer.timer` with sudo
         And I attach `contract_token` with sudo
         Then I verify that running `pro config set update_messaging_timer=-2` `with sudo` exits `1`
@@ -752,18 +764,19 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Run timer script to valid machine activity endpoint
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `apt update` with sudo
         And I run `apt install jq -y` with sudo
@@ -826,16 +839,17 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Run timer script to valid machine activity endpoint
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `rm /var/lib/ubuntu-advantage/machine-token.json` with sudo
         And I run `ua status` as non-root
@@ -852,8 +866,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -4,8 +4,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     @slow
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -31,8 +29,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Enable cc-eal with --access-only
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -54,8 +50,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     @series.jammy
     @series.lunar
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -78,8 +72,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | mantic  | lxd-container | 23.10      | Mantic Minotaur  |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Empty series affordance means no series, null means all series
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -130,8 +122,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | jammy   | lxd-container |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of different services using json format
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -201,8 +191,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | jammy   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of a service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -262,8 +250,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container | hello     | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline:  Attached enable of non-container services in a ubuntu lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -289,8 +275,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | mantic  | lxd-container |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable not entitled service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -324,8 +308,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of cis service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -410,8 +392,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  | lxd-container | Canonical_Ubuntu_16.04_CIS_v1.1.0-harden.sh |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of cis service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -492,8 +472,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.bionic
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of usg service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -514,8 +492,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  | lxd-container |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of usg service in a focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -577,8 +553,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.bionic
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached disable of livepatch in a lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -621,8 +595,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attach works when snapd cannot be installed
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get remove -y snapd` with sudo
@@ -661,8 +633,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.bionic
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable livepatch
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `canonical-livepatch status` `with sudo` exits `1`
@@ -693,8 +663,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | bionic  | lxd-vm       | enabled          |
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable livepatch
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -764,8 +732,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @slow
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario: Attached enable livepatch on a machine with fips active
         Given a `bionic` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -804,8 +770,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
 
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario: Attached enable fips on a machine with livepatch active
         Given a `bionic` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -837,8 +801,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     @slow
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable fips on a machine with livepatch active
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -880,8 +842,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     @slow
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable fips on a machine with fips-updates active
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -918,8 +878,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable ros on a machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -1082,8 +1040,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     # esm-infra is a good choice because it doesn't already have
     # other overrides that would interfere with the test
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
     Scenario: Cloud overrides for a generic aws Focal instance
        Given a `focal` `aws.generic` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -1112,8 +1068,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: APT auth file is edited correctly on enable
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -1143,8 +1097,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  | aws.generic   |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable esm-apps on a machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -1187,8 +1139,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container | ant      |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable with corrupt lock
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -2,8 +2,6 @@
 Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @slow
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -27,8 +25,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | xenial  | lxd-container |
             | bionic  | lxd-container |
 
-    @series.xenial
-    @series.bionic
     Scenario Outline: Enable cc-eal with --access-only
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -46,10 +42,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | xenial  | lxd-container |
             | bionic  | lxd-container |
 
-    @series.focal
-    @series.jammy
-    @series.lunar
-    @series.mantic
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -71,7 +63,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | lunar   | lxd-container | 23.04      | Lunar Lobster    |
             | mantic  | lxd-container | 23.10      | Mantic Minotaur  |
 
-    @series.lts
     Scenario Outline: Empty series affordance means no series, null means all series
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -121,7 +112,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | focal   | lxd-container |
             | jammy   | lxd-container |
 
-    @series.lts
     Scenario Outline: Attached enable of different services using json format
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -190,7 +180,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
            | jammy   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
-    @series.lts
     Scenario Outline: Attached enable of a service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -249,7 +238,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | bionic  | lxd-container | libkrad0  | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
            | focal   | lxd-container | hello     | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
-    @series.all
     Scenario Outline:  Attached enable of non-container services in a ubuntu lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -274,7 +262,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.lts
     Scenario Outline: Attached enable not entitled service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -306,8 +293,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container |
            | jammy   | lxd-container |
 
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attached enable of cis service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -391,7 +376,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | bionic  | lxd-container | Canonical_Ubuntu_18.04_CIS-harden.sh        |
            | xenial  | lxd-container | Canonical_Ubuntu_16.04_CIS_v1.1.0-harden.sh |
 
-    @series.focal
     Scenario Outline: Attached enable of cis service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -470,8 +454,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | release | machine_type  | cis_script                                  |
            | focal   | lxd-container | Canonical_Ubuntu_20.04_CIS-harden.sh        |
 
-    @series.bionic
-    @series.xenial
     Scenario Outline: Attached enable of usg service in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -491,7 +473,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | bionic  | lxd-container |
            | xenial  | lxd-container |
 
-    @series.focal
     Scenario Outline: Attached enable of usg service in a focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -551,8 +532,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | release | machine_type  |
            | focal   | lxd-container |
 
-    @series.bionic
-    @series.xenial
     Scenario Outline: Attached disable of livepatch in a lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -593,8 +572,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  | lxd-vm       | warning          |
            | bionic  | lxd-vm       | enabled          |
 
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attach works when snapd cannot be installed
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get remove -y snapd` with sudo
@@ -631,8 +608,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  | lxd-vm       |
            | bionic  | lxd-vm       |
 
-    @series.bionic
-    @series.xenial
     Scenario Outline: Attached enable livepatch
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `canonical-livepatch status` `with sudo` exits `1`
@@ -662,7 +637,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  | lxd-vm       | warning          |
            | bionic  | lxd-vm       | enabled          |
 
-    @series.xenial
     Scenario Outline: Attached enable livepatch
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -731,7 +705,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  | lxd-vm        |
 
     @slow
-    @series.bionic
     Scenario: Attached enable livepatch on a machine with fips active
         Given a `bionic` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -769,7 +742,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             {"_schema_version": "0.1", "errors": [{"message": "Cannot enable Livepatch when FIPS is enabled.", "message_code": "livepatch-error-when-fips-enabled", "service": "livepatch", "type": "service"}], "failed_services": ["livepatch"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
             """
 
-    @series.bionic
     Scenario: Attached enable fips on a machine with livepatch active
         Given a `bionic` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -799,8 +771,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
     @slow
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attached enable fips on a machine with livepatch active
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -840,8 +810,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | xenial  | lxd-vm       |
 
     @slow
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attached enable fips on a machine with fips-updates active
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -876,8 +844,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | bionic  | lxd-vm        |
            | xenial  | lxd-vm        |
 
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attached enable ros on a machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -1039,7 +1005,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     # have overrides, we can consider removing this
     # esm-infra is a good choice because it doesn't already have
     # other overrides that would interfere with the test
-    @series.focal
     Scenario: Cloud overrides for a generic aws Focal instance
        Given a `focal` `aws.generic` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
@@ -1067,7 +1032,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Stderr: E: Unable to locate package some-package-aws
         """
 
-    @series.xenial
     Scenario Outline: APT auth file is edited correctly on enable
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -1096,7 +1060,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | release | machine_type  |
            | xenial  | aws.generic   |
 
-    @series.lts
     Scenario Outline: Attached enable esm-apps on a machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -1138,7 +1101,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | bionic  | lxd-container | bundler  |
            | focal   | lxd-container | ant      |
 
-    @series.lts
     Scenario Outline: Attached enable with corrupt lock
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -4,9 +4,10 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     @slow
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro enable cc-eal` `as non-root` exits `1`
         And I will see the following on stderr:
@@ -24,15 +25,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             Please follow instructions in /usr/share/doc/ubuntu-commoncriteria/README to configure EAL2
             """
         Examples: ubuntu release
-            | release |
-            | xenial  |
-            | bionic  |
+            | release | machine_type  |
+            | xenial  | lxd-container |
+            | bionic  | lxd-container |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Enable cc-eal with --access-only
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         When I run `pro enable cc-eal --access-only` with sudo
         Then I will see the following on stdout:
@@ -44,17 +46,18 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
         Then I verify that running `apt-get install ubuntu-commoncriteria` `with sudo` exits `0`
         Examples: ubuntu release
-            | release |
-            | xenial  |
-            | bionic  |
+            | release | machine_type  |
+            | xenial  | lxd-container |
+            | bionic  | lxd-container |
 
     @series.focal
     @series.jammy
     @series.lunar
     @series.mantic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro enable cc-eal` `as non-root` exits `1`
         And I will see the following on stderr:
@@ -68,16 +71,17 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             CC EAL2 is not available for Ubuntu <version> (<full_name>).
             """
         Examples: ubuntu release
-            | release | version    | full_name        |
-            | focal   | 20.04 LTS  | Focal Fossa      |
-            | jammy   | 22.04 LTS  | Jammy Jellyfish  |
-            | lunar   | 23.04      | Lunar Lobster    |
-            | mantic  | 23.10      | Mantic Minotaur  |
+            | release | machine_type  | version    | full_name        |
+            | focal   | lxd-container | 20.04 LTS  | Focal Fossa      |
+            | jammy   | lxd-container | 22.04 LTS  | Jammy Jellyfish  |
+            | lunar   | lxd-container | 23.04      | Lunar Lobster    |
+            | mantic  | lxd-container | 23.10      | Mantic Minotaur  |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Empty series affordance means no series, null means all series
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
         When I set the machine token overlay to the following yaml
         """
@@ -119,16 +123,17 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Ubuntu Pro: ESM Infra enabled
         """
         Examples: ubuntu release
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
-            | jammy   |
+            | release | machine_type  |
+            | xenial  | lxd-container |
+            | bionic  | lxd-container |
+            | focal   | lxd-container |
+            | jammy   | lxd-container |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of different services using json format
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro enable foobar --format json` `as non-root` exits `1`
         And stdout is a json matching the `ua_operation` schema
@@ -189,16 +194,17 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | valid_services                                                                                                                             |
-           | xenial  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | machine_type  | valid_services                                                                                                                             |
+           | xenial  | lxd-container | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | lxd-container | anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | jammy   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of a service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro enable foobar` `as non-root` exits `1`
         And I will see the following on stderr:
@@ -250,15 +256,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | infra-pkg | esm-infra-url                       | msg                                                                                                                   |
-           | xenial  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | libkrad0  | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | hello     | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | machine_type  | infra-pkg | esm-infra-url                       | msg                                                                                                                   |
+           | xenial  | lxd-container | libkrad0  | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | lxd-container | libkrad0  | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | lxd-container | hello     | https://esm.ubuntu.com/infra/ubuntu | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline:  Attached enable of non-container services in a ubuntu lxd container
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro enable livepatch` `as non-root` exits `1`
         And I will see the following on stderr:
@@ -273,18 +280,19 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
 
         Examples: Un-supported services in containers
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | xenial  | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable not entitled service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
         """
         machineTokenInfo:
@@ -308,17 +316,18 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
 
         Examples: not entitled services
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of cis service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I verify that running `pro enable cis --access-only` `with sudo` exits `0`
         Then I will see the following on stdout:
@@ -396,14 +405,15 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: cis script
-           | release | cis_script                                  |
-           | bionic  | Canonical_Ubuntu_18.04_CIS-harden.sh        |
-           | xenial  | Canonical_Ubuntu_16.04_CIS_v1.1.0-harden.sh |
+           | release | machine_type  | cis_script                                  |
+           | bionic  | lxd-container | Canonical_Ubuntu_18.04_CIS-harden.sh        |
+           | xenial  | lxd-container | Canonical_Ubuntu_16.04_CIS_v1.1.0-harden.sh |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of cis service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I verify that running `pro enable cis` `with sudo` exits `0`
         Then I will see the following on stdout:
@@ -477,14 +487,15 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: cis script
-           | release | cis_script                                  |
-           | focal   | Canonical_Ubuntu_20.04_CIS-harden.sh        |
+           | release | machine_type  | cis_script                                  |
+           | focal   | lxd-container | Canonical_Ubuntu_20.04_CIS-harden.sh        |
 
     @series.bionic
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of usg service in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I verify that running `pro enable usg` `with sudo` exits `1`
         Then I will see the following on stdout:
@@ -498,14 +509,15 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: cis service
-           | release |
-           | bionic  |
-           | xenial  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | xenial  | lxd-container |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of usg service in a focal machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro enable usg` with sudo
         Then I will see the following on stdout:
@@ -560,14 +572,15 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
 
         Examples: cis service
-           | release |
-           | focal  |
+           | release | machine_type  |
+           | focal   | lxd-container |
 
     @series.bionic
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached disable of livepatch in a lxd vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro status` with sudo
         Then stdout matches regexp:
@@ -602,15 +615,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | livepatch_status |
-           | xenial  | warning          |
-           | bionic  | enabled          |
+           | release | machine_type | livepatch_status |
+           | xenial  | lxd-vm       | warning          |
+           | bionic  | lxd-vm       | enabled          |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attach works when snapd cannot be installed
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get remove -y snapd` with sudo
         And I create the file `/etc/apt/preferences.d/no-snapd` with the following
         """
@@ -641,15 +655,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Failed to install snapd on the system
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
+           | release | machine_type |
+           | xenial  | lxd-vm       |
+           | bionic  | lxd-vm       |
 
     @series.bionic
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable livepatch
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `canonical-livepatch status` `with sudo` exits `1`
         Then I will see the following on stderr:
             """
@@ -673,14 +688,15 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
 
         Examples: ubuntu release
-           | release | livepatch_status |
-           | xenial  | warning          |
-           | bionic  | enabled          |
+           | release | machine_type | livepatch_status |
+           | xenial  | lxd-vm       | warning          |
+           | bionic  | lxd-vm       | enabled          |
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable livepatch
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
@@ -743,14 +759,15 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
+           | release | machine_type  |
+           | xenial  | lxd-vm        |
 
     @slow
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario: Attached enable livepatch on a machine with fips active
-        Given a `bionic` machine with ubuntu-advantage-tools installed
+        Given a `bionic` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
             """
@@ -787,9 +804,10 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
 
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario: Attached enable fips on a machine with livepatch active
-        Given a `bionic` machine with ubuntu-advantage-tools installed
+        Given a `bionic` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
             """
@@ -819,9 +837,10 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     @slow
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable fips on a machine with livepatch active
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
             """
@@ -854,16 +873,17 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | xenial  |
+           | release | machine_type |
+           | bionic  | lxd-vm       |
+           | xenial  | lxd-vm       |
 
     @slow
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable fips on a machine with fips-updates active
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
             """
@@ -892,15 +912,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             """
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | xenial  |
+           | release | machine_type  |
+           | bionic  | lxd-vm        |
+           | xenial  | lxd-vm        |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable ros on a machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro status --all` as non-root
         Then stdout matches regexp
@@ -1052,18 +1073,19 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | ros-security-source                                    | ros-updates-source                                            |
-           | xenial  | https://esm.ubuntu.com/ros/ubuntu xenial-security/main | https://esm.ubuntu.com/ros-updates/ubuntu xenial-updates/main |
-           | bionic  | https://esm.ubuntu.com/ros/ubuntu bionic-security/main | https://esm.ubuntu.com/ros-updates/ubuntu bionic-updates/main |
+           | release | machine_type  | ros-security-source                                    | ros-updates-source                                            |
+           | xenial  | lxd-container | https://esm.ubuntu.com/ros/ubuntu xenial-security/main | https://esm.ubuntu.com/ros-updates/ubuntu xenial-updates/main |
+           | bionic  | lxd-container | https://esm.ubuntu.com/ros/ubuntu bionic-security/main | https://esm.ubuntu.com/ros-updates/ubuntu bionic-updates/main |
 
     # Overall test for overrides; in the future, when many services
     # have overrides, we can consider removing this
     # esm-infra is a good choice because it doesn't already have
     # other overrides that would interfere with the test
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     Scenario: Cloud overrides for a generic aws Focal instance
-       Given a `focal` machine with ubuntu-advantage-tools installed
+       Given a `focal` `aws.generic` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
         """
         machineTokenInfo:
@@ -1090,9 +1112,10 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: APT auth file is edited correctly on enable
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         When I run `wc -l /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
         Then I will see the following on stdout:
@@ -1116,13 +1139,14 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         3 /etc/apt/auth.conf.d/90ubuntu-advantage
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
+           | release | machine_type  |
+           | xenial  | aws.generic   |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable esm-apps on a machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro status --all` as non-root
         Then stdout matches regexp
@@ -1157,15 +1181,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | apps-pkg |
-           | xenial  | jq       |
-           | bionic  | bundler  |
-           | focal   | ant      |
+           | release | machine_type  | apps-pkg |
+           | xenial  | lxd-container | jq       |
+           | bionic  | lxd-container | bundler  |
+           | focal   | lxd-container | ant      |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable with corrupt lock
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro disable esm-infra --assume-yes` with sudo
         And I create the file `/var/lib/ubuntu-advantage/lock` with the following:
@@ -1182,8 +1207,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Attached status
 
-    @series.all
     Scenario Outline: Attached status in a ubuntu machine - formatted
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -40,7 +39,6 @@ Feature: Attached status
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.xenial
     Scenario Outline: Non-root status can see in-progress operations
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -80,8 +78,6 @@ Feature: Attached status
            | release | machine_type  |
            | xenial  | lxd-container |
 
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -128,7 +124,6 @@ Feature: Attached status
            | xenial  | lxd-container |
            | bionic  | lxd-container |
 
-    @series.focal
     Scenario Outline: Attached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -173,7 +168,6 @@ Feature: Attached status
            | release | machine_type  |
            | focal   | lxd-container |
 
-    @series.jammy
     Scenario Outline: Attached status in the latest LTS ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -2,9 +2,10 @@
 Feature: Attached status
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in a ubuntu machine - formatted
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro status --format json` as non-root
         Then stdout is a json matching the `ua_status` schema
@@ -33,18 +34,19 @@ Feature: Attached status
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Non-root status can see in-progress operations
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         When I run shell command `sudo pro enable cis >/dev/null & pro status` as non-root
         Then stdout matches regexp:
@@ -79,14 +81,15 @@ Feature: Attached status
         active
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I verify root and non-root `pro status` calls have the same output
         And I run `pro status` as non-root
@@ -127,14 +130,15 @@ Feature: Attached status
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I verify root and non-root `pro status` calls have the same output
         And I run `pro status` as non-root
@@ -174,13 +178,14 @@ Feature: Attached status
         """
 
         Examples: ubuntu release
-           | release |
-           | focal   |
+           | release | machine_type  |
+           | focal   | lxd-container |
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in the latest LTS ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I verify root and non-root `pro status` calls have the same output
         And I run `pro status` as non-root
@@ -219,5 +224,5 @@ Feature: Attached status
         """
 
         Examples: ubuntu release
-           | release |
-           | jammy   |
+           | release | machine_type  |
+           | jammy   | lxd-container |

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -2,8 +2,6 @@
 Feature: Attached status
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in a ubuntu machine - formatted
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -43,8 +41,6 @@ Feature: Attached status
            | mantic  | lxd-container |
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Non-root status can see in-progress operations
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -86,8 +82,6 @@ Feature: Attached status
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -135,8 +129,6 @@ Feature: Attached status
            | bionic  | lxd-container |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -182,8 +174,6 @@ Feature: Attached status
            | focal   | lxd-container |
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached status in the latest LTS ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -10,6 +10,49 @@ from pycloudlib.cloud import ImageType  # type: ignore
 DEFAULT_CONFIG_PATH = "~/.config/pycloudlib.toml"
 
 
+def cloud_factory(pro_config, cloud_name):
+    if cloud_name == "aws":
+        return EC2(
+            cloud_credentials_path=pro_config.cloud_credentials_path,
+            tag=pro_config.timed_job_tag,
+            timestamp_suffix=False,
+        )
+    if cloud_name == "azure":
+        return Azure(
+            cloud_credentials_path=pro_config.cloud_credentials_path,
+            tag=pro_config.timed_job_tag,
+            timestamp_suffix=False,
+        )
+    if cloud_name == "gcp":
+        return GCP(
+            cloud_credentials_path=pro_config.cloud_credentials_path,
+            tag=pro_config.timed_job_tag,
+            timestamp_suffix=False,
+        )
+    if cloud_name == "lxd-vm":
+        return LXDVirtualMachine(
+            cloud_credentials_path=pro_config.cloud_credentials_path,
+        )
+    if cloud_name == "lxd-container":
+        return LXDContainer(
+            cloud_credentials_path=pro_config.cloud_credentials_path,
+        )
+    raise RuntimeError("Invalid cloud name")
+
+
+class CloudManager:
+    def __init__(self, pro_config):
+        self.pro_config = pro_config
+        self.clouds = {}
+
+    def get(self, cloud_name):
+        cloud = self.clouds.get(cloud_name)
+        if cloud is None:
+            cloud = cloud_factory(self.pro_config, cloud_name)
+            self.clouds[cloud_name] = cloud
+        return cloud
+
+
 class Cloud:
     """Base class for cloud providers that should be tested through behave.
 

--- a/features/cloud_pro_clone.feature
+++ b/features/cloud_pro_clone.feature
@@ -1,6 +1,5 @@
 Feature: Creating golden images based on Cloud Ubuntu Pro instances
 
-    @series.lts
     Scenario Outline: Create a Pro fips-updates image and launch
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/cloud_pro_clone.feature
+++ b/features/cloud_pro_clone.feature
@@ -1,10 +1,11 @@
 Feature: Creating golden images based on Cloud Ubuntu Pro instances
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro
     @uses.config.machine_type.gcp.pro
     Scenario Outline: Create a Pro fips-updates image and launch
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -31,7 +32,7 @@ Feature: Creating golden images based on Cloud Ubuntu Pro instances
         When I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
         Then I verify that `activityInfo.activityToken` value has been updated on the contract
         Then I verify that `activityInfo.activityID` value has not been updated on the contract
-        When I launch a `<release>` machine named `clone` from the snapshot of `system-under-test`
+        When I launch a `<release>` `<machine_type>` machine named `clone` from the snapshot of `system-under-test`
         # The clone will run auto-attach on boot
         When I run `pro status --wait` `with sudo` on the `clone` machine
         Then the machine is attached
@@ -52,6 +53,8 @@ Feature: Creating golden images based on Cloud Ubuntu Pro instances
           status: enabled
         """
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
+           | release | machine_type  |
+           | bionic  | aws.pro       |
+           | bionic  | gcp.pro       |
+           | focal   | aws.pro       |
+           | focal   | gcp.pro       |

--- a/features/cloud_pro_clone.feature
+++ b/features/cloud_pro_clone.feature
@@ -1,9 +1,6 @@
 Feature: Creating golden images based on Cloud Ubuntu Pro instances
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro
-    @uses.config.machine_type.gcp.pro
     Scenario Outline: Create a Pro fips-updates image and launch
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -1,9 +1,10 @@
 Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Run collect-logs on an unattached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
         # simulate logrotate
         When I run `touch /var/log/ubuntu-advantage.log.1` with sudo
@@ -37,19 +38,20 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         ubuntu-advantage.service.txt
         """
         Examples: ubuntu release
-          | release |
-          | xenial  |
-          | bionic  |
-          | focal   |
-          | jammy   |
-          | lunar   |
-          | mantic  |
+          | release | machine_type  |
+          | xenial  | lxd-container |
+          | bionic  | lxd-container |
+          | focal   | lxd-container |
+          | jammy   | lxd-container |
+          | lunar   | lxd-container |
+          | mantic  | lxd-container |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Run collect-logs on an attached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
         # simulate logrotate
@@ -86,8 +88,8 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         ubuntu-esm-infra.list
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |

--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -1,6 +1,5 @@
 Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
-    @series.all
     Scenario Outline: Run collect-logs on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
@@ -44,7 +43,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
           | lunar   | lxd-container |
           | mantic  | lxd-container |
 
-    @series.lts
     @uses.config.contract_token
     Scenario Outline: Run collect-logs on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -1,8 +1,6 @@
 Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Run collect-logs on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
@@ -47,8 +45,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
           | mantic  | lxd-container |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Run collect-logs on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/config.feature
+++ b/features/config.feature
@@ -4,9 +4,10 @@ Feature: pro config sub-command
     @series.xenial
     @series.jammy
     @series.lunar
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: old ua_config in uaclient.conf is still supported
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro config show` with sudo
         Then I will see the following on stdout:
         """
@@ -50,7 +51,7 @@ Feature: pro config sub-command
         """
         """
         Examples: ubuntu release
-            | release |
-            | xenial  |
-            | jammy   |
-            | lunar   |
+            | release | machine_type  |
+            | xenial  | lxd-container |
+            | jammy   | lxd-container |
+            | lunar   | lxd-container |

--- a/features/config.feature
+++ b/features/config.feature
@@ -1,9 +1,6 @@
 Feature: pro config sub-command
 
     # earliest, latest lts[, latest stable]
-    @series.xenial
-    @series.jammy
-    @series.lunar
     Scenario Outline: old ua_config in uaclient.conf is still supported
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro config show` with sudo

--- a/features/config.feature
+++ b/features/config.feature
@@ -4,8 +4,6 @@ Feature: pro config sub-command
     @series.xenial
     @series.jammy
     @series.lunar
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: old ua_config in uaclient.conf is still supported
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro config show` with sudo

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -1,6 +1,5 @@
 Feature: Pro Upgrade Daemon only runs in environments where necessary
 
-    @series.all
     @uses.config.contract_token
     Scenario Outline: cloud-id-shim service is not installed on anything other than xenial
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -17,7 +16,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | lunar   | lxd-container |
             | mantic  | lxd-container |
 
-    @series.lts
     @uses.config.contract_token
     Scenario Outline: cloud-id-shim should run in postinst and on boot
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -53,7 +51,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | release | machine_type  |
             | xenial  | lxd-container |
 
-    @series.lts
     @uses.config.contract_token
     Scenario Outline: daemon should run when appropriate on gcp generic lts
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -209,7 +206,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | focal   | gcp.generic  |
             | jammy   | gcp.generic  |
 
-    @series.lts
     @uses.config.contract_token
     Scenario Outline: daemon should run when appropriate on azure generic lts
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -276,7 +272,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | focal   | azure.generic |
             | jammy   | azure.generic |
 
-    @series.lunar
     @uses.config.contract_token
     Scenario Outline: daemon does not start on gcp,azure generic non lts
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -299,7 +294,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | lunar   | azure.generic |
             | lunar   | gcp.generic   |
 
-    @series.all
     @uses.config.contract_token
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -336,7 +330,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | lunar   | lxd-vm        |
             | lunar   | aws.generic   |
 
-    @series.lts
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -367,7 +360,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | bionic  | aws.pro       |
             | focal   | aws.pro       |
 
-    @series.lts
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -2,8 +2,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
 
     @series.all
     @uses.config.contract_token
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: cloud-id-shim service is not installed on anything other than xenial
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Then I verify that running `systemctl status ubuntu-advantage-cloud-id-shim.service` `with sudo` exits `4`
@@ -21,8 +19,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
 
     @series.lts
     @uses.config.contract_token
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: cloud-id-shim should run in postinst and on boot
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # verify installing pro created the cloud-id file
@@ -59,8 +55,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
 
     @series.lts
     @uses.config.contract_token
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: daemon should run when appropriate on gcp generic lts
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # verify its enabled, but stops itself when not configured to poll
@@ -217,8 +211,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
 
     @series.lts
     @uses.config.contract_token
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.generic
     Scenario Outline: daemon should run when appropriate on azure generic lts
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # verify its enabled, but stops itself when not configured to poll
@@ -286,9 +278,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
 
     @series.lunar
     @uses.config.contract_token
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.generic
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: daemon does not start on gcp,azure generic non lts
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I wait `1` seconds
@@ -312,10 +301,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
 
     @series.all
     @uses.config.contract_token
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
-    @uses.config.machine_type.lxd-vm
-    @uses.config.machine_type.aws.generic
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Then I verify that running `systemctl status ubuntu-advantage.service` `with sudo` exits `3`
@@ -352,8 +337,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | lunar   | aws.generic   |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -385,9 +368,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | focal   | aws.pro       |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro
-    @uses.config.machine_type.azure.pro
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -2,27 +2,29 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
 
     @series.all
     @uses.config.contract_token
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: cloud-id-shim service is not installed on anything other than xenial
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Then I verify that running `systemctl status ubuntu-advantage-cloud-id-shim.service` `with sudo` exits `4`
         Then stderr matches regexp:
         """
         Unit ubuntu-advantage-cloud-id-shim.service could not be found.
         """
         Examples: version
-            | release |
-            | bionic  |
-            | focal   |
-            | jammy   |
-            | lunar   |
-            | mantic  |
+            | release | machine_type  |
+            | bionic  | lxd-container |
+            | focal   | lxd-container |
+            | jammy   | lxd-container |
+            | lunar   | lxd-container |
+            | mantic  | lxd-container |
 
     @series.lts
     @uses.config.contract_token
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: cloud-id-shim should run in postinst and on boot
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # verify installing pro created the cloud-id file
         When I run `cat /run/cloud-init/cloud-id` with sudo
         Then I will see the following on stdout
@@ -52,14 +54,15 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
         lxd
         """
         Examples: version
-            | release |
-            | xenial  |
+            | release | machine_type  |
+            | xenial  | lxd-container |
 
     @series.lts
     @uses.config.contract_token
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.generic
     Scenario Outline: daemon should run when appropriate on gcp generic lts
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # verify its enabled, but stops itself when not configured to poll
         When I run `journalctl -o cat -u ubuntu-advantage.service` with sudo
         Then stdout contains substring:
@@ -206,17 +209,18 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
         Active: inactive \(dead\)
         """
         Examples: version
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
-            | jammy   |
+            | release | machine_type |
+            | xenial  | gcp.generic  |
+            | bionic  | gcp.generic  |
+            | focal   | gcp.generic  |
+            | jammy   | gcp.generic  |
 
     @series.lts
     @uses.config.contract_token
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.generic
     Scenario Outline: daemon should run when appropriate on azure generic lts
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # verify its enabled, but stops itself when not configured to poll
         When I run `journalctl -o cat -u ubuntu-advantage.service` with sudo
         Then stdout contains substring:
@@ -274,18 +278,19 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
         inactive
         """
         Examples: version
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
-            | jammy   |
+            | release | machine_type  |
+            | xenial  | azure.generic |
+            | bionic  | azure.generic |
+            | focal   | azure.generic |
+            | jammy   | azure.generic |
 
     @series.lunar
     @uses.config.contract_token
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.generic
     @uses.config.machine_type.gcp.generic
     Scenario Outline: daemon does not start on gcp,azure generic non lts
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I wait `1` seconds
         When I run `journalctl -o cat -u ubuntu-advantage.service` with sudo
         Then stdout contains substring:
@@ -301,16 +306,18 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
         daemon ending
         """
         Examples: version
-            | release |
-            | lunar   |
+            | release | machine_type  |
+            | lunar   | azure.generic |
+            | lunar   | gcp.generic   |
 
     @series.all
     @uses.config.contract_token
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.machine_type.lxd-vm
     @uses.config.machine_type.aws.generic
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Then I verify that running `systemctl status ubuntu-advantage.service` `with sudo` exits `3`
         Then stdout matches regexp:
         """
@@ -327,17 +334,28 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
         \s*Condition: start condition failed.*
         """
         Examples: version
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
-            | jammy   |
-            | lunar   |
+            | release | machine_type  |
+            | xenial  | lxd-container |
+            | xenial  | lxd-vm        |
+            | xenial  | aws.generic   |
+            | bionic  | lxd-container |
+            | bionic  | lxd-vm        |
+            | bionic  | aws.generic   |
+            | focal   | lxd-container |
+            | focal   | lxd-vm        |
+            | focal   | aws.generic   |
+            | jammy   | lxd-container |
+            | jammy   | lxd-vm        |
+            | jammy   | aws.generic   |
+            | lunar   | lxd-container |
+            | lunar   | lxd-vm        |
+            | lunar   | aws.generic   |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -361,16 +379,17 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
         \s*Condition: start condition failed.*
         """
         Examples: version
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
+            | release | machine_type  |
+            | xenial  | aws.pro       |
+            | bionic  | aws.pro       |
+            | focal   | aws.pro       |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro
     @uses.config.machine_type.azure.pro
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -408,7 +427,10 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
         daemon starting
         """
         Examples: version
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
+            | release | machine_type  |
+            | xenial  | azure.pro     |
+            | xenial  | gcp.pro       |
+            | bionic  | azure.pro     |
+            | bionic  | gcp.pro       |
+            | focal   | azure.pro     |
+            | focal   | gcp.pro       |

--- a/features/detached_auto_attach.feature
+++ b/features/detached_auto_attach.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Attached cloud does not detach when auto-attaching after manually attaching
 
-    @series.lts
     Scenario Outline: No detaching on manually attached machine on all clouds
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/detached_auto_attach.feature
+++ b/features/detached_auto_attach.feature
@@ -2,10 +2,6 @@
 Feature: Attached cloud does not detach when auto-attaching after manually attaching
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
-    @uses.config.machine_type.azure.generic
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: No detaching on manually attached machine on all clouds
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/detached_auto_attach.feature
+++ b/features/detached_auto_attach.feature
@@ -2,11 +2,12 @@
 Feature: Attached cloud does not detach when auto-attaching after manually attaching
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     @uses.config.machine_type.azure.generic
     @uses.config.machine_type.gcp.generic
     Scenario Outline: No detaching on manually attached machine on all clouds
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro refresh` with sudo
         Then I will see the following on stdout:
@@ -28,7 +29,13 @@ Feature: Attached cloud does not detach when auto-attaching after manually attac
         """
 
         Examples: ubuntu release
-           | release | esm-service |
-           | bionic  | enabled     |
-           | focal   | enabled     |
-           | xenial  | enabled     |
+           | release | machine_type  | esm-service |
+           | xenial  | aws.generic   | enabled     |
+           | xenial  | azure.generic | enabled     |
+           | xenial  | gcp.generic   | enabled     |
+           | bionic  | aws.generic   | enabled     |
+           | bionic  | azure.generic | enabled     |
+           | bionic  | gcp.generic   | enabled     |
+           | focal   | aws.generic   | enabled     |
+           | focal   | azure.generic | enabled     |
+           | focal   | gcp.generic   | enabled     |

--- a/features/docker.feature
+++ b/features/docker.feature
@@ -3,7 +3,6 @@ Feature: Build docker images with pro services
 
     @slow
     @docker
-    @series.mantic
     Scenario Outline: Build docker images with pro services
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I have the `<container_release>` debs under test in `/home/ubuntu`

--- a/features/docker.feature
+++ b/features/docker.feature
@@ -4,8 +4,6 @@ Feature: Build docker images with pro services
     @slow
     @docker
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Build docker images with pro services
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I have the `<container_release>` debs under test in `/home/ubuntu`

--- a/features/docker.feature
+++ b/features/docker.feature
@@ -4,9 +4,10 @@ Feature: Build docker images with pro services
     @slow
     @docker
     @series.mantic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Build docker images with pro services
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I have the `<container_release>` debs under test in `/home/ubuntu`
         When I run `apt-get install -y docker.io docker-buildx jq` with sudo
         When I create the file `/home/ubuntu/Dockerfile` with the following:
@@ -73,7 +74,7 @@ Feature: Build docker images with pro services
         Then I verify that running `DOCKER_BUILDKIT=1 docker build . --no-cache --secret id=ua-attach-config,src=ua-attach-config.yaml -t ua-test` `with sudo` exits `1`
 
         Examples: ubuntu release
-           | release | container_release |enable_services | test_package_name | test_package_version |
-           | mantic  | xenial            | [ esm-infra ]  | curl              | esm                  |
-           | mantic  | bionic            | [ fips ]       | openssl           | fips                 |
-           | mantic  | focal             | [ esm-apps ]   | hello             | esm                  |
+           | release | machine_type | container_release |enable_services | test_package_name | test_package_version |
+           | mantic  | lxd-vm       | xenial            | [ esm-infra ]  | curl              | esm                  |
+           | mantic  | lxd-vm       | bionic            | [ fips ]       | openssl           | fips                 |
+           | mantic  | lxd-vm       | focal             | [ esm-apps ]   | hello             | esm                  |

--- a/features/enable_fips_cloud.feature
+++ b/features/enable_fips_cloud.feature
@@ -2,8 +2,6 @@
 Feature: FIPS enablement in cloud based machines
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: Attached enable of FIPS services in an ubuntu gcp vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -19,9 +17,6 @@ Feature: FIPS enablement in cloud based machines
             | xenial  | gcp.generic  | Xenial        | fips-updates  |
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
-    @uses.config.machine_type.azure.generic
     Scenario Outline: FIPS unholds packages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -57,10 +52,6 @@ Feature: FIPS enablement in cloud based machines
 
 
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
-    @uses.config.machine_type.azure.generic
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: FIPS unholds packages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -96,10 +87,6 @@ Feature: FIPS enablement in cloud based machines
            | bionic  | gcp.generic   | https://esm.ubuntu.com/fips/ubuntu bionic/main |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
-    @uses.config.machine_type.azure.generic
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: FIPS unholds packages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -134,8 +121,6 @@ Feature: FIPS enablement in cloud based machines
     @series.xenial
     @series.bionic
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.generic
     Scenario Outline: Enable FIPS in an ubuntu Azure vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -198,8 +183,6 @@ Feature: FIPS enablement in cloud based machines
 
     @slow
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
     Scenario Outline: Attached FIPS in an ubuntu Xenial AWS vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -279,8 +262,6 @@ Feature: FIPS enablement in cloud based machines
     @slow
     @series.bionic
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
     Scenario Outline: Attached enable of FIPS in an ubuntu AWS vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -343,8 +324,6 @@ Feature: FIPS enablement in cloud based machines
     @slow
     @series.bionic
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: Attached enable of FIPS in an ubuntu GCP vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -405,8 +384,6 @@ Feature: FIPS enablement in cloud based machines
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
     Scenario Outline: Attached enable of FIPS in an ubuntu image with cloud-init disabled
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `touch /etc/cloud/cloud-init.disabled` with sudo

--- a/features/enable_fips_cloud.feature
+++ b/features/enable_fips_cloud.feature
@@ -2,9 +2,10 @@
 Feature: FIPS enablement in cloud based machines
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.generic
     Scenario Outline: Attached enable of FIPS services in an ubuntu gcp vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro enable <fips_service> --assume-yes` `with sudo` exits `1`
         And stdout matches regexp:
@@ -13,15 +14,16 @@ Feature: FIPS enablement in cloud based machines
         """
 
         Examples: fips
-            | release | release_title | fips_service  |
-            | xenial  | Xenial        | fips          |
-            | xenial  | Xenial        | fips-updates  |
+            | release | machine_type | release_title | fips_service  |
+            | xenial  | gcp.generic  | Xenial        | fips          |
+            | xenial  | gcp.generic  | Xenial        | fips-updates  |
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     @uses.config.machine_type.azure.generic
     Scenario Outline: FIPS unholds packages
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
@@ -49,16 +51,18 @@ Feature: FIPS enablement in cloud based machines
         And I verify that `strongswan-hmac` installed version matches regexp `fips`
 
         Examples: ubuntu release
-           | release | fips-apt-source                                |
-           | xenial  | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | release | machine_type  | fips-apt-source                                |
+           | xenial  | aws.generic   | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | xenial  | azure.generic | https://esm.ubuntu.com/fips/ubuntu xenial/main |
 
 
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     @uses.config.machine_type.azure.generic
     @uses.config.machine_type.gcp.generic
     Scenario Outline: FIPS unholds packages
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
@@ -86,15 +90,18 @@ Feature: FIPS enablement in cloud based machines
         And I verify that `strongswan-hmac` installed version matches regexp `fips`
 
         Examples: ubuntu release
-           | release | fips-apt-source                                |
-           | bionic  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | release | machine_type  | fips-apt-source                                |
+           | bionic  | aws.generic   | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | azure.generic | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | gcp.generic   | https://esm.ubuntu.com/fips/ubuntu bionic/main |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     @uses.config.machine_type.azure.generic
     @uses.config.machine_type.gcp.generic
     Scenario Outline: FIPS unholds packages
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
@@ -118,16 +125,19 @@ Feature: FIPS enablement in cloud based machines
         And I verify that `strongswan-hmac` installed version matches regexp `fips`
 
         Examples: ubuntu release
-           | release | fips-apt-source                                |
-           | focal   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type  | fips-apt-source                                |
+           | focal   | aws.generic   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | azure.generic | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | gcp.generic   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
     @series.xenial
     @series.bionic
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.generic
     Scenario Outline: Enable FIPS in an ubuntu Azure vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
@@ -178,19 +188,20 @@ Feature: FIPS enablement in cloud based machines
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service | fips-package      | fips-kernel  | fips-apt-source                                |
-           | xenial  | FIPS         | fips         | ubuntu-fips       |  fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
-           | xenial  | FIPS Updates | fips-updates | ubuntu-fips       |  fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
-           | bionic  | FIPS         | fips         | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | FIPS Updates | fips-updates | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | FIPS         | fips         | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | FIPS Updates | fips-updates | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type  | fips-name    | fips-service | fips-package      | fips-kernel  | fips-apt-source                                |
+           | xenial  | azure.generic | FIPS         | fips         | ubuntu-fips       |  fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | xenial  | azure.generic | FIPS Updates | fips-updates | ubuntu-fips       |  fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | bionic  | azure.generic | FIPS         | fips         | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | azure.generic | FIPS Updates | fips-updates | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | focal   | azure.generic | FIPS         | fips         | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | azure.generic | FIPS Updates | fips-updates | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     Scenario Outline: Attached FIPS in an ubuntu Xenial AWS vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro disable livepatch` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
@@ -262,15 +273,16 @@ Feature: FIPS enablement in cloud based machines
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                |
-           | xenial  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
+           | xenial  | aws.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu xenial/main |
 
     @slow
     @series.bionic
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     Scenario Outline: Attached enable of FIPS in an ubuntu AWS vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro disable livepatch` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
@@ -322,18 +334,19 @@ Feature: FIPS enablement in cloud based machines
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
+           | bionic  | aws.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | aws.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | focal   | aws.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | aws.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
     @series.bionic
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.generic
     Scenario Outline: Attached enable of FIPS in an ubuntu GCP vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
@@ -384,18 +397,18 @@ Feature: FIPS enablement in cloud based machines
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
+           | bionic  | gcp.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | gcp.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | focal   | gcp.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | gcp.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
     @series.lts
     @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     Scenario Outline: Attached enable of FIPS in an ubuntu image with cloud-init disabled
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `touch /etc/cloud/cloud-init.disabled` with sudo
         And I reboot the machine
         And I verify that running `cloud-id` `with sudo` exits `1`
@@ -434,8 +447,8 @@ Feature: FIPS enablement in cloud based machines
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type |
+           | xenial  | aws.generic  |
+           | bionic  | aws.generic  |
+           | focal   | aws.generic  |
+           | jammy   | aws.generic  |

--- a/features/enable_fips_cloud.feature
+++ b/features/enable_fips_cloud.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: FIPS enablement in cloud based machines
 
-    @series.lts
     Scenario Outline: Attached enable of FIPS services in an ubuntu gcp vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -16,7 +15,6 @@ Feature: FIPS enablement in cloud based machines
             | xenial  | gcp.generic  | Xenial        | fips          |
             | xenial  | gcp.generic  | Xenial        | fips-updates  |
 
-    @series.xenial
     Scenario Outline: FIPS unholds packages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -51,7 +49,6 @@ Feature: FIPS enablement in cloud based machines
            | xenial  | azure.generic | https://esm.ubuntu.com/fips/ubuntu xenial/main |
 
 
-    @series.bionic
     Scenario Outline: FIPS unholds packages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -86,7 +83,6 @@ Feature: FIPS enablement in cloud based machines
            | bionic  | azure.generic | https://esm.ubuntu.com/fips/ubuntu bionic/main |
            | bionic  | gcp.generic   | https://esm.ubuntu.com/fips/ubuntu bionic/main |
 
-    @series.focal
     Scenario Outline: FIPS unholds packages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -118,9 +114,6 @@ Feature: FIPS enablement in cloud based machines
            | focal   | gcp.generic   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
-    @series.xenial
-    @series.bionic
-    @series.focal
     Scenario Outline: Enable FIPS in an ubuntu Azure vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -182,7 +175,6 @@ Feature: FIPS enablement in cloud based machines
            | focal   | azure.generic | FIPS Updates | fips-updates | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
-    @series.xenial
     Scenario Outline: Attached FIPS in an ubuntu Xenial AWS vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -260,8 +252,6 @@ Feature: FIPS enablement in cloud based machines
            | xenial  | aws.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu xenial/main |
 
     @slow
-    @series.bionic
-    @series.focal
     Scenario Outline: Attached enable of FIPS in an ubuntu AWS vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -322,8 +312,6 @@ Feature: FIPS enablement in cloud based machines
            | focal   | aws.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
-    @series.bionic
-    @series.focal
     Scenario Outline: Attached enable of FIPS in an ubuntu GCP vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -383,7 +371,6 @@ Feature: FIPS enablement in cloud based machines
            | focal   | gcp.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
-    @series.lts
     Scenario Outline: Attached enable of FIPS in an ubuntu image with cloud-init disabled
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `touch /etc/cloud/cloud-init.disabled` with sudo

--- a/features/enable_fips_container.feature
+++ b/features/enable_fips_container.feature
@@ -5,8 +5,6 @@ Feature: FIPS enablement in lxd containers
     @series.xenial
     @series.bionic
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -102,8 +100,6 @@ Feature: FIPS enablement in lxd containers
     @series.xenial
     @series.bionic
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Try to enable FIPS after FIPS Updates in a lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/enable_fips_container.feature
+++ b/features/enable_fips_container.feature
@@ -5,9 +5,10 @@ Feature: FIPS enablement in lxd containers
     @series.xenial
     @series.bionic
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd container
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan openssl <libssl> libgcrypt20` with sudo, retrying exit [100]
         And I run `pro enable fips<updates>` `with sudo` and stdin `y`
@@ -90,20 +91,21 @@ Feature: FIPS enablement in lxd containers
         And I verify that packages `<additional-fips-packages>` installed versions match regexp `fips`
 
         Examples: ubuntu release
-           | release | fips-name    | updates  | libssl      | additional-fips-packages                                             |
-           | xenial  | FIPS         |          | libssl1.0.0 | openssh-server-hmac openssh-client-hmac                              |
-           | xenial  | FIPS Updates | -updates | libssl1.0.0 | openssh-server-hmac openssh-client-hmac                              |
-           | bionic  | FIPS         |          | libssl1.1   | openssh-server-hmac openssh-client-hmac libgcrypt20 libgcrypt20-hmac |
-           | bionic  | FIPS Updates | -updates | libssl1.1   | openssh-server-hmac openssh-client-hmac libgcrypt20 libgcrypt20-hmac |
-           | focal   | FIPS         |          | libssl1.1   | libgcrypt20 libgcrypt20-hmac                                         |
-           | focal   | FIPS Updates | -updates | libssl1.1   | libgcrypt20 libgcrypt20-hmac                                         |
+           | release | machine_type  | fips-name    | updates  | libssl      | additional-fips-packages                                             |
+           | xenial  | lxd-container | FIPS         |          | libssl1.0.0 | openssh-server-hmac openssh-client-hmac                              |
+           | xenial  | lxd-container | FIPS Updates | -updates | libssl1.0.0 | openssh-server-hmac openssh-client-hmac                              |
+           | bionic  | lxd-container | FIPS         |          | libssl1.1   | openssh-server-hmac openssh-client-hmac libgcrypt20 libgcrypt20-hmac |
+           | bionic  | lxd-container | FIPS Updates | -updates | libssl1.1   | openssh-server-hmac openssh-client-hmac libgcrypt20 libgcrypt20-hmac |
+           | focal   | lxd-container | FIPS         |          | libssl1.1   | libgcrypt20 libgcrypt20-hmac                                         |
+           | focal   | lxd-container | FIPS Updates | -updates | libssl1.1   | libgcrypt20 libgcrypt20-hmac                                         |
 
     @series.xenial
     @series.bionic
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Try to enable FIPS after FIPS Updates in a lxd container
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -139,7 +141,7 @@ Feature: FIPS enablement in lxd containers
             fips +yes +n/a
             """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |

--- a/features/enable_fips_container.feature
+++ b/features/enable_fips_container.feature
@@ -2,9 +2,6 @@
 @uses.config.contract_token
 Feature: FIPS enablement in lxd containers
 
-    @series.xenial
-    @series.bionic
-    @series.focal
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -97,9 +94,6 @@ Feature: FIPS enablement in lxd containers
            | focal   | lxd-container | FIPS         |          | libssl1.1   | libgcrypt20 libgcrypt20-hmac                                         |
            | focal   | lxd-container | FIPS Updates | -updates | libssl1.1   | libgcrypt20 libgcrypt20-hmac                                         |
 
-    @series.xenial
-    @series.bionic
-    @series.focal
     Scenario Outline: Try to enable FIPS after FIPS Updates in a lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/enable_fips_pro.feature
+++ b/features/enable_fips_pro.feature
@@ -3,8 +3,6 @@ Feature: FIPS enablement in PRO cloud based machines
     @slow
     @series.bionic
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro
     Scenario Outline: Attached enable of FIPS in an ubuntu Azure PRO vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -63,8 +61,6 @@ Feature: FIPS enablement in PRO cloud based machines
     @slow
     @series.bionic
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.pro
     Scenario Outline: Attached enable of FIPS in an ubuntu Azure PRO vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -124,8 +120,6 @@ Feature: FIPS enablement in PRO cloud based machines
     @slow
     @series.bionic
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro
     Scenario Outline: Attached enable of FIPS in an ubuntu GCP PRO vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/enable_fips_pro.feature
+++ b/features/enable_fips_pro.feature
@@ -1,8 +1,6 @@
 Feature: FIPS enablement in PRO cloud based machines
 
     @slow
-    @series.bionic
-    @series.focal
     Scenario Outline: Attached enable of FIPS in an ubuntu Azure PRO vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -59,8 +57,6 @@ Feature: FIPS enablement in PRO cloud based machines
            | focal   | aws.pro      | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
-    @series.bionic
-    @series.focal
     Scenario Outline: Attached enable of FIPS in an ubuntu Azure PRO vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -118,8 +114,6 @@ Feature: FIPS enablement in PRO cloud based machines
 
 
     @slow
-    @series.bionic
-    @series.focal
     Scenario Outline: Attached enable of FIPS in an ubuntu GCP PRO vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/enable_fips_pro.feature
+++ b/features/enable_fips_pro.feature
@@ -3,9 +3,10 @@ Feature: FIPS enablement in PRO cloud based machines
     @slow
     @series.bionic
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro
     Scenario Outline: Attached enable of FIPS in an ubuntu Azure PRO vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -53,18 +54,19 @@ Feature: FIPS enablement in PRO cloud based machines
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
+           | bionic  | aws.pro      | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | aws.pro      | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | focal   | aws.pro      | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | aws.pro      | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
     @series.bionic
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.pro
     Scenario Outline: Attached enable of FIPS in an ubuntu Azure PRO vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -112,19 +114,20 @@ Feature: FIPS enablement in PRO cloud based machines
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
+           | bionic  | azure.pro    | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | azure.pro    | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | focal   | azure.pro    | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | azure.pro    | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
 
     @slow
     @series.bionic
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro
     Scenario Outline: Attached enable of FIPS in an ubuntu GCP PRO vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -172,8 +175,8 @@ Feature: FIPS enablement in PRO cloud based machines
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
+           | bionic  | gcp.pro      | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | gcp.pro      | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | focal   | gcp.pro      | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | gcp.pro      | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -4,9 +4,10 @@ Feature: FIPS enablement in lxd VMs
     @slow
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         When I run `pro status --format json` with sudo
         Then stdout contains substring
@@ -129,16 +130,17 @@ Feature: FIPS enablement in lxd VMs
         """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                |
-           | xenial  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu xenial/main |
-           | bionic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
+           | xenial  | lxd-vm       | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | bionic  | lxd-vm       | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
 
     @slow
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable of FIPS-updates in an ubuntu lxd vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro disable livepatch` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
@@ -267,16 +269,17 @@ Feature: FIPS enablement in lxd VMs
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                                |
-           | xenial  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu xenial-updates/main |
-           | bionic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu bionic-updates/main |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                                                |
+           | xenial  | lxd-vm       | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu xenial-updates/main |
+           | bionic  | lxd-vm       | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu bionic-updates/main |
 
     @slow
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable FIPS-updates while livepatch is enabled
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -325,15 +328,16 @@ Feature: FIPS enablement in lxd VMs
             livepatch +yes +enabled
             """
         Examples: ubuntu release
-           | release | livepatch_status |
-           | xenial  | warning          |
-           | bionic  | enabled          |
+           | release | machine_type | livepatch_status |
+           | xenial  | lxd-vm       | warning          |
+           | bionic  | lxd-vm       | enabled          |
 
     @slow
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         When I run `pro enable <fips-service> --assume-yes` with sudo
@@ -390,14 +394,15 @@ Feature: FIPS enablement in lxd VMs
             """
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                               |
-           | focal   | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                               |
+           | focal   | lxd-vm       | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main |
 
     @slow
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable of FIPS-updates in an ubuntu lxd vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         When I run `pro enable <fips-service> --assume-yes` with sudo
@@ -460,14 +465,15 @@ Feature: FIPS enablement in lxd VMs
         And I verify that files exist matching `/var/lib/ubuntu-advantage/services-once-enabled`
 
         Examples: ubuntu release
-           | release | fips-name    | fips-service |fips-apt-source                                               |
-           | focal   | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main |
+           | release | machine_type | fips-name    | fips-service |fips-apt-source                                               |
+           | focal   | lxd-vm       | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main |
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable fips-updates on fips enabled vm
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro enable fips --assume-yes` with sudo
         Then stdout matches regexp:
@@ -534,17 +540,18 @@ Feature: FIPS enablement in lxd VMs
             """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
+           | release | machine_type |
+           | xenial  | lxd-vm       |
+           | bionic  | lxd-vm       |
+           | focal   | lxd-vm       |
 
     @slow
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: FIPS enablement message when cloud init didn't run properly
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
         And I attach `contract_token` with sudo
         And I run `pro disable livepatch` with sudo
@@ -560,15 +567,16 @@ Feature: FIPS enablement in lxd VMs
         """
 
         Examples: ubuntu release
-        | release |
-        | xenial  |
-        | bionic  |
+        | release | machine_type |
+        | xenial  | lxd-vm       |
+        | bionic  | lxd-vm       |
 
     @slow
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: FIPS enablement message when cloud init didn't run properly
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
         And I attach `contract_token` with sudo
         And I run `pro enable fips --assume-yes` with sudo
@@ -583,15 +591,16 @@ Feature: FIPS enablement in lxd VMs
         """
 
         Examples: ubuntu release
-        | release |
-        | focal   |
+        | release | machine_type |
+        | focal   | lxd-vm       |
 
 
     @slow
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable fips-preview
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml
         """
         availableResources:
@@ -633,5 +642,5 @@ Feature: FIPS enablement in lxd VMs
         """
 
         Examples: ubuntu release
-           | release |
-           | jammy   |
+           | release | machine_type |
+           | jammy   | lxd-vm       |

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -2,8 +2,6 @@
 Feature: FIPS enablement in lxd VMs
 
     @slow
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -133,8 +131,6 @@ Feature: FIPS enablement in lxd VMs
            | bionic  | lxd-vm       | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
 
     @slow
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attached enable of FIPS-updates in an ubuntu lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -270,8 +266,6 @@ Feature: FIPS enablement in lxd VMs
            | bionic  | lxd-vm       | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu bionic-updates/main |
 
     @slow
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attached enable FIPS-updates while livepatch is enabled
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -327,7 +321,6 @@ Feature: FIPS enablement in lxd VMs
            | bionic  | lxd-vm       | enabled          |
 
     @slow
-    @series.focal
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -390,7 +383,6 @@ Feature: FIPS enablement in lxd VMs
            | focal   | lxd-vm       | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main |
 
     @slow
-    @series.focal
     Scenario Outline: Attached enable of FIPS-updates in an ubuntu lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -459,7 +451,6 @@ Feature: FIPS enablement in lxd VMs
            | focal   | lxd-vm       | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main |
 
     @slow
-    @series.lts
     Scenario Outline: Attached enable fips-updates on fips enabled vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -534,8 +525,6 @@ Feature: FIPS enablement in lxd VMs
            | focal   | lxd-vm       |
 
     @slow
-    @series.xenial
-    @series.bionic
     Scenario Outline: FIPS enablement message when cloud init didn't run properly
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
@@ -558,7 +547,6 @@ Feature: FIPS enablement in lxd VMs
         | bionic  | lxd-vm       |
 
     @slow
-    @series.focal
     Scenario Outline: FIPS enablement message when cloud init didn't run properly
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
@@ -580,7 +568,6 @@ Feature: FIPS enablement in lxd VMs
 
 
     @slow
-    @series.jammy
     Scenario Outline: Attached enable fips-preview
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -4,8 +4,6 @@ Feature: FIPS enablement in lxd VMs
     @slow
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -137,8 +135,6 @@ Feature: FIPS enablement in lxd VMs
     @slow
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable of FIPS-updates in an ubuntu lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -276,8 +272,6 @@ Feature: FIPS enablement in lxd VMs
     @slow
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable FIPS-updates while livepatch is enabled
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -334,8 +328,6 @@ Feature: FIPS enablement in lxd VMs
 
     @slow
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -399,8 +391,6 @@ Feature: FIPS enablement in lxd VMs
 
     @slow
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable of FIPS-updates in an ubuntu lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -470,8 +460,6 @@ Feature: FIPS enablement in lxd VMs
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable fips-updates on fips enabled vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -548,8 +536,6 @@ Feature: FIPS enablement in lxd VMs
     @slow
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: FIPS enablement message when cloud init didn't run properly
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
@@ -573,8 +559,6 @@ Feature: FIPS enablement in lxd VMs
 
     @slow
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: FIPS enablement message when cloud init didn't run properly
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
@@ -597,8 +581,6 @@ Feature: FIPS enablement in lxd VMs
 
     @slow
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached enable fips-preview
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I set the machine token overlay to the following yaml

--- a/features/environment.py
+++ b/features/environment.py
@@ -228,40 +228,19 @@ class UAClientBehaveConfig:
             random.choices(string.ascii_lowercase + string.digits, k=8)
         )
         timed_job_tag += "-" + random_suffix
+        self.timed_job_tag = timed_job_tag
 
-        self.clouds = {
-            "aws": cloud.EC2(
-                cloud_credentials_path=self.cloud_credentials_path,
-                tag=timed_job_tag,
-                timestamp_suffix=False,
-            ),
-            "azure": cloud.Azure(
-                cloud_credentials_path=self.cloud_credentials_path,
-                tag=timed_job_tag,
-                timestamp_suffix=False,
-            ),
-            "gcp": cloud.GCP(
-                cloud_credentials_path=self.cloud_credentials_path,
-                tag=timed_job_tag,
-                timestamp_suffix=False,
-            ),
-            "lxd-vm": cloud.LXDVirtualMachine(
-                cloud_credentials_path=self.cloud_credentials_path,
-            ),
-            "lxd-container": cloud.LXDContainer(
-                cloud_credentials_path=self.cloud_credentials_path,
-            ),
-        }
+        self.clouds = cloud.CloudManager(self)
         if "aws" in self.machine_type:
-            self.default_cloud = self.clouds["aws"]
+            self.default_cloud = self.clouds.get("aws")
         elif "azure" in self.machine_type:
-            self.default_cloud = self.clouds["azure"]
+            self.default_cloud = self.clouds.get("azure")
         elif "gcp" in self.machine_type:
-            self.default_cloud = self.clouds["gcp"]
+            self.default_cloud = self.clouds.get("gcp")
         elif "lxd-vm" in self.machine_type:
-            self.default_cloud = self.clouds["lxd-vm"]
+            self.default_cloud = self.clouds.get("lxd-vm")
         else:
-            self.default_cloud = self.clouds["lxd-container"]
+            self.default_cloud = self.clouds.get("lxd-container")
 
         # Finally, print the config options.  This helps users debug the use of
         # config options, and means they'll be included in test logs in CI.

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -1,8 +1,6 @@
 Feature: Ua fix command behaviour
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Useful SSL failure message when there aren't any ca-certs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -34,8 +32,6 @@ Feature: Ua fix command behaviour
            | mantic  | lxd-container |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -200,8 +196,6 @@ Feature: Ua fix command behaviour
 
     @series.xenial
     @uses.config.contract_token
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
@@ -549,8 +543,6 @@ Feature: Ua fix command behaviour
            | xenial  | lxd-container |
 
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario: Fix command on an unattached machine
         Given a `bionic` `lxd-container` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -832,8 +824,6 @@ Feature: Ua fix command behaviour
         """
 
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario: Fix command on a machine without security/updates source lists
         Given a `bionic` `lxd-container` machine with ubuntu-advantage-tools installed
         When I run `sed -i "/bionic-updates/d" /etc/apt/sources.list` with sudo

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -1,9 +1,10 @@
 Feature: Ua fix command behaviour
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Useful SSL failure message when there aren't any ca-certs
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
         When I run `apt remove ca-certificates -y` with sudo
         When I run `rm -f /etc/ssl/certs/ca-certificates.crt` with sudo
@@ -24,18 +25,19 @@ Feature: Ua fix command behaviour
             Please check your openssl configuration.
             """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
         Then I will see the following on stderr:
@@ -193,14 +195,15 @@ Feature: Ua fix command behaviour
         """
 
         Examples: ubuntu release details
-           | release |
-           | focal   |
+           | release | machine_type  |
+           | focal   | lxd-container |
 
     @series.xenial
     @uses.config.contract_token
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Fix command on an unattached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
         Then I will see the following on stderr:
         """
@@ -542,13 +545,14 @@ Feature: Ua fix command behaviour
         """
 
         Examples: ubuntu release details
-           | release |
-           | xenial  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
 
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario: Fix command on an unattached machine
-        Given a `bionic` machine with ubuntu-advantage-tools installed
+        Given a `bionic` `lxd-container` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
         Then I will see the following on stderr:
@@ -828,9 +832,10 @@ Feature: Ua fix command behaviour
         """
 
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario: Fix command on a machine without security/updates source lists
-        Given a `bionic` machine with ubuntu-advantage-tools installed
+        Given a `bionic` `lxd-container` machine with ubuntu-advantage-tools installed
         When I run `sed -i "/bionic-updates/d" /etc/apt/sources.list` with sudo
         And I run `sed -i "/bionic-security/d" /etc/apt/sources.list` with sudo
         And I run `apt-get update` with sudo

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -1,6 +1,5 @@
 Feature: Ua fix command behaviour
 
-    @series.all
     Scenario Outline: Useful SSL failure message when there aren't any ca-certs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -31,7 +30,6 @@ Feature: Ua fix command behaviour
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.focal
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -194,7 +192,6 @@ Feature: Ua fix command behaviour
            | release | machine_type  |
            | focal   | lxd-container |
 
-    @series.xenial
     @uses.config.contract_token
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -542,7 +539,6 @@ Feature: Ua fix command behaviour
            | release | machine_type  |
            | xenial  | lxd-container |
 
-    @series.bionic
     Scenario: Fix command on an unattached machine
         Given a `bionic` `lxd-container` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
@@ -823,7 +819,6 @@ Feature: Ua fix command behaviour
         .*✔.* USN-6385-1 \[related\] does not affect your system.
         """
 
-    @series.bionic
     Scenario: Fix command on a machine without security/updates source lists
         Given a `bionic` `lxd-container` machine with ubuntu-advantage-tools installed
         When I run `sed -i "/bionic-updates/d" /etc/apt/sources.list` with sudo

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -65,10 +65,11 @@ Feature: Pro supports multiple languages
            | focal   | lxd-container |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Pro client's commands run successfully in a different locale
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         ## Change the locale
         When I run `apt install language-pack-fr -y` with sudo
         And I run `update-locale LANG=fr_FR.UTF-8` with sudo
@@ -183,10 +184,10 @@ Feature: Pro supports multiple languages
         When I run `pro --version` with sudo
         Then I will see the uaclient version on stdout
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | xenial  | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -1,6 +1,5 @@
 Feature: Pro supports multiple languages
 
-    @series.lts
     Scenario Outline: Translation works
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run shell command `LANGUAGE=pt_BR.UTF-8 pro security-status` as non-root
@@ -20,7 +19,6 @@ Feature: Pro supports multiple languages
            | focal   | lxd-container |
            | jammy   | lxd-container |
 
-    @series.xenial
     # Note: Translations do work on xenial, but our test environment triggers a bug in python that
     #       causes it to think we're in an ascii-only environment
     Scenario Outline: Translation doesn't error when python thinks it's ascii only
@@ -39,7 +37,6 @@ Feature: Pro supports multiple languages
            | release | machine_type  |
            | xenial  | lxd-container |
 
-    @series.focal
     Scenario Outline: apt-hook translations work
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -58,7 +55,6 @@ Feature: Pro supports multiple languages
            | release | machine_type  |
            | focal   | lxd-container |
 
-    @series.all
     @uses.config.contract_token
     Scenario Outline: Pro client's commands run successfully in a different locale
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -1,8 +1,6 @@
 Feature: Pro supports multiple languages
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Translation works
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run shell command `LANGUAGE=pt_BR.UTF-8 pro security-status` as non-root
@@ -23,8 +21,6 @@ Feature: Pro supports multiple languages
            | jammy   | lxd-container |
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     # Note: Translations do work on xenial, but our test environment triggers a bug in python that
     #       causes it to think we're in an ascii-only environment
     Scenario Outline: Translation doesn't error when python thinks it's ascii only
@@ -44,8 +40,6 @@ Feature: Pro supports multiple languages
            | xenial  | lxd-container |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: apt-hook translations work
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -65,8 +59,6 @@ Feature: Pro supports multiple languages
            | focal   | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Pro client's commands run successfully in a different locale
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -1,8 +1,6 @@
 Feature: Pro Install and Uninstall related tests
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Do not fail on postinst when cloud-id returns error
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
@@ -19,8 +17,6 @@ Feature: Pro Install and Uninstall related tests
 
     @series.lts
     @uses.config.contract_token
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Purge package after attaching it to a machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -52,8 +48,6 @@ Feature: Pro Install and Uninstall related tests
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Do not fail during postinst with nonstandard python setup
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Works when in a python virtualenv

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -1,6 +1,5 @@
 Feature: Pro Install and Uninstall related tests
 
-    @series.all
     Scenario Outline: Do not fail on postinst when cloud-id returns error
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
@@ -15,7 +14,6 @@ Feature: Pro Install and Uninstall related tests
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.lts
     @uses.config.contract_token
     Scenario Outline: Purge package after attaching it to a machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -47,7 +45,6 @@ Feature: Pro Install and Uninstall related tests
            | jammy   | lxd-container |
 
     @slow
-    @series.lts
     Scenario Outline: Do not fail during postinst with nonstandard python setup
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Works when in a python virtualenv

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -1,26 +1,28 @@
 Feature: Pro Install and Uninstall related tests
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Do not fail on postinst when cloud-id returns error
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
         Then I verify that running `dpkg-reconfigure ubuntu-advantage-tools` `with sudo` exits `0`
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.lts
     @uses.config.contract_token
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Purge package after attaching it to a machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `touch /etc/apt/preferences.d/ubuntu-esm-infra` with sudo
         Then I verify that files exist matching `/var/log/ubuntu-advantage.log`
@@ -42,17 +44,18 @@ Feature: Pro Install and Uninstall related tests
         And I verify that no files exist matching `/etc/apt/preferences.d/ubuntu-*`
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Do not fail during postinst with nonstandard python setup
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Works when in a python virtualenv
         When I run `apt update` with sudo
         And I run `apt install python3-venv -y` with sudo
@@ -84,8 +87,8 @@ Feature: Pro Install and Uninstall related tests
         Then I verify that running `dpkg-reconfigure ubuntu-advantage-tools` `with sudo` exits `0`
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |

--- a/features/landscape.feature
+++ b/features/landscape.feature
@@ -5,8 +5,6 @@
 Feature: Enable landscape on Ubuntu
 
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Enable Landscape non-interactively
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo and options `--no-auto-enable`
@@ -155,8 +153,6 @@ Feature: Enable landscape on Ubuntu
             | mantic  | lxd-container |
 
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Enable Landscape interactively
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo and options `--no-auto-enable`

--- a/features/landscape.feature
+++ b/features/landscape.feature
@@ -4,7 +4,6 @@
 @uses.config.landscape_api_secret_key
 Feature: Enable landscape on Ubuntu
 
-    @series.mantic
     Scenario Outline: Enable Landscape non-interactively
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo and options `--no-auto-enable`
@@ -152,7 +151,6 @@ Feature: Enable landscape on Ubuntu
             | release | machine_type  |
             | mantic  | lxd-container |
 
-    @series.mantic
     Scenario Outline: Enable Landscape interactively
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo and options `--no-auto-enable`

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -2,8 +2,6 @@
 Feature: Livepatch
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Unattached livepatch status shows warning when on unsupported kernel
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change config key `livepatch_url` to use value `<livepatch_url>`
@@ -42,8 +40,6 @@ Feature: Livepatch
             | focal   | lxd-vm       | https://livepatch.staging.canonical.com |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attached livepatch status shows warning when on unsupported kernel
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -94,8 +90,6 @@ Feature: Livepatch
             | focal   | lxd-vm       |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: Attached livepatch status shows upgrade required when on an old kernel
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
@@ -145,8 +139,6 @@ Feature: Livepatch
 
     @series.lunar
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Livepatch is not enabled by default and can't be enabled on interim releases
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro status --all` with sudo
@@ -176,8 +168,6 @@ Feature: Livepatch
             | mantic  | lxd-vm       | 23.10 (Mantic Minotaur) |
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd.vm
     Scenario Outline: Livepatch is supported on interim HWE kernel
         # This test is intended to ensure that an interim HWE kernel has the correct support status
         # It should be kept up to date so that it runs on the latest LTS and installs the latest

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Livepatch
 
-    @series.focal
     Scenario Outline: Unattached livepatch status shows warning when on unsupported kernel
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change config key `livepatch_url` to use value `<livepatch_url>`
@@ -39,7 +38,6 @@ Feature: Livepatch
             | focal   | lxd-vm       | https://livepatch.canonical.com         |
             | focal   | lxd-vm       | https://livepatch.staging.canonical.com |
 
-    @series.focal
     Scenario Outline: Attached livepatch status shows warning when on unsupported kernel
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -89,7 +87,6 @@ Feature: Livepatch
             | release | machine_type |
             | focal   | lxd-vm       |
 
-    @series.focal
     Scenario Outline: Attached livepatch status shows upgrade required when on an old kernel
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token_staging` with sudo
@@ -137,8 +134,6 @@ Feature: Livepatch
             | release | machine_type | old_kernel_version |
             | focal   | gcp.generic  | 5.4.0-28-generic   |
 
-    @series.lunar
-    @series.mantic
     Scenario Outline: Livepatch is not enabled by default and can't be enabled on interim releases
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro status --all` with sudo
@@ -167,7 +162,6 @@ Feature: Livepatch
             | lunar   | lxd-vm       | 23.04 (Lunar Lobster)   |
             | mantic  | lxd-vm       | 23.10 (Mantic Minotaur) |
 
-    @series.jammy
     Scenario Outline: Livepatch is supported on interim HWE kernel
         # This test is intended to ensure that an interim HWE kernel has the correct support status
         # It should be kept up to date so that it runs on the latest LTS and installs the latest

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -1,8 +1,6 @@
 Feature: Logs in Json Array Formatter
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: The log file can be successfully parsed as json array
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -32,8 +30,6 @@ Feature: Logs in Json Array Formatter
           | mantic  | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd.container
     Scenario Outline: Non-root user and root user log files are different
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Confirm user log file does not exist 
@@ -65,8 +61,6 @@ Feature: Logs in Json Array Formatter
           | mantic  | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd.container
     Scenario Outline: Non-root user log files included in collect logs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When i verify that running `pro status` `with sudo` exits `0`

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -1,6 +1,5 @@
 Feature: Logs in Json Array Formatter
 
-    @series.all
     @uses.config.contract_token
     Scenario Outline: The log file can be successfully parsed as json array
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -29,7 +28,6 @@ Feature: Logs in Json Array Formatter
           | lunar   | lxd-container |
           | mantic  | lxd-container |
 
-    @series.all
     Scenario Outline: Non-root user and root user log files are different
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Confirm user log file does not exist 
@@ -60,7 +58,6 @@ Feature: Logs in Json Array Formatter
           | lunar   | lxd-container |
           | mantic  | lxd-container |
 
-    @series.all
     Scenario Outline: Non-root user log files included in collect logs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When i verify that running `pro status` `with sudo` exits `0`

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -1,10 +1,11 @@
 Feature: Logs in Json Array Formatter
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: The log file can be successfully parsed as json array
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt update` with sudo
         And I run `apt install jq -y` with sudo
         And I verify that running `pro status` `with sudo` exits `0`
@@ -22,18 +23,19 @@ Feature: Logs in Json Array Formatter
         """
         """
         Examples: ubuntu release
-          | release |
-          | xenial  |
-          | bionic  |
-          | focal   |
-          | jammy   |
-          | lunar   |
-          | mantic  |
+          | release | machine_type  |
+          | xenial  | lxd-container |
+          | bionic  | lxd-container |
+          | focal   | lxd-container |
+          | jammy   | lxd-container |
+          | lunar   | lxd-container |
+          | mantic  | lxd-container |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd.container
     Scenario Outline: Non-root user and root user log files are different
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Confirm user log file does not exist 
         When I verify `/var/log/ubuntu-advantage.log` is empty
         Then I verify that no files exist matching `/home/ubuntu/.cache/ubuntu-pro/ubuntu-pro.log`
@@ -54,18 +56,19 @@ Feature: Logs in Json Array Formatter
         Executed with sys.argv: ['/usr/bin/pro', 'attach'
         """
         Examples: ubuntu release
-          | release |
-          | xenial  |
-          | bionic  |
-          | focal   |
-          | jammy   |
-          | lunar   |
-          | mantic  |
+          | release | machine_type  |
+          | xenial  | lxd-container |
+          | bionic  | lxd-container |
+          | focal   | lxd-container |
+          | jammy   | lxd-container |
+          | lunar   | lxd-container |
+          | mantic  | lxd-container |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd.container
     Scenario Outline: Non-root user log files included in collect logs
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When i verify that running `pro status` `with sudo` exits `0`
         And I verify that running `pro collect-logs` `with sudo` exits `0`
         And I run `tar -tf ua_logs.tar.gz` as non-root
@@ -81,10 +84,10 @@ Feature: Logs in Json Array Formatter
         user0.log
         """
         Examples: ubuntu release
-          | release |
-          | xenial  |
-          | bionic  |
-          | focal   |
-          | jammy   |
-          | lunar   |
-          | mantic  |
+          | release | machine_type  |
+          | xenial  | lxd-container |
+          | bionic  | lxd-container |
+          | focal   | lxd-container |
+          | jammy   | lxd-container |
+          | lunar   | lxd-container |
+          | mantic  | lxd-container |

--- a/features/magic_attach.feature
+++ b/features/magic_attach.feature
@@ -1,9 +1,10 @@
 Feature: Magic attach flow related tests
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach using the magic attach flow
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/tmp/response-overlay.json` with the following:
         """
         {
@@ -49,8 +50,8 @@ Feature: Magic attach flow related tests
         And the machine is attached
 
         Examples: ubuntu release
-            | release |
-            | xenial  |
-            | bionic  |
-            | focal   |
-            | jammy   |
+            | release | machine_type  |
+            | xenial  | lxd-container |
+            | bionic  | lxd-container |
+            | focal   | lxd-container |
+            | jammy   | lxd-container |

--- a/features/magic_attach.feature
+++ b/features/magic_attach.feature
@@ -1,6 +1,5 @@
 Feature: Magic attach flow related tests
 
-    @series.lts
     Scenario Outline: Attach using the magic attach flow
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/tmp/response-overlay.json` with the following:

--- a/features/magic_attach.feature
+++ b/features/magic_attach.feature
@@ -1,8 +1,6 @@
 Feature: Magic attach flow related tests
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach using the magic attach flow
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/tmp/response-overlay.json` with the following:

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -2,8 +2,6 @@ Feature: MOTD Messages
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Contract update prevents contract expiration messages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -57,8 +55,6 @@ Feature: MOTD Messages
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Contract Expiration Messages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -1,7 +1,5 @@
 Feature: MOTD Messages
 
-    @series.xenial
-    @series.bionic
     @uses.config.contract_token
     Scenario Outline: Contract update prevents contract expiration messages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -53,8 +51,6 @@ Feature: MOTD Messages
            | bionic  | lxd-container | esm-apps  |
 
 
-    @series.xenial
-    @series.bionic
     Scenario Outline: Contract Expiration Messages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -2,10 +2,11 @@ Feature: MOTD Messages
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Contract update prevents contract expiration messages
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
         When I attach `contract_token` with sudo
         When I update contract to use `effectiveTo` as `$behave_var{today +2}`
@@ -49,16 +50,17 @@ Feature: MOTD Messages
         [\w\d.]+
         """
         Examples: ubuntu release
-           | release | service   |
-           | xenial  | esm-infra |
-           | bionic  | esm-apps  |
+           | release | machine_type  | service   |
+           | xenial  | lxd-container | esm-infra |
+           | bionic  | lxd-container | esm-apps  |
 
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Contract Expiration Messages
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
         And I run `apt-get install ansible -y` with sudo
         And I attach `contract_token` with sudo
@@ -147,6 +149,6 @@ Feature: MOTD Messages
 
         """
         Examples: ubuntu release
-           | release | service   |
-           | xenial  | esm-infra |
-           | bionic  | esm-infra |
+           | release | machine_type  | service   |
+           | xenial  | lxd-container | esm-infra |
+           | bionic  | lxd-container | esm-infra |

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -2,7 +2,6 @@
 Feature: Proxy configuration
 
     @slow
-    @series.lts
     Scenario Outline: Attach command when proxy is configured for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -157,8 +156,6 @@ Feature: Proxy configuration
            | jammy   | lxd-container |
 
     @slow
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attach command when proxy is configured
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -254,7 +251,6 @@ Feature: Proxy configuration
            | bionic  | lxd-vm       |
 
     @slow
-    @series.lts
     Scenario Outline: Attach command when authenticated proxy is configured for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -349,8 +345,6 @@ Feature: Proxy configuration
            | jammy   | lxd-container |
 
     @slow
-    @series.xenial
-    @series.bionic
     Scenario Outline: Attach command when authenticated proxy is configured
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -400,7 +394,6 @@ Feature: Proxy configuration
            | bionic  | lxd-vm       |
 
     @slow
-    @series.lts
     Scenario Outline: Attach command when proxy is configured manually via conf file for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -541,7 +534,6 @@ Feature: Proxy configuration
            | jammy   | lxd-container |
 
     @slow
-    @series.lts
     Scenario Outline: Attach command when authenticated proxy is configured manually for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -616,7 +608,6 @@ Feature: Proxy configuration
            | jammy   | lxd-container |
 
     @slow
-    @series.lts
     Scenario Outline: Attach command when proxy is configured globally
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -777,7 +768,6 @@ Feature: Proxy configuration
            | jammy   | lxd-container |
 
     @slow
-    @series.lts
     Scenario Outline: Attach command when authenticated proxy is configured globally
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -876,7 +866,6 @@ Feature: Proxy configuration
            | jammy   | lxd-container |
 
     @slow
-    @series.lts
     Scenario Outline: Get warning when configuring global or uaclient proxy
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -1028,7 +1017,6 @@ Feature: Proxy configuration
            | jammy   | lxd-container |
 
     @slow
-    @series.lts
     Scenario Outline: apt_http(s)_proxy still works
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -1164,7 +1152,6 @@ Feature: Proxy configuration
            | jammy   | lxd-container |
 
     @slow
-    @series.jammy
     Scenario: Enable realtime kernel through proxy on a machine with no internet
         Given a `jammy` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I disable any internet connection on the machine
@@ -1194,7 +1181,6 @@ Feature: Proxy configuration
         A reboot is required to complete install.
         """
 
-    @series.lts
     Scenario Outline: Support HTTPS-in-HTTPS proxies
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
 

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -3,8 +3,6 @@ Feature: Proxy configuration
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when proxy is configured for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -161,8 +159,6 @@ Feature: Proxy configuration
     @slow
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attach command when proxy is configured
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -259,8 +255,6 @@ Feature: Proxy configuration
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when authenticated proxy is configured for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -357,8 +351,6 @@ Feature: Proxy configuration
     @slow
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Attach command when authenticated proxy is configured
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -409,8 +401,6 @@ Feature: Proxy configuration
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when proxy is configured manually via conf file for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -552,8 +542,6 @@ Feature: Proxy configuration
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when authenticated proxy is configured manually for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -629,8 +617,6 @@ Feature: Proxy configuration
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when proxy is configured globally
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -792,8 +778,6 @@ Feature: Proxy configuration
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when authenticated proxy is configured globally
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -893,8 +877,6 @@ Feature: Proxy configuration
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Get warning when configuring global or uaclient proxy
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -1047,8 +1029,6 @@ Feature: Proxy configuration
 
     @slow
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: apt_http(s)_proxy still works
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
@@ -1185,8 +1165,6 @@ Feature: Proxy configuration
 
     @slow
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario: Enable realtime kernel through proxy on a machine with no internet
         Given a `jammy` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I disable any internet connection on the machine
@@ -1217,8 +1195,6 @@ Feature: Proxy configuration
         """
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Support HTTPS-in-HTTPS proxies
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
 

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -3,9 +3,10 @@ Feature: Proxy configuration
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when proxy is configured for uaclient
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -151,18 +152,19 @@ Feature: Proxy configuration
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @slow
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attach command when proxy is configured
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -251,15 +253,16 @@ Feature: Proxy configuration
         """
     
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
+           | release | machine_type |
+           | xenial  | lxd-vm       |
+           | bionic  | lxd-vm       |
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when authenticated proxy is configured for uaclient
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
@@ -345,18 +348,19 @@ Feature: Proxy configuration
         """
     
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @slow
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Attach command when authenticated proxy is configured
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
@@ -399,15 +403,16 @@ Feature: Proxy configuration
         """
     
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
+           | release | machine_type |
+           | xenial  | lxd-vm       |
+           | bionic  | lxd-vm       |
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when proxy is configured manually via conf file for uaclient
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -539,17 +544,18 @@ Feature: Proxy configuration
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when authenticated proxy is configured manually for uaclient
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
@@ -615,17 +621,18 @@ Feature: Proxy configuration
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when proxy is configured globally
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -777,17 +784,18 @@ Feature: Proxy configuration
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Attach command when authenticated proxy is configured globally
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
@@ -877,17 +885,18 @@ Feature: Proxy configuration
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Get warning when configuring global or uaclient proxy
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -1030,17 +1039,18 @@ Feature: Proxy configuration
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @slow
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: apt_http(s)_proxy still works
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
@@ -1167,17 +1177,18 @@ Feature: Proxy configuration
         \"https://localhost:12345\" is not working. Not setting as proxy.
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     @slow
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario: Enable realtime kernel through proxy on a machine with no internet
-        Given a `jammy` machine with ubuntu-advantage-tools installed
+        Given a `jammy` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I disable any internet connection on the machine
         Given a `focal` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
-    @series.jammy
     Scenario Outline: Enable Real-time kernel service in a container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -20,7 +19,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | release | machine_type  |
             | jammy   | lxd-container |
 
-    @series.lts
     Scenario Outline: Enable Real-time kernel service on unsupported release
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -41,7 +39,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | bionic  | lxd-vm       | 18.04 LTS  | Bionic Beaver   |
             | focal   | lxd-vm       | 20.04 LTS  | Focal Fossa     |
 
-    @series.jammy
     Scenario Outline: Enable Real-time kernel service
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -334,7 +331,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | release | machine_type |
             | jammy   | lxd-vm       |
 
-    @series.jammy
     Scenario Outline: Enable Real-time kernel service access-only
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -2,9 +2,10 @@
 Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Enable Real-time kernel service in a container
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
         Then I verify that running `pro enable realtime-kernel` `as non-root` exits `1`
         And I will see the following on stderr:
@@ -18,13 +19,14 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             Cannot install Real-time kernel on a container.
             """
         Examples: ubuntu release
-            | release |
-            | jammy   |
+            | release | machine_type  |
+            | jammy   | lxd-container |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Real-time kernel service on unsupported release
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
         Then I verify that running `pro enable realtime-kernel` `as non-root` exits `1`
         And I will see the following on stderr:
@@ -38,15 +40,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             Real-time kernel is not available for Ubuntu <version> (<full_name>).
             """
         Examples: ubuntu release
-            | release | version    | full_name       |
-            | xenial  | 16.04 LTS  | Xenial Xerus    |
-            | bionic  | 18.04 LTS  | Bionic Beaver   |
-            | focal   | 20.04 LTS  | Focal Fossa     |
+            | release | machine_type | version    | full_name       |
+            | xenial  | lxd-vm       | 16.04 LTS  | Xenial Xerus    |
+            | bionic  | lxd-vm       | 18.04 LTS  | Bionic Beaver   |
+            | focal   | lxd-vm       | 20.04 LTS  | Focal Fossa     |
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Real-time kernel service
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
         Then I verify that running `pro enable realtime-kernel` `as non-root` exits `1`
         And I will see the following on stderr:
@@ -334,13 +337,14 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-            | release |
-            | jammy   |
+            | release | machine_type |
+            | jammy   | lxd-vm       |
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Real-time kernel service access-only
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
         When I run `pro enable realtime-kernel --access-only` with sudo
         Then stdout matches regexp:
@@ -371,5 +375,5 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         realtime
         """
         Examples: ubuntu release
-            | release |
-            | jammy   |
+            | release | machine_type |
+            | jammy   | lxd-vm       |

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -2,8 +2,6 @@
 Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Enable Real-time kernel service in a container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -23,8 +21,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | jammy   | lxd-container |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Real-time kernel service on unsupported release
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -46,8 +42,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | focal   | lxd-vm       | 20.04 LTS  | Focal Fossa     |
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Real-time kernel service
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
@@ -341,8 +335,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | jammy   | lxd-vm       |
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     Scenario Outline: Enable Real-time kernel service access-only
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`

--- a/features/reboot_cmds.feature
+++ b/features/reboot_cmds.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Reboot Commands
 
-    @series.focal
     Scenario Outline: reboot-cmds removes fips package holds and updates packages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/reboot_cmds.feature
+++ b/features/reboot_cmds.feature
@@ -2,8 +2,6 @@
 Feature: Reboot Commands
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: reboot-cmds removes fips package holds and updates packages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/reboot_cmds.feature
+++ b/features/reboot_cmds.feature
@@ -2,9 +2,10 @@
 Feature: Reboot Commands
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: reboot-cmds removes fips package holds and updates packages
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         When I run `apt install -y strongswan` with sudo
         When I run `pro enable fips --assume-yes` with sudo
@@ -44,5 +45,5 @@ Feature: Reboot Commands
         *** <new_version> 1001
         """
         Examples: ubuntu release
-            | release | old_version      | new_version               |
-            | focal   | 5.8.2-1ubuntu3.5 | 5.8.2-1ubuntu3.fips.3.1.2 |
+            | release | machine_type  | old_version      | new_version               |
+            | focal   | lxd-container | 5.8.2-1ubuntu3.5 | 5.8.2-1ubuntu3.fips.3.1.2 |

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -1,10 +1,6 @@
 Feature: auto-attach retries periodically on failures
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
-    @uses.config.machine_type.azure.generic
-    @uses.config.machine_type.gcp.generic
     Scenario Outline: auto-attach retries for a month and updates status
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change contract to staging with sudo
@@ -135,10 +131,6 @@ Feature: auto-attach retries periodically on failures
 
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro
-    @uses.config.machine_type.azure.pro
-    @uses.config.machine_type.gcp.pro
     Scenario Outline: auto-attach retries stop if manual auto-attach succeeds
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -152,7 +144,7 @@ Feature: auto-attach retries periodically on failures
         When I create the file `/var/lib/ubuntu-advantage/response-overlay.json` with the following:
         """
         {
-            "https://contracts.canonical.com/v1/clouds/$behave_var{cloud}/token": [{
+            "https://contracts.canonical.com/v1/clouds/$behave_var{cloud system-under-test}/token": [{
               "type": "contract",
               "code": 400,
               "response": {
@@ -228,8 +220,6 @@ Feature: auto-attach retries periodically on failures
            | jammy   | gcp.pro      |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro
     Scenario Outline: gcp auto-detect triggers retries on fail
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -296,10 +286,6 @@ Feature: auto-attach retries periodically on failures
 
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro
-    @uses.config.machine_type.azure.pro
-    @uses.config.machine_type.gcp.pro
     Scenario Outline: auto-attach retries eventually succeed and clean up
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # modify the wait time to be shorter so we don't have to wait 15m
@@ -315,7 +301,7 @@ Feature: auto-attach retries periodically on failures
         When I create the file `/var/lib/ubuntu-advantage/response-overlay.json` with the following:
         """
         {
-            "https://contracts.canonical.com/v1/clouds/$behave_var{cloud}/token": [{
+            "https://contracts.canonical.com/v1/clouds/$behave_var{cloud system-under-test}/token": [{
               "type": "contract",
               "code": 400,
               "response": {

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -1,6 +1,5 @@
 Feature: auto-attach retries periodically on failures
 
-    @series.lts
     Scenario Outline: auto-attach retries for a month and updates status
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change contract to staging with sudo
@@ -130,7 +129,6 @@ Feature: auto-attach retries periodically on failures
            | jammy   | gcp.generic   |
 
 
-    @series.lts
     Scenario Outline: auto-attach retries stop if manual auto-attach succeeds
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -219,7 +217,6 @@ Feature: auto-attach retries periodically on failures
            | jammy   | azure.pro    |
            | jammy   | gcp.pro      |
 
-    @series.lts
     Scenario Outline: gcp auto-detect triggers retries on fail
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -285,7 +282,6 @@ Feature: auto-attach retries periodically on failures
            | jammy   | gcp.pro      |
 
 
-    @series.lts
     Scenario Outline: auto-attach retries eventually succeed and clean up
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # modify the wait time to be shorter so we don't have to wait 15m

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -1,11 +1,12 @@
 Feature: auto-attach retries periodically on failures
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     @uses.config.machine_type.azure.generic
     @uses.config.machine_type.gcp.generic
     Scenario Outline: auto-attach retries for a month and updates status
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I change contract to staging with sudo
         When I install ubuntu-advantage-pro
         When I reboot the machine
@@ -118,19 +119,28 @@ Feature: auto-attach retries periodically on failures
         You can try manually with `sudo pro auto-attach`.
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type  |
+           | xenial  | aws.generic   |
+           | xenial  | azure.generic |
+           | xenial  | gcp.generic   |
+           | bionic  | aws.generic   |
+           | bionic  | azure.generic |
+           | bionic  | gcp.generic   |
+           | focal   | aws.generic   |
+           | focal   | azure.generic |
+           | focal   | gcp.generic   |
+           | jammy   | aws.generic   |
+           | jammy   | azure.generic |
+           | jammy   | gcp.generic   |
 
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro
     @uses.config.machine_type.azure.pro
     @uses.config.machine_type.gcp.pro
     Scenario Outline: auto-attach retries stop if manual auto-attach succeeds
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -203,16 +213,25 @@ Feature: auto-attach retries periodically on failures
         Failed to automatically attach to Ubuntu Pro services
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type |
+           | xenial  | aws.pro      |
+           | xenial  | azure.pro    |
+           | xenial  | gcp.pro      |
+           | bionic  | aws.pro      |
+           | bionic  | azure.pro    |
+           | bionic  | gcp.pro      |
+           | focal   | aws.pro      |
+           | focal   | azure.pro    |
+           | focal   | gcp.pro      |
+           | jammy   | aws.pro      |
+           | jammy   | azure.pro    |
+           | jammy   | gcp.pro      |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro
     Scenario Outline: gcp auto-detect triggers retries on fail
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -269,19 +288,20 @@ Feature: auto-attach retries periodically on failures
         Failed to automatically attach to Ubuntu Pro services
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type |
+           | xenial  | gcp.pro      |
+           | bionic  | gcp.pro      |
+           | focal   | gcp.pro      |
+           | jammy   | gcp.pro      |
 
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro
     @uses.config.machine_type.azure.pro
     @uses.config.machine_type.gcp.pro
     Scenario Outline: auto-attach retries eventually succeed and clean up
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # modify the wait time to be shorter so we don't have to wait 15m
         When I replace `900,  # 15m (T+15m)` in `/usr/lib/python3/dist-packages/uaclient/daemon/retry_auto_attach.py` with `60,`
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -356,8 +376,16 @@ Feature: auto-attach retries periodically on failures
         Failed to automatically attach to Ubuntu Pro services
         """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type |
+           | xenial  | aws.pro      |
+           | xenial  | azure.pro    |
+           | xenial  | gcp.pro      |
+           | bionic  | aws.pro      |
+           | bionic  | azure.pro    |
+           | bionic  | gcp.pro      |
+           | focal   | aws.pro      |
+           | focal   | azure.pro    |
+           | focal   | gcp.pro      |
+           | jammy   | aws.pro      |
+           | jammy   | azure.pro    |
+           | jammy   | gcp.pro      |

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -2,10 +2,11 @@ Feature: Security status command behavior
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Run security status with JSON/YAML format
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt-get update` with sudo
         And I run `apt-get install ansible -y` with sudo
         And I run `pro security-status --format json` as non-root
@@ -87,15 +88,16 @@ Feature: Security status command behavior
         argument --format: invalid choice: 'unsupported' (choose from 'json', 'yaml', 'text')
         """
         Examples: ubuntu release
-           | release | package   | service   |
-           | xenial  | apport    | esm-infra |
-           | bionic  | ansible   | esm-apps  |
+           | release | machine_type  | package   | service   |
+           | xenial  | lxd-container | apport    | esm-infra |
+           | bionic  | lxd-container | ansible   | esm-apps  |
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     @uses.config.contract_token
     Scenario: Check for livepatch CVEs in security-status on an Ubuntu machine
-        Given a `xenial` machine with ubuntu-advantage-tools installed
+        Given a `xenial` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro security-status --format json` as non-root
         Then stdout is a json matching the `ua_security_status` schema
@@ -112,10 +114,11 @@ Feature: Security status command behavior
         """
 
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario: Run security status in an Ubuntu machine
-        Given a `xenial` machine with ubuntu-advantage-tools installed
+        Given a `xenial` `lxd-container` machine with ubuntu-advantage-tools installed
         When I install third-party / unknown packages in the machine
         # Ansible is in esm-apps
         And I run `apt-get install -y ansible` with sudo
@@ -455,10 +458,11 @@ Feature: Security status command behavior
         """
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario: Run security status in an Ubuntu machine
-        Given a `focal` machine with ubuntu-advantage-tools installed
+        Given a `focal` `lxd-container` machine with ubuntu-advantage-tools installed
         When I install third-party / unknown packages in the machine
         # Ansible is in esm-apps
         And I run `apt-get install -y ansible` with sudo
@@ -775,9 +779,10 @@ Feature: Security status command behavior
 
     # Latest released non-LTS
     @series.lunar
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario: Run security status in an Ubuntu machine
-        Given a `lunar` machine with ubuntu-advantage-tools installed
+        Given a `lunar` `lxd-container` machine with ubuntu-advantage-tools installed
         When I install third-party / unknown packages in the machine
         # Ansible is in esm-apps
         And I run `apt-get install -y ansible` with sudo

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -2,8 +2,6 @@ Feature: Security status command behavior
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Run security status with JSON/YAML format
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -93,8 +91,6 @@ Feature: Security status command behavior
            | bionic  | lxd-container | ansible   | esm-apps  |
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     @uses.config.contract_token
     Scenario: Check for livepatch CVEs in security-status on an Ubuntu machine
         Given a `xenial` `lxd-vm` machine with ubuntu-advantage-tools installed
@@ -114,8 +110,6 @@ Feature: Security status command behavior
         """
 
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario: Run security status in an Ubuntu machine
         Given a `xenial` `lxd-container` machine with ubuntu-advantage-tools installed
@@ -458,8 +452,6 @@ Feature: Security status command behavior
         """
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario: Run security status in an Ubuntu machine
         Given a `focal` `lxd-container` machine with ubuntu-advantage-tools installed
@@ -779,8 +771,6 @@ Feature: Security status command behavior
 
     # Latest released non-LTS
     @series.lunar
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario: Run security status in an Ubuntu machine
         Given a `lunar` `lxd-container` machine with ubuntu-advantage-tools installed
         When I install third-party / unknown packages in the machine

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -1,7 +1,5 @@
 Feature: Security status command behavior
 
-    @series.xenial
-    @series.bionic
     @uses.config.contract_token
     Scenario Outline: Run security status with JSON/YAML format
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -90,7 +88,6 @@ Feature: Security status command behavior
            | xenial  | lxd-container | apport    | esm-infra |
            | bionic  | lxd-container | ansible   | esm-apps  |
 
-    @series.xenial
     @uses.config.contract_token
     Scenario: Check for livepatch CVEs in security-status on an Ubuntu machine
         Given a `xenial` `lxd-vm` machine with ubuntu-advantage-tools installed
@@ -109,7 +106,6 @@ Feature: Security status command behavior
             patched: true
         """
 
-    @series.xenial
     @uses.config.contract_token
     Scenario: Run security status in an Ubuntu machine
         Given a `xenial` `lxd-container` machine with ubuntu-advantage-tools installed
@@ -451,7 +447,6 @@ Feature: Security status command behavior
         Enable esm-apps with: pro enable esm-apps
         """
 
-    @series.focal
     @uses.config.contract_token
     Scenario: Run security status in an Ubuntu machine
         Given a `focal` `lxd-container` machine with ubuntu-advantage-tools installed
@@ -770,7 +765,6 @@ Feature: Security status command behavior
         """
 
     # Latest released non-LTS
-    @series.lunar
     Scenario: Run security status in an Ubuntu machine
         Given a `lunar` `lxd-container` machine with ubuntu-advantage-tools installed
         When I install third-party / unknown packages in the machine

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -51,7 +51,7 @@ def given_a_machine(
         machine_type = context.pro_config.machine_type
 
     cloud = machine_type.split(".")[0]
-    context.pro_config.clouds[cloud].manage_ssh_key()
+    context.pro_config.clouds.get(cloud).manage_ssh_key()
 
     time_suffix = datetime.datetime.now().strftime("%m%d-%H%M%S%f")
     instance_name = "upro-behave-{series}-{machine_name}-{time_suffix}".format(
@@ -75,7 +75,7 @@ def given_a_machine(
         if user_data is not None:
             user_data_to_use += user_data
 
-    instance = context.pro_config.clouds[cloud].launch(
+    instance = context.pro_config.clouds.get(cloud).launch(
         series=series,
         machine_type=machine_type,
         instance_name=instance_name,
@@ -131,7 +131,7 @@ def when_i_take_a_snapshot(
 
     cloud = machine_type.split(".")[0]
     inst = context.machines[machine_name].instance
-    snapshot = context.pro_config.clouds[cloud].api.snapshot(inst)
+    snapshot = context.pro_config.clouds.get(cloud).api.snapshot(inst)
 
     context.snapshots[machine_name] = snapshot
 
@@ -139,7 +139,7 @@ def when_i_take_a_snapshot(
 
         def cleanup_snapshot() -> None:
             try:
-                context.pro_config.clouds[cloud].api.delete_image(
+                context.pro_config.clouds.get(cloud).api.delete_image(
                     context.snapshots[machine_name]
                 )
             except RuntimeError as e:

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -18,7 +18,7 @@ from features.util import (
 def when_i_install_uat(context, machine_name=SUT):
     instance = context.machines[machine_name].instance
     series = context.machines[machine_name].series
-    is_pro = "pro" in context.pro_config.machine_type
+    is_pro = "pro" in context.machines[machine_name].machine_type
     if context.pro_config.install_from is InstallationSource.ARCHIVE:
         instance.execute("sudo apt update")
         when_i_apt_install(

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -2,9 +2,6 @@
 Feature: Timer for regular background jobs while attached
 
     # earlies, latest lts, devel
-    @series.xenial
-    @series.jammy
-    @series.mantic
     Scenario Outline: Timer is stopped when detached, started when attached
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Then I verify the `ua-timer` systemd timer is disabled

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -5,9 +5,10 @@ Feature: Timer for regular background jobs while attached
     @series.xenial
     @series.jammy
     @series.mantic
-    @uses.config.machine_type.lxd.container
+    @uses.config.machine_type.any
+    @uses.config.machine_type.lxd-container
     Scenario Outline: Timer is stopped when detached, started when attached
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Then I verify the `ua-timer` systemd timer is disabled
         When I attach `contract_token` with sudo
         # 6 hour timer with 1 hour randomized delay -> potentially 7 hours
@@ -15,7 +16,7 @@ Feature: Timer for regular background jobs while attached
         When I run `pro detach --assume-yes` with sudo
         Then I verify the `ua-timer` systemd timer is disabled
         Examples: ubuntu release
-            | release |
-            | xenial  |
-            | jammy   |
-            | mantic  |
+            | release | machine_type  |
+            | xenial  | lxd-container |
+            | jammy   | lxd-container |
+            | mantic  | lxd-container |

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -5,8 +5,6 @@ Feature: Timer for regular background jobs while attached
     @series.xenial
     @series.jammy
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Timer is stopped when detached, started when attached
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Then I verify the `ua-timer` systemd timer is disabled

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -1,8 +1,6 @@
 Feature: Command behaviour when auto-attached in an ubuntu PRO image
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro
     Scenario Outline: Proxy auto-attach in an Ubuntu pro AWS machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `<machine_type>` machine named `proxy`
@@ -76,8 +74,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | focal   | aws.pro      | disabled | n/a      | disabled | usg        |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.pro
     Scenario Outline: Proxy auto-attach in an Ubuntu pro Azure machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `<machine_type>` machine named `proxy` with ingress ports `3128`
@@ -150,8 +146,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | focal   | azure.pro    | disabled | n/a      | disabled | enabled     | usg        |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro
     Scenario Outline: Proxy auto-attach in an Ubuntu Pro GCP machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `<machine_type>` machine named `proxy`
@@ -224,8 +218,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | focal   | gcp.pro      | disabled | n/a      | disabled | enabled     | Canonical Livepatch service     | usg        |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro
     Scenario Outline: Attached refresh in an Ubuntu pro AWS machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -352,8 +344,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
 
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.pro
     Scenario Outline: Attached refresh in an Ubuntu pro Azure machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -479,8 +469,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | jammy   | azure.pro    | n/a      | n/a      | disabled | hello     | hello    | enabled   | usg        |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro
     Scenario Outline: Attached refresh in an Ubuntu pro GCP machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -606,10 +594,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | jammy   | gcp.pro      | n/a      | n/a      | disabled | hello     | hello    | enabled   | Canonical Livepatch service     | usg        |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro
-    @uses.config.machine_type.aws.pro
-    @uses.config.machine_type.azure.pro
     Scenario Outline: Auto-attach service works on Pro Machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `systemctl start ua-auto-attach.service` with sudo
@@ -644,10 +628,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | jammy   | gcp.pro      |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro
-    @uses.config.machine_type.aws.pro
-    @uses.config.machine_type.azure.pro
     Scenario Outline: Auto-attach no-op when cloud-init has ubuntu_advantage on userdata
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:
         # This user_data should not do anything, just guarantee that the ua-auto-attach service
@@ -713,8 +693,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | jammy   | gcp.pro      |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.generic
     Scenario Outline: Unregistered Pro machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro auto-attach` `with sudo` exits `1`

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -1,6 +1,5 @@
 Feature: Command behaviour when auto-attached in an ubuntu PRO image
 
-    @series.lts
     Scenario Outline: Proxy auto-attach in an Ubuntu pro AWS machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `<machine_type>` machine named `proxy`
@@ -73,7 +72,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | bionic  | aws.pro      | disabled | disabled | disabled | cis        |
            | focal   | aws.pro      | disabled | n/a      | disabled | usg        |
 
-    @series.lts
     Scenario Outline: Proxy auto-attach in an Ubuntu pro Azure machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `<machine_type>` machine named `proxy` with ingress ports `3128`
@@ -145,7 +143,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | bionic  | azure.pro    | disabled | disabled | disabled | enabled     | cis        |
            | focal   | azure.pro    | disabled | n/a      | disabled | enabled     | usg        |
 
-    @series.lts
     Scenario Outline: Proxy auto-attach in an Ubuntu Pro GCP machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `<machine_type>` machine named `proxy`
@@ -217,7 +214,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | bionic  | gcp.pro      | disabled | disabled | disabled | enabled     | Canonical Livepatch service     | cis        |
            | focal   | gcp.pro      | disabled | n/a      | disabled | enabled     | Canonical Livepatch service     | usg        |
 
-    @series.lts
     Scenario Outline: Attached refresh in an Ubuntu pro AWS machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -343,7 +339,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | jammy   | aws.pro      | n/a      | n/a      | disabled | hello     | hello    | usg        | warning     |
 
 
-    @series.lts
     Scenario Outline: Attached refresh in an Ubuntu pro Azure machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -468,7 +463,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | focal   | azure.pro    | disabled | n/a      | disabled | hello     | ant      | enabled   | usg        |
            | jammy   | azure.pro    | n/a      | n/a      | disabled | hello     | hello    | enabled   | usg        |
 
-    @series.lts
     Scenario Outline: Attached refresh in an Ubuntu pro GCP machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -593,7 +587,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | focal   | gcp.pro      | disabled | n/a      | disabled | hello     | ant      | enabled   | Canonical Livepatch service     | usg        |
            | jammy   | gcp.pro      | n/a      | n/a      | disabled | hello     | hello    | enabled   | Canonical Livepatch service     | usg        |
 
-    @series.lts
     Scenario Outline: Auto-attach service works on Pro Machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `systemctl start ua-auto-attach.service` with sudo
@@ -627,7 +620,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | jammy   | azure.pro    |
            | jammy   | gcp.pro      |
 
-    @series.lts
     Scenario Outline: Auto-attach no-op when cloud-init has ubuntu_advantage on userdata
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:
         # This user_data should not do anything, just guarantee that the ua-auto-attach service
@@ -692,7 +684,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | jammy   | azure.pro    |
            | jammy   | gcp.pro      |
 
-    @series.lts
     Scenario Outline: Unregistered Pro machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro auto-attach` `with sudo` exits `1`

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -1,10 +1,11 @@
 Feature: Command behaviour when auto-attached in an ubuntu PRO image
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro
     Scenario Outline: Proxy auto-attach in an Ubuntu pro AWS machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        Given a `focal` `<machine_type>` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
@@ -69,16 +70,17 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         .*CONNECT 169.254.169.254.*
         """
         Examples: ubuntu release
-           | release | fips-s   | cc-eal-s | cis-s    | cis_or_usg |
-           | xenial  | disabled | disabled | disabled | cis        |
-           | bionic  | disabled | disabled | disabled | cis        |
-           | focal   | disabled | n/a      | disabled | usg        |
+           | release | machine_type | fips-s   | cc-eal-s | cis-s    | cis_or_usg |
+           | xenial  | aws.pro      | disabled | disabled | disabled | cis        |
+           | bionic  | aws.pro      | disabled | disabled | disabled | cis        |
+           | focal   | aws.pro      | disabled | n/a      | disabled | usg        |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.pro
     Scenario Outline: Proxy auto-attach in an Ubuntu pro Azure machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy` with ingress ports `3128`
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        Given a `focal` `<machine_type>` machine named `proxy` with ingress ports `3128`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
@@ -142,16 +144,17 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         .*CONNECT 169.254.169.254.*
         """
         Examples: ubuntu release
-           | release | fips-s   | cc-eal-s | cis-s    | livepatch-s | cis_or_usg |
-           | xenial  | disabled | disabled | disabled | enabled     | cis        |
-           | bionic  | disabled | disabled | disabled | enabled     | cis        |
-           | focal   | disabled | n/a      | disabled | enabled     | usg        |
+           | release | machine_type | fips-s   | cc-eal-s | cis-s    | livepatch-s | cis_or_usg |
+           | xenial  | azure.pro    | disabled | disabled | disabled | enabled     | cis        |
+           | bionic  | azure.pro    | disabled | disabled | disabled | enabled     | cis        |
+           | focal   | azure.pro    | disabled | n/a      | disabled | enabled     | usg        |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro
     Scenario Outline: Proxy auto-attach in an Ubuntu Pro GCP machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        Given a `focal` `<machine_type>` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
             """
@@ -215,15 +218,16 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         .*CONNECT metadata.*
         """
         Examples: ubuntu release
-           | release | fips-s   | cc-eal-s | cis-s    | livepatch-s | lp-desc                         | cis_or_usg |
-           | xenial  | n/a      | disabled | disabled | warning     | Current kernel is not supported | cis        |
-           | bionic  | disabled | disabled | disabled | enabled     | Canonical Livepatch service     | cis        |
-           | focal   | disabled | n/a      | disabled | enabled     | Canonical Livepatch service     | usg        |
+           | release | machine_type | fips-s   | cc-eal-s | cis-s    | livepatch-s | lp-desc                         | cis_or_usg |
+           | xenial  | gcp.pro      | n/a      | disabled | disabled | warning     | Current kernel is not supported | cis        |
+           | bionic  | gcp.pro      | disabled | disabled | disabled | enabled     | Canonical Livepatch service     | cis        |
+           | focal   | gcp.pro      | disabled | n/a      | disabled | enabled     | Canonical Livepatch service     | usg        |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro
     Scenario Outline: Attached refresh in an Ubuntu pro AWS machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -340,17 +344,18 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
 
         Examples: ubuntu release
-           | release | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | cis_or_usg | livepatch-s |
-           | xenial  | disabled | disabled | disabled | libkrad0  | jq       | cis        | enabled     |
-           | bionic  | disabled | disabled | disabled | libkrad0  | bundler  | cis        | enabled     |
-           | focal   | disabled | n/a      | disabled | hello     | ant      | usg        | enabled     |
-           | jammy   | n/a      | n/a      | disabled | hello     | hello    | usg        | warning     |
+           | release | machine_type | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | cis_or_usg | livepatch-s |
+           | xenial  | aws.pro      | disabled | disabled | disabled | libkrad0  | jq       | cis        | enabled     |
+           | bionic  | aws.pro      | disabled | disabled | disabled | libkrad0  | bundler  | cis        | enabled     |
+           | focal   | aws.pro      | disabled | n/a      | disabled | hello     | ant      | usg        | enabled     |
+           | jammy   | aws.pro      | n/a      | n/a      | disabled | hello     | hello    | usg        | warning     |
 
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.pro
     Scenario Outline: Attached refresh in an Ubuntu pro Azure machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -467,16 +472,17 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
 
         Examples: ubuntu release
-           | release | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | livepatch | cis_or_usg |
-           | xenial  | disabled | disabled | disabled | libkrad0  | jq       | enabled   | cis        |
-           | bionic  | disabled | disabled | disabled | libkrad0  | bundler  | enabled   | cis        |
-           | focal   | disabled | n/a      | disabled | hello     | ant      | enabled   | usg        |
-           | jammy   | n/a      | n/a      | disabled | hello     | hello    | enabled   | usg        |
+           | release | machine_type | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | livepatch | cis_or_usg |
+           | xenial  | azure.pro    | disabled | disabled | disabled | libkrad0  | jq       | enabled   | cis        |
+           | bionic  | azure.pro    | disabled | disabled | disabled | libkrad0  | bundler  | enabled   | cis        |
+           | focal   | azure.pro    | disabled | n/a      | disabled | hello     | ant      | enabled   | usg        |
+           | jammy   | azure.pro    | n/a      | n/a      | disabled | hello     | hello    | enabled   | usg        |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro
     Scenario Outline: Attached refresh in an Ubuntu pro GCP machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -593,18 +599,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
 
         Examples: ubuntu release
-           | release | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | livepatch | lp-desc                         | cis_or_usg |
-           | xenial  | n/a      | disabled | disabled | libkrad0  | jq       | warning   | Current kernel is not supported | cis        |
-           | bionic  | disabled | disabled | disabled | libkrad0  | bundler  | enabled   | Canonical Livepatch service     | cis        |
-           | focal   | disabled | n/a      | disabled | hello     | ant      | enabled   | Canonical Livepatch service     | usg        |
-           | jammy   | n/a      | n/a      | disabled | hello     | hello    | enabled   | Canonical Livepatch service     | usg        |
+           | release | machine_type | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | livepatch | lp-desc                         | cis_or_usg |
+           | xenial  | gcp.pro      | n/a      | disabled | disabled | libkrad0  | jq       | warning   | Current kernel is not supported | cis        |
+           | bionic  | gcp.pro      | disabled | disabled | disabled | libkrad0  | bundler  | enabled   | Canonical Livepatch service     | cis        |
+           | focal   | gcp.pro      | disabled | n/a      | disabled | hello     | ant      | enabled   | Canonical Livepatch service     | usg        |
+           | jammy   | gcp.pro      | n/a      | n/a      | disabled | hello     | hello    | enabled   | Canonical Livepatch service     | usg        |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro
     @uses.config.machine_type.aws.pro
     @uses.config.machine_type.azure.pro
     Scenario Outline: Auto-attach service works on Pro Machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `systemctl start ua-auto-attach.service` with sudo
         And I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
@@ -622,18 +629,27 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type |
+           | xenial  | aws.pro      |
+           | xenial  | azure.pro    |
+           | xenial  | gcp.pro      |
+           | bionic  | aws.pro      |
+           | bionic  | azure.pro    |
+           | bionic  | gcp.pro      |
+           | focal   | aws.pro      |
+           | focal   | azure.pro    |
+           | focal   | gcp.pro      |
+           | jammy   | aws.pro      |
+           | jammy   | azure.pro    |
+           | jammy   | gcp.pro      |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro
     @uses.config.machine_type.aws.pro
     @uses.config.machine_type.azure.pro
     Scenario Outline: Auto-attach no-op when cloud-init has ubuntu_advantage on userdata
-        Given a `<release>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:
         # This user_data should not do anything, just guarantee that the ua-auto-attach service
         # does nothing
         """
@@ -682,16 +698,25 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type |
+           | xenial  | aws.pro      |
+           | xenial  | azure.pro    |
+           | xenial  | gcp.pro      |
+           | bionic  | aws.pro      |
+           | bionic  | azure.pro    |
+           | bionic  | gcp.pro      |
+           | focal   | aws.pro      |
+           | focal   | azure.pro    |
+           | focal   | gcp.pro      |
+           | jammy   | aws.pro      |
+           | jammy   | azure.pro    |
+           | jammy   | gcp.pro      |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.generic
     Scenario Outline: Unregistered Pro machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro auto-attach` `with sudo` exits `1`
         Then stderr matches regexp:
         """
@@ -700,8 +725,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
-           | focal   |
-           | jammy   |
+           | release | machine_type |
+           | xenial  | aws.generic  |
+           | bionic  | aws.generic  |
+           | focal   | aws.generic  |
+           | jammy   | aws.generic  |

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -1,9 +1,10 @@
 Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.pro-fips
     Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips Azure machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -147,15 +148,16 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
 
         Examples: ubuntu release
-           | release | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
-           | xenial  | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                |
-           | bionic  | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | azure-fips          |
-           | focal   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | azure-fips          |
+           | release | machine_type   | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
+           | xenial  | azure.pro-fips | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                |
+           | bionic  | azure.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | azure-fips          |
+           | focal   | azure.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | azure-fips          |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.pro-fips
     Scenario Outline: Check fips packages are correctly installed on Azure Focal machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -181,14 +183,15 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
 
         Examples: ubuntu release
-           | release | fips-apt-source                                |
-           | focal   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type   | fips-apt-source                                |
+           | focal   | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.pro-fips
     Scenario Outline: Check fips packages are correctly installed on Azure Bionic & Xenial machines
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -218,14 +221,15 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
 
         Examples: ubuntu release
-           | release  | fips-apt-source                                 |
-           | xenial   | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
-           | bionic   | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
+           | release | machine_type   | fips-apt-source                                 |
+           | xenial  | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
+           | bionic  | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro-fips
     Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips AWS machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -368,15 +372,16 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
 
         Examples: ubuntu release
-           | release | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
-           | xenial  | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                |
-           | bionic  | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | aws-fips            |
-           | focal   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips            |
+           | release | machine_type | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
+           | xenial  | aws.pro-fips | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                |
+           | bionic  | aws.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | aws-fips            |
+           | focal   | aws.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips            |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro-fips
     Scenario Outline: Check fips packages are correctly installed on AWS Focal machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -402,14 +407,15 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
 
         Examples: ubuntu release
-           | release | fips-apt-source                                |
-           | focal   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type | fips-apt-source                                |
+           | focal   | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.aws.pro-fips
     Scenario Outline: Check fips packages are correctly installed on AWS Bionic & Xenial machines
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -439,16 +445,17 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
 
         Examples: ubuntu release
-           | release  | fips-apt-source                                 |
-           | xenial   | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
-           | bionic   | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
+           | release | machine_type | fips-apt-source                                 |
+           | xenial  | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
+           | bionic  | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.azure.pro-fips
     @uses.config.machine_type.aws.pro-fips
     @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check fips-updates can be enabled in a focal PRO FIPS machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -492,14 +499,17 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
 
         Examples: ubuntu release
-           | release  |
-           | focal    |
+           | release | machine_type   |
+           | focal   | aws.pro-fips   |
+           | focal   | azure.pro-fips |
+           | focal   | gcp.pro-fips   |
 
     @series.focal
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips GCP machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -641,14 +651,15 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
 
         Examples: ubuntu release
-           | release | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
-           | bionic  | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | gcp-fips            |
-           | focal   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | gcp-fips            |
+           | release | machine_type | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
+           | bionic  | gcp.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | gcp-fips            |
+           | focal   | gcp.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | gcp-fips            |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check fips packages are correctly installed on GCP Pro Focal machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -674,13 +685,14 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
 
         Examples: ubuntu release
-           | release | fips-apt-source                                |
-           | focal   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type | fips-apt-source                                |
+           | focal   | gcp.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check fips packages are correctly installed on GCP Pro Bionic machines
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
@@ -708,5 +720,5 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
 
         Examples: ubuntu release
-           | release  | fips-apt-source                                 |
-           | bionic   | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
+           | release | machine_type | fips-apt-source                                 |
+           | bionic  | gcp.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -1,8 +1,6 @@
 Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.pro-fips
     Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips Azure machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -154,8 +152,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | focal   | azure.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | azure-fips          |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.pro-fips
     Scenario Outline: Check fips packages are correctly installed on Azure Focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -188,8 +184,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.pro-fips
     Scenario Outline: Check fips packages are correctly installed on Azure Bionic & Xenial machines
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -226,8 +220,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | bionic  | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro-fips
     Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips AWS machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -378,8 +370,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | focal   | aws.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips            |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro-fips
     Scenario Outline: Check fips packages are correctly installed on AWS Focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -412,8 +402,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.aws.pro-fips
     Scenario Outline: Check fips packages are correctly installed on AWS Bionic & Xenial machines
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -450,10 +438,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | bionic  | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.azure.pro-fips
-    @uses.config.machine_type.aws.pro-fips
-    @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check fips-updates can be enabled in a focal PRO FIPS machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -506,8 +490,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
 
     @series.focal
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips GCP machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -656,8 +638,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | focal   | gcp.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | gcp-fips            |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check fips packages are correctly installed on GCP Pro Focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -689,8 +669,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | focal   | gcp.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.gcp.pro-fips
     Scenario Outline: Check fips packages are correctly installed on GCP Pro Bionic machines
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -1,6 +1,5 @@
 Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
 
-    @series.lts
     Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips Azure machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -151,7 +150,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | bionic  | azure.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | azure-fips          |
            | focal   | azure.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | azure-fips          |
 
-    @series.focal
     Scenario Outline: Check fips packages are correctly installed on Azure Focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -182,8 +180,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | release | machine_type   | fips-apt-source                                |
            | focal   | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
-    @series.xenial
-    @series.bionic
     Scenario Outline: Check fips packages are correctly installed on Azure Bionic & Xenial machines
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -219,7 +215,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | xenial  | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
            | bionic  | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
 
-    @series.lts
     Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips AWS machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -369,7 +364,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | bionic  | aws.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | aws-fips            |
            | focal   | aws.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips            |
 
-    @series.focal
     Scenario Outline: Check fips packages are correctly installed on AWS Focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -400,8 +394,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | release | machine_type | fips-apt-source                                |
            | focal   | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
-    @series.xenial
-    @series.bionic
     Scenario Outline: Check fips packages are correctly installed on AWS Bionic & Xenial machines
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -437,7 +429,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | xenial  | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
            | bionic  | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
 
-    @series.focal
     Scenario Outline: Check fips-updates can be enabled in a focal PRO FIPS machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -488,8 +479,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | focal   | azure.pro-fips |
            | focal   | gcp.pro-fips   |
 
-    @series.focal
-    @series.bionic
     Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips GCP machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -637,7 +626,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | bionic  | gcp.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | gcp-fips            |
            | focal   | gcp.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | gcp-fips            |
 
-    @series.focal
     Scenario Outline: Check fips packages are correctly installed on GCP Pro Focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
@@ -668,7 +656,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | release | machine_type | fips-apt-source                                |
            | focal   | gcp.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
-    @series.bionic
     Scenario Outline: Check fips packages are correctly installed on GCP Pro Bionic machines
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -2,7 +2,6 @@
 Feature: Upgrade between releases when uaclient is attached
 
     @slow
-    @series.all
     @upgrade
     Scenario Outline: Attached upgrade
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -56,7 +55,6 @@ Feature: Upgrade between releases when uaclient is attached
         | lunar   | lxd-container | mantic       | normal | --devel-release | esm-infra | n/a             | esm-apps | n/a             | true           |
 
     @slow
-    @series.xenial
     @upgrade
     Scenario Outline: Attached FIPS upgrade across LTS releases
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -3,8 +3,6 @@ Feature: Upgrade between releases when uaclient is attached
 
     @slow
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @upgrade
     Scenario Outline: Attached upgrade
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -59,8 +57,6 @@ Feature: Upgrade between releases when uaclient is attached
 
     @slow
     @series.xenial
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-vm
     @upgrade
     Scenario Outline: Attached FIPS upgrade across LTS releases
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -3,10 +3,11 @@ Feature: Upgrade between releases when uaclient is attached
 
     @slow
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @upgrade
     Scenario Outline: Attached upgrade
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `<before_cmd>` with sudo
         # Local PPAs are prepared and served only when testing with local debs
@@ -48,20 +49,21 @@ Feature: Upgrade between releases when uaclient is attached
         """
 
         Examples: ubuntu release
-        | release | next_release | prompt | devel_release   | service1  | service1_status | service2 | service2_status | before_cmd     |
-        | xenial  | bionic       | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-        | bionic  | focal        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-        | bionic  | focal        | lts    |                 | usg       | enabled         | usg      | enabled         | pro enable cis |
-        | focal   | jammy        | lts    | --devel-release | esm-infra | enabled         | esm-apps | enabled         | true           |
-        | jammy   | lunar        | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
-        | lunar   | mantic       | normal | --devel-release | esm-infra | n/a             | esm-apps | n/a             | true           |
+        | release | machine_type  | next_release | prompt | devel_release   | service1  | service1_status | service2 | service2_status | before_cmd     |
+        | xenial  | lxd-container | bionic       | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
+        | bionic  | lxd-container | focal        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
+        | bionic  | lxd-container | focal        | lts    |                 | usg       | enabled         | usg      | enabled         | pro enable cis |
+        | focal   | lxd-container | jammy        | lts    | --devel-release | esm-infra | enabled         | esm-apps | enabled         | true           |
+        | jammy   | lxd-container | lunar        | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
+        | lunar   | lxd-container | mantic       | normal | --devel-release | esm-infra | n/a             | esm-apps | n/a             | true           |
 
     @slow
     @series.xenial
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-vm
     @upgrade
     Scenario Outline: Attached FIPS upgrade across LTS releases
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `apt-get install lsof` with sudo, retrying exit [100]
         And I run `pro disable livepatch` with sudo
@@ -128,6 +130,6 @@ Feature: Upgrade between releases when uaclient is attached
         """
 
         Examples: ubuntu release
-        | release | next_release | fips-service  | fips-name    | source-file         |
-        | xenial  | bionic       | fips          | FIPS         | ubuntu-fips         |
-        | xenial  | bionic       | fips-updates  | FIPS Updates | ubuntu-fips-updates |
+        | release | machine_type | next_release | fips-service  | fips-name    | source-file         |
+        | xenial  | lxd-vm       | bionic       | fips          | FIPS         | ubuntu-fips         |
+        | xenial  | lxd-vm       | bionic       | fips-updates  | FIPS Updates | ubuntu-fips-updates |

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -2,8 +2,6 @@ Feature: Upgrade between releases when uaclient is unattached
 
     @slow
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @upgrade
     @uses.config.contract_token
     Scenario Outline: Unattached upgrade

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -1,7 +1,6 @@
 Feature: Upgrade between releases when uaclient is unattached
 
     @slow
-    @series.all
     @upgrade
     @uses.config.contract_token
     Scenario Outline: Unattached upgrade

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -2,11 +2,12 @@ Feature: Upgrade between releases when uaclient is unattached
 
     @slow
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @upgrade
     @uses.config.contract_token
     Scenario Outline: Unattached upgrade
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Local PPAs are prepared and served only when testing with local debs
         When I prepare the local PPAs to upgrade from `<release>` to `<next_release>`
         And I run `apt update` with sudo
@@ -59,9 +60,9 @@ Feature: Upgrade between releases when uaclient is unattached
         """
 
         Examples: ubuntu release
-        | release | next_release | prompt | devel_release   | service_status |
-        | xenial  | bionic       | lts    |                 | enabled        |
-        | bionic  | focal        | lts    |                 | enabled        |
-        | focal   | jammy        | lts    | --devel-release | enabled        |
-        | jammy   | lunar        | normal |                 | n/a            |
-        | lunar   | mantic       | normal | --devel-release | n/a            |
+        | release | machine_type  | next_release | prompt | devel_release   | service_status |
+        | xenial  | lxd-container | bionic       | lts    |                 | enabled        |
+        | bionic  | lxd-container | focal        | lts    |                 | enabled        |
+        | focal   | lxd-container | jammy        | lts    | --devel-release | enabled        |
+        | jammy   | lxd-container | lunar        | normal |                 | n/a            |
+        | lunar   | lxd-container | mantic       | normal | --devel-release | n/a            |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -1,9 +1,10 @@
 Feature: Command behaviour when unattached
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Validate systemd unit/timer syntax
         When I run `systemd-analyze verify /lib/systemd/system/ua-timer.timer` with sudo
         Then stderr does not match regexp:
@@ -23,18 +24,19 @@ Feature: Command behaviour when unattached
             """
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | xenial  | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro <command>` `as non-root` exits `1`
         Then I will see the following on stderr:
             """
@@ -48,24 +50,25 @@ Feature: Command behaviour when unattached
             """
 
         Examples: pro commands
-           | release | command |
-           | bionic  | detach  |
-           | bionic  | refresh |
-           | focal   | detach  |
-           | focal   | refresh |
-           | xenial  | detach  |
-           | xenial  | refresh |
-           | jammy   | detach  |
-           | jammy   | refresh |
-           | lunar   | detach  |
-           | lunar   | refresh |
-           | mantic  | detach  |
-           | mantic  | refresh |
+           | release | machine_type  | command |
+           | bionic  | lxd-container | detach  |
+           | bionic  | lxd-container | refresh |
+           | focal   | lxd-container | detach  |
+           | focal   | lxd-container | refresh |
+           | xenial  | lxd-container | detach  |
+           | xenial  | lxd-container | refresh |
+           | jammy   | lxd-container | detach  |
+           | jammy   | lxd-container | refresh |
+           | lunar   | lxd-container | detach  |
+           | lunar   | lxd-container | refresh |
+           | mantic  | lxd-container | detach  |
+           | mantic  | lxd-container | refresh |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Help command on an unattached machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro help esm-infra` as non-root
         Then I will see the following on stdout:
         """
@@ -101,18 +104,19 @@ Feature: Command behaviour when unattached
         """
 
         Examples: ubuntu release
-           | release  | infra-available |
-           | xenial   | yes             |
-           | bionic   | yes             |
-           | focal    | yes             |
-           | jammy    | yes             |
-           | lunar    | no              |
-           | mantic   | no              |
+           | release | machine_type  | infra-available |
+           | xenial  | lxd-container | yes             |
+           | bionic  | lxd-container | yes             |
+           | focal   | lxd-container | yes             |
+           | jammy   | lxd-container | yes             |
+           | lunar   | lxd-container | no              |
+           | mantic  | lxd-container | no              |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached enable/disable fails in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro <command> esm-infra` `as non-root` exits `1`
         Then I will see the following on stderr:
           """
@@ -169,24 +173,25 @@ Feature: Command behaviour when unattached
           """
 
         Examples: ubuntu release
-          | release | command  |
-          | xenial  | enable   |
-          | xenial  | disable  |
-          | bionic  | enable   |
-          | bionic  | disable  |
-          | focal   | enable   |
-          | focal   | disable  |
-          | jammy   | enable   |
-          | jammy   | disable  |
-          | lunar   | enable   |
-          | lunar   | disable  |
-          | mantic  | enable   |
-          | mantic  | disable  |
+          | release | machine_type  | command  |
+          | xenial  | lxd-container | enable   |
+          | xenial  | lxd-container | disable  |
+          | bionic  | lxd-container | enable   |
+          | bionic  | lxd-container | disable  |
+          | focal   | lxd-container | enable   |
+          | focal   | lxd-container | disable  |
+          | jammy   | lxd-container | enable   |
+          | jammy   | lxd-container | disable  |
+          | lunar   | lxd-container | enable   |
+          | lunar   | lxd-container | disable  |
+          | mantic  | lxd-container | enable   |
+          | mantic  | lxd-container | disable  |
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Check for newer versions of the client in an ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         #  Make sure we have a fresh, just rebooted, environment
         When I reboot the machine
         Then I verify that no files exist matching `/run/ubuntu-advantage/candidate-version`
@@ -259,20 +264,21 @@ Feature: Command behaviour when unattached
         """
 
         Examples: ubuntu release
-          | release |
-          | xenial  |
-          | bionic  |
-          | focal   |
-          | jammy   |
-          | lunar   |
-          | mantic  |
+          | release | machine_type  |
+          | xenial  | lxd-container |
+          | bionic  | lxd-container |
+          | focal   | lxd-container |
+          | jammy   | lxd-container |
+          | lunar   | lxd-container |
+          | mantic  | lxd-container |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     # Side effect: this verifies that `ua` still works as a command
     Scenario Outline: Verify autocomplete options
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I prepare the autocomplete test
         And I press tab twice to autocomplete the `ua` command
         Then stdout matches regexp:
@@ -322,18 +328,19 @@ Feature: Command behaviour when unattached
         """
 
         Examples: ubuntu release
-          | release |
-          # | xenial  | Can't rely on Xenial because of bash sorting things weirdly
-          | bionic  |
+          | release | machine_type  |
+          # | xenial  | lxd-container | Can't rely on Xenial because of bash sorting things weirdly
+          | bionic  | lxd-container |
 
     @series.focal
     @series.jammy
     @series.lunar
     @series.mantic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     # Side effect: this verifies that `ua` still works as a command
     Scenario Outline: Verify autocomplete options
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I prepare the autocomplete test
         And I press tab twice to autocomplete the `ua` command
         Then stdout matches regexp:
@@ -383,16 +390,17 @@ Feature: Command behaviour when unattached
         """
 
         Examples: ubuntu release
-          | release |
-          | focal   |
-          | jammy   |
-          | lunar   |
-          | mantic  |
+          | release | machine_type  |
+          | focal   | lxd-container |
+          | jammy   | lxd-container |
+          | lunar   | lxd-container |
+          | mantic  | lxd-container |
 
     @series.lts
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: esm cache failures don't generate errors
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I disable access to esm.ubuntu.com
         And I run `apt update` with sudo
         # Wait for the hook to fail
@@ -419,19 +427,20 @@ Feature: Command behaviour when unattached
         """
 
         Examples: ubuntu release
-          | release |
-          | xenial  |
-          | bionic  |
-          | focal   |
-          | jammy   |
+          | release | machine_type  |
+          | xenial  | lxd-container |
+          | bionic  | lxd-container |
+          | focal   | lxd-container |
+          | jammy   | lxd-container |
 
     @series.jammy
     @series.lunar
     @series.mantic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     # Services fail, degraded systemctl, but no crashes.
     Scenario Outline: services fail gracefully when yaml is broken/absent
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `apt update` with sudo
         And I run `rm -rf /usr/lib/python3/dist-packages/yaml` with sudo
         And I verify that running `pro status` `with sudo` exits `1`
@@ -494,17 +503,18 @@ Feature: Command behaviour when unattached
         """
 
         Examples: ubuntu release
-          | release | python_version | suffix                  |
-          | jammy   | python3.10     |                         |
+          | release | machine_type  | python_version | suffix                  |
+          | jammy   | lxd-container | python3.10     |                         |
           # Lunar+ has a BIG error message explaining why this is a clear user error...
-          | lunar   | python3.11     | --break-system-packages |
-          | mantic  | python3.11     | --break-system-packages |
+          | lunar   | lxd-container | python3.11     | --break-system-packages |
+          | mantic  | lxd-container | python3.11     | --break-system-packages |
 
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Warn users not to redirect/pipe human readable output
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run shell command `pro version | cat` as non-root
         Then I will see the following on stderr
         """
@@ -587,10 +597,10 @@ Feature: Command behaviour when unattached
         """
 
         Examples: ubuntu release
-          | release |
-          | xenial  |
-          | bionic  |
-          | focal   |
-          | jammy   |
-          | lunar   |
-          | mantic  |
+          | release | machine_type  |
+          | xenial  | lxd-container |
+          | bionic  | lxd-container |
+          | focal   | lxd-container |
+          | jammy   | lxd-container |
+          | lunar   | lxd-container |
+          | mantic  | lxd-container |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -1,8 +1,6 @@
 Feature: Command behaviour when unattached
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Validate systemd unit/timer syntax
@@ -33,8 +31,6 @@ Feature: Command behaviour when unattached
            | mantic  | lxd-container |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro <command>` `as non-root` exits `1`
@@ -65,8 +61,6 @@ Feature: Command behaviour when unattached
            | mantic  | lxd-container | refresh |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Help command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro help esm-infra` as non-root
@@ -113,8 +107,6 @@ Feature: Command behaviour when unattached
            | mantic  | lxd-container | no              |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached enable/disable fails in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro <command> esm-infra` `as non-root` exits `1`
@@ -188,8 +180,6 @@ Feature: Command behaviour when unattached
           | mantic  | lxd-container | disable  |
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Check for newer versions of the client in an ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         #  Make sure we have a fresh, just rebooted, environment
@@ -274,8 +264,6 @@ Feature: Command behaviour when unattached
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     # Side effect: this verifies that `ua` still works as a command
     Scenario Outline: Verify autocomplete options
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -336,8 +324,6 @@ Feature: Command behaviour when unattached
     @series.jammy
     @series.lunar
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     # Side effect: this verifies that `ua` still works as a command
     Scenario Outline: Verify autocomplete options
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -397,8 +383,6 @@ Feature: Command behaviour when unattached
           | mantic  | lxd-container |
 
     @series.lts
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: esm cache failures don't generate errors
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I disable access to esm.ubuntu.com
@@ -436,8 +420,6 @@ Feature: Command behaviour when unattached
     @series.jammy
     @series.lunar
     @series.mantic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     # Services fail, degraded systemctl, but no crashes.
     Scenario Outline: services fail gracefully when yaml is broken/absent
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -511,8 +493,6 @@ Feature: Command behaviour when unattached
 
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Warn users not to redirect/pipe human readable output
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run shell command `pro version | cat` as non-root

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -1,6 +1,5 @@
 Feature: Command behaviour when unattached
 
-    @series.all
     Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Validate systemd unit/timer syntax
@@ -30,7 +29,6 @@ Feature: Command behaviour when unattached
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.all
     Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro <command>` `as non-root` exits `1`
@@ -60,7 +58,6 @@ Feature: Command behaviour when unattached
            | mantic  | lxd-container | detach  |
            | mantic  | lxd-container | refresh |
 
-    @series.all
     Scenario Outline: Help command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro help esm-infra` as non-root
@@ -106,7 +103,6 @@ Feature: Command behaviour when unattached
            | lunar   | lxd-container | no              |
            | mantic  | lxd-container | no              |
 
-    @series.all
     Scenario Outline: Unattached enable/disable fails in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `pro <command> esm-infra` `as non-root` exits `1`
@@ -179,7 +175,6 @@ Feature: Command behaviour when unattached
           | mantic  | lxd-container | enable   |
           | mantic  | lxd-container | disable  |
 
-    @series.all
     Scenario Outline: Check for newer versions of the client in an ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         #  Make sure we have a fresh, just rebooted, environment
@@ -262,8 +257,6 @@ Feature: Command behaviour when unattached
           | lunar   | lxd-container |
           | mantic  | lxd-container |
 
-    @series.xenial
-    @series.bionic
     # Side effect: this verifies that `ua` still works as a command
     Scenario Outline: Verify autocomplete options
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -320,10 +313,6 @@ Feature: Command behaviour when unattached
           # | xenial  | lxd-container | Can't rely on Xenial because of bash sorting things weirdly
           | bionic  | lxd-container |
 
-    @series.focal
-    @series.jammy
-    @series.lunar
-    @series.mantic
     # Side effect: this verifies that `ua` still works as a command
     Scenario Outline: Verify autocomplete options
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -382,7 +371,6 @@ Feature: Command behaviour when unattached
           | lunar   | lxd-container |
           | mantic  | lxd-container |
 
-    @series.lts
     Scenario Outline: esm cache failures don't generate errors
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I disable access to esm.ubuntu.com
@@ -417,9 +405,6 @@ Feature: Command behaviour when unattached
           | focal   | lxd-container |
           | jammy   | lxd-container |
 
-    @series.jammy
-    @series.lunar
-    @series.mantic
     # Services fail, degraded systemctl, but no crashes.
     Scenario Outline: services fail gracefully when yaml is broken/absent
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -492,7 +477,6 @@ Feature: Command behaviour when unattached
           | mantic  | lxd-container | python3.11     | --break-system-packages |
 
 
-    @series.all
     Scenario Outline: Warn users not to redirect/pipe human readable output
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run shell command `pro version | cat` as non-root

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,9 +1,10 @@
 Feature: Unattached status
 
     @series.all
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached status in a ubuntu machine - formatted
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro status --format json` as non-root
         Then stdout is a json matching the `ua_status` schema
         When I run `pro status --format yaml` as non-root
@@ -33,19 +34,20 @@ Feature: Unattached status
             """
 
         Examples: ubuntu release
-           | release |
-           | bionic  |
-           | focal   |
-           | xenial  |
-           | jammy   |
-           | lunar   |
-           | mantic  |
+           | release | machine_type  |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | xenial  | lxd-container |
+           | jammy   | lxd-container |
+           | lunar   | lxd-container |
+           | mantic  | lxd-container |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached status in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify root and non-root `pro status` calls have the same output
         And I run `pro status` as non-root
         Then stdout matches regexp:
@@ -120,14 +122,15 @@ Feature: Unattached status
         """ 
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached status in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify root and non-root `pro status` calls have the same output
         When I run `pro status` as non-root
         Then stdout matches regexp:
@@ -200,13 +203,14 @@ Feature: Unattached status
         """ 
 
         Examples: ubuntu release
-           | release |
-           | focal   |
+           | release | machine_type  |
+           | focal   | lxd-container |
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached status in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify root and non-root `pro status` calls have the same output
         And I run `pro status` as non-root
         Then stdout matches regexp:
@@ -273,15 +277,16 @@ Feature: Unattached status
         """ 
 
         Examples: ubuntu release
-           | release |
-           | jammy   |
+           | release | machine_type  |
+           | jammy   | lxd-container |
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I do a preflight check for `contract_token` without the all flag
         Then stdout matches regexp:
         """
@@ -338,15 +343,16 @@ Feature: Unattached status
             warnings: []
             """
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I do a preflight check for `contract_token` without the all flag
         Then stdout matches regexp:
         """
@@ -405,14 +411,15 @@ Feature: Unattached status
         """
 
         Examples: ubuntu release
-           | release |
-           | focal   |
+           | release | machine_type  |
+           | focal   | lxd-container |
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I do a preflight check for `contract_token` without the all flag
         Then stdout matches regexp:
         """
@@ -468,16 +475,17 @@ Feature: Unattached status
         """
 
         Examples: ubuntu release
-           | release |
-           | jammy   |
+           | release | machine_type  |
+           | jammy   | lxd-container |
 
 
     @series.xenial
     @series.bionic
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `sed -i 's/contracts.can/contracts.staging.can/' /etc/ubuntu-advantage/uaclient.conf` with sudo
         And I verify that a preflight check for `contract_token_staging_expired` formatted as json exits 1
         Then stdout is a json matching the `ua_status` schema
@@ -520,15 +528,16 @@ Feature: Unattached status
         """
 
         Examples: ubuntu release
-           | release |
-           | xenial  |
-           | bionic  |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
 
     @series.focal
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `sed -i 's/contracts.can/contracts.staging.can/' /etc/ubuntu-advantage/uaclient.conf` with sudo
         And I verify that a preflight check for `contract_token_staging_expired` formatted as json exits 1
         Then stdout is a json matching the `ua_status` schema
@@ -570,14 +579,15 @@ Feature: Unattached status
         """
 
         Examples: ubuntu release
-           | release |
-           | focal   |
+           | release | machine_type  |
+           | focal   | lxd-container |
 
     @series.jammy
+    @uses.config.machine_type.any
     @uses.config.machine_type.lxd-container
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
-        Given a `<release>` machine with ubuntu-advantage-tools installed
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `sed -i 's/contracts.can/contracts.staging.can/' /etc/ubuntu-advantage/uaclient.conf` with sudo
         And I verify that a preflight check for `contract_token_staging_expired` formatted as json exits 1
         Then stdout is a json matching the `ua_status` schema
@@ -616,5 +626,5 @@ Feature: Unattached status
         """
 
         Examples: ubuntu release
-           | release |
-           | jammy   |
+           | release | machine_type  |
+           | jammy   | lxd-container |

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,6 +1,5 @@
 Feature: Unattached status
 
-    @series.all
     Scenario Outline: Unattached status in a ubuntu machine - formatted
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro status --format json` as non-root
@@ -40,8 +39,6 @@ Feature: Unattached status
            | lunar   | lxd-container |
            | mantic  | lxd-container |
 
-    @series.xenial
-    @series.bionic
     Scenario Outline: Unattached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify root and non-root `pro status` calls have the same output
@@ -122,7 +119,6 @@ Feature: Unattached status
            | xenial  | lxd-container |
            | bionic  | lxd-container |
 
-    @series.focal
     Scenario Outline: Unattached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify root and non-root `pro status` calls have the same output
@@ -200,7 +196,6 @@ Feature: Unattached status
            | release | machine_type  |
            | focal   | lxd-container |
 
-    @series.jammy
     Scenario Outline: Unattached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify root and non-root `pro status` calls have the same output
@@ -272,8 +267,6 @@ Feature: Unattached status
            | release | machine_type  |
            | jammy   | lxd-container |
 
-    @series.xenial
-    @series.bionic
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -337,7 +330,6 @@ Feature: Unattached status
            | xenial  | lxd-container |
            | bionic  | lxd-container |
 
-    @series.focal
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -402,7 +394,6 @@ Feature: Unattached status
            | release | machine_type  |
            | focal   | lxd-container |
 
-    @series.jammy
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -465,8 +456,6 @@ Feature: Unattached status
            | jammy   | lxd-container |
 
 
-    @series.xenial
-    @series.bionic
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -516,7 +505,6 @@ Feature: Unattached status
            | xenial  | lxd-container |
            | bionic  | lxd-container |
 
-    @series.focal
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -564,7 +552,6 @@ Feature: Unattached status
            | release | machine_type  |
            | focal   | lxd-container |
 
-    @series.jammy
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,8 +1,6 @@
 Feature: Unattached status
 
     @series.all
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached status in a ubuntu machine - formatted
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `pro status --format json` as non-root
@@ -44,8 +42,6 @@ Feature: Unattached status
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify root and non-root `pro status` calls have the same output
@@ -127,8 +123,6 @@ Feature: Unattached status
            | bionic  | lxd-container |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify root and non-root `pro status` calls have the same output
@@ -207,8 +201,6 @@ Feature: Unattached status
            | focal   | lxd-container |
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     Scenario Outline: Unattached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify root and non-root `pro status` calls have the same output
@@ -282,8 +274,6 @@ Feature: Unattached status
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -348,8 +338,6 @@ Feature: Unattached status
            | bionic  | lxd-container |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -415,8 +403,6 @@ Feature: Unattached status
            | focal   | lxd-container |
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token
     Scenario Outline: Simulate status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -481,8 +467,6 @@ Feature: Unattached status
 
     @series.xenial
     @series.bionic
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -533,8 +517,6 @@ Feature: Unattached status
            | bionic  | lxd-container |
 
     @series.focal
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -583,8 +565,6 @@ Feature: Unattached status
            | focal   | lxd-container |
 
     @series.jammy
-    @uses.config.machine_type.any
-    @uses.config.machine_type.lxd-container
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -541,7 +541,6 @@ Feature: Unattached status
         esm-apps        +yes       +no        +no           +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips            +yes       +yes       +no           +NIST-certified FIPS crypto packages
-        fips-preview    +.* +.* +.*
         fips-updates    +yes       +yes       +no           +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         ros             +yes       +no        +no           +Security Updates for the Robot Operating System

--- a/features/util.py
+++ b/features/util.py
@@ -21,6 +21,7 @@ import yaml
 from uaclient.system import get_dpkg_arch
 
 SUT = "system-under-test"
+BUILDER_NAME_PREFIX = "builder-"
 LXC_PROPERTY_MAP = {
     "image": {"series": "properties.release", "machine_type": "Type"},
     "container": {"series": "image.release", "machine_type": "image.type"},
@@ -308,12 +309,13 @@ def process_template_vars(
                     logger_fn,
                 )
         elif function_name == "cloud":
-            processed_template = _replace_and_log(
-                processed_template,
-                match.group(0),
-                context.pro_config.default_cloud.name,
-                logger_fn,
-            )
+            if args[1] in context.machines:
+                processed_template = _replace_and_log(
+                    processed_template,
+                    match.group(0),
+                    context.machines[args[1]].cloud,
+                    logger_fn,
+                )
         elif function_name == "today":
             dt = datetime.datetime.utcnow()
             if len(args) == 2:

--- a/features/util.py
+++ b/features/util.py
@@ -43,51 +43,6 @@ class InstallationSource(Enum):
     CUSTOM = "custom"
 
 
-def lxc_get_property(name: str, property_name: str, image: bool = False):
-    """Check series name of either an image or a container.
-
-    :param name:
-        The name of the container or the image to check its series.
-    :param property_name:
-        The name of the property to return.
-    :param image:
-        If image==True will check image properties
-        If image==False it will check container configuration to get
-        properties.
-
-    :return:
-        The value of the container or image property.
-       `None` if it could not detect it (
-           some images don't have this field in properties).
-    """
-    if not image:
-        property_name = LXC_PROPERTY_MAP["container"][property_name]
-        output = subprocess.check_output(
-            ["lxc", "config", "get", name, property_name],
-            universal_newlines=True,
-        )
-        return output.rstrip()
-    else:
-        property_keys = LXC_PROPERTY_MAP["image"][property_name].split(".")
-        output = subprocess.check_output(
-            ["lxc", "image", "show", name], universal_newlines=True
-        )
-        image_config = yaml.safe_load(output)
-        logging.info("--- `lxc image show` output: ", image_config)
-        value = image_config
-        for key_name in property_keys:
-            value = image_config.get(value, {})
-        if not value:
-            logging.info(
-                "--- Could not detect image property {name}."
-                " Add it via `lxc image edit`".format(
-                    name=".".join(property_keys)
-                )
-            )
-            return None
-        return value
-
-
 def repo_state_hash(
     exclude_dirs: Iterable[str] = (
         ".github",

--- a/tox.ini
+++ b/tox.ini
@@ -17,18 +17,6 @@ passenv =
     AZURE_CONFIG_DIR
     UACLIENT_BEHAVE_*
     https_proxy
-setenv =
-    awsgeneric: UACLIENT_BEHAVE_MACHINE_TYPE = aws.generic
-    awspro: UACLIENT_BEHAVE_MACHINE_TYPE = aws.pro
-    awspro-fips: UACLIENT_BEHAVE_MACHINE_TYPE = aws.pro-fips
-    azuregeneric: UACLIENT_BEHAVE_MACHINE_TYPE = azure.generic
-    azurepro: UACLIENT_BEHAVE_MACHINE_TYPE = azure.pro
-    azurepro-fips: UACLIENT_BEHAVE_MACHINE_TYPE = azure.pro-fips
-    gcpgeneric: UACLIENT_BEHAVE_MACHINE_TYPE = gcp.generic
-    gcppro: UACLIENT_BEHAVE_MACHINE_TYPE = gcp.pro
-    gcppro-fips: UACLIENT_BEHAVE_MACHINE_TYPE = gcp.pro-fips
-    vm: UACLIENT_BEHAVE_MACHINE_TYPE = lxd-vm
-    docker: UACLIENT_BEHAVE_MACHINE_TYPE = lxd-vm
 commands =
     test: py.test --junitxml=pytest_results.xml {posargs:--cov uaclient uaclient}
     flake8: flake8 uaclient lib setup.py features
@@ -36,21 +24,21 @@ commands =
     black: black --check --diff uaclient/ features/ lib/ setup.py
     isort: isort --check --diff uaclient/ features/ lib/ setup.py
     shellcheck: bash -O extglob -O nullglob -c "shellcheck -S warning tools/*.sh debian/*.{config,postinst,postrm,prerm} lib/*.sh sru/*.sh update-motd.d/*"
-    behave-any: behave -v -D machine_type=any {posargs}
+    behave-any: behave -v {posargs}
 
-    behave-lxd-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-container" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-container" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-container" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-22.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-container" --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-23.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-container" --tags="series.lunar,series.all" --tags="~upgrade"
-    behave-lxd-23.10: behave -v {posargs} --tags="uses.config.machine_type.lxd-container" --tags="series.mantic,series.all" --tags="~upgrade"
+    behave-lxd-16.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
+    behave-lxd-18.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
+    behave-lxd-20.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.focal,series.lts,series.all" --tags="~upgrade"
+    behave-lxd-22.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
+    behave-lxd-23.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.lunar,series.all" --tags="~upgrade"
+    behave-lxd-23.10: behave -v {posargs} -D machine_types=lxd-container --tags="series.mantic,series.all" --tags="~upgrade"
 
-    behave-vm-16.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-vm" --tags="series.xenial,series.all,series.lts" --tags="~upgrade"
-    behave-vm-18.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-vm" --tags="series.bionic,series.all,series.lts" --tags="~upgrade"
-    behave-vm-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-vm" --tags="series.focal,series.all,series.lts" --tags="~upgrade" --tags="~docker"
-    behave-vm-22.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-vm" --tags="series.jammy,series.all,series.lts" --tags="~upgrade"
-    behave-vm-23.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-vm" --tags="series.lunar,series.all" --tags="~upgrade"
-    behave-vm-23.10: behave -v {posargs} --tags="uses.config.machine_type.lxd-vm" --tags="series.mantic,series.all" --tags="~upgrade"
+    behave-vm-16.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.xenial,series.all,series.lts" --tags="~upgrade"
+    behave-vm-18.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.bionic,series.all,series.lts" --tags="~upgrade"
+    behave-vm-20.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.focal,series.all,series.lts" --tags="~upgrade" --tags="~docker"
+    behave-vm-22.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.jammy,series.all,series.lts" --tags="~upgrade"
+    behave-vm-23.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.lunar,series.all" --tags="~upgrade"
+    behave-vm-23.10: behave -v {posargs} -D machine_types=lxd-vm --tags="series.mantic,series.all" --tags="~upgrade"
 
     behave-upgrade-16.04: behave -v {posargs} --tags="upgrade" --tags="series.xenial,series.all"
     behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" --tags="series.bionic,series.all"
@@ -58,50 +46,50 @@ commands =
     behave-upgrade-22.04: behave -v {posargs} --tags="upgrade" --tags="series.jammy,series.all"
     behave-upgrade-23.04: behave -v {posargs} --tags="upgrade" --tags="series.lunar,series.all"
 
-    behave-docker-20.04: behave -v {posargs} --tags="uses.config.machine_type.lxd-vm" --tags="series.focal" features/docker.feature
+    behave-docker-20.04: behave -v {posargs} --tags="series.focal" features/docker.feature
 
-    behave-awsgeneric-16.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-awsgeneric-18.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-awsgeneric-20.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-awsgeneric-22.04: behave -v {posargs} --tags="uses.config.machine_type.aws.generic" --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
+    behave-awsgeneric-16.04: behave -v {posargs} -D machine_types=aws.generic --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
+    behave-awsgeneric-18.04: behave -v {posargs} -D machine_types=aws.generic --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
+    behave-awsgeneric-20.04: behave -v {posargs} -D machine_types=aws.generic --tags="series.focal,series.lts,series.all" --tags="~upgrade"
+    behave-awsgeneric-22.04: behave -v {posargs} -D machine_types=aws.generic --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
 
-    behave-awspro-16.04: behave -v {posargs} --tags="uses.config.machine_type.aws.pro" --tags="series.xenial,series.lts,series.all"
-    behave-awspro-18.04: behave -v {posargs} --tags="uses.config.machine_type.aws.pro" --tags="series.bionic,series.lts,series.all"
-    behave-awspro-20.04: behave -v {posargs} --tags="uses.config.machine_type.aws.pro" --tags="series.focal,series.lts,series.all"
-    behave-awspro-22.04: behave -v {posargs} --tags="uses.config.machine_type.aws.pro" --tags="series.jammy,series.lts,series.all"
+    behave-awspro-16.04: behave -v {posargs} -D machine_types=aws.pro --tags="series.xenial,series.lts,series.all"
+    behave-awspro-18.04: behave -v {posargs} -D machine_types=aws.pro --tags="series.bionic,series.lts,series.all"
+    behave-awspro-20.04: behave -v {posargs} -D machine_types=aws.pro --tags="series.focal,series.lts,series.all"
+    behave-awspro-22.04: behave -v {posargs} -D machine_types=aws.pro --tags="series.jammy,series.lts,series.all"
 
-    behave-awspro-fips-16.04: behave -v {posargs} --tags="uses.config.machine_type.aws.pro-fips" --tags="series.xenial,series.lts,series.all"
-    behave-awspro-fips-18.04: behave -v {posargs} --tags="uses.config.machine_type.aws.pro-fips" --tags="series.bionic,series.lts,series.all"
-    behave-awspro-fips-20.04: behave -v {posargs} --tags="uses.config.machine_type.aws.pro-fips" --tags="series.focal,series.lts,series.all"
+    behave-awspro-fips-16.04: behave -v {posargs} -D machine_types=aws.pro-fips --tags="series.xenial,series.lts,series.all"
+    behave-awspro-fips-18.04: behave -v {posargs} -D machine_types=aws.pro-fips --tags="series.bionic,series.lts,series.all"
+    behave-awspro-fips-20.04: behave -v {posargs} -D machine_types=aws.pro-fips --tags="series.focal,series.lts,series.all"
 
-    behave-azuregeneric-16.04: behave -v {posargs} --tags="uses.config.machine_type.azure.generic" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-azuregeneric-18.04: behave -v {posargs} --tags="uses.config.machine_type.azure.generic" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-azuregeneric-20.04: behave -v {posargs} --tags="uses.config.machine_type.azure.generic" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-azuregeneric-22.04: behave -v {posargs} --tags="uses.config.machine_type.azure.generic" --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
-    behave-azuregeneric-23.04: behave -v {posargs} --tags="uses.config.machine_type.azure.generic" --tags="series.lunar,series.all" --tags="~upgrade"
+    behave-azuregeneric-16.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
+    behave-azuregeneric-18.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
+    behave-azuregeneric-20.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.focal,series.lts,series.all" --tags="~upgrade"
+    behave-azuregeneric-22.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
+    behave-azuregeneric-23.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.lunar,series.all" --tags="~upgrade"
 
-    behave-azurepro-16.04: behave -v {posargs} --tags="uses.config.machine_type.azure.pro" --tags="series.xenial,series.lts,series.all"
-    behave-azurepro-18.04: behave -v {posargs} --tags="uses.config.machine_type.azure.pro" --tags="series.bionic,series.lts,series.all"
-    behave-azurepro-20.04: behave -v {posargs} --tags="uses.config.machine_type.azure.pro" --tags="series.focal,series.lts,series.all"
-    behave-azurepro-22.04: behave -v {posargs} --tags="uses.config.machine_type.azure.pro" --tags="series.jammy,series.lts,series.all"
+    behave-azurepro-16.04: behave -v {posargs} -D machine_types=azure.pro --tags="series.xenial,series.lts,series.all"
+    behave-azurepro-18.04: behave -v {posargs} -D machine_types=azure.pro --tags="series.bionic,series.lts,series.all"
+    behave-azurepro-20.04: behave -v {posargs} -D machine_types=azure.pro --tags="series.focal,series.lts,series.all"
+    behave-azurepro-22.04: behave -v {posargs} -D machine_types=azure.pro --tags="series.jammy,series.lts,series.all"
 
-    behave-azurepro-fips-16.04: behave -v {posargs} --tags="uses.config.machine_type.azure.pro-fips" --tags="series.xenial,series.lts,series.all"
-    behave-azurepro-fips-18.04: behave -v {posargs} --tags="uses.config.machine_type.azure.pro-fips" --tags="series.bionic,series.lts,series.all"
-    behave-azurepro-fips-20.04: behave -v {posargs} --tags="uses.config.machine_type.azure.pro-fips" --tags="series.focal,series.lts,series.all"
+    behave-azurepro-fips-16.04: behave -v {posargs} -D machine_types=azure.pro-fips --tags="series.xenial,series.lts,series.all"
+    behave-azurepro-fips-18.04: behave -v {posargs} -D machine_types=azure.pro-fips --tags="series.bionic,series.lts,series.all"
+    behave-azurepro-fips-20.04: behave -v {posargs} -D machine_types=azure.pro-fips --tags="series.focal,series.lts,series.all"
 
-    behave-gcpgeneric-16.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-gcpgeneric-18.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-gcpgeneric-20.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-gcpgeneric-22.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
-    behave-gcpgeneric-23.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.generic" --tags="series.lunar,series.all" --tags="~upgrade"
+    behave-gcpgeneric-16.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
+    behave-gcpgeneric-18.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
+    behave-gcpgeneric-20.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.focal,series.lts,series.all" --tags="~upgrade"
+    behave-gcpgeneric-22.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
+    behave-gcpgeneric-23.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.lunar,series.all" --tags="~upgrade"
 
-    behave-gcppro-16.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro" --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-gcppro-18.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-gcppro-20.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-gcppro-22.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro" --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-16.04: behave -v {posargs} -D machine_types=gcp.pro --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-18.04: behave -v {posargs} -D machine_types=gcp.pro --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-20.04: behave -v {posargs} -D machine_types=gcp.pro --tags="series.focal,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-22.04: behave -v {posargs} -D machine_types=gcp.pro --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
 
-    behave-gcppro-fips-18.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro-fips" --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-gcppro-fips-20.04: behave -v {posargs} --tags="uses.config.machine_type.gcp.pro-fips" --tags="series.focal,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-fips-18.04: behave -v {posargs} -D machine_types=gcp.pro-fips --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-fips-20.04: behave -v {posargs} -D machine_types=gcp.pro-fips --tags="series.focal,series.lts,series.all" --tags="~upgrade"
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the

--- a/tox.ini
+++ b/tox.ini
@@ -26,70 +26,70 @@ commands =
     shellcheck: bash -O extglob -O nullglob -c "shellcheck -S warning tools/*.sh debian/*.{config,postinst,postrm,prerm} lib/*.sh sru/*.sh update-motd.d/*"
     behave-any: behave -v {posargs}
 
-    behave-lxd-16.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-18.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-20.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-22.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
-    behave-lxd-23.04: behave -v {posargs} -D machine_types=lxd-container --tags="series.lunar,series.all" --tags="~upgrade"
-    behave-lxd-23.10: behave -v {posargs} -D machine_types=lxd-container --tags="series.mantic,series.all" --tags="~upgrade"
+    behave-lxd-16.04: behave -v {posargs} -D machine_types=lxd-container -D releases=xenial --tags="~upgrade"
+    behave-lxd-18.04: behave -v {posargs} -D machine_types=lxd-container -D releases=bionic --tags="~upgrade"
+    behave-lxd-20.04: behave -v {posargs} -D machine_types=lxd-container -D releases=focal --tags="~upgrade"
+    behave-lxd-22.04: behave -v {posargs} -D machine_types=lxd-container -D releases=jammy --tags="~upgrade"
+    behave-lxd-23.04: behave -v {posargs} -D machine_types=lxd-container -D releases=lunar --tags="~upgrade"
+    behave-lxd-23.10: behave -v {posargs} -D machine_types=lxd-container -D releases=mantic --tags="~upgrade"
 
-    behave-vm-16.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.xenial,series.all,series.lts" --tags="~upgrade"
-    behave-vm-18.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.bionic,series.all,series.lts" --tags="~upgrade"
-    behave-vm-20.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.focal,series.all,series.lts" --tags="~upgrade" --tags="~docker"
-    behave-vm-22.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.jammy,series.all,series.lts" --tags="~upgrade"
-    behave-vm-23.04: behave -v {posargs} -D machine_types=lxd-vm --tags="series.lunar,series.all" --tags="~upgrade"
-    behave-vm-23.10: behave -v {posargs} -D machine_types=lxd-vm --tags="series.mantic,series.all" --tags="~upgrade"
+    behave-vm-16.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=xenial --tags="~upgrade"
+    behave-vm-18.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=bionic --tags="~upgrade"
+    behave-vm-20.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=focal --tags="~upgrade" --tags="~docker"
+    behave-vm-22.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=jammy --tags="~upgrade"
+    behave-vm-23.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=lunar --tags="~upgrade"
+    behave-vm-23.10: behave -v {posargs} -D machine_types=lxd-vm -D releases=mantic --tags="~upgrade"
 
-    behave-upgrade-16.04: behave -v {posargs} --tags="upgrade" --tags="series.xenial,series.all"
-    behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" --tags="series.bionic,series.all"
-    behave-upgrade-20.04: behave -v {posargs} --tags="upgrade" --tags="series.focal,series.all"
-    behave-upgrade-22.04: behave -v {posargs} --tags="upgrade" --tags="series.jammy,series.all"
-    behave-upgrade-23.04: behave -v {posargs} --tags="upgrade" --tags="series.lunar,series.all"
+    behave-upgrade-16.04: behave -v {posargs} --tags="upgrade" -D releases=xenial
+    behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" -D releases=bionic
+    behave-upgrade-20.04: behave -v {posargs} --tags="upgrade" -D releases=focal
+    behave-upgrade-22.04: behave -v {posargs} --tags="upgrade" -D releases=jammy
+    behave-upgrade-23.04: behave -v {posargs} --tags="upgrade" -D releases=lunar
 
-    behave-docker-20.04: behave -v {posargs} --tags="series.focal" features/docker.feature
+    behave-docker-20.04: behave -v {posargs} -D releases=focal" features/docker.feature
 
-    behave-awsgeneric-16.04: behave -v {posargs} -D machine_types=aws.generic --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-awsgeneric-18.04: behave -v {posargs} -D machine_types=aws.generic --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-awsgeneric-20.04: behave -v {posargs} -D machine_types=aws.generic --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-awsgeneric-22.04: behave -v {posargs} -D machine_types=aws.generic --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
+    behave-awsgeneric-16.04: behave -v {posargs} -D machine_types=aws.generic -D releases=xenial --tags="~upgrade"
+    behave-awsgeneric-18.04: behave -v {posargs} -D machine_types=aws.generic -D releases=bionic --tags="~upgrade"
+    behave-awsgeneric-20.04: behave -v {posargs} -D machine_types=aws.generic -D releases=focal --tags="~upgrade"
+    behave-awsgeneric-22.04: behave -v {posargs} -D machine_types=aws.generic -D releases=jammy --tags="~upgrade"
 
-    behave-awspro-16.04: behave -v {posargs} -D machine_types=aws.pro --tags="series.xenial,series.lts,series.all"
-    behave-awspro-18.04: behave -v {posargs} -D machine_types=aws.pro --tags="series.bionic,series.lts,series.all"
-    behave-awspro-20.04: behave -v {posargs} -D machine_types=aws.pro --tags="series.focal,series.lts,series.all"
-    behave-awspro-22.04: behave -v {posargs} -D machine_types=aws.pro --tags="series.jammy,series.lts,series.all"
+    behave-awspro-16.04: behave -v {posargs} -D machine_types=aws.pro -D releases=xenial
+    behave-awspro-18.04: behave -v {posargs} -D machine_types=aws.pro -D releases=bionic
+    behave-awspro-20.04: behave -v {posargs} -D machine_types=aws.pro -D releases=focal
+    behave-awspro-22.04: behave -v {posargs} -D machine_types=aws.pro -D releases=jammy
 
-    behave-awspro-fips-16.04: behave -v {posargs} -D machine_types=aws.pro-fips --tags="series.xenial,series.lts,series.all"
-    behave-awspro-fips-18.04: behave -v {posargs} -D machine_types=aws.pro-fips --tags="series.bionic,series.lts,series.all"
-    behave-awspro-fips-20.04: behave -v {posargs} -D machine_types=aws.pro-fips --tags="series.focal,series.lts,series.all"
+    behave-awspro-fips-16.04: behave -v {posargs} -D machine_types=aws.pro-fips -D releases=xenial
+    behave-awspro-fips-18.04: behave -v {posargs} -D machine_types=aws.pro-fips -D releases=bionic
+    behave-awspro-fips-20.04: behave -v {posargs} -D machine_types=aws.pro-fips -D releases=focal
 
-    behave-azuregeneric-16.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-azuregeneric-18.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-azuregeneric-20.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-azuregeneric-22.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
-    behave-azuregeneric-23.04: behave -v {posargs} -D machine_types=azure.generic --tags="series.lunar,series.all" --tags="~upgrade"
+    behave-azuregeneric-16.04: behave -v {posargs} -D machine_types=azure.generic -D releases=xenial --tags="~upgrade"
+    behave-azuregeneric-18.04: behave -v {posargs} -D machine_types=azure.generic -D releases=bionic --tags="~upgrade"
+    behave-azuregeneric-20.04: behave -v {posargs} -D machine_types=azure.generic -D releases=focal --tags="~upgrade"
+    behave-azuregeneric-22.04: behave -v {posargs} -D machine_types=azure.generic -D releases=jammy --tags="~upgrade"
+    behave-azuregeneric-23.04: behave -v {posargs} -D machine_types=azure.generic -D releases=lunar --tags="~upgrade"
 
-    behave-azurepro-16.04: behave -v {posargs} -D machine_types=azure.pro --tags="series.xenial,series.lts,series.all"
-    behave-azurepro-18.04: behave -v {posargs} -D machine_types=azure.pro --tags="series.bionic,series.lts,series.all"
-    behave-azurepro-20.04: behave -v {posargs} -D machine_types=azure.pro --tags="series.focal,series.lts,series.all"
-    behave-azurepro-22.04: behave -v {posargs} -D machine_types=azure.pro --tags="series.jammy,series.lts,series.all"
+    behave-azurepro-16.04: behave -v {posargs} -D machine_types=azure.pro -D releases=xenial
+    behave-azurepro-18.04: behave -v {posargs} -D machine_types=azure.pro -D releases=bionic
+    behave-azurepro-20.04: behave -v {posargs} -D machine_types=azure.pro -D releases=focal
+    behave-azurepro-22.04: behave -v {posargs} -D machine_types=azure.pro -D releases=jammy
 
-    behave-azurepro-fips-16.04: behave -v {posargs} -D machine_types=azure.pro-fips --tags="series.xenial,series.lts,series.all"
-    behave-azurepro-fips-18.04: behave -v {posargs} -D machine_types=azure.pro-fips --tags="series.bionic,series.lts,series.all"
-    behave-azurepro-fips-20.04: behave -v {posargs} -D machine_types=azure.pro-fips --tags="series.focal,series.lts,series.all"
+    behave-azurepro-fips-16.04: behave -v {posargs} -D machine_types=azure.pro-fips -D releases=xenial
+    behave-azurepro-fips-18.04: behave -v {posargs} -D machine_types=azure.pro-fips -D releases=bionic
+    behave-azurepro-fips-20.04: behave -v {posargs} -D machine_types=azure.pro-fips -D releases=focal
 
-    behave-gcpgeneric-16.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-gcpgeneric-18.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-gcpgeneric-20.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-gcpgeneric-22.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
-    behave-gcpgeneric-23.04: behave -v {posargs} -D machine_types=gcp.generic --tags="series.lunar,series.all" --tags="~upgrade"
+    behave-gcpgeneric-16.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=xenial --tags="~upgrade"
+    behave-gcpgeneric-18.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=bionic --tags="~upgrade"
+    behave-gcpgeneric-20.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=focal --tags="~upgrade"
+    behave-gcpgeneric-22.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=jammy --tags="~upgrade"
+    behave-gcpgeneric-23.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=lunar --tags="~upgrade"
 
-    behave-gcppro-16.04: behave -v {posargs} -D machine_types=gcp.pro --tags="series.xenial,series.lts,series.all" --tags="~upgrade"
-    behave-gcppro-18.04: behave -v {posargs} -D machine_types=gcp.pro --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-gcppro-20.04: behave -v {posargs} -D machine_types=gcp.pro --tags="series.focal,series.lts,series.all" --tags="~upgrade"
-    behave-gcppro-22.04: behave -v {posargs} -D machine_types=gcp.pro --tags="series.jammy,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-16.04: behave -v {posargs} -D machine_types=gcp.pro -D releases=xenial --tags="~upgrade"
+    behave-gcppro-18.04: behave -v {posargs} -D machine_types=gcp.pro -D releases=bionic --tags="~upgrade"
+    behave-gcppro-20.04: behave -v {posargs} -D machine_types=gcp.pro -D releases=focal --tags="~upgrade"
+    behave-gcppro-22.04: behave -v {posargs} -D machine_types=gcp.pro -D releases=jammy --tags="~upgrade"
 
-    behave-gcppro-fips-18.04: behave -v {posargs} -D machine_types=gcp.pro-fips --tags="series.bionic,series.lts,series.all" --tags="~upgrade"
-    behave-gcppro-fips-20.04: behave -v {posargs} -D machine_types=gcp.pro-fips --tags="series.focal,series.lts,series.all" --tags="~upgrade"
+    behave-gcppro-fips-18.04: behave -v {posargs} -D machine_types=gcp.pro-fips -D releases=bionic --tags="~upgrade"
+    behave-gcppro-fips-20.04: behave -v {posargs} -D machine_types=gcp.pro-fips -D releases=focal --tags="~upgrade"
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the

--- a/tox.ini
+++ b/tox.ini
@@ -24,72 +24,7 @@ commands =
     black: black --check --diff uaclient/ features/ lib/ setup.py
     isort: isort --check --diff uaclient/ features/ lib/ setup.py
     shellcheck: bash -O extglob -O nullglob -c "shellcheck -S warning tools/*.sh debian/*.{config,postinst,postrm,prerm} lib/*.sh sru/*.sh update-motd.d/*"
-    behave-any: behave -v {posargs}
-
-    behave-lxd-16.04: behave -v {posargs} -D machine_types=lxd-container -D releases=xenial --tags="~upgrade"
-    behave-lxd-18.04: behave -v {posargs} -D machine_types=lxd-container -D releases=bionic --tags="~upgrade"
-    behave-lxd-20.04: behave -v {posargs} -D machine_types=lxd-container -D releases=focal --tags="~upgrade"
-    behave-lxd-22.04: behave -v {posargs} -D machine_types=lxd-container -D releases=jammy --tags="~upgrade"
-    behave-lxd-23.04: behave -v {posargs} -D machine_types=lxd-container -D releases=lunar --tags="~upgrade"
-    behave-lxd-23.10: behave -v {posargs} -D machine_types=lxd-container -D releases=mantic --tags="~upgrade"
-
-    behave-vm-16.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=xenial --tags="~upgrade"
-    behave-vm-18.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=bionic --tags="~upgrade"
-    behave-vm-20.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=focal --tags="~upgrade" --tags="~docker"
-    behave-vm-22.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=jammy --tags="~upgrade"
-    behave-vm-23.04: behave -v {posargs} -D machine_types=lxd-vm -D releases=lunar --tags="~upgrade"
-    behave-vm-23.10: behave -v {posargs} -D machine_types=lxd-vm -D releases=mantic --tags="~upgrade"
-
-    behave-upgrade-16.04: behave -v {posargs} --tags="upgrade" -D releases=xenial
-    behave-upgrade-18.04: behave -v {posargs} --tags="upgrade" -D releases=bionic
-    behave-upgrade-20.04: behave -v {posargs} --tags="upgrade" -D releases=focal
-    behave-upgrade-22.04: behave -v {posargs} --tags="upgrade" -D releases=jammy
-    behave-upgrade-23.04: behave -v {posargs} --tags="upgrade" -D releases=lunar
-
-    behave-docker-20.04: behave -v {posargs} -D releases=focal" features/docker.feature
-
-    behave-awsgeneric-16.04: behave -v {posargs} -D machine_types=aws.generic -D releases=xenial --tags="~upgrade"
-    behave-awsgeneric-18.04: behave -v {posargs} -D machine_types=aws.generic -D releases=bionic --tags="~upgrade"
-    behave-awsgeneric-20.04: behave -v {posargs} -D machine_types=aws.generic -D releases=focal --tags="~upgrade"
-    behave-awsgeneric-22.04: behave -v {posargs} -D machine_types=aws.generic -D releases=jammy --tags="~upgrade"
-
-    behave-awspro-16.04: behave -v {posargs} -D machine_types=aws.pro -D releases=xenial
-    behave-awspro-18.04: behave -v {posargs} -D machine_types=aws.pro -D releases=bionic
-    behave-awspro-20.04: behave -v {posargs} -D machine_types=aws.pro -D releases=focal
-    behave-awspro-22.04: behave -v {posargs} -D machine_types=aws.pro -D releases=jammy
-
-    behave-awspro-fips-16.04: behave -v {posargs} -D machine_types=aws.pro-fips -D releases=xenial
-    behave-awspro-fips-18.04: behave -v {posargs} -D machine_types=aws.pro-fips -D releases=bionic
-    behave-awspro-fips-20.04: behave -v {posargs} -D machine_types=aws.pro-fips -D releases=focal
-
-    behave-azuregeneric-16.04: behave -v {posargs} -D machine_types=azure.generic -D releases=xenial --tags="~upgrade"
-    behave-azuregeneric-18.04: behave -v {posargs} -D machine_types=azure.generic -D releases=bionic --tags="~upgrade"
-    behave-azuregeneric-20.04: behave -v {posargs} -D machine_types=azure.generic -D releases=focal --tags="~upgrade"
-    behave-azuregeneric-22.04: behave -v {posargs} -D machine_types=azure.generic -D releases=jammy --tags="~upgrade"
-    behave-azuregeneric-23.04: behave -v {posargs} -D machine_types=azure.generic -D releases=lunar --tags="~upgrade"
-
-    behave-azurepro-16.04: behave -v {posargs} -D machine_types=azure.pro -D releases=xenial
-    behave-azurepro-18.04: behave -v {posargs} -D machine_types=azure.pro -D releases=bionic
-    behave-azurepro-20.04: behave -v {posargs} -D machine_types=azure.pro -D releases=focal
-    behave-azurepro-22.04: behave -v {posargs} -D machine_types=azure.pro -D releases=jammy
-
-    behave-azurepro-fips-16.04: behave -v {posargs} -D machine_types=azure.pro-fips -D releases=xenial
-    behave-azurepro-fips-18.04: behave -v {posargs} -D machine_types=azure.pro-fips -D releases=bionic
-    behave-azurepro-fips-20.04: behave -v {posargs} -D machine_types=azure.pro-fips -D releases=focal
-
-    behave-gcpgeneric-16.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=xenial --tags="~upgrade"
-    behave-gcpgeneric-18.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=bionic --tags="~upgrade"
-    behave-gcpgeneric-20.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=focal --tags="~upgrade"
-    behave-gcpgeneric-22.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=jammy --tags="~upgrade"
-    behave-gcpgeneric-23.04: behave -v {posargs} -D machine_types=gcp.generic -D releases=lunar --tags="~upgrade"
-
-    behave-gcppro-16.04: behave -v {posargs} -D machine_types=gcp.pro -D releases=xenial --tags="~upgrade"
-    behave-gcppro-18.04: behave -v {posargs} -D machine_types=gcp.pro -D releases=bionic --tags="~upgrade"
-    behave-gcppro-20.04: behave -v {posargs} -D machine_types=gcp.pro -D releases=focal --tags="~upgrade"
-    behave-gcppro-22.04: behave -v {posargs} -D machine_types=gcp.pro -D releases=jammy --tags="~upgrade"
-
-    behave-gcppro-fips-18.04: behave -v {posargs} -D machine_types=gcp.pro-fips -D releases=bionic --tags="~upgrade"
-    behave-gcppro-fips-20.04: behave -v {posargs} -D machine_types=gcp.pro-fips -D releases=focal --tags="~upgrade"
+    behave: behave -v {posargs}
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
> And with everyone ~~super~~`behave-any`, no one will be!
>     - Syndrome (The Incredibles)

This extends the "behave-any" refactor to all integration tests. That means any combination of tests, regardless of the cloud/platform they run on, can be run with one command. After all tests have this support, it opens up a few simplifications, including removing all `@uses.config.machine_type.*` tags from all tests since they're no longer needed for filtering. This also allows consolidation of some tests since tests can now be parametrized by machine_type. I didn't perform all consolidation possible, only a few for now as demonstration.

In this PR, I'm maintaining the capability to run the tests in a per release, per platform matrix via the run-integration-tests.py script. However, after this refactor we don't have to split the tests up that way. One thing we could do instead is split the tests up by feature, and run whole feature files together.

Jenkins PR to go along with this one is here: https://github.com/canonical/server-jenkins-jobs/pull/292

## Test Steps
- CI should still pass and should run the same sets of tests that it did before
- try running a test across multiple platforms: `tox -e behave -- -n "Proxy auto-attach on a cloud Ubuntu Pro machine"`

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
