### PR TITLE
tests: update jammy tests for fips-updates

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -206,7 +206,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
        esm-infra     +yes        +Expanded Security Maintenance for Infrastructure
        fips          +<fips>     +NIST-certified FIPS crypto packages
        fips-preview  +.* +.*
-       fips-updates  +<fips>     +FIPS compliant crypto packages with stable security updates
+       fips-updates  +<fips-u>   +FIPS compliant crypto packages with stable security updates
        landscape     +(yes|no)   +Management and administration tool for Ubuntu
        livepatch     +(yes|no)   +(Canonical Livepatch service|Current kernel is not supported)
        realtime-kernel +<realtime-kernel> +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -249,11 +249,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
        """
 
        Examples: ubuntu release
-           | release | machine_type  | anbox | esm-apps | cc-eal | cis | fips | fips-update | ros | ros-updates | cis_or_usg | realtime-kernel |
-           | xenial  | lxd-container | no    | yes      | yes    | yes | yes  | yes         | yes | yes         | cis        | no              |
-           | bionic  | lxd-container | no    | yes      | yes    | yes | yes  | yes         | yes | yes         | cis        | no              |
-           | focal   | lxd-container | yes   | yes      | no     | yes | yes  | yes         | yes | no          | usg        | no              |
-           | jammy   | lxd-container | yes   | yes      | no     | yes | no   | no          | no  | no          | usg        | yes             |
+           | release | machine_type  | anbox | esm-apps | cc-eal | cis | fips | fips-u | ros | ros-updates | cis_or_usg | realtime-kernel |
+           | xenial  | lxd-container | no    | yes      | yes    | yes | yes  | yes    | yes | yes         | cis        | no              |
+           | bionic  | lxd-container | no    | yes      | yes    | yes | yes  | yes    | yes | yes         | cis        | no              |
+           | focal   | lxd-container | yes   | yes      | no     | yes | yes  | yes    | yes | no          | usg        | no              |
+           | jammy   | lxd-container | yes   | yes      | no     | yes | no   | yes    | no  | no          | usg        | yes             |
 
     Scenario Outline: Attached auto-attach in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -182,6 +182,7 @@ Feature: Attached status
         esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
         fips-preview    +yes      +disabled +Preview of FIPS crypto packages undergoing certification with NIST
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
         usg             +yes      +disabled +Security compliance and audit tools
 
         For a list of all Ubuntu Pro services, run 'pro status --all'
@@ -198,7 +199,7 @@ Feature: Attached status
         esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
         fips            +yes      +n/a      +NIST-certified FIPS crypto packages
         fips-preview    +yes      +disabled +Preview of FIPS crypto packages undergoing certification with NIST
-        fips-updates    +yes      +n/a      +FIPS compliant crypto packages with stable security updates
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
         landscape       +yes      +n/a      +Management and administration tool for Ubuntu
         livepatch       +yes      +n/a      +Canonical Livepatch service
         realtime-kernel +yes      +n/a      +Ubuntu kernel with PREEMPT_RT patches integrated

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -205,6 +205,7 @@ Feature: Unattached status
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips-preview    +yes       +.*
+        fips-updates    +yes       +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +Canonical Livepatch service
         realtime-kernel +yes       +Ubuntu kernel with PREEMPT_RT patches integrated
         usg             +yes       +Security compliance and audit tools
@@ -225,7 +226,7 @@ Feature: Unattached status
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips            +no        +NIST-certified FIPS crypto packages
         fips-preview    +yes       +.*
-        fips-updates    +no        +FIPS compliant crypto packages with stable security updates
+        fips-updates    +yes       +FIPS compliant crypto packages with stable security updates
         landscape       +no        +Management and administration tool for Ubuntu
         livepatch       +yes       +Canonical Livepatch service
         realtime-kernel +yes       +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -250,6 +251,7 @@ Feature: Unattached status
         esm-apps        +yes       +Expanded Security Maintenance for Applications
         esm-infra       +yes       +Expanded Security Maintenance for Infrastructure
         fips-preview    +yes       +.*
+        fips-updates    +yes       +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +Canonical Livepatch service
         realtime-kernel +yes       +Ubuntu kernel with PREEMPT_RT patches integrated
         usg             +yes       +Security compliance and audit tools
@@ -404,6 +406,7 @@ Feature: Unattached status
         esm-apps        +yes       +yes       +yes          +Expanded Security Maintenance for Applications
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips-preview    +yes       +yes       +no           +.*
+        fips-updates    +yes       +yes       +no           +FIPS compliant crypto packages with stable security updates
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         realtime-kernel +yes       +yes       +no           +Ubuntu kernel with PREEMPT_RT patches integrated
         usg             +yes       +yes       +no           +Security compliance and audit tools
@@ -418,7 +421,7 @@ Feature: Unattached status
         esm-infra       +yes       +yes       +yes          +Expanded Security Maintenance for Infrastructure
         fips            +no        +yes       +no           +NIST-certified FIPS crypto packages
         fips-preview    +yes       +yes       +no           +.*
-        fips-updates    +no        +yes       +no           +FIPS compliant crypto packages with stable security updates
+        fips-updates    +yes       +yes       +no           +FIPS compliant crypto packages with stable security updates
         landscape       +no        +yes       +no           +Management and administration tool for Ubuntu
         livepatch       +yes       +yes       +yes          +Canonical Livepatch service
         realtime-kernel +yes       +yes       +no           +Ubuntu kernel with PREEMPT_RT patches integrated
@@ -550,7 +553,7 @@ Feature: Unattached status
         Examples: ubuntu release
            | release | machine_type  |
            | focal   | lxd-container |
-
+ 
     @uses.config.contract_token_staging_expired
     Scenario Outline: Simulate status with expired token in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed


### PR DESCRIPTION
## Why is this needed?
The fips-updates service is now available for Jammy. We are now updating the Jammy tests to reflect that


## Test Steps
Run the modified integration tests

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
