### PR TITLE
Better unexpected exception msgs

### DIFF
--- a/debian/po/pt_BR.po
+++ b/debian/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-05 17:38-0300\n"
+"POT-Creation-Date: 2024-01-16 08:56-0500\n"
 "PO-Revision-Date: 2023-09-25 12:29-0400\n"
 "Last-Translator: Lucas Moura <lucas.moura@canonical.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -2593,10 +2593,11 @@ msgid ""
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1559
+#, python-brace-format
 msgid ""
-"Unexpected error(s) occurred.\n"
-"For more details, see the log: /var/log/ubuntu-advantage.log\n"
-"To file a bug run: ubuntu-bug ubuntu-advantage-tools"
+"An unexpected error occurred: {error_msg}\n"
+"For more details, see the log: {log_path}\n"
+"If you think this is a bug, please run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1569

--- a/debian/po/ubuntu-pro.pot
+++ b/debian/po/ubuntu-pro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-05 17:38-0300\n"
+"POT-Creation-Date: 2024-01-16 08:56-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2258,10 +2258,11 @@ msgid ""
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1559
+#, python-brace-format
 msgid ""
-"Unexpected error(s) occurred.\n"
-"For more details, see the log: /var/log/ubuntu-advantage.log\n"
-"To file a bug run: ubuntu-bug ubuntu-advantage-tools"
+"An unexpected error occurred: {error_msg}\n"
+"For more details, see the log: {log_path}\n"
+"If you think this is a bug, please run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1569

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -66,7 +66,7 @@ from uaclient.entitlements.entitlement_status import (
 )
 from uaclient.files import notices, state_files
 from uaclient.files.notices import Notice
-from uaclient.log import JsonArrayFormatter
+from uaclient.log import JsonArrayFormatter, get_user_or_root_log_file_path
 from uaclient.timer.update_messaging import refresh_motd, update_motd_messages
 from uaclient.yaml import safe_dump, safe_load
 
@@ -1766,7 +1766,10 @@ def main_error_handler(func):
             LOG.exception("Unhandled exception, please file a bug")
             lock.clear_lock_file_if_present()
             event.info(
-                info_msg=messages.UNEXPECTED_ERROR.format(error_msg=str(e)),
+                info_msg=messages.UNEXPECTED_ERROR.format(
+                    error_msg=str(e),
+                    log_path=get_user_or_root_log_file_path(),
+                ),
                 file_type=sys.stderr,
             )
             event.error(

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -1766,7 +1766,8 @@ def main_error_handler(func):
             LOG.exception("Unhandled exception, please file a bug")
             lock.clear_lock_file_if_present()
             event.info(
-                info_msg=messages.UNEXPECTED_ERROR.msg, file_type=sys.stderr
+                info_msg=messages.UNEXPECTED_ERROR.format(error_msg=str(e)),
+                file_type=sys.stderr,
             )
             event.error(
                 error_msg=getattr(e, "msg", str(e)), error_type="exception"

--- a/uaclient/cli/tests/test_cli.py
+++ b/uaclient/cli/tests/test_cli.py
@@ -492,7 +492,8 @@ class TestMain:
             (
                 TypeError("'NoneType' object is not subscriptable"),
                 messages.UNEXPECTED_ERROR.format(
-                    error_msg="'NoneType' object is not subscriptable"
+                    error_msg="'NoneType' object is not subscriptable",
+                    log_path="/var/log/ubuntu-advantage.log",
                 ),
                 "Unhandled exception, please file a bug",
             ),
@@ -510,6 +511,7 @@ class TestMain:
         m_log_exception,
         m_event_info,
         m_delete_cache_key,
+        # _m_get_user_or_root_log_path,
         event,
         exception,
         expected_error_msg,
@@ -530,7 +532,6 @@ class TestMain:
 
         exc = excinfo.value
         assert 1 == exc.code
-
         assert [
             mock.call(info_msg=expected_error_msg, file_type=mock.ANY)
         ] == m_event_info.call_args_list

--- a/uaclient/cli/tests/test_cli.py
+++ b/uaclient/cli/tests/test_cli.py
@@ -511,7 +511,6 @@ class TestMain:
         m_log_exception,
         m_event_info,
         m_delete_cache_key,
-        # _m_get_user_or_root_log_path,
         event,
         exception,
         expected_error_msg,

--- a/uaclient/cli/tests/test_cli.py
+++ b/uaclient/cli/tests/test_cli.py
@@ -491,7 +491,9 @@ class TestMain:
         (
             (
                 TypeError("'NoneType' object is not subscriptable"),
-                messages.UNEXPECTED_ERROR.msg,
+                messages.UNEXPECTED_ERROR.format(
+                    error_msg="'NoneType' object is not subscriptable"
+                ),
                 "Unhandled exception, please file a bug",
             ),
         ),

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -537,7 +537,6 @@ class TestActionAttach:
         m_process_entitlement_delta,
         m_enable_order,
         _m_attachment_data_file_write,
-        # _m_get_user_or_root_log_path,
         expected_exception,
         expected_msg,
         expected_outer_msg,

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -515,7 +515,10 @@ class TestActionAttach:
             ),
             (
                 Exception("error"),
-                messages.UNEXPECTED_ERROR.format(error_msg="error"),
+                messages.UNEXPECTED_ERROR.format(
+                    error_msg="error",
+                    log_path="/var/log/ubuntu-advantage.log",
+                ),
                 messages.E_ATTACH_FAILURE_UNEXPECTED,
             ),
         ),
