### PR TITLE
release-update: drop lunar

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        release: ['xenial', 'bionic', 'focal', 'jammy', 'lunar', 'mantic']
+        release: ['xenial', 'bionic', 'focal', 'jammy', 'mantic', 'noble']
     steps:
       - name: Prepare build tools
         env:
@@ -65,7 +65,7 @@ jobs:
       # as much information as possible from them.
       fail-fast: false
       matrix:
-        release: ['bionic', 'focal', 'jammy', 'lunar']
+        release: ['bionic', 'focal', 'jammy', 'mantic']
         platform: ['lxd-container']
         host_os: ['ubuntu-22.04']
         include:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 [![Released Jammy Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/jammy?label=Jammy&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/jammy/+source/ubuntu-advantage-tools)
 [![Released Lunar Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/lunar?label=Lunar&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/lunar/+source/ubuntu-advantage-tools)
 [![Released Mantic Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/mantic?label=Mantic&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/mantic/+source/ubuntu-advantage-tools)
+[![Released Noble Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/noble?label=Noble&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/mantic/+source/ubuntu-advantage-tools)
 
 The Ubuntu Pro Client (`pro`) is the official tool to enable Canonical offerings on your
 system.

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -67,17 +67,6 @@ Feature: Pro is expected version
             | jammy   | gcp.generic    |
             | jammy   | gcp.pro        |
             | jammy   | gcp.pro-fips   |
-            | lunar   | lxd-container  |
-            | lunar   | lxd-vm         |
-            | lunar   | aws.generic    |
-            | lunar   | aws.pro        |
-            | lunar   | aws.pro-fips   |
-            | lunar   | azure.generic  |
-            | lunar   | azure.pro      |
-            | lunar   | azure.pro-fips |
-            | lunar   | gcp.generic    |
-            | lunar   | gcp.pro        |
-            | lunar   | gcp.pro-fips   |
             | mantic  | lxd-container  |
             | mantic  | lxd-vm         |
             | mantic  | aws.generic    |
@@ -118,5 +107,4 @@ Feature: Pro is expected version
             | bionic  | lxd-container |
             | focal   | lxd-container |
             | jammy   | lxd-container |
-            | lunar   | lxd-container |
             | mantic  | lxd-container |

--- a/features/api.feature
+++ b/features/api.feature
@@ -29,7 +29,6 @@ Feature: Client behaviour for the API endpoints
         | bionic  | lxd-container |
         | focal   | lxd-container |
         | jammy   | lxd-container |
-        | lunar   | lxd-container |
         | mantic  | lxd-container |
 
     Scenario Outline: API invalid endpoint or args
@@ -51,7 +50,6 @@ Feature: Client behaviour for the API endpoints
            | bionic  | lxd-container |
            | focal   | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Basic endpoints
@@ -88,5 +86,4 @@ Feature: Client behaviour for the API endpoints
            | bionic  | lxd-container |
            | focal   | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |

--- a/features/api_packages.feature
+++ b/features/api_packages.feature
@@ -33,4 +33,4 @@ Feature: Package related API endpoints
             | bionic  | lxd-container | libcurl4        | 7.58.0-2ubuntu3  | esm-infra         |
             | focal   | lxd-container | libcurl4        | 7.68.0-1ubuntu2  | standard-security |
             | jammy   | lxd-container | libcurl4        | 7.81.0-1         | standard-security |
-            | lunar   | lxd-container | libcurl4        | 7.88.1-8ubuntu1  | standard-security |
+            | mantic  | lxd-container | libcurl4        | 8.2.1-1ubuntu3   | standard-security |

--- a/features/api_unattended_upgrades.feature
+++ b/features/api_unattended_upgrades.feature
@@ -207,5 +207,4 @@ Feature: api.u.unattended_upgrades.status.v1
            | bionic  | lxd-container | "Unattended-Upgrade::DevRelease": "false" |
            | focal   | lxd-container | "Unattended-Upgrade::DevRelease": "auto"  |
            | jammy   | lxd-container | "Unattended-Upgrade::DevRelease": "auto"  |
-           | lunar   | lxd-container | "Unattended-Upgrade::DevRelease": "auto"  |
            | mantic  | lxd-container | "Unattended-Upgrade::DevRelease": "auto"  |

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -673,7 +673,7 @@ Feature: APT Messages
           | bionic  | lxd-container |
           | focal   | lxd-container |
           | jammy   | lxd-container |
-          | lunar   | lxd-container |
+          | mantic  | lxd-container |
 
     Scenario Outline: Cloud and series-specific URLs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -744,4 +744,4 @@ Feature: APT Messages
         """
         Examples: ubuntu release
           | release | machine_type  |
-          | lunar   | lxd-container |
+          | mantic  | lxd-container |

--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -26,7 +26,6 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
            | bionic  | lxd-container |
            | focal   | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     @uses.config.contract_token_staging_expired
@@ -52,5 +51,4 @@ Feature: Command behaviour when trying to attach a machine to an Ubuntu
            | bionic  | lxd-container |
            | focal   | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -36,7 +36,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
 
         Examples: ubuntu release
             | release | machine_type  | landscape | status_string                                                           |
-            | lunar   | lxd-container | n/a       | No Ubuntu Pro services are available to this system.                    |
             | mantic  | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
 
     Scenario Outline: Attach command in a ubuntu lxd container

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -51,7 +51,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
@@ -75,7 +74,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Attached disable with json format
@@ -276,7 +274,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Attached show version in a ubuntu machine
@@ -297,7 +294,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Attached status in a ubuntu machine with feature overrides
@@ -366,7 +362,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Attached disable of different services in a ubuntu machine
@@ -527,7 +522,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | release | machine_type  | infra-status |
            | bionic  | lxd-container | enabled      |
            | xenial  | lxd-container | enabled      |
-           | lunar   | lxd-container | n/a          |
            | mantic  | lxd-container | n/a          |
 
     Scenario Outline: Help command on an attached machine
@@ -729,7 +723,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | bionic  | lxd-container |
            | focal   | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Run timer script to valid machine activity endpoint

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -61,7 +61,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | release | machine_type  | version    | full_name        |
             | focal   | lxd-container | 20.04 LTS  | Focal Fossa      |
             | jammy   | lxd-container | 22.04 LTS  | Jammy Jellyfish  |
-            | lunar   | lxd-container | 23.04      | Lunar Lobster    |
             | mantic  | lxd-container | 23.10      | Mantic Minotaur  |
 
     Scenario Outline: Empty series affordance means no series, null means all series
@@ -260,7 +259,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Attached enable not entitled service in a ubuntu machine

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -36,7 +36,6 @@ Feature: Attached status
            | bionic  | lxd-container |
            | focal   | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Non-root status can see in-progress operations

--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -42,7 +42,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
           | bionic  | lxd-container |
           | focal   | lxd-container |
           | jammy   | lxd-container |
-          | lunar   | lxd-container |
           | mantic  | lxd-container |
 
     @uses.config.contract_token

--- a/features/config.feature
+++ b/features/config.feature
@@ -49,4 +49,4 @@ Feature: pro config sub-command
             | release | machine_type  |
             | xenial  | lxd-container |
             | jammy   | lxd-container |
-            | lunar   | lxd-container |
+            | mantic  | lxd-container |

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -13,7 +13,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | bionic  | lxd-container |
             | focal   | lxd-container |
             | jammy   | lxd-container |
-            | lunar   | lxd-container |
             | mantic  | lxd-container |
 
     @uses.config.contract_token
@@ -291,8 +290,8 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
         """
         Examples: version
             | release | machine_type  |
-            | lunar   | azure.generic |
-            | lunar   | gcp.generic   |
+            | mantic  | azure.generic |
+            | mantic  | gcp.generic   |
 
     @uses.config.contract_token
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
@@ -326,9 +325,9 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
             | jammy   | lxd-container |
             | jammy   | lxd-vm        |
             | jammy   | aws.generic   |
-            | lunar   | lxd-container |
-            | lunar   | lxd-vm        |
-            | lunar   | aws.generic   |
+            | mantic  | lxd-container |
+            | mantic  | lxd-vm        |
+            | mantic  | aws.generic   |
 
     Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -27,7 +27,6 @@ Feature: Ua fix command behaviour
            | bionic  | lxd-container |
            | focal   | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Fix command on an unattached machine

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -62,7 +62,6 @@ Feature: Pro supports multiple languages
         """
         Examples: ubuntu release
            | release | machine_type  |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     # Note: Translations do work on xenial, but our test environment triggers a bug in python that
@@ -223,5 +222,4 @@ Feature: Pro supports multiple languages
            | focal   | lxd-container |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -11,7 +11,6 @@ Feature: Pro Install and Uninstall related tests
            | bionic  | lxd-container |
            | focal   | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     @uses.config.contract_token

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -159,7 +159,6 @@ Feature: Livepatch
         """
         Examples: ubuntu release
             | release | machine_type | pretty_name             |
-            | lunar   | lxd-vm       | 23.04 (Lunar Lobster)   |
             | mantic  | lxd-vm       | 23.10 (Mantic Minotaur) |
 
     Scenario Outline: Livepatch is supported on interim HWE kernel

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -25,7 +25,6 @@ Feature: Logs in Json Array Formatter
           | bionic  | lxd-container |
           | focal   | lxd-container |
           | jammy   | lxd-container |
-          | lunar   | lxd-container |
           | mantic  | lxd-container |
 
     Scenario Outline: Non-root user and root user log files are different
@@ -55,7 +54,6 @@ Feature: Logs in Json Array Formatter
           | bionic  | lxd-container |
           | focal   | lxd-container |
           | jammy   | lxd-container |
-          | lunar   | lxd-container |
           | mantic  | lxd-container |
 
     Scenario Outline: Non-root user log files included in collect logs
@@ -80,5 +78,4 @@ Feature: Logs in Json Array Formatter
           | bionic  | lxd-container |
           | focal   | lxd-container |
           | jammy   | lxd-container |
-          | lunar   | lxd-container |
           | mantic  | lxd-container |

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -766,7 +766,7 @@ Feature: Security status command behavior
 
     # Latest released non-LTS
     Scenario: Run security status in an Ubuntu machine
-        Given a `lunar` `lxd-container` machine with ubuntu-advantage-tools installed
+        Given a `mantic` `lxd-container` machine with ubuntu-advantage-tools installed
         When I install third-party / unknown packages in the machine
         # Ansible is in esm-apps
         And I run `apt-get install -y ansible` with sudo

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -215,7 +215,7 @@ def when_i_create_local_ppas(context, release, next_release):
     from features.steps.machines import given_a_machine
 
     # We need Kinetic or greater to support zstd when creating the PPAs
-    given_a_machine(context, "lunar", machine_name="ppa")
+    given_a_machine(context, "mantic", machine_name="ppa")
     when_i_run_command(
         context, "apt-get update", "with sudo", machine_name="ppa"
     )

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -51,8 +51,7 @@ Feature: Upgrade between releases when uaclient is attached
         | bionic  | lxd-container | focal        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
         | bionic  | lxd-container | focal        | lts    |                 | usg       | enabled         | usg      | enabled         | pro enable cis |
         | focal   | lxd-container | jammy        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-        | jammy   | lxd-container | lunar        | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
-        | lunar   | lxd-container | mantic       | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
+        | jammy   | lxd-container | mantic       | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
         | mantic  | lxd-container | noble        | normal | --devel-release | esm-infra | n/a             | esm-apps | n/a             | true           |
 
     @slow

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -41,11 +41,11 @@ Feature: Upgrade between releases when uaclient is unattached
         And I verify that the folder `/var/lib/ubuntu-advantage/apt-esm` does not exist
         When I run `apt update` with sudo
         And I run shell command `cat /var/lib/ubuntu-advantage/apt-esm/etc/apt/sources.list.d/ubuntu-esm-apps.list || true` with sudo
-        Then if `<next_release>` not in `lunar or mantic or noble` and stdout matches regexp:
+        Then if `<next_release>` not in `mantic or noble` and stdout matches regexp:
         """
         deb https://esm.ubuntu.com/apps/ubuntu <next_release>-apps-security main
         """
-        And if `<next_release>` not in `lunar or mantic or noble` and stdout matches regexp:
+        And if `<next_release>` not in `mantic or noble` and stdout matches regexp:
         """
         deb https://esm.ubuntu.com/apps/ubuntu <next_release>-apps-updates main
         """
@@ -61,6 +61,5 @@ Feature: Upgrade between releases when uaclient is unattached
         | xenial  | lxd-container | bionic       | lts    |                 | enabled        |
         | bionic  | lxd-container | focal        | lts    |                 | enabled        |
         | focal   | lxd-container | jammy        | lts    |                 | enabled        |
-        | jammy   | lxd-container | lunar        | normal |                 | n/a            |
-        | lunar   | lxd-container | mantic       | normal |                 | n/a            |
+        | jammy   | lxd-container | mantic       | normal |                 | n/a            |
         | mantic  | lxd-container | noble        | normal | --devel-release | n/a            |

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -26,7 +26,6 @@ Feature: Command behaviour when unattached
            | focal   | lxd-container |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
@@ -53,8 +52,6 @@ Feature: Command behaviour when unattached
            | xenial  | lxd-container | refresh |
            | jammy   | lxd-container | detach  |
            | jammy   | lxd-container | refresh |
-           | lunar   | lxd-container | detach  |
-           | lunar   | lxd-container | refresh |
            | mantic  | lxd-container | detach  |
            | mantic  | lxd-container | refresh |
 
@@ -100,7 +97,6 @@ Feature: Command behaviour when unattached
            | bionic  | lxd-container | yes             |
            | focal   | lxd-container | yes             |
            | jammy   | lxd-container | yes             |
-           | lunar   | lxd-container | no              |
            | mantic  | lxd-container | no              |
 
     Scenario Outline: Unattached enable/disable fails in a ubuntu machine
@@ -170,8 +166,6 @@ Feature: Command behaviour when unattached
           | focal   | lxd-container | disable  |
           | jammy   | lxd-container | enable   |
           | jammy   | lxd-container | disable  |
-          | lunar   | lxd-container | enable   |
-          | lunar   | lxd-container | disable  |
           | mantic  | lxd-container | enable   |
           | mantic  | lxd-container | disable  |
 
@@ -254,7 +248,6 @@ Feature: Command behaviour when unattached
           | bionic  | lxd-container |
           | focal   | lxd-container |
           | jammy   | lxd-container |
-          | lunar   | lxd-container |
           | mantic  | lxd-container |
 
     # Side effect: this verifies that `ua` still works as a command
@@ -318,7 +311,6 @@ Feature: Command behaviour when unattached
           | bionic  | lxd-container |
           | focal   | lxd-container |
           | jammy   | lxd-container |
-          | lunar   | lxd-container |
           | mantic  | lxd-container |
 
     Scenario Outline: esm cache failures don't generate errors
@@ -422,8 +414,7 @@ Feature: Command behaviour when unattached
         Examples: ubuntu release
           | release | machine_type  | python_version | suffix                  |
           | jammy   | lxd-container | python3.10     |                         |
-          # Lunar+ has a BIG error message explaining why this is a clear user error...
-          | lunar   | lxd-container | python3.11     | --break-system-packages |
+          # mantic+ has a BIG error message explaining why this is a clear user error...
           | mantic  | lxd-container | python3.11     | --break-system-packages |
 
 
@@ -516,5 +507,4 @@ Feature: Command behaviour when unattached
           | bionic  | lxd-container |
           | focal   | lxd-container |
           | jammy   | lxd-container |
-          | lunar   | lxd-container |
           | mantic  | lxd-container |

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -36,7 +36,6 @@ Feature: Unattached status
            | focal   | lxd-container |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
-           | lunar   | lxd-container |
            | mantic  | lxd-container |
 
     Scenario Outline: Unattached status in a ubuntu machine

--- a/tools/create-lp-release-branches.sh
+++ b/tools/create-lp-release-branches.sh
@@ -54,7 +54,8 @@ do
       bionic) version=${UA_VERSION}~18.04;;
       focal) version=${UA_VERSION}~20.04;;
       jammy) version=${UA_VERSION}~22.04;;
-      lunar) version=${UA_VERSION}~23.04;;
+      mantic) version=${UA_VERSION}~23.10;;
+      noble) version=${UA_VERSION}~24.04;;
   esac
   dch_cmd=(dch -m -v "${version}" -D "${release}" -b  "Backport new upstream release to $release (LP: #${SRU_BUG})")
   if [ -z "$DO_IT" ]; then

