### PR TITLE
config: make user-config world readable

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -429,6 +429,12 @@ case "$1" in
           chmod 0700 "$private_dir"
       fi
 
+      if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "30~"; then
+        if [ -f /var/lib/ubuntu-advantage/user-config.json ]; then
+            chmod 0644 /var/lib/ubuntu-advantage/user-config.json
+        fi
+      fi
+
       if [ "$VERSION_ID" = "16.04" ]; then
         if echo "$PREVIOUS_PKG_VER" | grep -q "14.04"; then
           mark_reboot_cmds_as_needed

--- a/features/config.feature
+++ b/features/config.feature
@@ -49,6 +49,40 @@ Feature: pro config sub-command
         Then I will see the following on stderr:
         """
         """
+        When I run `pro config set metering_timer=2000` with sudo
+        And I run `pro config show` with sudo
+        Then I will see the following on stdout:
+        """
+        http_proxy              None
+        https_proxy             None
+        apt_http_proxy          None
+        apt_https_proxy         None
+        ua_apt_http_proxy       None
+        ua_apt_https_proxy      None
+        global_apt_http_proxy   None
+        global_apt_https_proxy  None
+        update_messaging_timer  21600
+        metering_timer          2000
+        apt_news                False
+        apt_news_url            https://motd.ubuntu.com/aptnews.json
+        """
+        When I run `pro config show` as non-root
+        Then I will see the following on stdout:
+        """
+        http_proxy              None
+        https_proxy             None
+        apt_http_proxy          None
+        apt_https_proxy         None
+        ua_apt_http_proxy       None
+        ua_apt_https_proxy      None
+        global_apt_http_proxy   None
+        global_apt_https_proxy  None
+        update_messaging_timer  21600
+        metering_timer          2000
+        apt_news                False
+        apt_news_url            https://motd.ubuntu.com/aptnews.json
+        """
+
         Examples: ubuntu release
             | release |
             | xenial  |

--- a/sru/release-30/test-user-config-nonroot.sh
+++ b/sru/release-30/test-user-config-nonroot.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+series=$1
+install_from=$2 # either path to a .deb, or 'staging', or 'proposed'
+
+name=$series-dev
+
+function cleanup {
+  lxc delete $name --force
+}
+
+function on_err {
+  echo -e "Test Failed"
+  cleanup
+  exit 1
+}
+trap on_err ERR
+
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+
+# Install latest ubuntu-advantage-tools
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get install  -y ubuntu-advantage-tools > /dev/null
+echo -e "\n* Latest u-a-t is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+echo -e "\n* Modify metering job"
+echo "###########################################"
+lxc exec $name -- pro config set metering_timer=2000
+lxc exec $name -- pro config show
+echo -e "###########################################\n"
+
+echo -e "\n* Show that non-root user cannot see the modification"
+echo "###########################################"
+lxc exec --user 1000 $name -- pro config show
+echo -e "###########################################\n"
+
+
+# Upgrade u-a-t to new version
+# ----------------------------------------------------------------
+if [ $install_from == 'staging' ]; then
+  lxc exec $name -- sudo add-apt-repository ppa:ua-client/staging -y > /dev/null
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+elif [ $install_from == 'proposed' ]; then
+  lxc exec $name -- sh -c "echo \"deb http://archive.ubuntu.com/ubuntu $series-proposed main\" | tee /etc/apt/sources.list.d/proposed.list"
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+else
+  lxc file push $install_from $name/new-ua.deb
+  lxc exec $name -- dpkg -i /new-ua.deb > /dev/null
+fi
+# ----------------------------------------------------------------
+
+echo -e "\n* Show that non-root user now can see the modification"
+echo "###########################################"
+lxc exec --user 1000 $name -- pro config show
+echo -e "###########################################\n"
+
+echo -e "\n* notice that user-config is now world-readable"
+echo "###########################################"
+lxc exec $name -- ls -la /var/lib/ubuntu-advantage/user-config.json
+echo -e "###########################################\n"
+
+cleanup

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -228,7 +228,7 @@ class UserConfigData(DataObject):
 
 user_config_file = DataObjectFile(
     UserConfigData,
-    UAFile("user-config.json", private=True),
+    UAFile("user-config.json", private=False),
     DataObjectFileFormat.JSON,
     optional_type_errors_become_null=True,
 )


### PR DESCRIPTION
## Why is this needed?
To allow non-root users to see user-config changes performed by root users, we need to make the user-config file world-readable

## Test Steps
Verify that the modified integration test and the manual test are passing

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
