### PR TITLE
Add WSL test infrastructure

### DIFF
--- a/features/api_packages.feature
+++ b/features/api_packages.feature
@@ -31,6 +31,9 @@ Feature: Package related API endpoints
             | release | machine_type  | package         | outdated_version | provided_by       |
             | xenial  | lxd-container | libcurl3-gnutls | 7.47.0-1ubuntu2  | esm-infra         |
             | bionic  | lxd-container | libcurl4        | 7.58.0-2ubuntu3  | esm-infra         |
+            | bionic  | wsl           | libcurl4        | 7.58.0-2ubuntu3  | esm-infra         |
             | focal   | lxd-container | libcurl4        | 7.68.0-1ubuntu2  | standard-security |
+            | focal   | wsl           | libcurl4        | 7.68.0-1ubuntu2  | standard-security |
             | jammy   | lxd-container | libcurl4        | 7.81.0-1         | standard-security |
+            | jammy   | wsl           | libcurl4        | 7.81.0-1         | standard-security |
             | mantic  | lxd-container | libcurl4        | 8.2.1-1ubuntu3   | standard-security |

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -146,6 +146,7 @@ Feature: APT Messages
           | release | machine_type  | version |
           | xenial  | lxd-container | 16      |
           | bionic  | lxd-container | 18      |
+          | bionic  | wsl           | 18      |
 
     @uses.config.contract_token
     Scenario Outline: APT Hook advertises esm-apps on upgrade
@@ -203,7 +204,9 @@ Feature: APT Messages
         Examples: ubuntu release
           | release | machine_type  | package | more_msg                | learn_more_msg                                                    |
           | focal   | lxd-container | hello   | another security update | Learn more about Ubuntu Pro at https://ubuntu.com/pro             |
+          | focal   | wsl           | hello   | another security update | Learn more about Ubuntu Pro at https://ubuntu.com/pro             |
           | jammy   | lxd-container | hello   | another security update | Learn more about Ubuntu Pro at https://ubuntu.com/pro             |
+          | jammy   | wsl           | hello   | another security update | Learn more about Ubuntu Pro at https://ubuntu.com/pro             |
 
     @uses.config.contract_token
     Scenario Outline: APT News

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -48,9 +48,12 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         Examples: ubuntu release
            | release | machine_type  |
            | bionic  | lxd-container |
+           | bionic  | wsl           |
            | focal   | lxd-container |
+           | focal   | wsl           |
            | xenial  | lxd-container |
            | jammy   | lxd-container |
+           | jammy   | wsl           |
            | mantic  | lxd-container |
 
     Scenario Outline: Disable command on an attached machine
@@ -220,8 +223,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | release | machine_type  |
            | xenial  | lxd-container |
            | bionic  | lxd-container |
+           | bionic  | wsl           |
            | focal   | lxd-container |
+           | focal   | wsl           |
            | jammy   | lxd-container |
+           | jammy   | wsl           |
 
     Scenario Outline: Attached auto-attach in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -670,6 +676,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | release | machine_type  |
            | xenial  | lxd-container |
            | bionic  | lxd-container |
+           | bionic  | wsl           |
            | focal   | lxd-container |
            | jammy   | lxd-container |
            | mantic  | lxd-container |
@@ -798,6 +805,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            # This ends up in GH #943 but maybe can be improved?
            | xenial  | lxd-container | xenial-backports |
            | bionic  | lxd-container | bionic-updates   |
+           | bionic  | wsl           | bionic-updates   |
            | focal   | lxd-container | focal            |
            | jammy   | lxd-container | jammy            |
 

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -24,6 +24,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             | release | machine_type  |
             | xenial  | lxd-container |
             | bionic  | lxd-container |
+            | bionic  | wsl           |
 
     Scenario Outline: Enable cc-eal with --access-only
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -372,6 +373,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Examples: cis script
            | release | machine_type  | cis_script                                  |
            | bionic  | lxd-container | Canonical_Ubuntu_18.04_CIS-harden.sh        |