--- a/tools/run-integration-tests.py
+++ b/tools/run-integration-tests.py
@@ -13,7 +13,6 @@ SERIES_TO_VERSION = {
     "bionic": "18.04",
     "focal": "20.04",
     "jammy": "22.04",
-    "lunar": "23.04",
     "mantic": "23.10",
 }
 
@@ -27,16 +26,16 @@ PLATFORM_SERIES_TESTS = {
     "aws.generic": ["xenial", "bionic", "focal", "jammy"],
     "aws.pro": ["xenial", "bionic", "focal", "jammy"],
     "aws.pro-fips": ["xenial", "bionic", "focal"],
-    "azure.generic": ["xenial", "bionic", "focal", "jammy", "lunar"],
+    "azure.generic": ["xenial", "bionic", "focal", "jammy", "mantic"],
     "azure.pro": ["xenial", "bionic", "focal", "jammy"],
     "azure.pro-fips": ["xenial", "bionic", "focal"],
-    "gcp.generic": ["xenial", "bionic", "focal", "jammy", "lunar"],
+    "gcp.generic": ["xenial", "bionic", "focal", "jammy", "mantic"],
     "gcp.pro": ["xenial", "bionic", "focal", "jammy"],
     "gcp.pro-fips": ["bionic", "focal"],
-    "lxd-container": ["xenial", "bionic", "focal", "jammy", "lunar", "mantic"],
-    "lxd-vm": ["xenial", "bionic", "focal", "jammy", "lunar", "mantic"],
+    "lxd-container": ["xenial", "bionic", "focal", "jammy", "mantic"],
+    "lxd-vm": ["xenial", "bionic", "focal", "jammy", "mantic"],
     "docker": ["focal"],
-    "upgrade": ["xenial", "bionic", "focal", "jammy", "lunar"],
+    "upgrade": ["xenial", "bionic", "focal", "jammy", "mantic"],
 }
 
 PLATFORM_ARGS = {

--- a/uaclient/upgrade_lts_contract.py
+++ b/uaclient/upgrade_lts_contract.py
@@ -41,8 +41,8 @@ current_codename_to_past_codename = {
     "bionic": "xenial",
     "focal": "bionic",
     "jammy": "focal",
-    "lunar": "jammy",
     "mantic": "lunar",
+    "noble": "jammy",
 }
 
 LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))


### PR DESCRIPTION
## Why is this needed?
We can stop testing on lunar since our next release will go out after
lunar EOL.

Also configures CI to build package for noble, and run integration tests
for on mantic.

Fixes: #2871 

## Test Steps
Check that CI builds for noble and runs tests on mantic. Those tests should pass.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
