### PR TITLE
Fix/test fips messages

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -266,7 +266,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
             """
-            This machine is already attached to 'UA Client Test'
+            This machine is already attached to '.+'
             To use a different subscription first run: sudo pro detach.
             """
 

--- a/features/detached_auto_attach.feature
+++ b/features/detached_auto_attach.feature
@@ -14,7 +14,7 @@ Feature: Attached cloud does not detach when auto-attaching after manually attac
         When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
         """
-        This machine is already attached to 'UA Client Test'
+        This machine is already attached to '.+'
         To use a different subscription first run: sudo pro detach.
         """
         When I run `pro status` with sudo

--- a/features/enable_fips_cloud.feature
+++ b/features/enable_fips_cloud.feature
@@ -118,13 +118,13 @@ Feature: FIPS enablement in cloud based machines
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages
             Updating standard Ubuntu package lists
             <fips-name> enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -182,13 +182,13 @@ Feature: FIPS enablement in cloud based machines
         And I run `pro disable livepatch` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages
             Updating standard Ubuntu package lists
             <fips-name> enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -259,13 +259,13 @@ Feature: FIPS enablement in cloud based machines
         When I attach `contract_token` with sudo
         And I run `pro disable livepatch` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages
             Updating standard Ubuntu package lists
             <fips-name> enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -319,13 +319,13 @@ Feature: FIPS enablement in cloud based machines
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages
             Updating standard Ubuntu package lists
             <fips-name> enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -386,7 +386,7 @@ Feature: FIPS enablement in cloud based machines
         """
         When I attach `contract_token` with sudo
         And I run `pro enable fips --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
         """
         Could not determine cloud, defaulting to generic FIPS package.
         Updating FIPS package lists

--- a/features/enable_fips_container.feature
+++ b/features/enable_fips_container.feature
@@ -14,7 +14,7 @@ Feature: FIPS enablement in lxd containers
                      compliant.
             Warning: This action can take some time and cannot be undone.
             """
-        And stdout matches regexp:
+        And stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages

--- a/features/enable_fips_pro.feature
+++ b/features/enable_fips_pro.feature
@@ -18,13 +18,13 @@ Feature: FIPS enablement in PRO cloud based machines
             fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
             """
             When I run `pro enable <fips-service> --assume-yes` with sudo
-            Then stdout matches regexp:
+            Then stdout contains substring:
                 """
                 Updating <fips-name> package lists
                 Installing <fips-name> packages
                 Updating standard Ubuntu package lists
                 <fips-name> enabled
-                A reboot is required to complete install
+                A reboot is required to complete install.
                 """
             When I run `pro status --all` with sudo
             Then stdout matches regexp:
@@ -75,13 +75,13 @@ Feature: FIPS enablement in PRO cloud based machines
             fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
             """
             When I run `pro enable <fips-service> --assume-yes` with sudo
-            Then stdout matches regexp:
+            Then stdout contains substring:
                 """
                 Updating <fips-name> package lists
                 Installing <fips-name> packages
                 Updating standard Ubuntu package lists
                 <fips-name> enabled
-                A reboot is required to complete install
+                A reboot is required to complete install.
                 """
             When I run `pro status --all` with sudo
             Then stdout matches regexp:
@@ -133,13 +133,13 @@ Feature: FIPS enablement in PRO cloud based machines
             fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
             """
         When I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages
             Updating standard Ubuntu package lists
             <fips-name> enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -628,13 +628,13 @@ Feature: FIPS enablement in lxd VMs
         And I run `apt update` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         When I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
         """
         Updating <fips-name> package lists
         Installing <fips-name> packages
         Updating standard Ubuntu package lists
         <fips-name> enabled
-        A reboot is required to complete install
+        A reboot is required to complete install.
         """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -19,13 +19,13 @@ Feature: FIPS enablement in lxd VMs
             This will install the FIPS packages. The Livepatch service will be unavailable.
             Warning: This action can take some time and cannot be undone.
             """
-        And stdout matches regexp:
+        And stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages
             Updating standard Ubuntu package lists
             <fips-name> enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -143,13 +143,13 @@ Feature: FIPS enablement in lxd VMs
             This will install the FIPS packages including security updates.
             Warning: This action can take some time and cannot be undone.
             """
