### PR TITLE
timer: make jobs-status file world readable

### DIFF
--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -8,9 +8,9 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         # simulate logrotate
         When I run `touch /var/log/ubuntu-advantage.log.1` with sudo
         When I run `touch /var/log/ubuntu-advantage.log.2.gz` with sudo
-        When I run `pro collect-logs` with sudo
+        When I run `pro collect-logs` as non-root
         Then I verify that files exist matching `ua_logs.tar.gz`
-        When I run `tar zxf ua_logs.tar.gz` as non-root
+        When I run `tar zxf ua_logs.tar.gz` with sudo
         Then I verify that files exist matching `logs/`
         When I run `sh -c "ls -1 logs/ | sort -d"` as non-root
         # On Xenial, the return value for inexistent services is the same as for dead ones (3).
@@ -55,7 +55,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         # simulate logrotate
         When I run `touch /var/log/ubuntu-advantage.log.1` with sudo
         When I run `touch /var/log/ubuntu-advantage.log.2.gz` with sudo
-        When I run `pro collect-logs` with sudo
+        When I run `pro collect-logs` as non-root
         Then I verify that files exist matching `ua_logs.tar.gz`
         When I run `tar zxf ua_logs.tar.gz` as non-root
         Then I verify that files exist matching `logs/`

--- a/sru/release-31/test-jobs-status-world-readable.sh
+++ b/sru/release-31/test-jobs-status-world-readable.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+series=$1
+install_from=$2 # either path to a .deb, or 'staging', or 'proposed'
+
+name=$series-dev
+
+function cleanup {
+  lxc delete $name --force
+}
+
+function on_err {
+  echo -e "Test Failed"
+  cleanup
+  exit 1
+}
+trap on_err ERR
+
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+
+# Install latest ubuntu-advantage-tools
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get install  -y ubuntu-advantage-tools > /dev/null
+echo -e "\n* Latest u-a-t is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+echo -e "\n* Create jobs-status file"
+echo "###########################################"
+lxc exec $name -- python3 /usr/lib/ubuntu-advantage/timer.py
+lxc exec $name -- ls -la /var/lib/ubuntu-advantage/jobs-status.json
+echo -e "###########################################\n"
+
+
+# Upgrade u-a-t to new version
+# ----------------------------------------------------------------
+if [ $install_from == 'staging' ]; then
+  lxc exec $name -- sudo add-apt-repository ppa:ua-client/staging -y > /dev/null
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+elif [ $install_from == 'proposed' ]; then
+  lxc exec $name -- sh -c "echo \"deb http://archive.ubuntu.com/ubuntu $series-proposed main\" | tee /etc/apt/sources.list.d/proposed.list"
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+else
+  lxc file push $install_from $name/new-ua.deb
+  lxc exec $name -- dpkg -i /new-ua.deb > /dev/null
+fi
+# ----------------------------------------------------------------
+
+echo -e "\n* re-create jobs-status file and notice that is now world-readable"
+echo "###########################################"
+lxc exec $name -- python3 /usr/lib/ubuntu-advantage/timer.py
+lxc exec $name -- ls -la /var/lib/ubuntu-advantage/jobs-status.json
+echo -e "###########################################\n"
+
+cleanup

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -130,7 +130,7 @@ class AllTimerJobsState(DataObject):
 
 timer_jobs_state_file = DataObjectFile(
     AllTimerJobsState,
-    UAFile("jobs-status.json"),
+    UAFile("jobs-status.json", private=False),
     DataObjectFileFormat.JSON,
 )
 


### PR DESCRIPTION
## Why is this needed?
When running collect-logs as non-root, we might fail trying to collect the jobs-status information. Since there is no private date in this file, we are making it world readable now.

Fixes: #2601

## Test Steps
Run the modified integration test and the manual test in this PR

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
