### PR TITLE
cloud_override option in u.pro.attach.auto.full_auto_attach.v1 to support auto-attached pro docker builds

### DIFF
--- a/features/docker.feature
+++ b/features/docker.feature
@@ -119,3 +119,47 @@ Feature: Build docker images with pro services
            | jammy   | aws.pro      | aws            | xenial            | [ "esm-infra" ] | curl              | esm                  | --network=host   |
            | jammy   | azure.pro    | azure          | bionic            | [ "fips" ]      | openssl           | fips                 |                  |
            | jammy   | gcp.pro      | gce            | focal             | [ "esm-apps" ]  | hello             | esm                  |                  |
+
+    Scenario Outline: Build pro docker images auto-attached instances - API arg method
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        When I have the `<container_release>` debs under test in `/home/ubuntu`
+        When I run `apt-get update` with sudo
+        When I apt install `docker.io docker-buildx`
+        When I create the file `/home/ubuntu/Dockerfile` with the following:
+        """
+        FROM ubuntu:<container_release>
+        ARG PRO_CLOUD_OVERRIDE=
+
+        COPY ./ubuntu-advantage-tools.deb /ua.deb
+
+        RUN --mount=type=secret,id=ua-attach-config \
+            apt-get update \
+            && apt-get install --no-install-recommends -y ubuntu-advantage-tools ca-certificates \
+
+            && ((dpkg -i /ua.deb || true)) \
+
+            && apt-get install -f \
+
+            && pro --debug api u.pro.attach.auto.full_auto_attach.v1 --data "{\"cloud_override\": \"$PRO_CLOUD_OVERRIDE\", \"enable\": <enable_services>}" \
+
+            && apt-get install -y <test_package_name> \
+
+            # If you need ca-certificates, remove it from this line
+            && apt-get purge --auto-remove -y ubuntu-advantage-tools ca-certificates \
+
+            && rm -rf /var/lib/apt/lists/*
+        """
+        # Build succeeds
+        When I run shell command `DOCKER_BUILDKIT=1 docker build . -t test --build-arg PRO_CLOUD_OVERRIDE=<cloud_override> <extra_build_args>` with sudo
+
+        # Service successfully enabled (Correct version of package installed)
+        When I run `docker run test dpkg-query --showformat='${Version}' --show <test_package_name>` with sudo
+        Then stdout matches regexp:
+        """
+        <test_package_version>
+        """
+        Examples: ubuntu release
+           | release | machine_type | cloud_override | container_release | enable_services   | test_package_name | test_package_version | extra_build_args |
+           | jammy   | aws.pro      | aws            | xenial            | [ \"esm-infra\" ] | curl              | esm                  | --network=host   |
+           | jammy   | azure.pro    | azure          | bionic            | [ \"fips\" ]      | openssl           | fips                 |                  |
+           | jammy   | gcp.pro      | gce            | focal             | [ \"esm-apps\" ]  | hello             | esm                  |                  |

--- a/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
@@ -18,15 +18,18 @@ class FullAutoAttachOptions(DataObject):
     fields = [
         Field("enable", data_list(StringDataValue), False),
         Field("enable_beta", data_list(StringDataValue), False),
+        Field("cloud_override", StringDataValue, False),
     ]
 
     def __init__(
         self,
         enable: Optional[List[str]] = None,
         enable_beta: Optional[List[str]] = None,
+        cloud_override: Optional[str] = None,
     ):
         self.enable = enable
         self.enable_beta = enable_beta
+        self.cloud_override = cloud_override
 
 
 class FullAutoAttachResult(DataObject, AdditionalInfo):
@@ -103,7 +106,9 @@ def _full_auto_attach_in_lock(
     ):
         raise exceptions.AutoAttachDisabledError()
 
-    instance = identity.cloud_instance_factory()
+    instance = identity.cloud_instance_factory(
+        cloud_override=options.cloud_override
+    )
     enable_default_services = (
         options.enable is None and options.enable_beta is None
     )

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -55,7 +55,9 @@ def get_cloud_type() -> Tuple[Optional[str], Optional[NoCloudTypeReason]]:
     return (None, NoCloudTypeReason.NO_CLOUD_DETECTED)
 
 
-def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
+def cloud_instance_factory(
+    cloud_override: Optional[str] = None,
+) -> clouds.AutoAttachCloudInstance:
     """
     :raises CloudFactoryError: if no cloud instance object can be constructed
     :raises CloudFactoryNoCloudError: if no cloud instance object can be
@@ -75,7 +77,11 @@ def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
         "gce": gcp.UAAutoAttachGCPInstance,
     }  # type: Dict[str, Type[clouds.AutoAttachCloudInstance]]
 
-    cloud_type, _ = get_cloud_type()
+    if cloud_override is not None:
+        cloud_type = cloud_override
+    else:
+        cloud_type, _ = get_cloud_type()
+
     if not cloud_type:
         raise exceptions.CloudFactoryNoCloudError()
     cls = cloud_instance_map.get(cloud_type)


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This adds integration test coverage for our settings_overrides.cloud_type config option. It also adds a more ergonomic way of overriding the cloud_type for only a single auto-attach operation by adding a new optional parameter to the full_auto_attach.v1 API. This is useful in situations where cloud-id cannot identify the cloud. In particular, this is useful for making pro docker containers on auto-attached instances.

## Test Steps

Run the new integration tests

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