-        And stdout matches regexp:
+        And stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages
             Updating standard Ubuntu package lists
             <fips-name> enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -281,13 +281,13 @@ Feature: FIPS enablement in lxd VMs
             livepatch +yes +<livepatch_status>
             """
         When I run `pro enable fips-updates --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             Updating FIPS Updates package lists
             Installing FIPS Updates packages
             Updating standard Ubuntu package lists
             FIPS Updates enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -329,13 +329,13 @@ Feature: FIPS enablement in lxd VMs
         When I attach `contract_token` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         When I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages
             Updating standard Ubuntu package lists
             <fips-name> enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -392,13 +392,13 @@ Feature: FIPS enablement in lxd VMs
         When I attach `contract_token` with sudo
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         When I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             Updating <fips-name> package lists
             Installing <fips-name> packages
             Updating standard Ubuntu package lists
             <fips-name> enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -460,13 +460,13 @@ Feature: FIPS enablement in lxd VMs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro enable fips --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             Updating FIPS package lists
             Installing FIPS packages
             Updating standard Ubuntu package lists
             FIPS enabled
-            A reboot is required to complete install
+            A reboot is required to complete install.
             """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
@@ -480,7 +480,7 @@ Feature: FIPS enablement in lxd VMs
             fips
             """
         When I verify that running `pro enable fips-updates --assume-yes` `with sudo` exits `0`
-        Then stdout matches regexp:
+        Then stdout contains substring:
             """
             One moment, checking your subscription first
             Disabling incompatible service: FIPS

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -153,7 +153,7 @@ Feature: Pro supports multiple languages
         When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
         """
-        This machine is already attached to 'UA Client Test'
+        This machine is already attached to '.+'
         To use a different subscription first run: sudo pro detach.
             """
         # status command

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -1174,7 +1174,7 @@ Feature: Proxy configuration
         """
         When I run `pro disable livepatch --assume-yes` with sudo
         When I run `pro enable realtime-kernel` `with sudo` and stdin `y`
-        Then stdout matches regexp:
+        Then stdout contains substring:
         """
         Installing Real-time kernel packages
         Real-time kernel enabled

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -60,7 +60,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Updating standard Ubuntu package lists
         Installing Real-time kernel packages
         Real-time kernel enabled
-        A reboot is required to complete install.
+        A reboot is required to complete install\.
         """
         When I run `apt-cache policy ubuntu-realtime` as non-root
         Then stdout does not match regexp:

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -448,7 +448,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
         """
         When I run `pro enable fips-updates --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
         """
         One moment, checking your subscription first
         Disabling incompatible service: FIPS

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -63,13 +63,13 @@ Feature: Upgrade between releases when uaclient is attached
         And I run `apt-get install lsof` with sudo, retrying exit [100]
         And I run `pro disable livepatch` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
+        Then stdout contains substring:
         """
         Updating <fips-name> package lists
         Installing <fips-name> packages
         Updating standard Ubuntu package lists
         <fips-name> enabled
-        A reboot is required to complete install
+        A reboot is required to complete install.
         """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:

--- a/uaclient/livepatch.py
+++ b/uaclient/livepatch.py
@@ -131,6 +131,11 @@ def status() -> Optional[LivepatchStatusStatus]:
             [LIVEPATCH_CMD, "status", "--verbose", "--format", "json"]
         )
     except exceptions.ProcessExecutionError as e:
+        # only raise an error if there is a legitimate problem, not just lack
+        # of enablement
+        if re.match("Machine is not enabled.", e.stderr):
+            LOG.warning(e.stderr)
+            return None
         LOG.warning(
             "canonical-livepatch returned error when checking status:\n%s",
             exc_info=e,


### PR DESCRIPTION
This changes updates the integration tests to include new messages about checking subscription, disabling livepatch, etc.

Also adds the new period to reboot message in integration tests.

## Why is this needed?
When testing new FIPS messages, I ran into failing integration tests that seemed unrelated to my changes.  This change brings upstream in line with the current message set specifically for FIPS messages (and a reboot period), but is not a comprehensive review of all message/integration test mismatches.  I tested against GCP.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly [N/A]
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) --> [N/A]

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
