### PR TITLE
collect-logs: include esm-cache and apt-news services

### DIFF
--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -15,9 +15,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         # So the -error suffix does not appear there.
         Then stdout matches regexp:
         """
+        apt-news.service.txt
         build.info
         cloud-id.txt
         cloud-init-journal.txt
+        esm-cache.service.txt
         jobs-status.json
         livepatch-status.txt-error
         pro-journal.txt
@@ -60,9 +62,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         # So the -error suffix does not appear there.
         Then stdout matches regexp:
         """
+        apt-news.service.txt
         build.info
         cloud-id.txt
         cloud-init-journal.txt
+        esm-cache.service.txt
         jobs-status.json
         livepatch-status.txt-error
         pro-journal.txt

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -32,6 +32,8 @@ LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
 
 
 UA_SERVICES = (
+    "apt-news.service",
+    "esm-cache.service",
     "ua-timer.service",
     "ua-timer.timer",
     "ua-auto-attach.path",

--- a/uaclient/cli/tests/test_cli_collect_logs.py
+++ b/uaclient/cli/tests/test_cli_collect_logs.py
@@ -129,6 +129,10 @@ class TestActionCollectLogs:
                     "-o",
                     "short-precise",
                     "-u",
+                    "apt-news.service",
+                    "-u",
+                    "esm-cache.service",
+                    "-u",
                     "ua-timer.service",
                     "-u",
                     "ua-auto-attach.service",
@@ -138,6 +142,10 @@ class TestActionCollectLogs:
                     "ubuntu-advantage.service",
                 ],
                 rcs=None,
+            ),
+            mock.call(["systemctl", "status", "apt-news.service"], rcs=[0, 3]),
+            mock.call(
+                ["systemctl", "status", "esm-cache.service"], rcs=[0, 3]
             ),
             mock.call(["systemctl", "status", "ua-timer.service"], rcs=[0, 3]),
             mock.call(["systemctl", "status", "ua-timer.timer"], rcs=[0, 3]),


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because... it
Fixes: #2860

## Test Steps
Run collect logs with this patch and see the services there.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: 

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
