### PR TITLE
systemd: change u-a.service type from exec to simple

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -55,7 +55,7 @@ ubuntu-advantage-tools (30) mantic; urgency=medium
       + add journald logging for the daemon and systemd timer
       + remove daemon and timer log files
       + standardize the logging calls through the codebase (GH: #2632)
-    - systemd: change ubuntu-advantage.service type from 'notify' to 'exec',
+    - systemd: change ubuntu-advantage.service type from 'notify' to 'simple',
       dropping the dependency on python3-systemd (LP: #2038417) (GH: #2692)
     - tests:
       + add scenarios where cloud-init is present but disabled (LP: #1938208)

--- a/systemd/ubuntu-advantage.service
+++ b/systemd/ubuntu-advantage.service
@@ -24,7 +24,6 @@ ConditionPathExists=|/run/cloud-init/cloud-id-azure
 ConditionPathExists=|/run/ubuntu-advantage/flags/auto-attach-failed
 
 [Service]
-Type=exec
 ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/daemon.py
 WorkingDirectory=/var/lib/ubuntu-advantage/
 


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because 'exec' is not a valid service type on Xenial/Bionic, so the only available service type is 'simple'.

## Test Steps
Integration tests which involve `ubuntu-advantage.service` must pass.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
