### PR TITLE
cli: retry grabbing the lock

### DIFF
--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -180,7 +180,7 @@ def assert_lock_file(lock_holder=None):
     def wrapper(f):
         @wraps(f)
         def new_f(*args, cfg, **kwargs):
-            with lock.SingleAttemptLock(cfg=cfg, lock_holder=lock_holder):
+            with lock.SpinLock(cfg=cfg, lock_holder=lock_holder, sleep_time=1):
                 retval = f(*args, cfg=cfg, **kwargs)
             return retval
 

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -177,10 +177,12 @@ class TestActionAttach:
         }
         assert expected == json.loads(capsys.readouterr()[0])
 
+    @mock.patch("time.sleep")
     @mock.patch("uaclient.system.subp")
     def test_lock_file_exists(
         self,
         m_subp,
+        m_sleep,
         capsys,
         FakeConfig,
         event,
@@ -190,7 +192,7 @@ class TestActionAttach:
         cfg.write_cache("lock", "123:pro disable")
         with pytest.raises(LockHeldError) as exc_info:
             action_attach(mock.MagicMock(), cfg=cfg)
-        assert [mock.call(["ps", "123"])] == m_subp.call_args_list
+        assert [mock.call(["ps", "123"])] * 12 == m_subp.call_args_list
         assert (
             "Unable to perform: pro attach.\n"
             "Operation in progress: pro disable (pid:123)"

--- a/uaclient/cli/tests/test_cli_detach.py
+++ b/uaclient/cli/tests/test_cli_detach.py
@@ -103,10 +103,12 @@ class TestActionDetach:
         }
         assert expected == json.loads(capsys.readouterr()[0])
 
+    @mock.patch("time.sleep")
     @mock.patch("uaclient.system.subp")
     def test_lock_file_exists(
         self,
         m_subp,
+        m_sleep,
         m_prompt,
         FakeConfig,
         capsys,
@@ -118,7 +120,7 @@ class TestActionDetach:
         cfg.write_cache("lock", "123:pro enable")
         with pytest.raises(exceptions.LockHeldError) as err:
             action_detach(args, cfg=cfg)
-        assert [mock.call(["ps", "123"])] == m_subp.call_args_list
+        assert [mock.call(["ps", "123"])] * 12 == m_subp.call_args_list
         expected_error_msg = messages.E_LOCK_HELD_ERROR.format(
             lock_request="pro detach", lock_holder="pro enable", pid="123"
         )

--- a/uaclient/cli/tests/test_cli_disable.py
+++ b/uaclient/cli/tests/test_cli_disable.py
@@ -532,10 +532,12 @@ class TestDisable:
             expected["errors"][0]["additional_info"] = expected_info
         assert expected == json.loads(fake_stdout.getvalue())
 
+    @mock.patch("time.sleep")
     @mock.patch("uaclient.system.subp")
     def test_lock_file_exists(
         self,
         m_subp,
+        m_sleep,
         FakeConfig,
         event,
     ):
@@ -549,7 +551,7 @@ class TestDisable:
         with pytest.raises(exceptions.LockHeldError) as err:
             args.service = ["esm-infra"]
             action_disable(args, cfg)
-        assert [mock.call(["ps", "123"])] == m_subp.call_args_list
+        assert [mock.call(["ps", "123"])] * 12 == m_subp.call_args_list
         assert expected_error.msg == err.value.msg
 
         args.assume_yes = True

--- a/uaclient/cli/tests/test_cli_enable.py
+++ b/uaclient/cli/tests/test_cli_enable.py
@@ -131,10 +131,12 @@ class TestActionEnable:
         }
         assert expected == json.loads(capsys.readouterr()[0])
 
+    @mock.patch("time.sleep")
     @mock.patch("uaclient.system.subp")
     def test_lock_file_exists(
         self,
         m_subp,
+        m_sleep,
         _refresh,
         capsys,
         event,
@@ -147,7 +149,7 @@ class TestActionEnable:
 
         with pytest.raises(exceptions.LockHeldError) as err:
             action_enable(args, cfg=cfg)
-        assert [mock.call(["ps", "123"])] == m_subp.call_args_list
+        assert [mock.call(["ps", "123"])] * 12 == m_subp.call_args_list
 
         expected_message = messages.E_LOCK_HELD_ERROR.format(
             lock_request="pro enable", lock_holder="pro disable", pid="123"

--- a/uaclient/cli/tests/test_cli_refresh.py
+++ b/uaclient/cli/tests/test_cli_refresh.py
@@ -75,14 +75,15 @@ class TestActionRefresh:
         else:
             action_refresh(mock.MagicMock(target=target), cfg=cfg)
 
+    @mock.patch("time.sleep")
     @mock.patch("uaclient.system.subp")
-    def test_lock_file_exists(self, m_subp, FakeConfig):
+    def test_lock_file_exists(self, m_subp, m_sleep, FakeConfig):
         """Check inability to refresh if operation holds lock file."""
         cfg = FakeConfig().for_attached_machine()
         cfg.write_cache("lock", "123:pro disable")
         with pytest.raises(exceptions.LockHeldError) as err:
             action_refresh(mock.MagicMock(), cfg=cfg)
-        assert [mock.call(["ps", "123"])] == m_subp.call_args_list
+        assert [mock.call(["ps", "123"])] * 12 == m_subp.call_args_list
         assert (
             "Unable to perform: pro refresh.\n"
             "Operation in progress: pro disable (pid:123)"


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This helps when the timer job is running in the background and a cli command happens to collide with it. The timer job is usually over quickly, so retrying several times with a small sleep time should be sufficient.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->
Everything should still work. Maybe try running more than one command at once and see one wait until the other is finished.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