+           | bionic  | wsl           | Canonical_Ubuntu_18.04_CIS-harden.sh        |
            | xenial  | lxd-container | Canonical_Ubuntu_16.04_CIS_v1.1.0-harden.sh |
 
     Scenario Outline: Attached enable of cis service in a ubuntu machine
@@ -513,6 +515,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Examples: cis service
            | release | machine_type  |
            | focal   | lxd-container |
+           | focal   | wsl           |
 
     Scenario Outline: Attached disable of livepatch in a lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -541,6 +544,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | release | machine_type | livepatch_status |
            | xenial  | lxd-vm       | warning          |
            | bionic  | lxd-vm       | enabled          |
+           | bionic  | wsl          | enabled          |
 
     Scenario Outline: Attach works when snapd cannot be installed
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -910,6 +914,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | release | machine_type  | ros-security-source                                    | ros-updates-source                                            |
            | xenial  | lxd-container | https://esm.ubuntu.com/ros/ubuntu xenial-security/main | https://esm.ubuntu.com/ros-updates/ubuntu xenial-updates/main |
            | bionic  | lxd-container | https://esm.ubuntu.com/ros/ubuntu bionic-security/main | https://esm.ubuntu.com/ros-updates/ubuntu bionic-updates/main |
+           | bionic  | wsl           | https://esm.ubuntu.com/ros/ubuntu bionic-security/main | https://esm.ubuntu.com/ros-updates/ubuntu bionic-updates/main |
 
     # Overall test for overrides; in the future, when many services
     # have overrides, we can consider removing this

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -332,6 +332,7 @@ Feature: Attached status
            | release | machine_type  |
            | xenial  | lxd-container |
            | bionic  | lxd-container |
+           | bionic  | wsl           |
 
     @uses.config.contract_token
     Scenario Outline: Attached status in a ubuntu machine
@@ -378,6 +379,7 @@ Feature: Attached status
         Examples: ubuntu release
            | release | machine_type  |
            | focal   | lxd-container |
+           | focal   | wsl           |
 
     @uses.config.contract_token
     Scenario Outline: Attached status in the latest LTS ubuntu machine

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -1,11 +1,17 @@
 import json
 import logging
 import os
+import shlex
+import time
+from contextlib import suppress
 from typing import List, Optional
 
 import pycloudlib  # type: ignore
 import toml
+from paramiko.ssh_exception import NoValidConnectionsError, SSHException
 from pycloudlib.cloud import ImageType  # type: ignore
+from pycloudlib.errors import PycloudlibTimeoutError  # type: ignore
+from pycloudlib.result import Result  # type: ignore
 
 DEFAULT_CONFIG_PATH = "~/.config/pycloudlib.toml"
 
@@ -37,6 +43,13 @@ def cloud_factory(pro_config, cloud_name):
         return LXDContainer(
             cloud_credentials_path=pro_config.cloud_credentials_path,
         )
+    if cloud_name == "wsl":
+        return WSL(
+            wsl_pubkey_path=pro_config.wsl_pubkey_path,
+            wsl_privkey_path=pro_config.wsl_privkey_path,
+            wsl_ip_address=pro_config.wsl_ip_address,
+            cloud_credentials_path=pro_config.cloud_credentials_path,
+        )
     raise RuntimeError("Invalid cloud name")
 
 
@@ -51,6 +64,9 @@ class CloudManager:
             cloud = cloud_factory(self.pro_config, cloud_name)
             self.clouds[cloud_name] = cloud
         return cloud
+
+    def has(self, cloud_name: str):
+        return cloud_name in self.clouds
 
 
 class Cloud:
@@ -763,3 +779,488 @@ class LXDContainer(_LXD):
     def pycloudlib_cls(self):
         """Return the pycloudlib cls to be used as an api."""
         return pycloudlib.LXDContainer
