### PR TITLE
tests: fix mantic EOL date in the security-status test

### DIFF
--- a/features/logs.feature
+++ b/features/logs.feature
@@ -30,7 +30,8 @@ Feature: Logs in Json Array Formatter
     Scenario Outline: Non-root user and root user log files are different
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Confirm user log file does not exist 
-        When I verify `/var/log/ubuntu-advantage.log` is empty
+        When I run `truncate -s 0 /var/log/ubuntu-advantage.log` with sudo
+        And I verify `/var/log/ubuntu-advantage.log` is empty
         Then I verify that no files exist matching `/home/ubuntu/.cache/ubuntu-pro/ubuntu-pro.log`
         When I verify that running `pro status` `as non-root` exits `0`
         Then I verify that files exist matching `/home/ubuntu/.cache/ubuntu-pro/ubuntu-pro.log`

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -784,7 +784,7 @@ Feature: Security status command behavior
             pro security-status --help
         for a list of available options\.
 
-        Main/Restricted packages receive updates until 1/2024\.
+        Main/Restricted packages receive updates until 7/2024\.
 
         Ubuntu Pro is not available for non-LTS releases\.
         """
@@ -795,7 +795,7 @@ Feature: Security status command behavior
         \d+ packages installed:
          +\d+ packages from Ubuntu Main/Restricted repository
 
-        Main/Restricted packages receive updates until 1/2024\.
+        Main/Restricted packages receive updates until 7/2024\.
 
         Ubuntu Pro is not available for non-LTS releases\.
         """
@@ -826,7 +826,7 @@ Feature: Security status command behavior
             sudo apt-get update
         to get the latest package information from apt\.
 
-        Main/Restricted packages receive updates until 1/2024\.
+        Main/Restricted packages receive updates until 7/2024\.
 
         Ubuntu Pro is not available for non-LTS releases\.
         """
@@ -848,7 +848,7 @@ Feature: Security status command behavior
             sudo apt-get update
         to get the latest package information from apt\.
 
-        Main/Restricted packages receive updates until 1/2024\.
+        Main/Restricted packages receive updates until 7/2024\.
 
         Ubuntu Pro is not available for non-LTS releases\.
         """


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it fixes a test which has a wrong date.

## Test Steps
The security status test itself

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
