### PR TITLE
plan: fix error when variable is not set

### DIFF
--- a/features/api_fix_plan.feature
+++ b/features/api_fix_plan.feature
@@ -237,3 +237,19 @@ Feature: Fix plan API endpoints
         Examples: ubuntu release details
            | release |
            | bionic  |
+
+    @series.mantic
+    @uses.config.machine_type.lxd-vm
+    Scenario Outline: Fix command on an unattached machine
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2022-40982"]}'` as non-root
+        Then stdout is a json matching the `api_response` schema
+        And the json API response data matches the `cve_fix_plan` schema
+        And stdout matches regexp:
+        """
+        {"_schema_version": "v1", "data": {"attributes": {"cves_data": {"cves": \[{"additional_data": {}, "affected_packages": \["linux"\], "description": ".*", "error": null, "expected_status": "still-affected", "plan": \[\], "title": "CVE-2022-40982", "warnings": \[{"data": {"source_packages": \["linux"\], "status": "pending"}, "order": 1, "warning_type": "security-issue-not-fixed"}\]}\], "expected_status": "still-affected"}}, "meta": {"environment_vars": \[\]}, "type": "CVEFixPlan"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
+        """
+
+        Examples: ubuntu release details
+           | release |
+           | mantic  |

--- a/uaclient/api/u/pro/security/fix/__init__.py
+++ b/uaclient/api/u/pro/security/fix/__init__.py
@@ -792,6 +792,8 @@ def _generate_fix_plan(
     additional_data=None
 ) -> FixPlanResult:
     count = len(affected_pkg_status)
+    src_pocket_pkgs = defaultdict(list)
+
     fix_plan = get_fix_plan(
         title=issue_id,
         description=issue_description,


### PR DESCRIPTION
## Why is this needed?
There is a corner case scenario where we end up with a src_pocket_pkgs variable unset. We are now fixing this issue by using a default value for this variable

## Test Steps
Run the new integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