+
+
+class WSLCloud(pycloudlib.cloud.BaseCloud):
+    def __init__(
+        self,
+        wsl_pubkey_path: str,
+        wsl_privkey_path: str,
+        wsl_ip_address: str,
+    ):
+        self.wsl_pubkey_path = wsl_pubkey_path
+        self.wsl_privkey_path = wsl_privkey_path
+        self.wsl_ip_address = wsl_ip_address
+        super().__init__(tag="wsl")
+
+    def _check_and_set_config(self, config_file, required_values):
+        self.config = {
+            "public_key_path": self.wsl_pubkey_path,
+            "private_key_path": self.wsl_privkey_path,
+        }
+
+    def daily_image(self, release, **kwargs):
+        return self.released_images(release, **kwargs)
+
+    def delete_image(self, image_name):
+        raise NotImplementedError
+
+    def get_instance(self, instance_name):
+        raise NotImplementedError
+
+    def image_serial(self, release):
+        raise NotImplementedError
+
+    def launch(self, series: str):
+        instance_parameters = self.released_image(series)
+        inst = WSLInstance(
+            self.key_pair,
+            series=series,
+            ip_address=self.wsl_ip_address,
+        )
+        inst._wait_for_execute()
+        inst.delete()
+        inst.uninstall_ubuntu_installer(instance_parameters["appxname"])
+
+        inst.install_ubuntu_distro(
+            store_id=instance_parameters["store_id"],
+        )
+        inst.launch_ubuntu_distro(
+            launcher_name=instance_parameters["launcher"],
+        )
+        inst.create_non_root_user()
+
+        return inst
+
+    def snapshot(self):
+        raise NotImplementedError
+
+    def released_image(self, release: str, **kwargs):
+        wsl_releases = {
+            "jammy": {
+                "name": "Ubuntu-22.04",
+                "store_id": "9PN20MSR04DW",
+                "launcher": "ubuntu2204.exe",
+                "appxname": "Ubuntu22.04LTS",
+            },
+            "focal": {
+                "name": "Ubuntu-20.04",
+                "store_id": "9MTTCL66CPXJ",
+                "launcher": "ubuntu2004.exe",
+                "appxname": "Ubuntu20.04LTS",
+            },
+            "bionic": {
+                "name": "Ubuntu-18.04",
+                "store_id": "9PNKSF5ZN4SW",
+                "launcher": "ubuntu1804.exe",
+                "appxname": "Ubuntu18.04LTS",
+            },
+        }
+
+        return wsl_releases.get(release)
+
+
+class WSLInstance(pycloudlib.instance.BaseInstance):
+    WSL_UBUNTU_MAP = {
+        "jammy": "Ubuntu-22.04",
+        "focal": "Ubuntu-20.04",
+        "bionic": "Ubuntu-18.04",
+    }
+
+    def __init__(
+        self,
+        key_pair,
+        series: str,
+        ip_address: str,
+    ):
+        super().__init__(key_pair)
+        self.ip_address = ip_address
+        self.series = self.WSL_UBUNTU_MAP.get(series, "None")
+
+    def install_ubuntu_distro(self, store_id: str):
+        install_cmd = (
+            'winget install --id "{}" --accept-source-agreements '
+            "--accept-package-agreements --silent"
+        )
+        self.execute(
+            install_cmd.format(store_id),
+            run_on_wsl=False,
+            check_stderr=True,
+        )
+
+    def launch_ubuntu_distro(self, launcher_name: str):
+        self.execute(
+            "{} install --root --ui=none".format(launcher_name),
+            run_on_wsl=False,
+            check_stderr=True,
+        )
+
+    def create_non_root_user(self, username="ubuntu"):
+        self.execute(
+            'sh -c "sudo adduser --disabled-password --gecos test {}"'.format(
+                username
+            ),
+            run_on_wsl=True,
+            use_sudo=True,
+            check_stderr=True,
+        )
+
+        self.execute(
+            "passwd -d {}".format(username),
+            run_on_wsl=True,
+            check_stderr=True,
+            use_sudo=True,
+        )
+
+        configure_cmd = "sh -c \"echo '{} ALL=(ALL:ALL) NOPASSWD:ALL' | sudo EDITOR='tee -a' visudo\""  # noqa
+        self.execute(
+            configure_cmd.format(username),
+            run_on_wsl=True,
+            use_sudo=True,
+            check_stderr=True,
+        )
+
+    def execute(
+        self,
+        command,
+        stdin=None,
+        run_on_wsl=True,
+        use_sudo=False,
+        check_stderr=False,
+        **kwargs
+    ):
+        if isinstance(command, list):
+            command = shlex.join(command)
+
+        if isinstance(command, str):
+            if run_on_wsl:
+                script_path = "/tmp/wsl-bash-script.sh"
+                with open(script_path, "w") as f:
+                    f.write(command)
+
+                self.push_file(
+                    local_path=script_path,
+                    remote_path=script_path,
+                )
+
+                user = "root" if use_sudo else "ubuntu"
+                script_cmd = "bash {}".format(script_path)
+                wsl_cmd = "wsl -d {} -u {} --exec {}"
+                command = wsl_cmd.format(
+                    self.series,
+                    user,
+                    script_cmd,
+                )
+
+        ret = self._ssh(command, stdin)
+
+        if ret.stderr and check_stderr:
+            logging.info("--- Error running cmd:\n{}".format(command))
+            logging.info(ret.stderr)
+            raise Exception("Command failed")
+
+        return ret
+
+    def _ssh(self, cmd, stdin=None):
+        """Run a command via SSH.
+
+        Args:
+            command: string or list of the command to run
+            stdin: optional, values to be passed in
+
+        Returns:
+            tuple of stdout, stderr and the return code
+
+        """
+        # I need to redefine this method here just to avoid calling
+        # shell_pack, as it won't work on Windows or WSL instances
+        client = self._ssh_connect()
+        try:
+            fp_in, fp_out, fp_err = client.exec_command(cmd)
+        except (ConnectionResetError, NoValidConnectionsError, EOFError) as e:
+            raise SSHException from e
+        channel = fp_in.channel
+
+        if stdin is not None:
+            fp_in.write(stdin)
+            fp_in.close()
+
+        channel.shutdown_write()
+
+        out = fp_out.read()
+        err = fp_err.read()
+        return_code = channel.recv_exit_status()
+
+        out = "" if not out else out.rstrip().decode("utf-8")
+        err = "" if not err else err.rstrip().decode("utf-8")
+
+        return Result(out, err, return_code)
+
+    def delete(self, wait=False):
+        self.execute("wsl --shutdown", run_on_wsl=False, check_stderr=True)
+        self.execute(
+            "wsl --unregister {}".format(self.series),
+            run_on_wsl=False,
+            check_stderr=True,
+        )
+
+    def push_file(self, local_path, remote_path):
+        windows_local_path = r"C:\Users\ubuntu\AppData\Local\Temp\pro_file"
+        super().push_file(local_path, windows_local_path)
+
+        wsl_cmd = "wsl -d {} -u root --exec {}".format(
+            self.series,
+            "mv /mnt/c/Users/ubuntu/AppData/Local/Temp/pro_file {}".format(
+                remote_path
+            ),
+        )
+
+        self.execute(
+            wsl_cmd,
+            run_on_wsl=False,
+        )
+
+    def uninstall_ubuntu_installer(self, appx_name: str):
+        distro_installer_cmd = (
+            'powershell -Command "(Get-AppxPackage | Where-Object Name -like'
+            " 'CanonicalGroupLimited.{}').PackageFullName\""
+        )
+        distro_installer_path = self.execute(
+            distro_installer_cmd.format(appx_name),
+            run_on_wsl=False,
+            check_stderr=True,
+        )
+
+        if distro_installer_path.stdout:
+            distro_installer_remove_cmd = (
+                'powershell -Command "Remove-AppxPackage (Get-AppxPackage | Where-Object Name -like'  # noqa
+                " 'CanonicalGroupLimited.{}').PackageFullName\""
+            )
+            self.execute(
+                distro_installer_remove_cmd.format(appx_name),
+                run_on_wsl=False,
+                check_stderr=True,
+            )
+
+    @property
+    def ip(self):
+        return self.ip_address
+
+    def id(self):
+        return "wsl"
+
+    def _do_restart(self):
+        pass
+
+    @property
+    def name(self):
+        return self.series
+
+    def shutdown(self):
+        self.execute(
+            "wsl -d {} --shutdown".format(self.series),
+            run_on_wsl=False,
+            check_stderr=True,
+        )
+
+    def start(self):
+        pass
+
+    def wait_for_delete(self):
+        pass
+
+    def wait_for_stop(self):
+        pass
+
+    def _wait_for_execute(self):
+        # Wait 40 minutes before failing. AWS EC2 metal instances can take
+        # over 20 minutes to start or restart, so we shouldn't lower
+        # this timeout
+        start = time.time()
+        end = start + 40 * 60
+        while time.time() < end:
+            with suppress(SSHException, OSError):
+                ret = self.execute("dir", run_on_wsl=False)
+                if not ret.failed:
+                    return
+            time.sleep(1)
+
+        raise PycloudlibTimeoutError(
+            "Instance can't be reached after 40 minutes. "
+            "Failed to obtain new boot id",
+        )
+
+
+class WSL(Cloud):
+    name = ""
+
+    def __init__(
+        self,
+        wsl_pubkey_path: str,
+        wsl_privkey_path: str,
+        wsl_ip_address: str,
+        cloud_credentials_path: Optional[str],
+    ) -> None:
+        self._api = None
+        self._azure_api = None
+        self.wsl_pubkey_path = wsl_pubkey_path
+        self.wsl_privkey_path = wsl_privkey_path
+        self.wsl_ip_address = wsl_ip_address
+        self.cloud_credentials_path = cloud_credentials_path
+        self._ssh_key_managed = False
+
+    @property
+    def pycloudlib_cls(self):
+        """Return the pycloudlib cls to be used as an api."""
+        return WSLCloud
+
+    @property
+    def azure_api(self):
+        if self._azure_api is None:
+            self._azure_api = pycloudlib.Azure(
+                config_file=self.cloud_credentials_path,
+                tag="wsl",
+            )
+
+        return self._azure_api
+
+    @property
+    def api(self) -> pycloudlib.cloud.BaseCloud:
+        """Return the api used to interact with the cloud provider."""
+        if self._api is None:
+            self._api = self.pycloudlib_cls(
+                wsl_pubkey_path=self.wsl_pubkey_path,
+                wsl_privkey_path=self.wsl_privkey_path,
+                wsl_ip_address=self.wsl_ip_address,
+            )
+
+        return self._api
+
+    def stop_windows_machine(self):
+        windows_machine = self.azure_api.get_instance(
+            instance_id="wsl-test",
+            search_all=True,
+        )
+
+        windows_machine.shutdown(wait=True)
+
+    def start_windows_machine(self):
+        windows_machine = self.azure_api.get_instance(
+            instance_id="wsl-test",
+            search_all=True,
+        )
+
+        start = windows_machine._client.virtual_machines.begin_start(
+            resource_group_name=windows_machine._instance["rg_name"],
+            vm_name=windows_machine.name,
+        )
+        start.wait()
+
+    def _create_instance(
+        self,
+        series: str,
+        machine_type: str,
+        instance_name: Optional[str] = None,
+        image_name: Optional[str] = None,
+        user_data: Optional[str] = None,
+        ephemeral: bool = False,
+        inbound_ports: Optional[List[str]] = None,
+    ) -> pycloudlib.instance:
+        """Create an instance for on the cloud provider.
+
+        :param series:
+            The ubuntu release to be used when creating an instance. We will
+            create an image based on this value if the user does not provide
+            a image_name value
+
+        :returns:
+            A cloud provider instance
+        """
+        return self.api.launch(series)
+
+    def launch(
+        self,
+        series: str,
+        machine_type: str,
+        instance_name: Optional[str] = None,
+        image_name: Optional[str] = None,
+        user_data: Optional[str] = None,
+        ephemeral: bool = False,
+        inbound_ports: Optional[List[str]] = None,
+    ) -> pycloudlib.instance.BaseInstance:
+        """Create and wait for cloud provider instance to be ready.
+
+        :param series:
+            The ubuntu release to be used when creating an instance. We will
+            create an image based on this value if the used does not provide
+            a image_name value
+
+        :returns:
+            An cloud provider instance
+        """
+
+        self.start_windows_machine()
+
+        inst = self._create_instance(
+            series=series,
+            machine_type=machine_type,
+        )
+        logging.info("--- WSL {} instance launched.".format(inst.name))
+
+        return inst
+
+    def get_instance_id(
+        self, instance: pycloudlib.instance.BaseInstance
+    ) -> str:
+        """Return the instance identifier.
+
+        :param instance:
+            An instance created on the cloud provider
+
+        :returns:
+            The string of the unique instance id
+        """
+        return instance.id
+
+    def locate_image_name(
+        self,
+        series: str,
+        machine_type: str,
+        daily: bool = True,
+        include_deprecated: bool = False,
+    ) -> str:
+        """Locate and return the WSL image name to use for vm provision.
+
+        :param series:
+            The ubuntu release to be used when locating the image name
+
+        :returns:
+            A image name to use when provisioning a virtual machine
+            based on the series value
+        """
+        if not series:
+            raise ValueError(
+                "Must provide either series or image_name to launch azure"
+            )
+
+        return self.api.released_image(release=series)
+
+    def manage_ssh_key(
+        self,
+        private_key_path: Optional[str] = None,
+        key_name: Optional[str] = None,
+    ) -> None:
+        """Create and manage ssh key pairs to be used in the cloud provider.
+
+        :param private_key_path:
+            Location of the private key path to use. If None, the location
+            will be a default location.
+        """
+        if self._ssh_key_managed:
+            logging.debug("SSH key already set up")
+            return
+
+        self.api.use_key(
+            public_key_path=self.wsl_pubkey_path,
+            private_key_path=self.wsl_privkey_path,
+        )

