### PR TITLE
tests: fix integration tests to expect updated messages

### DIFF
--- a/features/api_configure_retry_service.feature
+++ b/features/api_configure_retry_service.feature
@@ -35,7 +35,7 @@ Feature: api.u.pro.attach.auto.configure_retry_service
         When I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:
         """
-        Failed to automatically attach to Ubuntu Pro services 1 time\(s\).
+        Failed to automatically attach to an Ubuntu Pro subscription 1 time\(s\).
         The failure was due to: an unknown error.
         The next attempt is scheduled for \d+-\d+-\d+T\d+:\d+:00.*.
         You can try manually with `sudo pro auto-attach`.
@@ -44,7 +44,7 @@ Feature: api.u.pro.attach.auto.configure_retry_service
         Then stdout matches regexp:
         """
         NOTICES
-        Failed to automatically attach to Ubuntu Pro services 1 time\(s\).
+        Failed to automatically attach to an Ubuntu Pro subscription 1 time\(s\).
         The failure was due to: an unknown error.
         The next attempt is scheduled for \d+-\d+-\d+T\d+:\d+:00.*.
         You can try manually with `sudo pro auto-attach`.

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -629,14 +629,14 @@ Feature: APT Messages
         Calculating upgrade...
         #
         # *Your Ubuntu Pro subscription has EXPIRED*
-        # Renew your service at https://ubuntu.com/pro/dashboard
+        # Renew your subscription at https://ubuntu.com/pro/dashboard
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
         When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
-        "*Your Ubuntu Pro subscription has EXPIRED*\nRenew your service at https://ubuntu.com/pro/dashboard"
+        "*Your Ubuntu Pro subscription has EXPIRED*\nRenew your subscription at https://ubuntu.com/pro/dashboard"
         """
         When I create the file `/tmp/machine-token-overlay.json` with the following:
         """
@@ -658,14 +658,14 @@ Feature: APT Messages
         Calculating upgrade...
         #
         # *Your Ubuntu Pro subscription has EXPIRED*
-        # Renew your service at https://ubuntu.com/pro/dashboard
+        # Renew your subscription at https://ubuntu.com/pro/dashboard
         #
         0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
         """
         When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
         Then I will see the following on stdout
         """
-        "*Your Ubuntu Pro subscription has EXPIRED*\nRenew your service at https://ubuntu.com/pro/dashboard"
+        "*Your Ubuntu Pro subscription has EXPIRED*\nRenew your subscription at https://ubuntu.com/pro/dashboard"
         """
         Examples: ubuntu release
           | release | machine_type  |

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -41,7 +41,7 @@ Feature: MOTD Messages
 
         \*Your Ubuntu Pro subscription has EXPIRED\*
         \d+ additional security updates require Ubuntu Pro with '<service>' enabled.
-        Renew your service at https:\/\/ubuntu.com\/pro\/dashboard
+        Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard
 
         [\w\d.]+
         """
@@ -105,7 +105,7 @@ Feature: MOTD Messages
 
         \*Your Ubuntu Pro subscription has EXPIRED\*
         \d+ additional security updates require Ubuntu Pro with '<service>' enabled.
-        Renew your service at https:\/\/ubuntu.com\/pro\/dashboard
+        Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard
 
         """
         When I run `apt-get upgrade -y` with sudo
@@ -116,7 +116,7 @@ Feature: MOTD Messages
         [\w\d.]+
 
         \*Your Ubuntu Pro subscription has EXPIRED\*
-        Renew your service at https:\/\/ubuntu.com\/pro\/dashboard
+        Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard
 
         """
         When I create the file `/tmp/machine-token-overlay.json` with the following:
@@ -137,7 +137,7 @@ Feature: MOTD Messages
         [\w\d.]+
 
         \*Your Ubuntu Pro subscription has EXPIRED\*
-        Renew your service at https:\/\/ubuntu.com\/pro\/dashboard
+        Renew your subscription at https:\/\/ubuntu.com\/pro\/dashboard
 
         """
         Examples: ubuntu release

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -30,7 +30,7 @@ Feature: auto-attach retries periodically on failures
         When I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:
         """
-        Failed to automatically attach to Ubuntu Pro services 1 time\(s\).
+        Failed to automatically attach to an Ubuntu Pro subscription 1 time\(s\).
         The failure was due to: Canonical servers did not recognize this machine as Ubuntu Pro: ".*".
         The next attempt is scheduled for \d+-\d+-\d+T\d+:\d+:00.*.
         You can try manually with `sudo pro auto-attach`.