@@ -534,6 +537,7 @@ class TestActionAttach:
         m_process_entitlement_delta,
         m_enable_order,
         _m_attachment_data_file_write,
+        # _m_get_user_or_root_log_path,
         expected_exception,
         expected_msg,
         expected_outer_msg,

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -515,7 +515,7 @@ class TestActionAttach:
             ),
             (
                 Exception("error"),
-                messages.UNEXPECTED_ERROR,
+                messages.UNEXPECTED_ERROR.format(error_msg="error"),
                 messages.E_ATTACH_FAILURE_UNEXPECTED,
             ),
         ),

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -24,6 +24,7 @@ from uaclient.defaults import (
 )
 from uaclient.files.state_files import attachment_data_file
 from uaclient.http import serviceclient
+from uaclient.log import get_user_or_root_log_file_path
 
 # Here we describe every endpoint from the ua-contracts
 # service that is used by this client implementation.
@@ -541,7 +542,10 @@ def process_entitlements_delta(
             failed_services=[
                 (
                     name,
-                    messages.UNEXPECTED_ERROR.format(error_msg=str(exception)),
+                    messages.UNEXPECTED_ERROR.format(
+                        error_msg=str(exception),
+                        log_path=get_user_or_root_log_file_path(),
+                    ),
                 )
                 for name, exception in zip(failed_services, unexpected_errors)
             ]

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -492,7 +492,7 @@ def process_entitlements_delta(
     from uaclient.entitlements import entitlements_enable_order
 
     delta_error = False
-    unexpected_error = False
+    unexpected_errors = []
 
     # We need to sort our entitlements because some of them
     # depend on other service to be enable first.
@@ -523,7 +523,7 @@ def process_entitlements_delta(
             )
         except Exception as e:
             LOG.exception(e)
-            unexpected_error = True
+            unexpected_errors.append(e)
             failed_services.append(name)
             LOG.exception(
                 "Unexpected error processing contract delta for %s: %r",
@@ -536,10 +536,14 @@ def process_entitlements_delta(
             if service_enabled and deltas:
                 event.service_processed(name)
     event.services_failed(failed_services)
-    if unexpected_error:
+    if len(unexpected_errors) > 0:
         raise exceptions.AttachFailureUnknownError(
             failed_services=[
-                (name, messages.UNEXPECTED_ERROR) for name in failed_services
+                (
+                    name,
+                    messages.UNEXPECTED_ERROR.format(error_msg=str(exception)),
+                )
+                for name, exception in zip(failed_services, unexpected_errors)
             ]
         )
     elif delta_error:

--- a/uaclient/log.py
+++ b/uaclient/log.py
@@ -70,7 +70,7 @@ def get_user_or_root_log_file_path() -> str:
     if util.we_are_currently_root():
         return UAConfig().log_file
     else:
-        return "~/.cache/" + defaults.USER_CACHE_SUBDIR + "/ubuntu-pro.log"
+        return get_user_log_file()
 
 
 def get_user_log_file() -> str:

--- a/uaclient/log.py
+++ b/uaclient/log.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from typing import Any, Dict, List  # noqa: F401
 
 from uaclient import defaults, system, util
+from uaclient.config import UAConfig
 
 
 class RedactionFilter(logging.Filter):
@@ -59,6 +60,17 @@ class JsonArrayFormatter(logging.Formatter):
 
         local_log_record["extra"] = extra_message_dict
         return json.dumps(list(local_log_record.values()))
+
+
+def get_user_or_root_log_file_path() -> str:
+    """
+    Gets the correct log_file path,
+    adjusting for whether the user is root or not.
+    """
+    if util.we_are_currently_root():
+        return UAConfig().log_file
+    else:
+        return "~/.cache/" + defaults.USER_CACHE_SUBDIR + "/ubuntu-pro.log"
 
 
 def get_user_log_file() -> str:

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1553,13 +1553,14 @@ It is only possible to enable Anbox Cloud on a container using
 the --access-only flag.""",
 )
 
-UNEXPECTED_ERROR = NamedMessage(
+UNEXPECTED_ERROR = FormattedNamedMessage(
     "unexpected-error",
     t.gettext(
         """\
-Unexpected error(s) occurred.
-For more details, see the log: /var/log/ubuntu-advantage.log
-To file a bug run: ubuntu-bug ubuntu-advantage-tools"""
+Unexpected error(s) occurred: {error_msg}
+For more details, see the log: ~/.cache/ubuntu-pro/ubuntu-pro.log
+First, try searching online for solutions to this error.
+Otherwise, file a bug using the command: ubuntu-bug ubuntu-advantage-tools"""
     ),
 )
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1557,10 +1557,9 @@ UNEXPECTED_ERROR = FormattedNamedMessage(
     "unexpected-error",
     t.gettext(
         """\
-Unexpected error(s) occurred: {error_msg}
-For more details, see the log: ~/.cache/ubuntu-pro/ubuntu-pro.log
-First, try searching online for solutions to this error.
-Otherwise, file a bug using the command: ubuntu-bug ubuntu-advantage-tools"""
+An unexpected error occurred: {error_msg}
+For more details, see the log: {log_path}
+If you think this is a bug, please run: ubuntu-bug ubuntu-advantage-tools"""
     ),
 )
 

--- a/uaclient/tests/test_log.py
+++ b/uaclient/tests/test_log.py
@@ -2,6 +2,7 @@ import json
 import logging
 from io import StringIO
 
+import mock
 import pytest
 
 from uaclient import log as pro_log
@@ -158,3 +159,42 @@ class TestLoggerFormatter:
             assert val[6].get("key") == extra.get("key")
         else:
             assert 7 == len(val)
+
+
+class TestLogHelpers:
+    def test_get_user_or_root_log_file_path(self):
+        """
+        Tests that the correct default log_file storage location is retrieved
+        when the user is root.
+        """
+        # test root log file path
+        with mock.patch(
+            "uaclient.util.we_are_currently_root",
+            return_value=True,
+        ):
+            assert (
+                pro_log.get_user_or_root_log_file_path()
+                == "/var/log/ubuntu-advantage.log"
+            )
+        # test default user log file path
+        with mock.patch(
+            "uaclient.util.we_are_currently_root",
+            return_value=False,
+        ):
+            assert (
+                pro_log.get_user_or_root_log_file_path()
+                == "~/.cache/ubuntu-pro/ubuntu-pro.log"
+            )
+        # test custom user log file path
+        with mock.patch(
+            "uaclient.config.UAConfig.log_file", new_callable=mock.PropertyMock
+        ) as mock_log_file:
+            expected_log_file = "/tmp/foo.log"
+            mock_log_file.return_value = expected_log_file
+            with mock.patch(
+                "uaclient.util.we_are_currently_root", return_value=True
+            ) as mock_root:
+                result = pro_log.get_user_or_root_log_file_path()
+                mock_root.assert_called()
+                mock_log_file.assert_called()
+                assert expected_log_file == result


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
The unexpected error message does not reflect accurate log location when run by non root, and also the error message obfuscates the original error message so the end user has no context for what actually went wrong. This PR fixes that. 

Changes `messages.UnexpectedError` from a `NamedMessage` to a `FormattedNamedMessage` so that it must be formatted with a string representing an exception/error message to give better context on what errors actually occurred.   

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->

## Please Squash this PR with this commit message
cli: improved cli/log message for unexpected errors

Fixes: #2600


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