--- a/features/environment.py
+++ b/features/environment.py
@@ -93,6 +93,9 @@ class UAClientBehaveConfig:
         "userdata_file",
         "check_version",
         "sbuild_chroot",
+        "wsl_pubkey_path",
+        "wsl_privkey_path",
+        "wsl_ip_address",
     ]
     redact_options = [
         "contract_token",
@@ -132,6 +135,9 @@ class UAClientBehaveConfig:
         userdata_file: Optional[str] = None,
         check_version: Optional[str] = None,
         sbuild_chroot: Optional[str] = None,
+        wsl_pubkey_path: Optional[str] = None,
+        wsl_privkey_path: Optional[str] = None,
+        wsl_ip_address: Optional[str] = None,
     ) -> None:
         # First, store the values we've detected
         self.cloud_credentials_path = cloud_credentials_path
@@ -154,6 +160,10 @@ class UAClientBehaveConfig:
         self.userdata_file = userdata_file
         self.check_version = check_version
         self.sbuild_chroot = sbuild_chroot
+        self.wsl_pubkey_path = wsl_pubkey_path
+        self.wsl_privkey_path = wsl_privkey_path
+        self.wsl_ip_address = wsl_ip_address
+
         self.machine_types = (
             machine_types.split(",") if machine_types else None
         )