@@ -39,7 +39,7 @@ Feature: auto-attach retries periodically on failures
         Then stdout matches regexp:
         """
         NOTICES
-        Failed to automatically attach to Ubuntu Pro services 1 time\(s\).
+        Failed to automatically attach to an Ubuntu Pro subscription 1 time\(s\).
         The failure was due to: Canonical servers did not recognize this machine as Ubuntu Pro: ".*".
         The next attempt is scheduled for \d+-\d+-\d+T\d+:\d+:00.*.
         You can try manually with `sudo pro auto-attach`.
@@ -66,7 +66,7 @@ Feature: auto-attach retries periodically on failures
         When I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:
         """
-        Failed to automatically attach to Ubuntu Pro services 11 time\(s\).
+        Failed to automatically attach to an Ubuntu Pro subscription 11 time\(s\).
         The failure was due to: an unknown error.
         The next attempt is scheduled for \d+-\d+-\d+T\d+:\d+:00.*.
         You can try manually with `sudo pro auto-attach`.
@@ -75,7 +75,7 @@ Feature: auto-attach retries periodically on failures
         Then stdout matches regexp:
         """
         NOTICES
-        Failed to automatically attach to Ubuntu Pro services 11 time\(s\).
+        Failed to automatically attach to an Ubuntu Pro subscription 11 time\(s\).
         The failure was due to: an unknown error.
         The next attempt is scheduled for \d+-\d+-\d+T\d+:\d+:00.*.
         You can try manually with `sudo pro auto-attach`.
@@ -101,7 +101,7 @@ Feature: auto-attach retries periodically on failures
         When I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:
         """
-        Failed to automatically attach to Ubuntu Pro services 19 time\(s\).
+        Failed to automatically attach to an Ubuntu Pro subscription 19 time\(s\).
         The most recent failure was due to: an unknown error.
         Try re-launching the instance or report this issue by running `ubuntu-bug ubuntu-advantage-tools`
         You can try manually with `sudo pro auto-attach`.
@@ -110,7 +110,7 @@ Feature: auto-attach retries periodically on failures
         Then stdout matches regexp:
         """
         NOTICES
-        Failed to automatically attach to Ubuntu Pro services 19 time\(s\).
+        Failed to automatically attach to an Ubuntu Pro subscription 19 time\(s\).
         The most recent failure was due to: an unknown error.
         Try re-launching the instance or report this issue by running `ubuntu-bug ubuntu-advantage-tools`
         You can try manually with `sudo pro auto-attach`.
@@ -172,13 +172,13 @@ Feature: auto-attach retries periodically on failures
         When I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:
         """
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         When I run `pro status` with sudo
         Then stdout matches regexp:
         """
         NOTICES
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         When I append the following on uaclient config:
         """
@@ -196,13 +196,13 @@ Feature: auto-attach retries periodically on failures
         Then I verify that running `run-parts /etc/update-motd.d/` `with sudo` exits `0,1`
         Then stdout does not match regexp:
         """
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         When I run `pro status` with sudo
         Then stdout does not match regexp:
         """
         NOTICES
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         Examples: ubuntu release
            | release | machine_type |
@@ -268,13 +268,13 @@ Feature: auto-attach retries periodically on failures
         When I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:
         """
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         When I run `pro status` with sudo
         Then stdout matches regexp:
         """
         NOTICES
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         Examples: ubuntu release
            | release | machine_type |
@@ -327,13 +327,13 @@ Feature: auto-attach retries periodically on failures
         When I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:
         """
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         When I run `pro status` with sudo
         Then stdout matches regexp:
         """
         NOTICES
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         When I append the following on uaclient config:
         """
@@ -351,13 +351,13 @@ Feature: auto-attach retries periodically on failures
         Then I verify that running `run-parts /etc/update-motd.d/` `with sudo` exits `0,1`
         Then stdout does not match regexp:
         """
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         When I run `pro status` with sudo
         Then stdout does not match regexp:
         """
         NOTICES
-        Failed to automatically attach to Ubuntu Pro services
+        Failed to automatically attach to an Ubuntu Pro subscription
         """
         Examples: ubuntu release
            | release | machine_type |


### PR DESCRIPTION


## Why is this needed?
Recently some messages were updated to have more consistent terminology around the use of the words "service" and "subscription". This commit updates the related behave tests to expect the new messages.
## Test Steps
CI should pass

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
