### PR TITLE
snap: install snapd as a snap before installing snaps if necessary

### DIFF
--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -197,3 +197,41 @@ Feature: Livepatch
         Examples: ubuntu release
             | release | machine_type | release_num |
             | jammy   | lxd-vm       | 22.04       |
+
+    @series.xenial
+    @uses.config.machine_type.any
+    @uses.config.machine_type.lxd.vm
+    Scenario Outline: snapd installed as a snap if necessary
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        When I run `snap list` with sudo
+        Then stdout does not contain substring:
+        """
+        snapd
+        """
+        When I set the machine token overlay to the following yaml
+        """
+        machineTokenInfo:
+          contractInfo:
+            resourceEntitlements:
+              - type: livepatch
+                directives:
+                  requiredSnaps:
+                    - name: core22
+        """
+        When I attach `contract_token` with sudo
+        Then stdout contains substring:
+        """
+        Installing snapd snap
+        """
+        When I run `snap list` with sudo
+        Then stdout contains substring:
+        """
+        snapd
+        """
+        And stdout contains substring:
+        """
+        core22
+        """
+        Examples: ubuntu release
+            | release | machine_type |
+            | xenial  | lxd-vm       |

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -495,6 +495,20 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             event.info(messages.INSTALLING_PACKAGES.format(packages="snapd"))
             snap.install_snapd()
 
+        if not snap.is_snapd_installed_as_a_snap():
+            event.info(
+                messages.INSTALLING_PACKAGES.format(packages="snapd snap")
+            )
+            try:
+                snap.install_snap("snapd")
+            except exceptions.ProcessExecutionError as e:
+                LOG.warning("Failed to install snapd as a snap", exc_info=e)
+                event.info(
+                    messages.EXECUTING_COMMAND_FAILED.format(
+                        command="snap install snapd"
+                    )
+                )
+
         snap.run_snapd_wait_cmd()
 
         http_proxy = http.validate_proxy(

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -90,6 +90,20 @@ class LivepatchEntitlement(UAEntitlement):
             event.info(messages.INSTALLING_PACKAGES.format(packages="snapd"))
             snap.install_snapd()
 
+        if not snap.is_snapd_installed_as_a_snap():
+            event.info(
+                messages.INSTALLING_PACKAGES.format(packages="snapd snap")
+            )
+            try:
+                snap.install_snap("snapd")
+            except exceptions.ProcessExecutionError as e:
+                LOG.warning("Failed to install snapd as a snap", exc_info=e)
+                event.info(
+                    messages.EXECUTING_COMMAND_FAILED.format(
+                        command="snap install snapd"
+                    )
+                )
+
         snap.run_snapd_wait_cmd()
 
         http_proxy = http.validate_proxy(

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -1275,6 +1275,9 @@ class TestHandleRequiredSnaps:
     @mock.patch(
         "uaclient.entitlements.base.UAEntitlement._base_entitlement_cfg"
     )
+    @mock.patch(
+        "uaclient.snap.is_snapd_installed_as_a_snap", return_value=True
+    )
     @mock.patch("uaclient.snap.is_snapd_installed", return_value=True)
     @mock.patch("uaclient.snap.run_snapd_wait_cmd")
     @mock.patch("uaclient.snap.get_snap_info")
@@ -1289,6 +1292,7 @@ class TestHandleRequiredSnaps:
         m_get_snap_info,
         m_run_snapd_wait_cmd,
         m_is_snapd_installed,
+        m_is_snapd_installed_as_a_snap,
         m_base_ent_cfg,
         entitlement_cfg,
         concrete_entitlement_factory,
@@ -1305,11 +1309,13 @@ class TestHandleRequiredSnaps:
 
         if not entitlement_cfg:
             assert 0 == m_is_snapd_installed.call_count
+            assert 0 == m_is_snapd_installed_as_a_snap.call_count
             assert 0 == m_run_snapd_wait_cmd.call_count
             assert 0 == m_validate_proxy.call_count
             assert 0 == m_configure_snap_proxy.call_count
         else:
             assert 1 == m_is_snapd_installed.call_count
+            assert 1 == m_is_snapd_installed_as_a_snap.call_count
             assert 1 == m_run_snapd_wait_cmd.call_count
             assert 2 == m_validate_proxy.call_count
             assert 1 == m_configure_snap_proxy.call_count

--- a/uaclient/snap.py
+++ b/uaclient/snap.py
@@ -35,6 +35,11 @@ def is_snapd_installed() -> bool:
     return "snapd" in apt.get_installed_packages_names()
 
 
+def is_snapd_installed_as_a_snap() -> bool:
+    """Returns whether or not snapd is installed as a snap"""
+    return any((snap.name == "snapd" for snap in get_installed_snaps()))
+
+
 def configure_snap_proxy(
     http_proxy: Optional[str] = None,
     https_proxy: Optional[str] = None,

--- a/uaclient/tests/test_snap.py
+++ b/uaclient/tests/test_snap.py
@@ -10,8 +10,51 @@ from uaclient.snap import (
     get_config_option_value,
     get_installed_snaps,
     get_snap_info,
+    is_snapd_installed_as_a_snap,
     unconfigure_snap_proxy,
 )
+
+
+class TestIsSnapdInstalledAsASnap:
+    @pytest.mark.parametrize(
+        ["installed_snaps", "expected"],
+        [
+            ([], False),
+            (
+                [
+                    SnapPackage(
+                        "one", "123", "456", "oldest/unstable", "someone"
+                    )
+                ],
+                False,
+            ),
+            (
+                [
+                    SnapPackage(
+                        "snapd", "123", "456", "oldest/unstable", "someone"
+                    )
+                ],
+                True,
+            ),
+            (
+                [
+                    SnapPackage(
+                        "one", "123", "456", "oldest/unstable", "someone"
+                    ),
+                    SnapPackage(
+                        "snapd", "123", "456", "oldest/unstable", "someone"
+                    ),
+                ],
+                True,
+            ),
+        ],
+    )
+    @mock.patch("uaclient.snap.get_installed_snaps")
+    def test_is_snapd_installed_as_a_snap(
+        self, m_get_installed_snaps, installed_snaps, expected
+    ):
+        m_get_installed_snaps.return_value = installed_snaps
+        assert expected == is_snapd_installed_as_a_snap()
 
 
 class TestConfigureSnapProxy:


### PR DESCRIPTION
## Why is this needed?
If a service requires installing the `core22` snap, and snapd hasn't already bootstrapped itself as a snap (like it does when installing some other snaps), then the snap install will fail. To prevent this, we check before installing the actual snap if snapd is installed as a snap. If it isn't, we run `snap install snapd`.

## Test Steps
New integration test will pass with these changes and fail on the archive version
```
tox -e behave-any -- -n "snapd installed as a snap if necessary" # will pass
tox -e behave-any -- -n "snapd installed as a snap if necessary" -D install_from=archive # will fail
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