@@ -449,6 +459,10 @@ def after_all(context):
             logging.error(
                 "Failed to delete instance ssh keys:\n{}".format(str(e))
             )
+
+        if context.pro_config.clouds.has("wsl"):
+            cloud_instance = context.pro_config.clouds.get("wsl")
+            cloud_instance.stop_windows_machine()
 
     # Builder snapshots don't get an auto-cleanup function, so clean them here
     builder_snapshots = [

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -189,6 +189,7 @@ Feature: Ua fix command behaviour
         Examples: ubuntu release details
            | release | machine_type  |
            | focal   | lxd-container |
+           | focal   | wsl           |
 
     @uses.config.contract_token
     Scenario Outline: Fix command on an unattached machine
@@ -537,8 +538,8 @@ Feature: Ua fix command behaviour
            | release | machine_type  |
            | xenial  | lxd-container |
 
-    Scenario: Fix command on an unattached machine
-        Given a `bionic` `lxd-container` machine with ubuntu-advantage-tools installed
+    Scenario Outline: Fix command on an unattached machine
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I apt update
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
         Then I will see the following on stderr:
@@ -833,8 +834,13 @@ Feature: Ua fix command behaviour
         .*✔.* CVE-2023-42752 does not affect your system.
         """
 
-    Scenario: Fix command on a machine without security/updates source lists
-        Given a `bionic` `lxd-container` machine with ubuntu-advantage-tools installed
+        Examples: ubuntu release details
+           | release | machine_type  |
+           | bionix  | lxd-container |
+           | bionic  | wsl           |
+
+    Scenario Outline: Fix command on a machine without security/updates source lists
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I run `sed -i "/bionic-updates/d" /etc/apt/sources.list` with sudo
         And I run `sed -i "/bionic-security/d" /etc/apt/sources.list` with sudo
         And I apt update
@@ -854,3 +860,8 @@ Feature: Ua fix command behaviour
         1 package is still affected: openssl
         .*✘.* CVE-2023-0286 is not resolved.
         """
+
+        Examples: ubuntu release details
+           | release | machine_type  |
+           | bionix  | lxd-container |
+           | bionic  | wsl           |

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -49,6 +49,7 @@ Feature: MOTD Messages
            | release | machine_type  | service   |
            | xenial  | lxd-container | esm-infra |
            | bionic  | lxd-container | esm-apps  |
+           | bionic  | wsl           | esm-apps  |
 
 
     Scenario Outline: Contract Expiration Messages
@@ -71,7 +72,6 @@ Feature: MOTD Messages
         CAUTION: Your Ubuntu Pro subscription will expire in 2 days.
         Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard to ensure
         continued security coverage for your applications.
-
         """
         When I set the machine token overlay to the following yaml
         """
@@ -84,12 +84,11 @@ Feature: MOTD Messages
         Then stdout matches regexp:
         """
         [\w\d.]+
-
+        
         CAUTION: Your Ubuntu Pro subscription expired on \d+ \w+ \d+.
         Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard to ensure
         continued security coverage for your applications.
         Your grace period will expire in 11 days.
-
         """
         When I set the machine token overlay to the following yaml
         """
@@ -102,11 +101,10 @@ Feature: MOTD Messages
         Then stdout matches regexp:
         """
         [\w\d.]+
-
+        
         \*Your Ubuntu Pro subscription has EXPIRED\*
         \d+ additional security updates require Ubuntu Pro with '<service>' enabled.
         Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard
-
         """
         When I apt upgrade
         When I run `pro refresh messages` with sudo
@@ -114,10 +112,9 @@ Feature: MOTD Messages
         Then stdout matches regexp:
         """
         [\w\d.]+
-
+        
         \*Your Ubuntu Pro subscription has EXPIRED\*
         Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard
-
         """
         When I create the file `/var/lib/ubuntu-advantage/machine-token-overlay.json` with the following:
         """
@@ -135,12 +132,13 @@ Feature: MOTD Messages
         Then stdout matches regexp:
         """
         [\w\d.]+
-
+        
         \*Your Ubuntu Pro subscription has EXPIRED\*
         Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard
-
         """
+
         Examples: ubuntu release
            | release | machine_type  | service   |
            | xenial  | lxd-container | esm-infra |
            | bionic  | lxd-container | esm-infra |
+           | bionic  | wsl           | esm-infra |

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -87,6 +87,7 @@ Feature: Security status command behavior
            | release | machine_type  | package   | service   |
            | xenial  | lxd-container | apport    | esm-infra |
            | bionic  | lxd-container | ansible   | esm-apps  |
+           | bionic  | wsl           | ansible   | esm-apps  |
 
     @uses.config.contract_token
     Scenario: Check for livepatch CVEs in security-status on an Ubuntu machine
@@ -448,8 +449,8 @@ Feature: Security status command behavior
         """
 
     @uses.config.contract_token
-    Scenario: Run security status in an Ubuntu machine
-        Given a `focal` `lxd-container` machine with ubuntu-advantage-tools installed
+    Scenario Outline: Run security status in an Ubuntu machine
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I install third-party / unknown packages in the machine
         # Ansible is in esm-apps
         And I apt install `ansible`
@@ -763,6 +764,11 @@ Feature: Security status command behavior
 
         Enable esm-apps with: pro enable esm-apps
         """
+
+        Examples: ubuntu release
+           | release | machine_type  |
+           | focal   | lxd-container |
+           | focal   | wsl           |
 
     # Latest released non-LTS
     Scenario: Run security status in an Ubuntu machine

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -46,12 +46,18 @@ Feature: Command behaviour when unattached
            | release | machine_type  | command |
            | bionic  | lxd-container | detach  |
            | bionic  | lxd-container | refresh |
+           | bionic  | wsl           | detach  |
+           | bionic  | wsl           | refresh |
            | focal   | lxd-container | detach  |
            | focal   | lxd-container | refresh |
+           | focal   | wsl           | detach  |
+           | focal   | wsl           | refresh |
            | xenial  | lxd-container | detach  |
            | xenial  | lxd-container | refresh |
            | jammy   | lxd-container | detach  |
            | jammy   | lxd-container | refresh |
+           | jammy   | wsl           | detach  |
+           | jammy   | wsl           | refresh |
            | mantic  | lxd-container | detach  |
            | mantic  | lxd-container | refresh |
 
@@ -95,8 +101,11 @@ Feature: Command behaviour when unattached
            | release | machine_type  | infra-available |
            | xenial  | lxd-container | yes             |
            | bionic  | lxd-container | yes             |
+           | bionic  | wsl           | yes             |
            | focal   | lxd-container | yes             |
+           | focal   | wsl           | yes             |
            | jammy   | lxd-container | yes             |
+           | jammy   | wsl           | yes             |
            | mantic  | lxd-container | no              |
 
     Scenario Outline: Unattached enable/disable fails in a ubuntu machine
@@ -162,10 +171,16 @@ Feature: Command behaviour when unattached
           | xenial  | lxd-container | disable  |
           | bionic  | lxd-container | enable   |
           | bionic  | lxd-container | disable  |
+          | bionic  | wsl           | enable   |
+          | bionic  | wsl           | disable  |
           | focal   | lxd-container | enable   |
           | focal   | lxd-container | disable  |
+          | focal   | wsl           | enable   |
+          | focal   | wsl           | disable  |
           | jammy   | lxd-container | enable   |
           | jammy   | lxd-container | disable  |
+          | jammy   | wsl           | enable   |
+          | jammy   | wsl           | disable  |
           | mantic  | lxd-container | enable   |
           | mantic  | lxd-container | disable  |
 

--- a/types-requirements.txt
+++ b/types-requirements.txt
@@ -2,3 +2,4 @@ mypy
 types-PyYAML
 types-toml
 types-pycurl
+types-paramiko


### PR DESCRIPTION
## Why is this needed?
To properly test the Pro client on WSL instances, we need to have an infrastructure that allow us to launch those instance in a Windows machine, install the required Pro client package on them and run the pro commands.

This PR is adding that infrastructure, but there are still some items we need to discuss before merging.

1) Are we going to use a default name for the windows machine or should that be configurable ?
2) We are not using all of the shell safe mechanisms we have for the Ubuntu based tests, should we consider making use of them here too ?
3) Should we mark all container tests as WSL supported ?

## Test Steps
After setting up a windows machine, use the provided infrastructure to run any test marked as supporting WSL

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
