### PR TITLE
Change order of operations when purging services

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -991,6 +991,198 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main  | http://archive.ubuntu.com/ubuntu focal-updates/main            |
 
     @slow
+    @series.bionic
+    @series.focal
+    @uses.config.machine_type.gcp.generic
+    Scenario Outline: Disable and purge fips
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `apt update` with sudo
+        And I run `pro enable <fips-service> --assume-yes` with sudo
+        And I reboot the machine
+        And I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        <fips-service>   +yes   +enabled
+        """
+        When  I run `uname -r` as non-root
+        Then stdout matches regexp:
+        """
+        fips
+        """
+        And I verify that `openssh-server` is installed from apt source `<fips-source>`
+        And I verify that `linux-gcp-fips` is installed from apt source `<fips-source>`
+        When I run `pro disable <fips-service> --purge` `with sudo` and stdin `y\ny`
+        Then stdout matches regexp:
+        """
+        \(The --purge flag is still experimental - use with caution\)
+
+        Purging the <fips-name> packages would uninstall the following kernel\(s\):
+        .*
+        .* is the current running kernel\.
+        If you cannot guarantee that other kernels in this system are bootable and
+        working properly, \*do not proceed\*\. You may end up with an unbootable system\.
+        Do you want to proceed\? \(y/N\)
+        """
+        And stdout matches regexp:
+        """
+        The following package\(s\) will be REMOVED:
+        (.|\n)+
+
+        The following package\(s\) will be reinstalled from the archive:
+        (.|\n)+
+
+        Do you want to proceed\? \(y/N\)
+        """
+        When I reboot the machine
+        And I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        <fips-service>   +yes   +disabled
+        """
+        When  I run `uname -r` as non-root
+        Then stdout does not match regexp:
+        """
+        fips
+        """
+        And I verify that `openssh-server` is installed from apt source `<archive-source>`
+        And I verify that `linux-gcp-fips` is not installed
+        Examples: ubuntu release
+           | release | fips-service | fips-name    | fips-source                                                    | archive-source                                                   |
+           | bionic  | fips         | FIPS         | https://esm.ubuntu.com/fips/ubuntu bionic/main                 | https://esm.ubuntu.com/infra/ubuntu bionic-infra-security/main   |
+           | bionic  | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu bionic-updates/main | https://esm.ubuntu.com/infra/ubuntu bionic-infra-security/main   |
+           | focal   | fips         | FIPS         | https://esm.ubuntu.com/fips/ubuntu focal/main                  | http://us-west2.gce.archive.ubuntu.com/ubuntu focal-updates/main |
+           | focal   | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main  | http://us-west2.gce.archive.ubuntu.com/ubuntu focal-updates/main |
+
+    @slow
+    @series.bionic
+    @series.focal
+    @uses.config.machine_type.aws.generic
+    Scenario Outline: Disable and purge fips
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `apt update` with sudo
+        And I run `pro enable <fips-service> --assume-yes` with sudo
+        And I reboot the machine
+        And I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        <fips-service>   +yes   +enabled
+        """
+        When  I run `uname -r` as non-root
+        Then stdout matches regexp:
+        """
+        fips
+        """
+        And I verify that `openssh-server` is installed from apt source `<fips-source>`
+        And I verify that `linux-aws-fips` is installed from apt source `<fips-source>`
+        When I run `pro disable <fips-service> --purge` `with sudo` and stdin `y\ny`
+        Then stdout matches regexp:
+        """
+        \(The --purge flag is still experimental - use with caution\)
+
+        Purging the <fips-name> packages would uninstall the following kernel\(s\):
+        .*
+        .* is the current running kernel\.
+        If you cannot guarantee that other kernels in this system are bootable and
+        working properly, \*do not proceed\*\. You may end up with an unbootable system\.
+        Do you want to proceed\? \(y/N\)
+        """
+        And stdout matches regexp:
+        """
+        The following package\(s\) will be REMOVED:
+        (.|\n)+
+
+        The following package\(s\) will be reinstalled from the archive:
+        (.|\n)+
+
+        Do you want to proceed\? \(y/N\)
+        """
+        When I reboot the machine
+        And I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        <fips-service>   +yes   +disabled
+        """
+        When  I run `uname -r` as non-root
+        Then stdout does not match regexp:
+        """
+        fips
+        """
+        And I verify that `openssh-server` is installed from apt source `<archive-source>`
+        And I verify that `linux-aws-fips` is not installed
+        Examples: ubuntu release
+           | release | fips-service | fips-name    | fips-source                                                    | archive-source                                                    |
+           | bionic  | fips         | FIPS         | https://esm.ubuntu.com/fips/ubuntu bionic/main                 | https://esm.ubuntu.com/infra/ubuntu bionic-infra-security/main    |
+           | bionic  | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu bionic-updates/main | https://esm.ubuntu.com/infra/ubuntu bionic-infra-security/main    |
+           | focal   | fips         | FIPS         | https://esm.ubuntu.com/fips/ubuntu focal/main                  | http://us-east-2.ec2.archive.ubuntu.com/ubuntu focal-updates/main |
+           | focal   | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main  | http://us-east-2.ec2.archive.ubuntu.com/ubuntu focal-updates/main |
+
+    @slow
+    @series.bionic
+    @series.focal
+    @uses.config.machine_type.azure.generic
+    Scenario Outline: Disable and purge fips
+        Given a `<release>` machine with ubuntu-advantage-tools installed
+        When I attach `contract_token` with sudo
+        And I run `apt update` with sudo
+        And I run `pro enable <fips-service> --assume-yes` with sudo
+        And I reboot the machine
+        And I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        <fips-service>   +yes   +enabled
+        """
+        When  I run `uname -r` as non-root
+        Then stdout matches regexp:
+        """
+        fips
+        """
+        And I verify that `openssh-server` is installed from apt source `<fips-source>`
+        And I verify that `linux-azure-fips` is installed from apt source `<fips-source>`
+        When I run `pro disable <fips-service> --purge` `with sudo` and stdin `y\ny`
+        Then stdout matches regexp:
+        """
+        \(The --purge flag is still experimental - use with caution\)
+
+        Purging the <fips-name> packages would uninstall the following kernel\(s\):
+        .*
+        .* is the current running kernel\.
+        If you cannot guarantee that other kernels in this system are bootable and
+        working properly, \*do not proceed\*\. You may end up with an unbootable system\.
+        Do you want to proceed\? \(y/N\)
+        """
+        And stdout matches regexp:
+        """
+        The following package\(s\) will be REMOVED:
+        (.|\n)+
+
+        The following package\(s\) will be reinstalled from the archive:
+        (.|\n)+
+
+        Do you want to proceed\? \(y/N\)
+        """
+        When I reboot the machine
+        And I run `pro status` with sudo
+        Then stdout matches regexp:
+        """
+        <fips-service>   +yes   +disabled
+        """
+        When  I run `uname -r` as non-root
+        Then stdout does not match regexp:
+        """
+        fips
+        """
+        And I verify that `openssh-server` is installed from apt source `<archive-source>`
+        And I verify that `linux-azure-fips` is not installed
+        Examples: ubuntu release
+           | release | fips-service | fips-name    | fips-source                                                    | archive-source                                                 |
+           | bionic  | fips         | FIPS         | https://esm.ubuntu.com/fips/ubuntu bionic/main                 | https://esm.ubuntu.com/infra/ubuntu bionic-infra-security/main |
+           | bionic  | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu bionic-updates/main | https://esm.ubuntu.com/infra/ubuntu bionic-infra-security/main |
+           | focal   | fips         | FIPS         | https://esm.ubuntu.com/fips/ubuntu focal/main                  | http://azure.archive.ubuntu.com/ubuntu focal-updates/main      |
+           | focal   | fips-updates | FIPS Updates | https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main  | http://azure.archive.ubuntu.com/ubuntu focal-updates/main      |
+
+    @slow
     @series.lts
     @uses.config.machine_type.lxd-vm
     Scenario Outline: Disable does not purge if no other kernel found

--- a/features/steps/packages.py
+++ b/features/steps/packages.py
@@ -62,9 +62,14 @@ def verify_package_not_installed(context, package):
     when_i_run_command(
         context, "apt-cache policy {}".format(package), "as non-root"
     )
-    assert_that(
-        context.process.stdout.strip(), contains_string("Installed: (none)")
-    )
+    output = context.process.stdout.strip()
+    if "Installed" in output:
+        assert_that(
+            context.process.stdout.strip(),
+            contains_string("Installed: (none)"),
+        )
+    # If no output or it doesn't contain installation information,
+    # then the package is neither installed nor known
 
 
 @then("I verify that `{package}` is installed from apt source `{apt_source}`")

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -239,13 +239,15 @@ class RepoEntitlement(base.UAEntitlement):
         return True
 
     def execute_removal(self, packages_to_remove):
-        # We need to check for package.current_ver again, because there is an
-        # intermediate step between listing the packages and acting on them.
+        # We need to check again if the package is installed, because there is
+        # an intermediate step between listing the packages and acting on them.
+        # Some reinstalls may also uninstall dependencies.
         # Packages may be removed between those operations.
+        installed_packages = apt.get_installed_packages_names()
         to_remove = [
             package.name
             for package in packages_to_remove
-            if package.current_ver
+            if package.name in installed_packages
         ]
         if to_remove:
             apt.purge_packages(
@@ -256,13 +258,14 @@ class RepoEntitlement(base.UAEntitlement):
             )
 
     def execute_reinstall(self, packages_to_reinstall):
-        # We need to check for package.current_ver again, because there is an
-        # intermediate step between listing the packages and acting on them.
+        # We need to check again if the package is installed, because there is
+        # an intermediate step between listing the packages and acting on them.
         # Packages may be removed between those operations.
+        installed_packages = apt.get_installed_packages_names()
         to_reinstall = [
             "{}={}".format(package.name, version.ver_str)
             for (package, version) in packages_to_reinstall
-            if package.current_ver
+            if package.name in installed_packages
         ]
         if to_reinstall:
             apt.reinstall_packages(to_reinstall)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -164,8 +164,8 @@ class RepoEntitlement(base.UAEntitlement):
         self.remove_apt_config(silent=silent)
 
         if self.purge and self.origin:
-            self.execute_removal(packages_to_remove)
             self.execute_reinstall(packages_to_reinstall)
+            self.execute_removal(packages_to_remove)
         return True
 
     def purge_kernel_check(self, package_list):

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -864,13 +864,16 @@ class TestPurge:
         ),
     )
     @mock.patch(M_PATH + "apt.purge_packages")
+    @mock.patch(M_PATH + "apt.get_installed_packages_names")
     def test_execute_removal(
         self,
+        m_installed_packages,
         m_apt_purge,
         remove,
         expected_remove,
         entitlement_factory,
     ):
+        m_installed_packages.return_value = ["remove1", "remove2"]
         entitlement = entitlement_factory(
             RepoTestEntitlement,
             affordances={"series": ["xenial"]},
@@ -903,13 +906,16 @@ class TestPurge:
         ),
     )
     @mock.patch(M_PATH + "apt.run_apt_install_command")
+    @mock.patch(M_PATH + "apt.get_installed_packages_names")
     def test_execute_reinstall(
         self,
+        m_installed_packages,
         m_apt_install,
         reinstall,
         expected_install,
         entitlement_factory,
     ):
+        m_installed_packages.return_value = ["reinstall1", "reinstall2"]
         entitlement = entitlement_factory(
             RepoTestEntitlement,
             affordances={"series": ["xenial"]},


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because now purge works on generic kernels.

## Test Steps
See fixed bug - it does not happen here anymore.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
