### PR TITLE
auto-label docs PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+# Add "docs" label to any PR against this branch
+docs:
+- '**'

--- a/.github/workflows/label-docs.yaml
+++ b/.github/workflows/label-docs.yaml
@@ -1,0 +1,17 @@
+name: "Pull Request Labeler"
+
+on:
+- pull_request_target
+
+jobs:
+  docs:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        dot: true
+


### PR DESCRIPTION
This should auto-label any PRs against the docs branch, so that they are easily identified in the list of open Pull Requests.