### PR TITLE
Replace status tests

### DIFF
--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -31,11 +31,8 @@ Feature: Performing attach using ua-airgapped
         And I disable any internet connection on the machine
         And I change config key `contract_url` to use value `http://$behave_var{machine-ip contracts}:8484`
         And I attach `contract_token` with sudo
-        Then stdout matches regexp:
-        """
-        esm-apps     +yes      +enabled .*
-        esm-infra    +yes      +enabled .*
-        """
+        Then I verify that `esm-infra` is enabled
+        And I verify that `esm-apps` is enabled
         When I run `apt-cache policy hello` with sudo
         Then stdout matches regexp:
         """

--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -4,11 +4,7 @@ Feature: Enable anbox on Ubuntu
     Scenario Outline: Enable Anbox cloud service in a container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo and options `--no-auto-enable`
-        When I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        anbox-cloud +yes +disabled
-        """
+        Then I verify that `anbox-cloud` is disabled
         Then I verify that running `pro enable anbox-cloud` `as non-root` exits `1`
         And I will see the following on stderr:
         """
@@ -28,22 +24,14 @@ Feature: Enable anbox on Ubuntu
         Updating Anbox Cloud package lists
         Anbox Cloud access enabled
         """
-        When I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        anbox-cloud +yes +enabled
-        """
+        And I verify that `anbox-cloud` is enabled
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has priority `500`
         """
         https://archive.anbox-cloud.io/stable <release>/main amd64 Packages
         """
         When I run `pro disable anbox-cloud` with sudo
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        anbox-cloud +yes +disabled
-        """
+        Then I verify that `anbox-cloud` is disabled
 
         Examples: ubuntu release
             | release | machine_type  |
@@ -74,11 +62,7 @@ Feature: Enable anbox on Ubuntu
         Updating Anbox Cloud package lists
         Anbox Cloud access enabled
         """
-        When I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        anbox-cloud +yes +enabled
-        """
+        And I verify that `anbox-cloud` is enabled
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has priority `500`
         """
@@ -91,11 +75,7 @@ Feature: Enable anbox on Ubuntu
         When I run `cat /var/lib/ubuntu-advantage/private/anbox-cloud-credentials` with sudo
         Then stdout is a json matching the `anbox_cloud_credentials` schema
         When I run `pro disable anbox-cloud` with sudo
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        anbox-cloud +yes +disabled
-        """
+        Then I verify that `anbox-cloud` is disabled
         And I verify that no files exist matching `/var/lib/ubuntu-advantage/private/anbox-cloud-credentials`
         When I run `pro enable anbox-cloud --assume-yes` with sudo
         Then I will see the following on stdout:
@@ -115,11 +95,7 @@ Feature: Enable anbox on Ubuntu
         configuration changes.
         For more information, see https://anbox-cloud.io/docs/tut/installing-appliance#initialise
         """
-        When I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        anbox-cloud +yes +enabled
-        """
+        Then I verify that `anbox-cloud` is enabled
         When I run `apt-cache policy` with sudo
         Then apt-cache policy for the following url has priority `500`
         """
@@ -132,11 +108,7 @@ Feature: Enable anbox on Ubuntu
         When I run `cat /var/lib/ubuntu-advantage/private/anbox-cloud-credentials` with sudo
         Then stdout is a json matching the `anbox_cloud_credentials` schema
         When I run `pro disable anbox-cloud` with sudo
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        anbox-cloud +yes +disabled
-        """
+        Then I verify that `anbox-cloud` is disabled
         And I verify that no files exist matching `/var/lib/ubuntu-advantage/private/anbox-cloud-credentials`
 
         Examples: ubuntu release

--- a/features/api_full_auto_attach.feature
+++ b/features/api_full_auto_attach.feature
@@ -16,15 +16,9 @@ Feature: Full Auto-Attach Endpoint
         full_auto_attach(FullAutoAttachOptions(enable=["esm-infra"]))
         """
         And I run `python3 /tmp/full_auto_attach.py` with sudo
-        And I run `pro status --all` with sudo
-        Then stdout matches regexp:
-        """
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        """
-        Then stdout matches regexp:
-        """
-        livepatch     +yes +(disabled|n/a)  +(Canonical Livepatch service|Current kernel is not supported)
-        """
+        Then I verify that `esm-infra` is enabled
+        And I verify that `livepatch` is disabled
+
         Examples:
            | release | machine_type |
            | xenial  | aws.pro      |

--- a/features/api_security.feature
+++ b/features/api_security.feature
@@ -18,11 +18,7 @@ Feature: API security/security status tests
     Scenario Outline: Call package manifest endpoint for machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        """
+        Then I verify that `esm-infra` is enabled
         When I run `apt update` with sudo
         And I run `apt upgrade -y` with sudo
         And I run `apt install jq bzip2 -y` with sudo

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -6,31 +6,31 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         When I attach `contract_token` with sudo
         Then I verify that running `pro refresh` `as non-root` exits `1`
         And stderr matches regexp:
-            """
-            This command must be run as root \(try using sudo\).
-            """
+        """
+        This command must be run as root \(try using sudo\).
+        """
         When I run `pro refresh` with sudo
         Then I will see the following on stdout:
-            """
-            Successfully processed your pro configuration.
-            Successfully refreshed your subscription.
-            Successfully updated Ubuntu Pro related APT and MOTD messages.
-            """
+        """
+        Successfully processed your pro configuration.
+        Successfully refreshed your subscription.
+        Successfully updated Ubuntu Pro related APT and MOTD messages.
+        """
         When I run `pro refresh config` with sudo
         Then I will see the following on stdout:
-            """
-            Successfully processed your pro configuration.
-            """
+        """
+        Successfully processed your pro configuration.
+        """
         When I run `pro refresh contract` with sudo
         Then I will see the following on stdout:
-            """
-            Successfully refreshed your subscription.
-            """
+        """
+        Successfully refreshed your subscription.
+        """
         When I run `pro refresh messages` with sudo
         Then I will see the following on stdout:
-            """
-            Successfully updated Ubuntu Pro related APT and MOTD messages.
-            """
+        """
+        Successfully updated Ubuntu Pro related APT and MOTD messages.
+        """
         When I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
         And I run `sh -c "ls /var/log/ubuntu-advantage* | sort -d"` as non-root
         Then stdout matches regexp:
@@ -53,28 +53,62 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | jammy   | lxd-container |
            | mantic  | lxd-container |
 
-    Scenario Outline: Attached disable of an already disabled service in a ubuntu machine
+    Scenario Outline: Disable command on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro disable livepatch` `as non-root` exits `1`
         And stderr matches regexp:
-            """
-            This command must be run as root \(try using sudo\).
-            """
-        And I verify that running `pro disable livepatch` `with sudo` exits `1`
-        And I will see the following on stdout:
-            """
-            Livepatch is not currently enabled
-            See: sudo pro status
-            """
+        """
+        This command must be run as root \(try using sudo\).
+        """
+        When I verify that running `pro disable foobar` `as non-root` exits `1`
+        Then stderr matches regexp:
+        """
+        This command must be run as root \(try using sudo\).
+        """
+        When I verify that running `pro disable livepatch` `with sudo` exits `1`
+        Then I will see the following on stdout:
+        """
+        Livepatch is not currently enabled
+        See: sudo pro status
+        """
+        When I verify that running `pro disable foobar` `with sudo` exits `1`
+        Then stderr matches regexp:
+        """
+        Cannot disable unknown service 'foobar'.
+        <msg>
+        """
+        When I verify that running `pro disable livepatch foobar` `as non-root` exits `1`
+        Then stderr matches regexp:
+        """
+        This command must be run as root \(try using sudo\)
+        """
+        When I verify that running `pro disable livepatch foobar` `with sudo` exits `1`
+        Then I will see the following on stdout:
+        """
+        Livepatch is not currently enabled
+        See: sudo pro status
+        """
+        And stderr matches regexp:
+        """
+        Cannot disable unknown service 'foobar'.
+        <msg>
+        """
+        When I verify that running `pro disable esm-infra` `as non-root` exits `1`
+        Then stderr matches regexp:
+        """
+        This command must be run as root \(try using sudo\).
+        """
+        When I run `pro disable esm-infra` with sudo
+        Then I verify that `esm-infra` is disabled
+        And I verify that running `apt update` `with sudo` exits `0`
 
         Examples: ubuntu release
-           | release | machine_type  |
-           | bionic  | lxd-container |
-           | focal   | lxd-container |
-           | xenial  | lxd-container |
-           | jammy   | lxd-container |
-           | mantic  | lxd-container |
+           | release | machine_type  | msg                                                                                                                                            |
+           | xenial  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | bionic  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
+           | focal   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | jammy   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
     Scenario Outline: Attached disable with json format
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -82,27 +116,27 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         Then I verify that running `pro disable foobar --format json` `as non-root` exits `1`
         And stdout is a json matching the `ua_operation` schema
         And I will see the following on stdout:
-            """
-            {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-            """
+        """
+        {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
         Then I verify that running `pro disable foobar --format json` `with sudo` exits `1`
         And stdout is a json matching the `ua_operation` schema
         And I will see the following on stdout:
-            """
-            {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-            """
+        """
+        {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
         Then I verify that running `pro disable foobar --format json --assume-yes` `as non-root` exits `1`
         And stdout is a json matching the `ua_operation` schema
         And I will see the following on stdout:
-            """
-            {"_schema_version": "0.1", "errors": [{"message": "This command must be run as root (try using sudo).", "message_code": "nonroot-user", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-            """
+        """
+        {"_schema_version": "0.1", "errors": [{"message": "This command must be run as root (try using sudo).", "message_code": "nonroot-user", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
         And I verify that running `pro disable foobar --format json --assume-yes` `with sudo` exits `1`
         And stdout is a json matching the `ua_operation` schema
         And I will see the following on stdout:
-            """
-            {"_schema_version": "0.1", "errors": [{"additional_info": {"invalid_service": "foobar", "operation": "disable", "service_msg": "Try <valid_services>"}, "message": "Cannot disable unknown service 'foobar'.\nTry <valid_services>", "message_code": "invalid-service-or-failure", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-            """
+        """
+        {"_schema_version": "0.1", "errors": [{"additional_info": {"invalid_service": "foobar", "operation": "disable", "service_msg": "Try <valid_services>"}, "message": "Cannot disable unknown service 'foobar'.\nTry <valid_services>", "message_code": "invalid-service-or-failure", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
         And I verify that running `pro disable livepatch --format json --assume-yes` `with sudo` exits `1`
         And stdout is a json matching the `ua_operation` schema
         And I will see the following on stdout:
@@ -130,44 +164,6 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | focal   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
            | jammy   | lxd-container | anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
 
-    Scenario Outline: Attached disable of a service in a ubuntu machine
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        Then I verify that running `pro disable foobar` `as non-root` exits `1`
-        And stderr matches regexp:
-            """
-            This command must be run as root \(try using sudo\).
-            """
-        And I verify that running `pro disable foobar` `with sudo` exits `1`
-        And stderr matches regexp:
-            """
-            Cannot disable unknown service 'foobar'.
-            <msg>
-            """
-        And I verify that running `pro disable esm-infra` `as non-root` exits `1`
-        And stderr matches regexp:
-            """
-            This command must be run as root \(try using sudo\).
-            """
-        When I run `pro disable esm-infra` with sudo
-        Then I will see the following on stdout:
-            """
-            Updating package lists
-            """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-            """
-            esm-infra    +yes      +disabled +Expanded Security Maintenance for Infrastructure
-            """
-        And I verify that running `apt update` `with sudo` exits `0`
-
-        Examples: ubuntu release
-           | release | machine_type  | msg                                                                                                                                            |
-           | xenial  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
-
     Scenario Outline: Attached detach in an ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -191,82 +187,56 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         Updating package lists
         This machine is now detached.
         """
-       When I run `pro status --all` as non-root
-       Then stdout matches regexp:
-       """
-       SERVICE       +AVAILABLE  DESCRIPTION
-       anbox-cloud   +<anbox>    .*
-       cc-eal        +<cc-eal>   +Common Criteria EAL2 Provisioning Packages
-       """
-       Then stdout matches regexp:
-       """
-       esm-apps      +<esm-apps> +Expanded Security Maintenance for Applications
-       esm-infra     +yes        +Expanded Security Maintenance for Infrastructure
-       fips          +<fips>     +NIST-certified FIPS crypto packages
-       fips-preview  +.* +.*
-       fips-updates  +<fips-u>   +FIPS compliant crypto packages with stable security updates
-       landscape     +(yes|no)   +Management and administration tool for Ubuntu
-       livepatch     +(yes|no)   +(Canonical Livepatch service|Current kernel is not supported)
-       realtime-kernel +<realtime-kernel> +Ubuntu kernel with PREEMPT_RT patches integrated
-       ros           +<ros>      +Security Updates for the Robot Operating System
-       ros-updates   +<ros-updates>      +All Updates for the Robot Operating System
-       """
-       Then stdout matches regexp:
-       """
-       <cis_or_usg>           +<cis>      +Security compliance and audit tools
-       """
-       And stdout matches regexp:
-       """
-       This machine is not attached to an Ubuntu Pro subscription.
-       """
-       And I verify that running `apt update` `with sudo` exits `0`
-       When I attach `contract_token` with sudo
-       Then I verify that running `pro enable foobar --format json` `as non-root` exits `1`
-       And stdout is a json matching the `ua_operation` schema
-       And I will see the following on stdout:
-       """
-       {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        And the machine is unattached
+        And I verify that running `apt update` `with sudo` exits `0`
+        When I attach `contract_token` with sudo
+        Then I verify that running `pro enable foobar --format json` `as non-root` exits `1`
+        And stdout is a json matching the `ua_operation` schema
+        And I will see the following on stdout:
         """
-       Then I verify that running `pro enable foobar --format json` `with sudo` exits `1`
-       And stdout is a json matching the `ua_operation` schema
-       And I will see the following on stdout:
-       """
-       {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-       """
-       Then I verify that running `pro detach --format json --assume-yes` `as non-root` exits `1`
-       And stdout is a json matching the `ua_operation` schema
-       And I will see the following on stdout:
-       """
-       {"_schema_version": "0.1", "errors": [{"message": "This command must be run as root (try using sudo).", "message_code": "nonroot-user", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
-       """
-       When I run `pro detach --format json --assume-yes` with sudo
-       Then stdout is a json matching the `ua_operation` schema
-       And I will see the following on stdout:
-       """
-       {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": false, "processed_services": ["esm-apps", "esm-infra"], "result": "success", "warnings": []}
-       """
+        {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+         """
+        Then I verify that running `pro enable foobar --format json` `with sudo` exits `1`
+        And stdout is a json matching the `ua_operation` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": "0.1", "errors": [{"message": "json formatted response requires --assume-yes flag.", "message_code": "json-format-require-assume-yes", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
+        Then I verify that running `pro detach --format json --assume-yes` `as non-root` exits `1`
+        And stdout is a json matching the `ua_operation` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": "0.1", "errors": [{"message": "This command must be run as root (try using sudo).", "message_code": "nonroot-user", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+        """
+        When I run `pro detach --format json --assume-yes` with sudo
+        Then stdout is a json matching the `ua_operation` schema
+        And I will see the following on stdout:
+        """
+        {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": false, "processed_services": ["esm-apps", "esm-infra"], "result": "success", "warnings": []}
+        """
+        And the machine is unattached
 
        Examples: ubuntu release
-           | release | machine_type  | anbox | esm-apps | cc-eal | cis | fips | fips-u | ros | ros-updates | cis_or_usg | realtime-kernel |
-           | xenial  | lxd-container | no    | yes      | yes    | yes | yes  | yes    | yes | yes         | cis        | no              |
-           | bionic  | lxd-container | no    | yes      | yes    | yes | yes  | yes    | yes | yes         | cis        | no              |
-           | focal   | lxd-container | yes   | yes      | no     | yes | yes  | yes    | yes | no          | usg        | no              |
-           | jammy   | lxd-container | yes   | yes      | no     | yes | no   | yes    | no  | no          | usg        | yes             |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     Scenario Outline: Attached auto-attach in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that running `pro auto-attach` `as non-root` exits `1`
         And stderr matches regexp:
-            """
-            This command must be run as root \(try using sudo\).
-            """
+        """
+        This command must be run as root \(try using sudo\).
+        """
         When I verify that running `pro auto-attach` `with sudo` exits `2`
         Then stderr matches regexp:
-            """
-            This machine is already attached to '.+'
-            To use a different subscription first run: sudo pro detach.
-            """
+        """
+        This machine is already attached to '.+'
+        To use a different subscription first run: sudo pro detach.
+        """
 
         Examples: ubuntu release
            | release | machine_type  |
@@ -364,32 +334,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
            | jammy   | lxd-container |
            | mantic  | lxd-container |
 
-    Scenario Outline: Attached disable of different services in a ubuntu machine
+    Scenario Outline: Attached enable when reboot required
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        Then I verify that running `pro disable esm-infra livepatch foobar` `as non-root` exits `1`
-        And stderr matches regexp:
-        """
-        This command must be run as root \(try using sudo\)
-        """
-        And I verify that running `pro disable esm-infra livepatch foobar` `with sudo` exits `1`
-        And I will see the following on stdout:
-        """
-        Updating package lists
-        Livepatch is not currently enabled
-        See: sudo pro status
-        """
-        And stderr matches regexp:
-        """
-        Cannot disable unknown service 'foobar'.
-        <msg>
-        """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        esm-infra    +yes      +disabled +Expanded Security Maintenance for Infrastructure
-        """
-        When I run `touch /var/run/reboot-required` with sudo
+        And I run `pro disable esm-infra` with sudo
+        And I run `touch /var/run/reboot-required` with sudo
         And I run `touch /var/run/reboot-required.pkgs` with sudo
         And I run `pro enable esm-infra` with sudo
         Then stdout matches regexp:
@@ -403,11 +352,11 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
 
         Examples: ubuntu release
-           | release | machine_type  | msg                                                                                                                                            |
-           | xenial  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | bionic  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-infra, fips, fips-preview,\nfips-updates, landscape, livepatch, realtime-kernel, ros, ros-updates. |
-           | focal   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
-           | jammy   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-infra, fips, fips-preview, fips-updates,\nlandscape, livepatch, realtime-kernel, ros, ros-updates, usg. |
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
     Scenario Outline: Help command on an attached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -799,18 +748,10 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `rm /var/lib/ubuntu-advantage/machine-token.json` with sudo
-        And I run `ua status` as non-root
-        Then stdout matches regexp:
-        """
-        SERVICE +AVAILABLE +DESCRIPTION
-        """
+        Then the machine is unattached
         When I run `dpkg-reconfigure ubuntu-advantage-tools` with sudo
         Then I verify that files exist matching `/var/lib/ubuntu-advantage/machine-token.json`
-        When I run `ua status` as non-root
-        Then stdout matches regexp:
-        """
-        SERVICE +ENTITLED +STATUS +DESCRIPTION
-        """
+        Then the machine is attached
 
         Examples: ubuntu release
            | release | machine_type  |
@@ -849,11 +790,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
 
         Do you want to proceed\? \(y/N\)
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        esm-apps   +yes   +disabled   +Expanded Security Maintenance for Applications
-        """
+        And I verify that `esm-apps` is disabled
         And I verify that `ansible` is installed from apt source `http://archive.ubuntu.com/ubuntu <pocket>/universe`
 
         Examples: ubuntu release
@@ -887,11 +824,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         And I run `apt update` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
         And I reboot the machine
-        And I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        <fips-service>   +yes   +enabled
-        """
+        Then I verify that `<fips-service>` is eanbled
         When  I run `uname -r` as non-root
         Then stdout matches regexp:
         """
@@ -922,11 +855,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         Do you want to proceed\? \(y/N\)
         """
         When I reboot the machine
-        And I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        <fips-service>   +yes   +disabled
-        """
+        Then I verify that `<fips-service>` is disabled
         When  I run `uname -r` as non-root
         Then stdout does not match regexp:
         """
@@ -934,6 +863,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         """
         And I verify that `openssh-server` is installed from apt source `<archive-source>`
         And I verify that `<kernel-package>` is not installed
+
         Examples: ubuntu release
            | release | machine_type  | fips-service | fips-name    | kernel-package   | fips-source                                                    | archive-source                                                    |
            | xenial  | lxd-vm        | fips         | FIPS         | linux-fips       | https://esm.ubuntu.com/fips/ubuntu xenial/main                 | https://esm.ubuntu.com/infra/ubuntu xenial-infra-security/main    |

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -1,7 +1,6 @@
 @uses.config.contract_token
 Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
 
-    @slow
     Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -477,55 +476,39 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         When I attach `contract_token` with sudo
         And I run `pro enable usg` with sudo
         Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            Updating Ubuntu Security Guide package lists
-            Ubuntu Security Guide enabled
-            Visit https://ubuntu.com/security/certifications/docs/usg for the next steps
-            """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-            """
-            usg         +yes    +enabled   +Security compliance and audit tools
-            """
+        """
+        One moment, checking your subscription first
+        Updating Ubuntu Security Guide package lists
+        Ubuntu Security Guide enabled
+        Visit https://ubuntu.com/security/certifications/docs/usg for the next steps
+        """
+        And I verify that `usg` is enabled
         When I run `pro disable usg` with sudo
         Then stdout matches regexp:
             """
             Updating package lists
             """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-            """
-            usg         +yes    +disabled   +Security compliance and audit tools
-            """
+        And I verify that `usg` is disabled
         When I run `pro enable cis` with sudo
         Then I will see the following on stdout:
-            """
-            One moment, checking your subscription first
-            From Ubuntu 20.04 onward 'pro enable cis' has been
-            replaced by 'pro enable usg'. See more information at:
-            https://ubuntu.com/security/certifications/docs/usg
-            Updating CIS Audit package lists
-            Updating standard Ubuntu package lists
-            Installing CIS Audit packages
-            CIS Audit enabled
-            Visit https://ubuntu.com/security/cis to learn how to use CIS
-            """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-            """
-            usg         +yes    +enabled   +Security compliance and audit tools
-            """
+        """
+        One moment, checking your subscription first
+        From Ubuntu 20.04 onward 'pro enable cis' has been
+        replaced by 'pro enable usg'. See more information at:
+        https://ubuntu.com/security/certifications/docs/usg
+        Updating CIS Audit package lists
+        Updating standard Ubuntu package lists
+        Installing CIS Audit packages
+        CIS Audit enabled
+        Visit https://ubuntu.com/security/cis to learn how to use CIS
+        """
+        And I verify that `usg` is enabled
         When I run `pro disable usg` with sudo
         Then stdout matches regexp:
-            """
-            Updating package lists
-            """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-            """
-            usg         +yes    +disabled   +Security compliance and audit tools
-            """
+        """
+        Updating package lists
+        """
+        And I verify that `usg` is disabled
 
         Examples: cis service
            | release | machine_type  |
@@ -851,25 +834,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     Scenario Outline: Attached enable ros on a machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `pro status --all` as non-root
-        Then stdout matches regexp
-        """
-        ros +yes +disabled +Security Updates for the Robot Operating System
-        """
+        Then I verify that `ros` is disabled
         When I run `pro enable ros --assume-yes` with sudo
-        And I run `pro status --all` as non-root
-        Then stdout matches regexp
-        """
-        ros +yes +enabled +Security Updates for the Robot Operating System
-        """
-        And stdout matches regexp
-        """
-        esm-apps +yes +enabled +Expanded Security Maintenance for Applications
-        """
-        And stdout matches regexp
-        """
-        esm-infra +yes +enabled +Expanded Security Maintenance for Infrastructure
-        """
+        Then I verify that `ros` is enabled
+        And I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
         When I verify that running `pro disable esm-apps` `with sudo` and stdin `N` exits `1`
         Then stdout matches regexp
         """
@@ -883,15 +852,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Disable ROS ESM Security Updates and proceed to disable Ubuntu Pro: ESM Apps\? \(y\/N\) Disabling dependent service: ROS ESM Security Updates
         Updating package lists
         """
-        When I run `pro status --all` as non-root
-        Then stdout matches regexp
-        """
-        ros +yes +disabled +Security Updates for the Robot Operating System
-        """
-        And stdout matches regexp
-        """
-        esm-apps +yes +disabled +Expanded Security Maintenance for Applications
-        """
+        And I verify that `ros` is disabled
+        And I verify that `esm-apps` is disabled
         When I verify that running `pro enable ros` `with sudo` and stdin `N` exits `1`
         Then stdout matches regexp
         """
@@ -908,19 +870,9 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Updating ROS ESM Security Updates package lists
         ROS ESM Security Updates enabled
         """
-        When I run `pro status --all` as non-root
-        Then stdout matches regexp
-        """
-        ros +yes +enabled +Security Updates for the Robot Operating System
-        """
-        And stdout matches regexp
-        """
-        esm-apps +yes +enabled +Expanded Security Maintenance for Applications
-        """
-        And stdout matches regexp
-        """
-        esm-infra +yes +enabled +Expanded Security Maintenance for Infrastructure
-        """
+        And I verify that `ros` is enabled
+        And I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
         When I run `apt-cache policy` as non-root
         Then apt-cache policy for the following url has priority `500`
         """
@@ -930,11 +882,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Then I verify that `python3-catkin-pkg` is installed from apt source `<ros-security-source>`
 
         When I run `pro enable ros-updates --assume-yes` with sudo
-        And I run `pro status --all` as non-root
-        Then stdout matches regexp
-        """
-        ros-updates +yes +enabled +All Updates for the Robot Operating System
-        """
+        Then I verify that `ros-updates` is enabled
         When I run `apt-cache policy` as non-root
         Then apt-cache policy for the following url has priority `500`
         """
@@ -949,6 +897,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Disable ROS ESM All Updates and proceed to disable ROS ESM Security Updates\? \(y\/N\) Disabling dependent service: ROS ESM All Updates
         Updating package lists
         """
+        And I verify that `ros-updates` is disabled
         When I run `pro enable ros-updates` `with sudo` and stdin `y`
         Then stdout matches regexp
         """
@@ -959,37 +908,17 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Updating ROS ESM All Updates package lists
         ROS ESM All Updates enabled
         """
-        When I run `pro status --all` as non-root
-        Then stdout matches regexp
-        """
-        ros-updates +yes +enabled +All Updates for the Robot Operating System
-        """
-        And stdout matches regexp
-        """
-        ros +yes +enabled +Security Updates for the Robot Operating System
-        """
+        And I verify that `ros-updates` is enabled
+        And I verify that `ros` is enabled
         When I run `pro disable ros-updates --assume-yes` with sudo
-        When I run `pro disable ros --assume-yes` with sudo
-        When I run `pro disable esm-apps --assume-yes` with sudo
-        When I run `pro disable esm-infra --assume-yes` with sudo
-        When I run `pro enable ros-updates --assume-yes` with sudo
-        When I run `pro status --all` as non-root
-        Then stdout matches regexp
-        """
-        ros-updates +yes +enabled +All Updates for the Robot Operating System
-        """
-        And stdout matches regexp
-        """
-        ros +yes +enabled +Security Updates for the Robot Operating System
-        """
-        And stdout matches regexp
-        """
-        esm-apps +yes +enabled +Expanded Security Maintenance for Applications
-        """
-        And stdout matches regexp
-        """
-        esm-infra +yes +enabled +Expanded Security Maintenance for Infrastructure
-        """
+        And I run `pro disable ros --assume-yes` with sudo
+        And I run `pro disable esm-apps --assume-yes` with sudo
+        And I run `pro disable esm-infra --assume-yes` with sudo
+        And I run `pro enable ros-updates --assume-yes` with sudo
+        Then I verify that `ros-updates` is enabled
+        And I verify that `ros` is enabled
+        And I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
         When I run `pro detach` `with sudo` and stdin `y`
         Then stdout matches regexp:
         """
@@ -999,6 +928,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Updating package lists
         This machine is now detached.
         """
+        And the machine is unattached
 
         Examples: ubuntu release
            | release | machine_type  | ros-security-source                                    | ros-updates-source                                            |
@@ -1067,11 +997,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     Scenario Outline: Attached enable esm-apps on a machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `pro status --all` as non-root
-        Then stdout matches regexp
-        """
-        esm-apps +yes +enabled +Expanded Security Maintenance for Applications
-        """
+        Then I verify that `esm-apps` is enabled
         And I verify that running `apt update` `with sudo` exits `0`
         When I run `apt-cache policy` as non-root
         Then apt-cache policy for the following url has priority `510`

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -517,15 +517,9 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     Scenario Outline: Attached disable of livepatch in a lxd vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        esm-apps     +yes      +enabled  +Expanded Security Maintenance for Applications
-        esm-infra    +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        fips         +yes      +disabled +NIST-certified FIPS crypto packages
-        fips-updates +yes      +disabled +FIPS compliant crypto packages with stable security updates
-        livepatch    +yes      +<livepatch_status>  +Canonical Livepatch service
-        """
+        Then I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
+        And I verify that `livepatch` status is `<livepatch_status>`
         When I run `pro disable livepatch` with sudo
         Then I verify that running `canonical-livepatch status` `with sudo` exits `1`
         And stderr matches regexp:
@@ -533,15 +527,9 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Machine is not enabled. Please run 'sudo canonical-livepatch enable' with the
         token obtained from https://ubuntu.com/livepatch.
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        esm-apps     +yes      +enabled  +Expanded Security Maintenance for Applications
-        esm-infra    +yes      +enabled  +Expanded Security Maintenance for Infrastructure
-        fips         +yes      +disabled +NIST-certified FIPS crypto packages
-        fips-updates +yes      +disabled +FIPS compliant crypto packages with stable security updates
-        livepatch    +yes      +disabled +Canonical Livepatch service
-        """
+        And I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
+        And I verify that `livepatch` is disabled
         When I verify that running `pro enable livepatch --access-only` `with sudo` exits `1`
         Then I will see the following on stdout:
         """
@@ -572,13 +560,9 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Enabling default service livepatch
         Failed to enable default services, check: sudo pro status
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        livepatch +yes +disabled
-        """
-        Then I verify that running `pro enable livepatch` `with sudo` exits `1`
-        Then I will see the following on stdout:
+        And I verify that `livepatch` is disabled
+        And I verify that running `pro enable livepatch` `with sudo` exits `1`
+        And I will see the following on stdout:
         """
         One moment, checking your subscription first
         Installing snapd
@@ -594,25 +578,21 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I verify that running `canonical-livepatch status` `with sudo` exits `1`
         Then I will see the following on stderr:
-            """
-            sudo: canonical-livepatch: command not found
-            """
+        """
+        sudo: canonical-livepatch: command not found
+        """
         When I attach `contract_token` with sudo
         Then stdout matches regexp:
-            """
-            Installing canonical-livepatch snap
-            Canonical Livepatch enabled
-            """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-            """
-            livepatch +yes +<livepatch_status>
-            """
+        """
+        Installing canonical-livepatch snap
+        Canonical Livepatch enabled
+        """
+        And I verify that `livepatch` status is `<livepatch_status>`
         When I run `canonical-livepatch status` with sudo
         Then stdout matches regexp:
-            """
-            running: true
-            """
+        """
+        running: true
+        """
 
         Examples: ubuntu release
            | release | machine_type | livepatch_status |
@@ -627,11 +607,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         Installing canonical-livepatch snap
         Canonical Livepatch enabled
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        livepatch +yes +warning
-        """
+        And I verify that `livepatch` status is warning
         When I run `pro api u.pro.security.status.reboot_required.v1` with sudo
         Then stdout matches regexp:
         """

--- a/features/attached_status.feature
+++ b/features/attached_status.feature
@@ -1,6 +1,6 @@
-@uses.config.contract_token
 Feature: Attached status
 
+    @uses.config.contract_token
     Scenario Outline: Attached status in a ubuntu machine - formatted
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -38,6 +38,7 @@ Feature: Attached status
            | jammy   | lxd-container |
            | mantic  | lxd-container |
 
+    @uses.config.contract_token
     Scenario Outline: Non-root status can see in-progress operations
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -77,6 +78,214 @@ Feature: Attached status
            | release | machine_type  |
            | xenial  | lxd-container |
 
+    Scenario Outline: Attached status in a ubuntu Pro machine
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        log_level: debug
+        """
+        And I run `pro auto-attach` with sudo
+        When I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        cc-eal          +yes      +disabled +Common Criteria EAL2 Provisioning Packages
+        cis             +yes      +disabled +Security compliance and audit tools
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
+        livepatch       +yes      +enabled  +Canonical Livepatch service
+        """
+        When I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        anbox-cloud     +yes      +n/a      +Scalable Android in the cloud
+        cc-eal          +yes      +disabled +Common Criteria EAL2 Provisioning Packages
+        cis             +yes      +disabled +Security compliance and audit tools
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-preview    +yes      +n/a      +Preview of FIPS crypto packages undergoing certification with NIST
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
+        livepatch       +yes      +enabled  +Canonical Livepatch service
+        """
+
+        Examples: ubuntu release
+           | release | machine_type  |
+           | xenial  | aws.pro       |
+           | xenial  | azure.pro     |
+
+    Scenario Outline: Attached status in a ubuntu Pro machine
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        log_level: debug
+        """
+        And I run `pro auto-attach` with sudo
+        And I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        cc-eal          +yes      +disabled +Common Criteria EAL2 Provisioning Packages
+        cis             +yes      +disabled +Security compliance and audit tools
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        livepatch       +yes      +warning  +Current kernel is not supported
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        anbox-cloud     +yes      +n/a      +Scalable Android in the cloud
+        cc-eal          +yes      +disabled +Common Criteria EAL2 Provisioning Packages
+        cis             +yes      +disabled +Security compliance and audit tools
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        fips            +yes      +n/a      +NIST-certified FIPS crypto packages
+        fips-preview    +yes      +n/a      +Preview of FIPS crypto packages undergoing certification with NIST
+        fips-updates    +yes      +n/a      +FIPS compliant crypto packages with stable security updates
+        livepatch       +yes      +warning  +Current kernel is not supported
+        """
+
+        Examples: ubuntu release
+           | release | machine_type  |
+           | xenial  | gcp.pro       |
+
+    Scenario Outline: Attached status in a ubuntu Pro machine
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        log_level: debug
+        """
+        And I run `pro auto-attach` with sudo
+        And I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        cc-eal          +yes      +disabled +Common Criteria EAL2 Provisioning Packages
+        cis             +yes      +disabled +Security compliance and audit tools
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
+        livepatch       +yes      +enabled  +Canonical Livepatch service
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        anbox-cloud     +yes      +n/a      +Scalable Android in the cloud
+        cc-eal          +yes      +disabled +Common Criteria EAL2 Provisioning Packages
+        cis             +yes      +disabled +Security compliance and audit tools
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-preview    +yes      +n/a      +Preview of FIPS crypto packages undergoing certification with NIST
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
+        livepatch       +yes      +enabled  +Canonical Livepatch service
+        """
+
+        Examples: ubuntu release
+           | release | machine_type  |
+           | bionic  | aws.pro       |
+           | bionic  | azure.pro     |
+           | bionic  | gcp.pro       |
+
+    Scenario Outline: Attached status in a ubuntu Pro machine
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        log_level: debug
+        """
+        And I run `pro auto-attach` with sudo
+        And I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        anbox-cloud     +yes      +disabled +Scalable Android in the cloud
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
+        livepatch       +yes      +enabled  +Canonical Livepatch service
+        usg             +yes      +disabled +Security compliance and audit tools
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        anbox-cloud     +yes      +disabled +Scalable Android in the cloud
+        cc-eal          +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        fips            +yes      +disabled +NIST-certified FIPS crypto packages
+        fips-preview    +yes      +n/a      +Preview of FIPS crypto packages undergoing certification with NIST
+        fips-updates    +yes      +disabled +FIPS compliant crypto packages with stable security updates
+        livepatch       +yes      +enabled  +Canonical Livepatch service
+        usg             +yes      +disabled +Security compliance and audit tools
+        """
+
+        Examples: ubuntu release
+           | release | machine_type  |
+           | focal   | aws.pro       |
+           | focal   | azure.pro     |
+           | focal   | gcp.pro       |
+
+    Scenario Outline: Attached status in a ubuntu Pro machine
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
+        """
+        contract_url: 'https://contracts.canonical.com'
+        log_level: debug
+        """
+        And I run `pro auto-attach` with sudo
+        And I verify root and non-root `pro status` calls have the same output
+        And I run `pro status` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        anbox-cloud     +yes      +disabled +Scalable Android in the cloud
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        fips-preview    +yes      +disabled +Preview of FIPS crypto packages undergoing certification with NIST
+        livepatch       +yes      +enabled  +Canonical Livepatch service
+        usg             +yes      +disabled +Security compliance and audit tools
+        """
+        When I verify root and non-root `pro status --all` calls have the same output
+        And I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        SERVICE         +ENTITLED +STATUS   +DESCRIPTION
+        anbox-cloud     +yes      +disabled +Scalable Android in the cloud
+        cc-eal          +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
+        esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
+        esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
+        fips            +yes      +n/a      +NIST-certified FIPS crypto packages
+        fips-preview    +yes      +disabled +Preview of FIPS crypto packages undergoing certification with NIST
+        fips-updates    +yes      +n/a      +FIPS compliant crypto packages with stable security updates
+        livepatch       +yes      +enabled  +Canonical Livepatch service
+        usg             +yes      +disabled +Security compliance and audit tools
+        """
+
+        Examples: ubuntu release
+           | release | machine_type  |
+           | jammy   | aws.pro       |
+           | jammy   | azure.pro     |
+           | jammy   | gcp.pro       |
+
+    @uses.config.contract_token
     Scenario Outline: Attached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -124,6 +333,7 @@ Feature: Attached status
            | xenial  | lxd-container |
            | bionic  | lxd-container |
 
+    @uses.config.contract_token
     Scenario Outline: Attached status in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
@@ -169,6 +379,7 @@ Feature: Attached status
            | release | machine_type  |
            | focal   | lxd-container |
 
+    @uses.config.contract_token
     Scenario Outline: Attached status in the latest LTS ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/detached_auto_attach.feature
+++ b/features/detached_auto_attach.feature
@@ -17,20 +17,16 @@ Feature: Attached cloud does not detach when auto-attaching after manually attac
         This machine is already attached to '.+'
         To use a different subscription first run: sudo pro detach.
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        esm-infra    +yes      +<esm-service> +Expanded Security Maintenance for Infrastructure
-        """
+        And I verify that `esm-infra` is enabled
 
         Examples: ubuntu release
-           | release | machine_type  | esm-service |
-           | xenial  | aws.generic   | enabled     |
-           | xenial  | azure.generic | enabled     |
-           | xenial  | gcp.generic   | enabled     |
-           | bionic  | aws.generic   | enabled     |
-           | bionic  | azure.generic | enabled     |
-           | bionic  | gcp.generic   | enabled     |
-           | focal   | aws.generic   | enabled     |
-           | focal   | azure.generic | enabled     |
-           | focal   | gcp.generic   | enabled     |
+           | release | machine_type  |
+           | xenial  | aws.generic   |
+           | xenial  | azure.generic |
+           | xenial  | gcp.generic   |
+           | bionic  | aws.generic   |
+           | bionic  | azure.generic |
+           | bionic  | gcp.generic   |
+           | focal   | aws.generic   |
+           | focal   | azure.generic |
+           | focal   | gcp.generic   |

--- a/features/enable_fips_cloud.feature
+++ b/features/enable_fips_cloud.feature
@@ -114,23 +114,19 @@ Feature: FIPS enablement in cloud based machines
            | focal   | gcp.generic   | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
-    Scenario Outline: Enable FIPS in an ubuntu Azure vm
+    Scenario Outline: Enable FIPS in a cloud VM
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         And I run `pro enable <fips-service> --assume-yes` with sudo
         Then stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                enabled
-            """
+        """
+        Updating <fips-name> package lists
+        Installing <fips-name> packages
+        Updating standard Ubuntu package lists
+        <fips-name> enabled
+        A reboot is required to complete install
+        """
+        And I verify that `<fips-service>` is enabled
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         When I run `apt-cache policy <fips-package>` as non-root
@@ -141,9 +137,9 @@ Feature: FIPS enablement in cloud based machines
         When I reboot the machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            <fips-kernel>
-            """
+        """
+        <fips-kernel>
+        """
         When I run `cat /proc/sys/crypto/fips_enabled` with sudo
         Then I will see the following on stdout:
         """
@@ -160,219 +156,25 @@ Feature: FIPS enablement in cloud based machines
         .*Installed: \(none\)
         """
         When I reboot the machine
-        And I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                disabled
-            """
+        Then I verify that `<fips-service>` is disabled
 
         Examples: ubuntu release
-           | release | machine_type  | fips-name    | fips-service | fips-package      | fips-kernel  | fips-apt-source                                |
-           | xenial  | azure.generic | FIPS         | fips         | ubuntu-fips       |  fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
-           | xenial  | azure.generic | FIPS Updates | fips-updates | ubuntu-fips       |  fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
-           | bionic  | azure.generic | FIPS         | fips         | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | azure.generic | FIPS Updates | fips-updates | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | azure.generic | FIPS         | fips         | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | azure.generic | FIPS Updates | fips-updates | ubuntu-azure-fips |  azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
-
-    @slow
-    Scenario Outline: Attached FIPS in an ubuntu Xenial AWS vm
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `pro disable livepatch` with sudo
-        And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo
-        And I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                enabled
-            """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
-        When I run `apt-cache policy ubuntu-fips` as non-root
-        Then stdout does not match regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I reboot the machine
-        And  I run `uname -r` as non-root
-        Then stdout matches regexp:
-            """
-            fips
-            """
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        1
-        """
-        When I run `pro disable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
-        """
-        Updating package lists
-        """
-        When I run `apt-cache policy ubuntu-fips` as non-root
-        Then stdout matches regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I reboot the machine
-        Then I verify that `openssh-server` installed version matches regexp `fips`
-        And I verify that `openssh-client` installed version matches regexp `fips`
-        And I verify that `strongswan` installed version matches regexp `fips`
-        And I verify that `openssh-server-hmac` installed version matches regexp `fips`
-        And I verify that `openssh-client-hmac` installed version matches regexp `fips`
-        And I verify that `strongswan-hmac` installed version matches regexp `fips`
-        When I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
-        Then I will see the following on stdout:
-        """
-        openssh-client was already not hold.
-        openssh-server was already not hold.
-        strongswan was already not hold.
-        """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                disabled
-            """
-
-        Examples: ubuntu release
-           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
-           | xenial  | aws.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu xenial/main |
-
-    @slow
-    Scenario Outline: Attached enable of FIPS in an ubuntu AWS vm
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `pro disable livepatch` with sudo
-        And I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                enabled
-            """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        When I run `apt-cache policy ubuntu-aws-fips` as non-root
-        Then stdout does not match regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I reboot the machine
-        And  I run `uname -r` as non-root
-        Then stdout matches regexp:
-            """
-            aws-fips
-            """
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        1
-        """
-        When I run `pro disable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
-        """
-        Updating package lists
-        """
-        When I run `apt-cache policy ubuntu-aws-fips` as non-root
-        Then stdout matches regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I reboot the machine
-        And I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                disabled
-            """
-
-        Examples: ubuntu release
-           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | aws.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | aws.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | aws.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | aws.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-
-    @slow
-    Scenario Outline: Attached enable of FIPS in an ubuntu GCP vm
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                enabled
-            """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
-        Then stdout does not match regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I reboot the machine
-        And  I run `uname -r` as non-root
-        Then stdout matches regexp:
-            """
-            gcp-fips
-            """
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        1
-        """
-        When I run `pro disable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
-        """
-        Updating package lists
-        """
-        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
-        Then stdout matches regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I reboot the machine
-        And I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                disabled
-            """
-
-        Examples: ubuntu release
-           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | gcp.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | gcp.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | gcp.generic  | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | gcp.generic  | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type  | fips-name    | fips-service | fips-package      | fips-kernel | fips-apt-source                                |
+           | xenial  | azure.generic | FIPS         | fips         | ubuntu-fips       | fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | xenial  | azure.generic | FIPS Updates | fips-updates | ubuntu-fips       | fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | xenial  | aws.generic   | FIPS         | fips         | ubuntu-fips       | fips        | https://esm.ubuntu.com/fips/ubuntu xenial/main |
+           | bionic  | azure.generic | FIPS         | fips         | ubuntu-azure-fips | azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | azure.generic | FIPS Updates | fips-updates | ubuntu-azure-fips | azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | aws.generic   | FIPS         | fips         | ubuntu-aws-fips   | aws-fips    | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | aws.generic   | FIPS Updates | fips-updates | ubuntu-aws-fips   | aws-fips    | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | gcp.generic   | FIPS         | fips         | ubuntu-gcp-fips   | gcp-fips    | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | gcp.generic   | FIPS Updates | fips-updates | ubuntu-gcp-fips   | gcp-fips    | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | focal   | azure.generic | FIPS         | fips         | ubuntu-azure-fips | azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | azure.generic | FIPS Updates | fips-updates | ubuntu-azure-fips | azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | aws.generic   | FIPS         | fips         | ubuntu-aws-fips   | aws-fips    | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | aws.generic   | FIPS Updates | fips-updates | ubuntu-aws-fips   | aws-fips    | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | gcp.generic   | FIPS         | fips         | ubuntu-gcp-fips   | gcp-fips    | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | gcp.generic   | FIPS Updates | fips-updates | ubuntu-gcp-fips   | gcp-fips    | https://esm.ubuntu.com/fips/ubuntu focal/main  |
 
     @slow
     Scenario Outline: Attached enable of FIPS in an ubuntu image with cloud-init disabled

--- a/features/enable_fips_container.feature
+++ b/features/enable_fips_container.feature
@@ -7,32 +7,29 @@ Feature: FIPS enablement in lxd containers
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan openssl <libssl> libgcrypt20` with sudo, retrying exit [100]
         And I run `pro enable fips<updates>` `with sudo` and stdin `y`
         Then stdout matches regexp:
-            """
-            Warning: Enabling <fips-name> in a container.
-                     This will install the FIPS packages but not the kernel.
-                     This container must run on a host with <fips-name> enabled to be
-                     compliant.
-            Warning: This action can take some time and cannot be undone.
-            """
+        """
+        Warning: Enabling <fips-name> in a container.
+                 This will install the FIPS packages but not the kernel.
+                 This container must run on a host with <fips-name> enabled to be
+                 compliant.
+        Warning: This action can take some time and cannot be undone.
+        """
         And stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            Please run `apt upgrade` to ensure all FIPS packages are updated to the correct
-            version.
-            """
+        """
+        Updating <fips-name> package lists
+        Installing <fips-name> packages
+        Updating standard Ubuntu package lists
+        <fips-name> enabled
+        A reboot is required to complete install.
+        Please run `apt upgrade` to ensure all FIPS packages are updated to the correct
+        version.
+        """
+        And I verify that `fips<updates>` is enabled
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
-            """
-            fips<updates> +yes                enabled
-            """
-        And stdout matches regexp:
-            """
-            FIPS support requires system reboot to complete configuration
-            """
+        """
+        FIPS support requires system reboot to complete configuration
+        """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that `openssh-server` is installed from apt source `https://esm.ubuntu.com/fips<updates>/ubuntu <release><updates>/main`
         And I verify that `openssh-client` is installed from apt source `https://esm.ubuntu.com/fips<updates>/ubuntu <release><updates>/main`
@@ -45,36 +42,33 @@ Feature: FIPS enablement in lxd containers
         When I reboot the machine
         When I run `pro status --all` with sudo
         Then stdout does not match regexp:
-            """
-            FIPS support requires system reboot to complete configuration
-            """
+        """
+        FIPS support requires system reboot to complete configuration
+        """
         When I run `pro disable fips<updates>` `with sudo` and stdin `y`
         Then stdout matches regexp:
-            """
-            This will disable the <fips-name> entitlement but the <fips-name> packages will remain installed.
-            """
+        """
+        This will disable the <fips-name> entitlement but the <fips-name> packages will remain installed.
+        """
         And stdout matches regexp:
-            """
-            Updating package lists
-            """
+        """
+        Updating package lists
+        """
         And stdout does not match regexp:
-            """
-            A reboot is required to complete disable operation
-            """
+        """
+        A reboot is required to complete disable operation
+        """
+        And I verify that `fips<updates>` is disabled
         When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            fips<updates> +yes                disabled
-            """
         Then stdout does not match regexp:
-            """
-            Disabling <fips-name> requires system reboot to complete operation
-            """
+        """
+        Disabling <fips-name> requires system reboot to complete operation
+        """
         When I run `apt-cache policy ubuntu-fips` as non-root
         Then stdout does not match regexp:
-            """
-            .*Installed: \(none\)
-            """
+        """
+        .*Installed: \(none\)
+        """
         Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
         And I verify that `strongswan` installed version matches regexp `fips`
@@ -96,39 +90,27 @@ Feature: FIPS enablement in lxd containers
     Scenario Outline: Try to enable FIPS after FIPS Updates in a lxd container
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            fips-updates +yes +disabled
-            """
-        And stdout matches regexp:
-            """
-            fips +yes +disabled
-            """
+        Then I verify that `fips-updates` is disabled
+        And I verify that `fips` is disabled
         When I run `pro enable fips-updates --assume-yes` with sudo
+        Then I verify that `fips-updates` is enabled
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
-            """
-            fips-updates +yes +enabled
-            """
-        And stdout matches regexp:
-            """
-            fips +yes +n/a
-            """
+        """
+        fips +yes +n/a
+        """
         When I verify that running `pro enable fips --assume-yes` `with sudo` exits `1`
         Then stdout matches regexp:
-            """
-            Cannot enable FIPS when FIPS Updates is enabled.
-            """
+        """
+        Cannot enable FIPS when FIPS Updates is enabled.
+        """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
-            """
-            fips-updates +yes +enabled
-            """
-        And stdout matches regexp:
-            """
-            fips +yes +n/a
-            """
+        """
+        fips +yes +n/a
+        """
+        And I verify that `fips-updates` is enabled
+
         Examples: ubuntu release
            | release | machine_type  |
            | xenial  | lxd-container |

--- a/features/enable_fips_pro.feature
+++ b/features/enable_fips_pro.feature
@@ -1,173 +1,56 @@
 Feature: FIPS enablement in PRO cloud based machines
 
     @slow
-    Scenario Outline: Attached enable of FIPS in an ubuntu Azure PRO vm
+    Scenario Outline: Attached enable of FIPS in an ubuntu Aws PRO vm
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
         log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
         """
         And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` with sudo
-        Then stdout matches regexp:
-            """
-            fips          +yes +disabled +NIST-certified FIPS crypto packages
-            fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-            """
-            When I run `pro enable <fips-service> --assume-yes` with sudo
-            Then stdout contains substring:
-                """
-                Updating <fips-name> package lists
-                Installing <fips-name> packages
-                Updating standard Ubuntu package lists
-                <fips-name> enabled
-                A reboot is required to complete install.
-                """
-            When I run `pro status --all` with sudo
-            Then stdout matches regexp:
-                """
-                <fips-service> +yes                enabled
-                """
-            And I verify that running `apt update` `with sudo` exits `0`
-            And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-            When I run `apt-cache policy ubuntu-aws-fips` as non-root
-            Then stdout does not match regexp:
-            """
-            .*Installed: \(none\)
-            """
-            When I reboot the machine
-            And  I run `uname -r` as non-root
-            Then stdout matches regexp:
-                """
-                aws-fips
-                """
-            When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-            Then I will see the following on stdout:
-            """
-            1
-            """
-
-        Examples: ubuntu release
-           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | aws.pro      | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | aws.pro      | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | aws.pro      | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | aws.pro      | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-
-    @slow
-    Scenario Outline: Attached enable of FIPS in an ubuntu Azure PRO vm
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` with sudo
-        Then stdout matches regexp:
-            """
-            fips          +yes +disabled +NIST-certified FIPS crypto packages
-            fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-            """
-            When I run `pro enable <fips-service> --assume-yes` with sudo
-            Then stdout contains substring:
-                """
-                Updating <fips-name> package lists
-                Installing <fips-name> packages
-                Updating standard Ubuntu package lists
-                <fips-name> enabled
-                A reboot is required to complete install.
-                """
-            When I run `pro status --all` with sudo
-            Then stdout matches regexp:
-                """
-                <fips-service> +yes                enabled
-                """
-            And I verify that running `apt update` `with sudo` exits `0`
-            And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-            When I run `apt-cache policy ubuntu-azure-fips` as non-root
-            Then stdout does not match regexp:
-            """
-            .*Installed: \(none\)
-            """
-            When I reboot the machine
-            And  I run `uname -r` as non-root
-            Then stdout matches regexp:
-                """
-                azure-fips
-                """
-            When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-            Then I will see the following on stdout:
-            """
-            1
-            """
-
-        Examples: ubuntu release
-           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | azure.pro    | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | azure.pro    | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | azure.pro    | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | azure.pro    | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-
-
-    @slow
-    Scenario Outline: Attached enable of FIPS in an ubuntu GCP PRO vm
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` with sudo
-        Then stdout matches regexp:
-            """
-            fips          +yes +disabled +NIST-certified FIPS crypto packages
-            fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-            """
+        Then I verify that `fips` is disabled
+        And I verify that `fips-updates` is disabled
         When I run `pro enable <fips-service> --assume-yes` with sudo
         Then stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                enabled
-            """
+        """
+        Updating <fips-name> package lists
+        Installing <fips-name> packages
+        Updating standard Ubuntu package lists
+        <fips-name> enabled
+        A reboot is required to complete install
+        """
+        And I verify that `<fips-service>` is enabled
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
+        When I run `apt-cache policy <package-name>` as non-root
         Then stdout does not match regexp:
-            """
-            .*Installed: \(none\)
-            """
+        """
+        .*Installed: \(none\)
+        """
         When I reboot the machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            gcp-fips
-            """
+        """
+        <kernel-name>
+        """
         When I run `cat /proc/sys/crypto/fips_enabled` with sudo
         Then I will see the following on stdout:
-            """
-            1
-            """
+        """
+        1
+        """
 
         Examples: ubuntu release
-           | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
-           | bionic  | gcp.pro      | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | bionic  | gcp.pro      | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu bionic/main |
-           | focal   | gcp.pro      | FIPS         | fips         |https://esm.ubuntu.com/fips/ubuntu focal/main  |
-           | focal   | gcp.pro      | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type | fips-name    | fips-service | package-name      | kernel-name | fips-apt-source                                |
+           | bionic  | aws.pro      | FIPS         | fips         | ubuntu-aws-fips   | aws-fips    | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | aws.pro      | FIPS Updates | fips-updates | ubuntu-aws-fips   | aws-fips    | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | azure.pro    | FIPS         | fips         | ubuntu-azure-fips | azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | azure.pro    | FIPS Updates | fips-updates | ubuntu-azure-fips | azure-fips  | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | gcp.pro      | FIPS         | fips         | ubuntu-gcp-fips   | gcp-fips    | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | bionic  | gcp.pro      | FIPS Updates | fips-updates | ubuntu-gcp-fips   | gcp-fips    | https://esm.ubuntu.com/fips/ubuntu bionic/main |
+           | focal   | aws.pro      | FIPS         | fips         | ubuntu-aws-fips   | aws-fips    | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | aws.pro      | FIPS Updates | fips-updates | ubuntu-aws-fips   | aws-fips    | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | azure.pro    | FIPS         | fips         | ubuntu-azure-fips | azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | azure.pro    | FIPS Updates | fips-updates | ubuntu-azure-fips | azure-fips  | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | gcp.pro      | FIPS         | fips         | ubuntu-gcp-fips   | gcp-fips    | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | focal   | gcp.pro      | FIPS Updates | fips-updates | ubuntu-gcp-fips   | gcp-fips    | https://esm.ubuntu.com/fips/ubuntu focal/main  |

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -15,27 +15,23 @@ Feature: FIPS enablement in lxd VMs
         And I run `apt-mark hold openssh-client openssh-server strongswan` with sudo
         And I run `pro enable <fips-service>` `with sudo` and stdin `y`
         Then stdout matches regexp:
-            """
-            This will install the FIPS packages. The Livepatch service will be unavailable.
-            Warning: This action can take some time and cannot be undone.
-            """
+        """
+        This will install the FIPS packages. The Livepatch service will be unavailable.
+        Warning: This action can take some time and cannot be undone.
+        """
         And stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            """
+        """
+        Updating <fips-name> package lists
+        Installing <fips-name> packages
+        Updating standard Ubuntu package lists
+        <fips-name> enabled
+        A reboot is required to complete install.
+        """
         When I run `pro status --all` with sudo
         Then stdout matches regexp:
-            """
-            <fips-service> +yes                enabled
-            """
-        And stdout matches regexp:
-            """
-            FIPS support requires system reboot to complete configuration
-            """
+        """
+        FIPS support requires system reboot to complete configuration
+        """
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
@@ -98,11 +94,8 @@ Feature: FIPS enablement in lxd VMs
         openssh-server was already not hold.
         strongswan was already not hold.
         """
+        And I verify that `<fips-service>` is disabled
         When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-        """
-        <fips-service> +yes                disabled
-        """
         Then stdout does not match regexp:
         """
         Disabling FIPS requires system reboot to complete operation
@@ -120,11 +113,7 @@ Feature: FIPS enablement in lxd VMs
         """
         {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": true, "processed_services": ["<fips-service>"], "result": "success", "warnings": []}
         """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-        """
-        <fips-service> +yes                disabled
-        """
+        And I verify that `<fips-service>` is disabled
 
         Examples: ubuntu release
            | release | machine_type | fips-name    | fips-service |fips-apt-source                                |
@@ -139,23 +128,19 @@ Feature: FIPS enablement in lxd VMs
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         When I run `pro enable <fips-service>` `with sudo` and stdin `y`
         Then stdout matches regexp:
-            """
-            This will install the FIPS packages including security updates.
-            Warning: This action can take some time and cannot be undone.
-            """
+        """
+        This will install the FIPS packages including security updates.
+        Warning: This action can take some time and cannot be undone.
+        """
         And stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                enabled
-            """
+        """
+        Updating <fips-name> package lists
+        Installing <fips-name> packages
+        Updating standard Ubuntu package lists
+        <fips-name> enabled
+        A reboot is required to complete install.
+        """
+        And I verify that `<fips-service>` is enabled
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
@@ -168,13 +153,12 @@ Feature: FIPS enablement in lxd VMs
         """
         {"available": "no", "blocked_by": [{"name": "fips-updates", "reason": "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS Updates installs security patches that aren't officially certified.", "reason_code": "fips-updates-invalidates-fips"}], "description": "NIST-certified FIPS crypto packages", "description_override": null, "entitled": "yes", "name": "fips", "status": "n/a", "status_details": "Cannot enable FIPS when FIPS Updates is enabled.", "warning": null}
         """
-
         When I reboot the machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            fips
-            """
+        """
+        fips
+        """
         When I run `cat /proc/sys/crypto/fips_enabled` with sudo
         Then I will see the following on stdout:
         """
@@ -182,14 +166,14 @@ Feature: FIPS enablement in lxd VMs
         """
         When I run `pro disable <fips-service>` `with sudo` and stdin `y`
         Then stdout matches regexp:
-            """
-            This will disable the FIPS Updates entitlement but the FIPS Updates packages will remain installed.
-            """
+        """
+        This will disable the FIPS Updates entitlement but the FIPS Updates packages will remain installed.
+        """
         And stdout matches regexp:
-            """
-            Updating package lists
-            A reboot is required to complete disable operation
-            """
+        """
+        Updating package lists
+        A reboot is required to complete disable operation
+        """
         When I reboot the machine
         Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
@@ -204,39 +188,20 @@ Feature: FIPS enablement in lxd VMs
         openssh-server was already not hold.
         strongswan was already not hold.
         """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                disabled
-            """
+        And I verify that `<fips-service>` is disabled
         When I verify that running `pro enable fips --assume-yes` `with sudo` exits `1`
         Then stdout matches regexp:
-            """
-            Cannot enable FIPS because FIPS Updates was once enabled.
-            """
+        """
+        Cannot enable FIPS because FIPS Updates was once enabled.
+        """
         And I verify that files exist matching `/var/lib/ubuntu-advantage/services-once-enabled`
-
         When I run `pro enable <fips-service> --assume-yes` with sudo
-        When I reboot the machine
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes +enabled
-            """
-        Then stdout matches regexp:
-            """
-            livepatch +yes +disabled
-            """
+        And I reboot the machine
+        Then I verify that `<fips-service>` is enabled
+        And I verify that `livepatch` is disabled
         When I run `pro enable livepatch --assume-yes` with sudo
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes +enabled
-            """
-        Then stdout matches regexp:
-            """
-            livepatch +yes +enabled
-            """
+        Then I verify that `<fips-service>` is enabled
+        And I verify that `livepatch` is enabled
         When I run `pro status --all --format json` with sudo
         Then stdout contains substring:
         """
@@ -256,11 +221,7 @@ Feature: FIPS enablement in lxd VMs
         """
         {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": true, "processed_services": ["<fips-service>"], "result": "success", "warnings": []}
         """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                disabled
-            """
+        And I verify that `<fips-service>` is disabled
 
         Examples: ubuntu release
            | release | machine_type | fips-name    | fips-service |fips-apt-source                                                |
@@ -271,57 +232,37 @@ Feature: FIPS enablement in lxd VMs
     Scenario Outline: Attached enable FIPS-updates while livepatch is enabled
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            fips-updates +yes                disabled
-            """
-        Then stdout matches regexp:
-            """
-            livepatch +yes +<livepatch_status>
-            """
+        Then I verify that `fips-updates` is disabled
+        And I verify that `livepatch` is enabled
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then stdout contains substring:
-            """
-            Updating FIPS Updates package lists
-            Installing FIPS Updates packages
-            Updating standard Ubuntu package lists
-            FIPS Updates enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            fips-updates +yes                enabled
-            """
-        Then stdout matches regexp:
-            """
-            livepatch +yes +<livepatch_status>
-            """
+        """
+        Updating FIPS Updates package lists
+        Installing FIPS Updates packages
+        Updating standard Ubuntu package lists
+        FIPS Updates enabled
+        A reboot is required to complete install.
+        """
+        And I verify that `fips-updates` is enabled
+        And I verify that `livepatch` is enabled
         When I reboot the machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            fips
-            """
+        """
+        fips
+        """
         When I run `cat /proc/sys/crypto/fips_enabled` with sudo
         Then I will see the following on stdout:
         """
         1
         """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            fips-updates +yes                enabled
-            """
-        Then stdout matches regexp:
-            """
-            livepatch +yes +enabled
-            """
+        And I verify that `fips-updates` is enabled
+        And I verify that `livepatch` is enabled
+
         Examples: ubuntu release
-           | release | machine_type | livepatch_status |
-           | xenial  | lxd-vm       | warning          |
-           | bionic  | lxd-vm       | enabled          |
+           | release | machine_type |
+           | xenial  | lxd-vm       |
+           | bionic  | lxd-vm       |
 
     @slow
     Scenario Outline: Attached enable of FIPS in an ubuntu lxd vm
@@ -330,18 +271,14 @@ Feature: FIPS enablement in lxd VMs
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         When I run `pro enable <fips-service> --assume-yes` with sudo
         Then stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                enabled
-            """
+        """
+        Updating <fips-name> package lists
+        Installing <fips-name> packages
+        Updating standard Ubuntu package lists
+        <fips-name> enabled
+        A reboot is required to complete install.
+        """
+        And I verify that `<fips-service>` is enabled
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
@@ -350,9 +287,9 @@ Feature: FIPS enablement in lxd VMs
         When I reboot the machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            fips
-            """
+        """
+        fips
+        """
         When I run `cat /proc/sys/crypto/fips_enabled` with sudo
         Then I will see the following on stdout:
         """
@@ -360,10 +297,10 @@ Feature: FIPS enablement in lxd VMs
         """
         When I run `pro disable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
-            """
-            Updating package lists
-            A reboot is required to complete disable operation
-            """
+        """
+        Updating package lists
+        A reboot is required to complete disable operation
+        """
         When I reboot the machine
         Then I verify that `openssh-server` installed version matches regexp `fips`
         And I verify that `openssh-client` installed version matches regexp `fips`
@@ -376,11 +313,7 @@ Feature: FIPS enablement in lxd VMs
         openssh-server was already not hold.
         strongswan was already not hold.
         """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                disabled
-            """
+        And I verify that `<fips-service>` is disabled
 
         Examples: ubuntu release
            | release | machine_type | fips-name    | fips-service |fips-apt-source                               |
@@ -393,18 +326,14 @@ Feature: FIPS enablement in lxd VMs
         And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         When I run `pro enable <fips-service> --assume-yes` with sudo
         Then stdout contains substring:
-            """
-            Updating <fips-name> package lists
-            Installing <fips-name> packages
-            Updating standard Ubuntu package lists
-            <fips-name> enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            <fips-service> +yes                enabled
-            """
+        """
+        Updating <fips-name> package lists
+        Installing <fips-name> packages
+        Updating standard Ubuntu package lists
+        <fips-name> enabled
+        A reboot is required to complete install.
+        """
+        And I verify that `<fips-service>` is enabled
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
         And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
@@ -413,9 +342,9 @@ Feature: FIPS enablement in lxd VMs
         When I reboot the machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            fips
-            """
+        """
+        fips
+        """
         When I run `cat /proc/sys/crypto/fips_enabled` with sudo
         Then I will see the following on stdout:
         """
@@ -423,37 +352,34 @@ Feature: FIPS enablement in lxd VMs
         """
         When I run `pro disable <fips-service> --assume-yes` with sudo
         Then stdout matches regexp:
-            """
-            Updating package lists
-            A reboot is required to complete disable operation
-            """
+        """
+        Updating package lists
+        A reboot is required to complete disable operation
+        """
         When I reboot the machine
-        Then I verify that `openssh-server` installed version matches regexp `fips`
-        And I verify that `openssh-client` installed version matches regexp `fips`
-        And I verify that `strongswan` installed version matches regexp `fips`
-        And I verify that `strongswan-hmac` installed version matches regexp `fips`
+        Then I verify that `openssh-server` installed version matches regexp `<fips-package-str>`
+        And I verify that `openssh-client` installed version matches regexp `<fips-package-str>`
+        And I verify that `strongswan` installed version matches regexp `<fips-package-str>`
+        And I verify that `strongswan-hmac` installed version matches regexp `<fips-package-str>`
         When I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
-        Then I will see the following on stdout:
-        """
-        openssh-client was already not hold.
-        openssh-server was already not hold.
-        strongswan was already not hold.
-        """
-        When I run `pro status --all` with sudo
         Then stdout matches regexp:
-            """
-            <fips-service> +yes                disabled
-            """
+        """
+        openssh-client was already (not|not on) hold.
+        openssh-server was already (not|not on) hold.
+        strongswan was already (not|not on) hold.
+        """
+        And I verify that `<fips-service>` is disabled
         When I verify that running `pro enable fips --assume-yes` `with sudo` exits `1`
         Then stdout matches regexp:
-            """
-            Cannot enable FIPS because FIPS Updates was once enabled.
-            """
+        """
+        Cannot enable FIPS because FIPS Updates was once enabled.
+        """
         And I verify that files exist matching `/var/lib/ubuntu-advantage/services-once-enabled`
 
         Examples: ubuntu release
-           | release | machine_type | fips-name    | fips-service |fips-apt-source                                               |
-           | focal   | lxd-vm       | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main |
+           | release | machine_type | fips-name    | fips-service | fips-package-str | fips-apt-source                                               |
+           | focal   | lxd-vm       | FIPS Updates | fips-updates | fips             | https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main |
+           | jammy   | lxd-vm       | FIPS Updates | fips-updates | Fips             | https://esm.ubuntu.com/fips-updates/ubuntu jammy-updates/main |
 
     @slow
     Scenario Outline: Attached enable fips-updates on fips enabled vm
@@ -461,69 +387,54 @@ Feature: FIPS enablement in lxd VMs
         When I attach `contract_token` with sudo
         And I run `pro enable fips --assume-yes` with sudo
         Then stdout contains substring:
-            """
-            Updating FIPS package lists
-            Installing FIPS packages
-            Updating standard Ubuntu package lists
-            FIPS enabled
-            A reboot is required to complete install.
-            """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            fips +yes                enabled
-            """
+        """
+        Updating FIPS package lists
+        Installing FIPS packages
+        Updating standard Ubuntu package lists
+        FIPS enabled
+        A reboot is required to complete install.
+        """
+        And I verify that `fips` is enabled
+        And I verify that `livepatch` is disabled
         When I reboot the machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
-            """
-            fips
-            """
+        """
+        fips
+        """
         When I verify that running `pro enable fips-updates --assume-yes` `with sudo` exits `0`
         Then stdout contains substring:
-            """
-            One moment, checking your subscription first
-            Disabling incompatible service: FIPS
-            Updating FIPS Updates package lists
-            Installing FIPS Updates packages
-            Updating standard Ubuntu package lists
-            FIPS Updates enabled
-            A reboot is required to complete install.
-            """
-            When I run `pro status --all` with sudo
-            Then stdout matches regexp:
-                """
-                fips-updates +yes                enabled
-                """
-            And stdout matches regexp:
-                """
-                fips +yes                n/a
-                """
-            When I reboot the machine
-            And  I run `pro enable livepatch` with sudo
-            And I run `pro status --all` with sudo
-            Then stdout matches regexp:
-                """
-                fips-updates +yes                enabled
-                """
-            And stdout matches regexp:
-                """
-                fips +yes                n/a
-                """
-            And stdout matches regexp:
-                """
-                livepatch +yes                (enabled|warning)
-                """
-            When  I run `uname -r` as non-root
-            Then stdout matches regexp:
-                """
-                fips
-                """
-            When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-            Then I will see the following on stdout:
-            """
-            1
-            """
+        """
+        One moment, checking your subscription first
+        Disabling incompatible service: FIPS
+        Updating FIPS Updates package lists
+        Installing FIPS Updates packages
+        Updating standard Ubuntu package lists
+        FIPS Updates enabled
+        A reboot is required to complete install.
+        """
+        And I verify that `fips-updates` is enabled
+        And I verify that `fips` is disabled
+        When I reboot the machine
+        And  I run `pro enable livepatch` with sudo
+        Then I verify that `fips-updates` is enabled
+        And I verify that `fips` is disabled
+        And I verify that `livepatch` is enabled
+        When I run `pro status --all` with sudo
+        Then stdout matches regexp:
+        """
+        fips +yes +n/a
+        """
+        When  I run `uname -r` as non-root
+        Then stdout matches regexp:
+        """
+        fips
+        """
+        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+        Then I will see the following on stdout:
+        """
+        1
+        """
 
         Examples: ubuntu release
            | release | machine_type |
@@ -536,64 +447,24 @@ Feature: FIPS enablement in lxd VMs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I delete the file `/run/cloud-init/instance-data.json`
         And I attach `contract_token` with sudo
-        And I run `pro disable livepatch` with sudo
         And I run `pro enable fips --assume-yes` with sudo
         Then stdout matches regexp:
         """
         Could not determine cloud, defaulting to generic FIPS package.
         """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-        """
-        fips +yes                enabled
-        """
+        And I verify that `fips` is enabled
 
         Examples: ubuntu release
         | release | machine_type |
         | xenial  | lxd-vm       |
         | bionic  | lxd-vm       |
-
-    @slow
-    Scenario Outline: FIPS enablement message when cloud init didn't run properly
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I delete the file `/run/cloud-init/instance-data.json`
-        And I attach `contract_token` with sudo
-        And I run `pro enable fips --assume-yes` with sudo
-        Then stdout matches regexp:
-        """
-        Could not determine cloud, defaulting to generic FIPS package.
-        """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-        """
-        fips +yes                enabled
-        """
-
-        Examples: ubuntu release
-        | release | machine_type |
         | focal   | lxd-vm       |
-
 
     @slow
     Scenario Outline: Attached enable fips-preview
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I set the machine token overlay to the following yaml
-        """
-        availableResources:
-          - available: true
-            name: fips-preview
-        machineTokenInfo:
-          contractInfo:
-            resourceEntitlements:
-              - type: fips-preview
-                entitled: true
-        """
-        And I attach `contract_token` with sudo
-        And I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        fips-preview +yes +disabled +.*
-        """
+        When I attach `contract_token` with sudo
+        Then I verify that `fips-preview` is disabled
         When I verify that running `pro enable fips-preview` `with sudo` and stdin `N` exits `1`
         Then stdout matches regexp:
         """
@@ -620,73 +491,3 @@ Feature: FIPS enablement in lxd VMs
         Examples: ubuntu release
            | release | machine_type |
            | jammy   | lxd-vm       |
-
-    @slow
-    Scenario Outline: Attached enable of FIPS-updates in an ubuntu lxd vm
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
-        And I run `apt update` with sudo
-        And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
-        When I run `pro enable <fips-service> --assume-yes` with sudo
-        Then stdout contains substring:
-        """
-        Updating <fips-name> package lists
-        Installing <fips-name> packages
-        Updating standard Ubuntu package lists
-        <fips-name> enabled
-        A reboot is required to complete install.
-        """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-        """
-        <fips-service> +yes                enabled
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
-        When I reboot the machine
-        And  I run `uname -r` as non-root
-        Then stdout matches regexp:
-        """
-        fips
-        """
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        1
-        """
-        When I run `pro disable <fips-service> --assume-yes` with sudo
-        Then stdout matches regexp:
-        """
-        Updating package lists
-        A reboot is required to complete disable operation
-        """
-        When I reboot the machine
-        Then I verify that `openssh-server` installed version matches regexp `Fips`
-        And I verify that `openssh-client` installed version matches regexp `Fips`
-        And I verify that `strongswan` installed version matches regexp `Fips`
-        And I verify that `strongswan-hmac` installed version matches regexp `Fips`
-        When I run `apt-mark unhold openssh-client openssh-server strongswan` with sudo
-        Then I will see the following on stdout:
-        """
-        openssh-client was already not on hold.
-        openssh-server was already not on hold.
-        strongswan was already not on hold.
-        """
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-        """
-        <fips-service> +yes                disabled
-        """
-        When I verify that running `pro enable fips --assume-yes` `with sudo` exits `1`
-        Then stdout matches regexp:
-        """
-        Cannot enable FIPS because FIPS Updates was once enabled.
-        """
-        And I verify that files exist matching `/var/lib/ubuntu-advantage/services-once-enabled`
-
-        Examples: ubuntu release
-           | release | machine_type | fips-name    | fips-service |fips-apt-source                                                       |
-           | jammy   | lxd-vm       | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu jammy-updates/main |

--- a/features/landscape.feature
+++ b/features/landscape.feature
@@ -66,6 +66,7 @@ Feature: Enable landscape on Ubuntu
         """
         # This will become obsolete soon: #2864
         When I run `pro status` with sudo
+        # I am keeping this check until the non-root landscape-config check works as expected
         Then stdout matches regexp:
         """
         landscape +yes +warning
@@ -99,6 +100,7 @@ Feature: Enable landscape on Ubuntu
         """
         # This will become obsolete soon: #2864
         When I run `pro status` with sudo
+        # I am keeping this check until the non-root landscape-config check works as expected
         Then stdout matches regexp:
         """
         landscape +yes +warning
@@ -174,16 +176,11 @@ Feature: Enable landscape on Ubuntu
         Installing landscape-client
         Executing `landscape-config`
         """
-        Then stderr contains substring:
+        And stderr contains substring:
         """
         Invalid account name or registration key.
         """
-        # This will become obsolete soon: #2864
         When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        landscape +yes +warning
-        """
         Then stdout contains substring:
         """
         Landscape is installed and configured but not registered.

--- a/features/landscape.feature
+++ b/features/landscape.feature
@@ -26,22 +26,10 @@ Feature: Enable landscape on Ubuntu
         """
         Registration request sent successfully.
         """
-        When I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        landscape +yes +enabled
-        """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        landscape +yes +enabled
-        """
+        And I verify that `landscape` is enabled
+
         When I run `sudo pro disable landscape` with sudo
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        landscape +yes +disabled
-        """
+        Then I verify that `landscape` is disabled
 
         # Enable with assume-yes
         When I run `pro enable landscape --assume-yes -- --computer-title $behave_var{machine-name system-under-test} --account-name pro-client-qa --registration-key $behave_var{config landscape_registration_key}` with sudo
@@ -53,19 +41,11 @@ Feature: Enable landscape on Ubuntu
         Executing `landscape-config --computer-title $behave_var{machine-name system-under-test} --account-name pro-client-qa --registration-key <REDACTED> --silent`
         Landscape enabled
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        landscape +yes +enabled
-        """
+        And I verify that `landscape` is enabled
 
         # stopping the service effectively disables it
         When I run `systemctl stop landscape-client` with sudo
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        landscape +yes +disabled
-        """
+        Then I verify that `landscape` is disabled
         When I verify that running `sudo pro disable landscape` `with sudo` exits `1`
         Then I will see the following on stdout:
         """
@@ -108,11 +88,7 @@ Feature: Enable landscape on Ubuntu
         """
         {"_schema_version": "0.1", "errors": [], "failed_services": [], "needs_reboot": false, "processed_services": ["landscape"], "result": "success", "warnings": []}
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        landscape +yes +enabled
-        """
+        And I verify that `landscape` is enabled
         When I run `sudo pro disable landscape` with sudo
 
         # Fail to enable with assume-yes and format json
@@ -177,11 +153,7 @@ Feature: Enable landscape on Ubuntu
         """
         Registration request sent successfully.
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        landscape +yes +enabled
-        """
+        And I verify that `landscape` is enabled
         When I run `pro disable landscape` with sudo
 
         When I verify that running `pro enable landscape` `with sudo` and the following stdin exits `1`

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -118,11 +118,7 @@ Feature: Livepatch
         """
         <old_kernel_version>
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        livepatch +yes +enabled +Canonical Livepatch service
-        """
+        And I verify that `livepatch` is enabled
         Then stdout does not contain substring:
         """
         NOTICES
@@ -173,10 +169,8 @@ Feature: Livepatch
         When I reboot the machine
         When I attach `contract_token` with sudo
         When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        livepatch +yes +enabled +Canonical Livepatch service
-        """
+        Then I verify that `livepatch` is enabled
+
         Examples: ubuntu release
             | release | machine_type | release_num |
             | jammy   | lxd-vm       | 22.04       |

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -99,11 +99,8 @@ Feature: Livepatch
         """
         <old_kernel_version>
         """
+        And I verify that `livepatch` status is warning
         When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        livepatch +yes +warning +Canonical Livepatch service
-        """
         Then stdout contains substring:
         """
         NOTICES

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -4,12 +4,12 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: Attach command when proxy is configured for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
-            """
+        """
+        dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         And I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
@@ -39,8 +39,7 @@ Feature: Proxy configuration
         """
         .*CONNECT contracts.canonical.com.*
         """
-        When I run `pro status` with sudo
-        Then the machine is attached
+        And the machine is attached
         When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I run `pro config set ua_apt_http_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
@@ -158,12 +157,12 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: Attach command when proxy is configured
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
-            """
+        """
+        dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         And I run `pro config set http_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
         And I run `pro config set https_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
@@ -200,11 +199,11 @@ Feature: Proxy configuration
         """
         When I run `pro refresh config` with sudo
         Then I will see the following on stdout:
-            """
-            Setting snap proxy
-            Setting Livepatch proxy
-            Successfully processed your pro configuration.
-            """
+        """
+        Setting snap proxy
+        Setting Livepatch proxy
+        Successfully processed your pro configuration.
+        """
         When I create the file `/var/lib/ubuntu-advantage/user-config.json` with the following:
         """
         {
@@ -253,14 +252,14 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: Attach command when authenticated proxy is configured for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
-            """
+        """
+        dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         And I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
@@ -347,14 +346,14 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: Attach command when authenticated proxy is configured
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
-            """
+        """
+        dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         And I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
@@ -396,12 +395,12 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: Attach command when proxy is configured manually via conf file for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
-            """
+        """
+        dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         When I create the file `/var/lib/ubuntu-advantage/user-config.json` with the following:
         """
@@ -418,8 +417,7 @@ Feature: Proxy configuration
         """
         .*CONNECT contracts.canonical.com.*
         """
-        When I run `pro status` with sudo
-        Then the machine is attached
+        And the machine is attached
         When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         When I create the file `/var/lib/ubuntu-advantage/user-config.json` with the following:
         """
@@ -536,14 +534,14 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: Attach command when authenticated proxy is configured manually for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
-            """
+        """
+        dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         When I create the file `/var/lib/ubuntu-advantage/user-config.json` with the following:
         """
@@ -610,12 +608,12 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: Attach command when proxy is configured globally
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
-            """
+        """
+        dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         And I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
@@ -650,8 +648,7 @@ Feature: Proxy configuration
         """
         .*CONNECT contracts.canonical.com.*
         """
-        When I run `pro status` with sudo
-        Then the machine is attached
+        And the machine is attached
         When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         And I run `pro config set global_apt_http_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
@@ -770,14 +767,14 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: Attach command when authenticated proxy is configured globally
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt update` `with sudo` on the `proxy` machine
         And I run `apt install squid apache2-utils -y` `with sudo` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
-            """
+        """
+        dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         And I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
@@ -868,12 +865,12 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: Get warning when configuring global or uaclient proxy
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
-            """
+        """
+        dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         And I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
@@ -1019,7 +1016,7 @@ Feature: Proxy configuration
     @slow
     Scenario Outline: apt_http(s)_proxy still works
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
         """
@@ -1155,23 +1152,20 @@ Feature: Proxy configuration
     Scenario: Enable realtime kernel through proxy on a machine with no internet
         Given a `jammy` `lxd-vm` machine with ubuntu-advantage-tools installed
         When I disable any internet connection on the machine
-        Given a `focal` machine named `proxy`
+        Given a `focal` `lxd-container` machine named `proxy`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
-            """
+        """
+        dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_access allow all
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         And I run `pro config set https_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
         And I run `pro config set http_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
         And I run `pro config set global_apt_http_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
         And I run `pro config set global_apt_https_proxy=http://$behave_var{machine-ip proxy}:3128` with sudo
         And I attach `contract_token` with sudo
-        Then stdout matches regexp:
-        """
-        esm-apps     +yes      +enabled      +Expanded Security Maintenance for Applications
-        esm-infra     +yes      +enabled      +Expanded Security Maintenance for Infrastructure
-        """
+        Then I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
         When I run `pro disable livepatch --assume-yes` with sudo
         When I run `pro enable realtime-kernel` `with sudo` and stdin `y`
         Then stdout contains substring:

--- a/features/reboot_cmds.feature
+++ b/features/reboot_cmds.feature
@@ -7,7 +7,6 @@ Feature: Reboot Commands
         When I run `apt install -y strongswan` with sudo
         When I run `pro enable fips --assume-yes` with sudo
         When I reboot the machine
-        When I run `pro status` with sudo
         Then I verify that `fips` is enabled
         When I run `apt install -y --allow-downgrades strongswan=<old_version>` with sudo
         When I run `apt-mark hold strongswan` with sudo

--- a/features/reboot_cmds.feature
+++ b/features/reboot_cmds.feature
@@ -8,10 +8,7 @@ Feature: Reboot Commands
         When I run `pro enable fips --assume-yes` with sudo
         When I reboot the machine
         When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        fips +yes +enabled
-        """
+        Then I verify that `fips` is enabled
         When I run `apt install -y --allow-downgrades strongswan=<old_version>` with sudo
         When I run `apt-mark hold strongswan` with sudo
         When I run `dpkg-reconfigure ubuntu-advantage-tools` with sudo

--- a/features/steps/status.py
+++ b/features/steps/status.py
@@ -1,6 +1,9 @@
-from behave import when
+import json
+
+from behave import then, when
 
 from features.steps.shell import when_i_run_command
+from features.util import SUT
 
 
 @when("I do a preflight check for `{contract_token}` {user_spec}")
@@ -28,3 +31,46 @@ def when_i_attempt_preflight(context, contract_token, user_spec, exit_codes):
 
     expected_codes = exit_codes.split(",")
     assert str(context.process.returncode) in expected_codes
+
+
+def get_enabled_services(context, machine_name=SUT):
+    when_i_run_command(
+        context,
+        "pro api u.pro.status.enabled_services.v1",
+        "as non-root",
+        machine_name=machine_name,
+    )
+
+    data = json.loads(context.process.stdout.strip())
+    enabled_services = []
+    for enabled_service in data["data"]["attributes"]["enabled_services"]:
+        if enabled_service["variant_enabled"]:
+            enabled_services.append(enabled_service["variant_name"])
+        else:
+            enabled_services.append(enabled_service["name"])
+
+    return enabled_services
+
+
+@then("I verify that `{service}` is disabled")
+def i_verify_that_service_is_disabled(context, service):
+    enabled_services = get_enabled_services(context)
+
+    if service in enabled_services:
+        raise AssertionError(
+            "Expected {} to not be enabled\nEnabled services: {}".format(
+                service, ", ".join(enabled_services)
+            )
+        )
+
+
+@then("I verify that `{service}` is enabled")
+def i_verify_that_service_is_enabled(context, service):
+    enabled_services = get_enabled_services(context)
+
+    if service not in enabled_services:
+        raise AssertionError(
+            "Expected {} to be enabled\nEnabled services: {}".format(
+                service, ", ".join(enabled_services)
+            )
+        )

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -215,7 +215,7 @@ def when_i_create_local_ppas(context, release, next_release):
     from features.steps.machines import given_a_machine
 
     # We need Kinetic or greater to support zstd when creating the PPAs
-    given_a_machine(context, "mantic", machine_name="ppa")
+    given_a_machine(context, "mantic", "lxd-container", machine_name="ppa")
     when_i_run_command(
         context, "apt-get update", "with sudo", machine_name="ppa"
     )

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -5,59 +5,32 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         Given a `focal` `<machine_type>` machine named `proxy` with ingress ports `3389`
         When I run `apt install squid -y` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
-            """
-            dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_port 3389\nhttp_access allow all
-            """
+        """
+        dns_v4_first on\nacl all src 0.0.0.0\/0\nhttp_port 3389\nhttp_access allow all
+        """
         And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
         # This also tests that legacy `ua_config` settings still work
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
         log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
         ua_config:
           http_proxy: http://$behave_var{machine-ip proxy}:3389
           https_proxy: http://$behave_var{machine-ip proxy}:3389
         """
         And I verify `/var/log/squid/access.log` is empty on `proxy` machine
         When I run `pro auto-attach` with sudo
-        When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-            """
-            SERVICE       +ENTITLED +STATUS +DESCRIPTION
-            anbox-cloud   +(yes|no)  .*
-            cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
-            """
-        Then stdout matches regexp:
-            """
-            esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-            esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-            fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
-            fips-preview  +yes  +n/a      +.*
-            fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
-            livepatch     +yes +<livepatch-s>  +<lp-desc>
-            """
-        Then stdout matches regexp:
-            """
-            <cis_or_usg>           +yes  +<cis-s>  +Security compliance and audit tools
-            """
+        Then I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
+        And I verify that `livepatch` is enabled
         When I run `pro enable <cis_or_usg>` with sudo
-        And I run `pro status` with sudo
-        Then stdout matches regexp:
-            """
-            <cis_or_usg>         +yes    +enabled   +Security compliance and audit tools
-            """
+        Then I verify that `<cis_or_usg>` is enabled
         When I run `pro disable <cis_or_usg>` with sudo
         Then stdout matches regexp:
-            """
-            Updating package lists
-            """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-            """
-            <cis_or_usg>         +yes    +disabled   +Security compliance and audit tools
-            """
+        """
+        Updating package lists
+        """
+        And I verify that `<cis_or_usg>` is disabled
         When I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
         Then stdout matches regexp:
         """
@@ -71,6 +44,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
         .*CONNECT metadata.*
         """
+
         Examples: ubuntu release
            | release | machine_type | fips-s   | cc-eal-s | cis-s    | livepatch-s | lp-desc                         | cis_or_usg |
            | xenial  | aws.pro      | disabled | disabled | disabled | enabled     | Canonical Livepatch service     | cis        |
@@ -83,56 +57,17 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
            | focal   | azure.pro    | disabled | n/a      | disabled | enabled     | Canonical Livepatch service     | usg        |
            | focal   | gcp.pro      | disabled | n/a      | disabled | enabled     | Canonical Livepatch service     | usg        |
 
-    Scenario Outline: Attached refresh in an Ubuntu pro AWS machine
+    Scenario Outline: Attached refresh in an Ubuntu pro cloud machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
         log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
         """
         And I run `pro auto-attach` with sudo
-        And I run `pro status --all --wait` as non-root
-        Then stdout matches regexp:
-        """
-        SERVICE       +ENTITLED +STATUS +DESCRIPTION
-        anbox-cloud   +(yes|no)  .*
-        cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
-        """
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
-        fips-preview  +yes +<fips-p> +.*
-        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
-        livepatch     +yes +<livepatch-s>  +(Canonical Livepatch service|Current kernel is not supported)
-        """
-        Then stdout matches regexp:
-        """
-        <cis_or_usg>           +yes  +<cis-s>  +Security compliance and audit tools
-        """
-        When I run `pro status --all` as non-root
-        Then stdout matches regexp:
-        """
-        SERVICE       +ENTITLED +STATUS +DESCRIPTION
-        anbox-cloud   +(yes|no)  .*
-        cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
-        """
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
-        fips-preview  +yes +<fips-p> +.*
-        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
-        livepatch     +yes +<livepatch-s>  +(Canonical Livepatch service|Current kernel is not supported)
-        """
-        Then stdout matches regexp:
-        """
-        <cis_or_usg>           +yes  +<cis-s>  +Security compliance and audit tools
-        """
+        Then I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
+        And I verify that `livepatch` is enabled
         When I run `systemctl start ua-auto-attach.service` with sudo
         And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
         Then stdout matches regexp:
@@ -203,263 +138,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
         """
 
         Examples: ubuntu release
-           | release | machine_type | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | cis_or_usg | livepatch-s | fips-p   |
-           | xenial  | aws.pro      | disabled | disabled | disabled | libkrad0  | jq       | cis        | enabled     | n/a      |
-           | bionic  | aws.pro      | disabled | disabled | disabled | libkrad0  | bundler  | cis        | enabled     | n/a      |
-           | focal   | aws.pro      | disabled | n/a      | disabled | hello     | ant      | usg        | enabled     | n/a      |
-           | jammy   | aws.pro      | n/a      | n/a      | disabled | hello     | hello    | usg        | warning     | disabled |
-
-    Scenario Outline: Attached refresh in an Ubuntu pro Azure machine
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --all --wait` as non-root
-        Then stdout matches regexp:
-        """
-        SERVICE       +ENTITLED +STATUS +DESCRIPTION
-        anbox-cloud   +(yes|no)  .*
-        cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
-        """
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
-        fips-preview  +yes +<fips-p> +.*
-        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
-        livepatch     +yes +<livepatch>  +Canonical Livepatch service
-        """
-        Then stdout matches regexp:
-        """
-        <cis_or_usg>           +yes +<cis-s> +Security compliance and audit tools
-        """
-        When I run `pro status --all` as non-root
-        Then stdout matches regexp:
-        """
-        SERVICE      +ENTITLED +STATUS +DESCRIPTION
-        anbox-cloud   +(yes|no)  .*
-        cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
-        """
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
-        fips-preview  +yes +<fips-p> +.*
-        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
-        livepatch     +yes +<livepatch>  +Canonical Livepatch service
-        """
-        Then stdout matches regexp:
-        """
-        <cis_or_usg>           +yes  +<cis-s>  +Security compliance and audit tools
-        """
-        When I run `systemctl start ua-auto-attach.service` with sudo
-        And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
-        Then stdout matches regexp:
-        """
-        .*status=0\/SUCCESS.*
-        """
-        And stdout matches regexp:
-        """
-        Active: inactive \(dead\).*
-        \s*Condition: start condition failed.*
-        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
-        """
-        When I verify that running `pro auto-attach` `with sudo` exits `2`
-        Then stderr matches regexp:
-        """
-        This machine is already attached to '.*'
-        To use a different subscription first run: sudo pro detach.
-        """
-        When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        When I run `apt install -y <infra-pkg>/<release>-infra-security` with sudo, retrying exit [100]
-        And I run `apt-cache policy <infra-pkg>` as non-root
-        Then stdout matches regexp:
-        """
-        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
-        """
-        And stdout matches regexp:
-        """
-        Installed: .*[~+]esm
-        """
-        When I run `apt install -y <apps-pkg>/<release>-apps-security` with sudo, retrying exit [100]
-        And I run `apt-cache policy <apps-pkg>` as non-root
-        Then stdout matches regexp:
-        """
-        Version table:
-        \s*\*\*\* .* 510
-        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
-        """
-        When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
-        """
-        """
-        And I reboot the machine
-        And  I verify that running `systemctl status ua-reboot-cmds.service` `as non-root` exits `0,3`
-        Then stdout matches regexp:
-        """
-        .*status=0\/SUCCESS.*
-        """
-        When I run `ua api u.pro.attach.auto.should_auto_attach.v1` with sudo
-        Then stdout matches regexp:
-        """
-        {"_schema_version": "v1", "data": {"attributes": {"should_auto_attach": true}, "meta": {"environment_vars": \[\]}, "type": "ShouldAutoAttach"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
-        """
-
-        Examples: ubuntu release
-           | release | machine_type | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | livepatch | cis_or_usg | fips-p   |
-           | xenial  | azure.pro    | disabled | disabled | disabled | libkrad0  | jq       | enabled   | cis        | n/a      |
-           | bionic  | azure.pro    | disabled | disabled | disabled | libkrad0  | bundler  | enabled   | cis        | n/a      |
-           | focal   | azure.pro    | disabled | n/a      | disabled | hello     | ant      | enabled   | usg        | n/a      |
-           | jammy   | azure.pro    | n/a      | n/a      | disabled | hello     | hello    | enabled   | usg        | disabled |
-
-    Scenario Outline: Attached refresh in an Ubuntu pro GCP machine
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --all --wait` as non-root
-        Then stdout matches regexp:
-        """
-        SERVICE       +ENTITLED +STATUS +DESCRIPTION
-        anbox-cloud   +(yes|no)  .*
-        cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
-        """
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
-        fips-preview  +yes +<fips-p> +.*
-        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
-        livepatch     +yes +<livepatch>  +<lp-desc>
-        """
-        Then stdout matches regexp:
-        """
-        <cis_or_usg>           +yes +<cis-s> +Security compliance and audit tools
-        """
-        When I run `pro status --all` as non-root
-        Then stdout matches regexp:
-        """
-        SERVICE       +ENTITLED +STATUS +DESCRIPTION
-        anbox-cloud   +(yes|no)  .*
-        cc-eal        +yes +<cc-eal-s>  +Common Criteria EAL2 Provisioning Packages
-        """
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +<fips-s> +NIST-certified FIPS crypto packages
-        fips-preview  +yes +<fips-p> +.*
-        fips-updates  +yes +<fips-s> +FIPS compliant crypto packages with stable security updates
-        livepatch     +yes +<livepatch>  +<lp-desc>
-        """
-        Then stdout matches regexp:
-        """
-        <cis_or_usg>           +yes  +<cis-s>  +Security compliance and audit tools
-        """
-        When I run `systemctl start ua-auto-attach.service` with sudo
-        And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
-        Then stdout matches regexp:
-        """
-        .*status=0\/SUCCESS.*
-        """
-        And stdout matches regexp:
-        """
-        Active: inactive \(dead\).*
-        \s*Condition: start condition failed.*
-        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
-        """
-        When I verify that running `pro auto-attach` `with sudo` exits `2`
-        Then stderr matches regexp:
-        """
-        This machine is already attached to '.*'
-        To use a different subscription first run: sudo pro detach.
-        """
-        When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        When I run `apt install -y <infra-pkg>/<release>-infra-security` with sudo, retrying exit [100]
-        And I run `apt-cache policy <infra-pkg>` as non-root
-        Then stdout matches regexp:
-        """
-        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
-        """
-        And stdout matches regexp:
-        """
-        Installed: .*[~+]esm
-        """
-        When I run `apt install -y <apps-pkg>/<release>-apps-security` with sudo, retrying exit [100]
-        And I run `apt-cache policy <apps-pkg>` as non-root
-        Then stdout matches regexp:
-        """
-        Version table:
-        \s*\*\*\* .* 510
-        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
-        """
-        When I create the file `/var/lib/ubuntu-advantage/marker-reboot-cmds-required` with the following:
-        """
-        """
-        And I reboot the machine
-        And  I verify that running `systemctl status ua-reboot-cmds.service` `as non-root` exits `0,3`
-        Then stdout matches regexp:
-        """
-        .*status=0\/SUCCESS.*
-        """
-        When I run `ua api u.pro.attach.auto.should_auto_attach.v1` with sudo
-        Then stdout matches regexp:
-        """
-        {"_schema_version": "v1", "data": {"attributes": {"should_auto_attach": true}, "meta": {"environment_vars": \[\]}, "type": "ShouldAutoAttach"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
-        """
-
-        Examples: ubuntu release
-           | release | machine_type | fips-s   | cc-eal-s | cis-s    | infra-pkg | apps-pkg | livepatch | lp-desc                         | cis_or_usg | fips-p   |
-           | xenial  | gcp.pro      | n/a      | disabled | disabled | libkrad0  | jq       | warning   | Current kernel is not supported | cis        | n/a      |
-           | bionic  | gcp.pro      | disabled | disabled | disabled | libkrad0  | bundler  | enabled   | Canonical Livepatch service     | cis        | n/a      |
-           | focal   | gcp.pro      | disabled | n/a      | disabled | hello     | ant      | enabled   | Canonical Livepatch service     | usg        | n/a      |
-           | jammy   | gcp.pro      | n/a      | n/a      | disabled | hello     | hello    | enabled   | Canonical Livepatch service     | usg        | disabled |
+           | release | machine_type | infra-pkg | apps-pkg |
+           | xenial  | aws.pro      | libkrad0  | jq       |
+           | xenial  | azure.pro    | libkrad0  | jq       |
+           | xenial  | gcp.pro      | libkrad0  | jq       |
+           | bionic  | aws.pro      | libkrad0  | bundler  |
+           | bionic  | azure.pro    | libkrad0  | bundler  |
+           | bionic  | gcp.pro      | libkrad0  | bundler  |
+           | focal   | aws.pro      | hello     | ant      |
+           | focal   | azure.pro    | hello     | ant      |
+           | focal   | gcp.pro      | hello     | ant      |
+           | jammy   | aws.pro      | hello     | hello    |
+           | jammy   | azure.pro    | hello     | hello    |
+           | jammy   | gcp.pro      | hello     | hello    |
 
     Scenario Outline: Auto-attach service works on Pro Machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/ubuntu_pro_fips.feature
+++ b/features/ubuntu_pro_fips.feature
@@ -5,22 +5,16 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
         log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
         features:
           allow_xenial_fips_on_cloud: true
         """
         And I run `pro auto-attach` with sudo
         And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
+        Then I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
+        And I verify that `fips` is enabled
+        And I verify that `fips-updates` is disabled
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         When I run `uname -r` as non-root
@@ -28,7 +22,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         <fips-kernel-version>
         """
-        When I run `apt-cache policy ubuntu-azure-fips` as non-root
+        When I run `apt-cache policy <fips-package>` as non-root
         Then stdout does not match regexp:
         """
         .*Installed: \(none\)
@@ -112,12 +106,9 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         FIPS Updates enabled
         A reboot is required to complete install.
         """
+        Then I verify that `fips-updates` is enabled
         When I run `pro status` with sudo
         Then stdout matches regexp:
-        """
-        fips-updates  +yes +enabled +FIPS compliant crypto packages with stable security updates
-        """
-        And stdout matches regexp:
         """
         NOTICES
         FIPS support requires system reboot to complete configuration.
@@ -128,7 +119,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         <fips-kernel-version>
         """
-        When I run `apt-cache policy ubuntu-azure-fips` as non-root
+        When I run `apt-cache policy <fips-package>` as non-root
         Then stdout does not match regexp:
         """
         .*Installed: \(none\)
@@ -146,30 +137,29 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
 
         Examples: ubuntu release
-           | release | machine_type   | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
-           | xenial  | azure.pro-fips | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                |
-           | bionic  | azure.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | azure-fips          |
-           | focal   | azure.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | azure-fips          |
+           | release | machine_type   | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version | fips-package      |
+           | xenial  | azure.pro-fips | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                | ubuntu-fips       |
+           | xenial  | aws.pro-fips   | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                | ubuntu-fips       |
+           | bionic  | azure.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | azure-fips          | ubuntu-azure-fips |
+           | bionic  | aws.pro-fips   | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | aws-fips            | ubuntu-aws-fips   |
+           | bionic  | gcp.pro-fips   | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | gcp-fips            | ubuntu-gcp-fips   |
+           | focal   | azure.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | azure-fips          | ubuntu-azure-fips |
+           | focal   | aws.pro-fips   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips            | ubuntu-aws-fips   |
+           | focal   | gcp.pro-fips   | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | gcp-fips            | ubuntu-gcp-fips   |
 
     Scenario Outline: Check fips packages are correctly installed on Azure Focal machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
         log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
         """
         And I run `pro auto-attach` with sudo
         And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
+        Then I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
+        And I verify that `fips` is enabled
+        And I verify that `fips-updates` is disabled
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
@@ -178,8 +168,10 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
 
         Examples: ubuntu release
-           | release | machine_type   | fips-apt-source                                |
-           | focal   | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
+           | release | machine_type   | fips-apt-source                               |
+           | focal   | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main |
+           | focal   | aws.pro-fips   | https://esm.ubuntu.com/fips/ubuntu focal/main |
+           | focal   | gcp.pro-fips   | https://esm.ubuntu.com/fips/ubuntu focal/main |
 
     Scenario Outline: Check fips packages are correctly installed on Azure Bionic & Xenial machines
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -194,14 +186,10 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         """
         And I run `pro auto-attach` with sudo
         And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
+        Then I verify that `esm-apps` is enabled
+        And I verify that `esm-infra` is enabled
+        And I verify that `fips` is enabled
+        And I verify that `fips-updates` is disabled
         And I verify that running `apt update` `with sudo` exits `0`
         And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
         And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
@@ -214,239 +202,22 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         Examples: ubuntu release
            | release | machine_type   | fips-apt-source                                 |
            | xenial  | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
+           | xenial  | aws.pro-fips   | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
            | bionic  | azure.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
-
-    Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips AWS machine
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        When I run `uname -r` as non-root
-        Then stdout matches regexp:
-        """
-        <fips-kernel-version>
-        """
-        When I run `apt-cache policy ubuntu-aws-fips` as non-root
-        Then stdout does not match regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        1
-        """
-        When I run `systemctl daemon-reload` with sudo
-        When I run `systemctl start ua-auto-attach.service` with sudo
-        And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
-        Then stdout matches regexp:
-        """
-        .*status=0\/SUCCESS.*
-        """
-        And stdout matches regexp:
-        """
-        Active: inactive \(dead\).*
-        \s*Condition: start condition failed.*
-        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
-        """
-        When I verify that running `pro auto-attach` `with sudo` exits `2`
-        Then stderr matches regexp:
-        """
-        This machine is already attached to '.*'
-        To use a different subscription first run: sudo pro detach.
-        """
-        When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `1001`
-        """
-        <fips-apt-source> amd64 Packages
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        When I run `apt install -y <infra-pkg>/<release>-infra-security` with sudo, retrying exit [100]
-        And I run `apt-cache policy <infra-pkg>` as non-root
-        Then stdout matches regexp:
-        """
-        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
-        """
-        Then stdout matches regexp:
-        """
-        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
-        """
-        And stdout matches regexp:
-        """
-        Installed: .*[~+]esm
-        """
-        When I run `apt install -y <apps-pkg>/<release>-apps-security` with sudo, retrying exit [100]
-        And I run `apt-cache policy <apps-pkg>` as non-root
-        Then stdout matches regexp:
-        """
-        Version table:
-        \s*\*\*\* .* 510
-        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
-        """
-        When I run `pro enable fips-updates --assume-yes` with sudo
-        Then I will see the following on stdout:
-        """
-        One moment, checking your subscription first
-        Disabling incompatible service: FIPS
-        Updating FIPS Updates package lists
-        Installing FIPS Updates packages
-        Updating standard Ubuntu package lists
-        FIPS Updates enabled
-        A reboot is required to complete install.
-        """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        fips-updates  +yes +enabled +FIPS compliant crypto packages with stable security updates
-        """
-        And stdout matches regexp:
-        """
-        NOTICES
-        FIPS support requires system reboot to complete configuration.
-        """
-        When I reboot the machine
-        And I run `uname -r` as non-root
-        Then stdout matches regexp:
-        """
-        <fips-kernel-version>
-        """
-        When I run `apt-cache policy ubuntu-aws-fips` as non-root
-        Then stdout does not match regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        1
-        """
-        When I run `pro status` with sudo
-        Then stdout does not match regexp:
-        """
-        NOTICES
-        FIPS support requires system reboot to complete configuration.
-        """
-
-        Examples: ubuntu release
-           | release | machine_type | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
-           | xenial  | aws.pro-fips | libkrad0  | jq       | https://esm.ubuntu.com/fips/ubuntu xenial/main | fips                |
-           | bionic  | aws.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | aws-fips            |
-           | focal   | aws.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | aws-fips            |
-
-    Scenario Outline: Check fips packages are correctly installed on AWS Focal machine
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
-
-        Examples: ubuntu release
-           | release | machine_type | fips-apt-source                                |
-           | focal   | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
-
-    Scenario Outline: Check fips packages are correctly installed on AWS Bionic & Xenial machines
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        features:
-          allow_xenial_fips_on_cloud: true
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
-
-        Examples: ubuntu release
-           | release | machine_type | fips-apt-source                                 |
-           | xenial  | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu xenial/main  |
-           | bionic  | aws.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
+           | bionic  | aws.pro-fips   | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
+           | bionic  | gcp.pro-fips   | https://esm.ubuntu.com/fips/ubuntu bionic/main  |
 
     Scenario Outline: Check fips-updates can be enabled in a focal PRO FIPS machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
         """
         contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
         log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
         """
         And I run `pro auto-attach` with sudo
         And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
+        Then I verify that `fips` is enabled
+        And I verify that `fips-updates` is disabled
         When I run `pro enable fips-updates --assume-yes` with sudo
         Then stdout contains substring:
         """
@@ -458,11 +229,8 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
         FIPS Updates enabled
         A reboot is required to complete install.
         """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        fips-updates  +yes +enabled +FIPS compliant crypto packages with stable security updates
-        """
+        And I verify that `fips` is disabled
+        And I verify that `fips-updates` is enabled
         When I reboot the machine
         And  I run `uname -r` as non-root
         Then stdout matches regexp:
@@ -480,213 +248,3 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO fips image
            | focal   | aws.pro-fips   |
            | focal   | azure.pro-fips |
            | focal   | gcp.pro-fips   |
-
-    Scenario Outline: Check fips is enabled correctly on Ubuntu pro fips GCP machine
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        When I run `uname -r` as non-root
-        Then stdout matches regexp:
-        """
-        <fips-kernel-version>
-        """
-        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
-        Then stdout does not match regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        1
-        """
-        When I run `systemctl daemon-reload` with sudo
-        When I run `systemctl start ua-auto-attach.service` with sudo
-        And I verify that running `systemctl status ua-auto-attach.service` `as non-root` exits `0,3`
-        Then stdout matches regexp:
-        """
-        .*status=0\/SUCCESS.*
-        """
-        And stdout matches regexp:
-        """
-        Active: inactive \(dead\).*
-        \s*Condition: start condition failed.*
-        .*ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json was not met
-        """
-        When I verify that running `pro auto-attach` `with sudo` exits `2`
-        Then stderr matches regexp:
-        """
-        This machine is already attached to '.*'
-        To use a different subscription first run: sudo pro detach.
-        """
-        When I run `apt-cache policy` with sudo
-        Then apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/apps/ubuntu <release>-apps-updates/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `510`
-        """
-        https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
-        """
-        And apt-cache policy for the following url has priority `1001`
-        """
-        <fips-apt-source> amd64 Packages
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        When I run `apt install -y <infra-pkg>/<release>-infra-security` with sudo, retrying exit [100]
-        And I run `apt-cache policy <infra-pkg>` as non-root
-        Then stdout matches regexp:
-        """
-        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-security/main amd64 Packages
-        """
-        Then stdout matches regexp:
-        """
-        \s*510 https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates/main amd64 Packages
-        """
-        And stdout matches regexp:
-        """
-        Installed: .*[~+]esm
-        """
-        When I run `apt install -y <apps-pkg>/<release>-apps-security` with sudo, retrying exit [100]
-        And I run `apt-cache policy <apps-pkg>` as non-root
-        Then stdout matches regexp:
-        """
-        Version table:
-        \s*\*\*\* .* 510
-        \s*510 https://esm.ubuntu.com/apps/ubuntu <release>-apps-security/main amd64 Packages
-        """
-        When I run `pro enable fips-updates --assume-yes` with sudo
-        Then I will see the following on stdout:
-        """
-        One moment, checking your subscription first
-        Disabling incompatible service: FIPS
-        Updating FIPS Updates package lists
-        Installing FIPS Updates packages
-        Updating standard Ubuntu package lists
-        FIPS Updates enabled
-        A reboot is required to complete install.
-        """
-        When I run `pro status` with sudo
-        Then stdout matches regexp:
-        """
-        fips-updates  +yes +enabled +FIPS compliant crypto packages with stable security updates
-        """
-        And stdout matches regexp:
-        """
-        NOTICES
-        FIPS support requires system reboot to complete configuration.
-        """
-        When I reboot the machine
-        And I run `uname -r` as non-root
-        Then stdout matches regexp:
-        """
-        <fips-kernel-version>
-        """
-        When I run `apt-cache policy ubuntu-gcp-fips` as non-root
-        Then stdout does not match regexp:
-        """
-        .*Installed: \(none\)
-        """
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        1
-        """
-        When I run `pro status` with sudo
-        Then stdout does not match regexp:
-        """
-        NOTICES
-        FIPS support requires system reboot to complete configuration.
-        """
-
-        Examples: ubuntu release
-           | release | machine_type | infra-pkg | apps-pkg | fips-apt-source                                | fips-kernel-version |
-           | bionic  | gcp.pro-fips | libkrad0  | bundler  | https://esm.ubuntu.com/fips/ubuntu bionic/main | gcp-fips            |
-           | focal   | gcp.pro-fips | hello     | 389-ds   | https://esm.ubuntu.com/fips/ubuntu focal/main  | gcp-fips            |
-
-    Scenario Outline: Check fips packages are correctly installed on GCP Pro Focal machine
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
-
-        Examples: ubuntu release
-           | release | machine_type | fips-apt-source                                |
-           | focal   | gcp.pro-fips | https://esm.ubuntu.com/fips/ubuntu focal/main  |
-
-    Scenario Outline: Check fips packages are correctly installed on GCP Pro Bionic machines
-        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:
-        """
-        contract_url: 'https://contracts.canonical.com'
-        data_dir: /var/lib/ubuntu-advantage
-        log_level: debug
-        log_file: /var/log/ubuntu-advantage.log
-        """
-        And I run `pro auto-attach` with sudo
-        And I run `pro status --wait` as non-root
-        And I run `pro status` as non-root
-        Then stdout matches regexp:
-        """
-        esm-apps      +yes +enabled +Expanded Security Maintenance for Applications
-        esm-infra     +yes +enabled +Expanded Security Maintenance for Infrastructure
-        fips          +yes +enabled +NIST-certified FIPS crypto packages
-        fips-updates  +yes +disabled +FIPS compliant crypto packages with stable security updates
-        """
-        And I verify that running `apt update` `with sudo` exits `0`
-        And I verify that running `grep Traceback /var/log/ubuntu-advantage.log` `with sudo` exits `1`
-        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
-
-        Examples: ubuntu release
-           | release | machine_type | fips-apt-source                                 |
-           | bionic  | gcp.pro-fips | https://esm.ubuntu.com/fips/ubuntu bionic/main  |

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -9,7 +9,7 @@ Feature: Upgrade between releases when uaclient is attached
         And I run `<before_cmd>` with sudo
         # Local PPAs are prepared and served only when testing with local debs
         And I prepare the local PPAs to upgrade from `<release>` to `<next_release>`
-        And I run `apt-get dist-upgrade --assume-yes` with sudo
+        And I run `DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade --assume-yes` with sudo
         # Some packages upgrade may require a reboot
         And I reboot the machine
         And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
@@ -71,10 +71,7 @@ Feature: Upgrade between releases when uaclient is attached
         A reboot is required to complete install.
         """
         When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-        """
-        <fips-service> +yes                enabled
-        """
+        Then I verify that `<fips-service>` is enabled
         And I verify that running `apt update` `with sudo` exits `0`
         When I reboot the machine
         And  I run `uname -r` as non-root
@@ -89,7 +86,7 @@ Feature: Upgrade between releases when uaclient is attached
         """
          # Local PPAs are prepared and served only when testing with local debs
         When I prepare the local PPAs to upgrade from `<release>` to `<next_release>`
-        And I run `apt-get dist-upgrade -y --allow-downgrades` with sudo
+        And I run `DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y --allow-downgrades` with sudo
         # A package may need a reboot after running dist-upgrade
         And I reboot the machine
         And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
@@ -109,10 +106,7 @@ Feature: Upgrade between releases when uaclient is attached
         """
         """
         When I run `pro status --all` with sudo
-        Then stdout matches regexp:
-        """
-        <fips-service> +yes                enabled
-        """
+        Then I verify that `<fips-service>` is enabled
         When  I run `uname -r` as non-root
         Then stdout matches regexp:
         """

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -18,7 +18,7 @@ Feature: Upgrade between releases when uaclient is unattached
         """
         deb https://esm.ubuntu.com/infra/ubuntu <release>-infra-updates main
         """
-        When I run `apt-get dist-upgrade --assume-yes` with sudo
+        When I run `DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade --assume-yes` with sudo
         # Some packages upgrade may require a reboot
         And I reboot the machine
         And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following

--- a/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
@@ -15,7 +15,9 @@ class TestEnabledServicesV1:
 
         m_cls_1 = mock.MagicMock()
         m_inst_1 = mock.MagicMock(variants={})
-        type(m_inst_1).name = mock.PropertyMock(return_value="ent1")
+        type(m_inst_1).presentation_name = mock.PropertyMock(
+            return_value="ent1"
+        )
         m_inst_1.user_facing_status.return_value = (
             UserFacingStatus.ACTIVE,
             "",
@@ -32,7 +34,9 @@ class TestEnabledServicesV1:
 
         m_cls_2 = mock.MagicMock()
         m_inst_2 = mock.MagicMock(variants={"variant": m_variant_cls})
-        type(m_inst_2).name = mock.PropertyMock(return_value="ent2")
+        type(m_inst_2).presentation_name = mock.PropertyMock(
+            return_value="ent2"
+        )
         m_inst_2.user_facing_status.return_value = (
             UserFacingStatus.ACTIVE,
             "",
@@ -41,7 +45,9 @@ class TestEnabledServicesV1:
 
         m_cls_3 = mock.MagicMock()
         m_inst_3 = mock.MagicMock()
-        type(m_inst_3).name = mock.PropertyMock(return_value="ent3")
+        type(m_inst_3).presentation_name = mock.PropertyMock(
+            return_value="ent3"
+        )
         m_inst_3.user_facing_status.return_value = (
             UserFacingStatus.INACTIVE,
             "",

--- a/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
@@ -1,11 +1,13 @@
 import mock
 
 from uaclient import entitlements
+from uaclient.api.data_types import ErrorWarningObject
 from uaclient.api.u.pro.status.enabled_services.v1 import (
     EnabledService,
     _enabled_services,
 )
 from uaclient.entitlements.entitlement_status import UserFacingStatus
+from uaclient.messages import NamedMessage
 
 
 class TestEnabledServicesV1:
@@ -52,8 +54,31 @@ class TestEnabledServicesV1:
             UserFacingStatus.INACTIVE,
             "",
         )
+        m_cls_3.return_value = m_inst_3
 
-        ents = [m_cls_1, m_cls_2, m_cls_3]
+        m_cls_4 = mock.MagicMock()
+        m_inst_4 = mock.MagicMock()
+        type(m_inst_4).presentation_name = mock.PropertyMock(
+            return_value="ent4"
+        )
+        m_inst_4.user_facing_status.return_value = (
+            UserFacingStatus.INAPPLICABLE,
+            "",
+        )
+        m_cls_4.return_value = m_inst_4
+
+        m_cls_5 = mock.MagicMock()
+        m_inst_5 = mock.MagicMock()
+        type(m_inst_5).presentation_name = mock.PropertyMock(
+            return_value="ent5"
+        )
+        m_inst_5.user_facing_status.return_value = (
+            UserFacingStatus.WARNING,
+            NamedMessage(name="warning_code", msg="warning_msg"),
+        )
+        m_cls_5.return_value = m_inst_5
+
+        ents = [m_cls_1, m_cls_2, m_cls_3, m_cls_4, m_cls_5]
         expected_enabled_services = [
             EnabledService(name="ent1"),
             EnabledService(
@@ -61,15 +86,25 @@ class TestEnabledServicesV1:
                 variant_enabled=True,
                 variant_name="variant",
             ),
+            EnabledService(name="ent5"),
+        ]
+
+        expected_warnings = [
+            ErrorWarningObject(
+                title="warning_msg",
+                code="warning_code",
+                meta={"service": "ent5"},
+            )
         ]
 
         with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
-            actual_enabled_services = _enabled_services(
-                cfg=mock.MagicMock()
-            ).enabled_services
+            enabled_services_ret = _enabled_services(cfg=mock.MagicMock())
 
         assert 1 == m_is_attached.call_count
-        assert expected_enabled_services == actual_enabled_services
+        assert (
+            expected_enabled_services == enabled_services_ret.enabled_services
+        )
+        assert expected_warnings == enabled_services_ret.warnings
 
     @mock.patch("uaclient.api.u.pro.status.enabled_services.v1._is_attached")
     def test_enabled_services_when_unattached(self, m_is_attached):

--- a/uaclient/api/u/pro/status/enabled_services/v1.py
+++ b/uaclient/api/u/pro/status/enabled_services/v1.py
@@ -56,13 +56,13 @@ def _enabled_services(cfg: UAConfig) -> EnabledServicesResult:
     for ent_cls in ENTITLEMENT_CLASSES:
         ent = ent_cls(cfg)
         if ent.user_facing_status()[0] == UserFacingStatus.ACTIVE:
-            enabled_service = EnabledService(name=ent.name)
+            enabled_service = EnabledService(name=ent.presentation_name)
             for _, variant_cls in ent.variants.items():
                 variant = variant_cls(cfg)
 
                 if variant.user_facing_status()[0] == UserFacingStatus.ACTIVE:
                     enabled_service = EnabledService(
-                        name=ent.name,
+                        name=ent.presentation_name,
                         variant_enabled=True,
                         variant_name=variant.variant_name,
                     )

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -683,7 +683,10 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         ret = []
         for service in self.incompatible_services:
             ent_status, _ = service.entitlement(self.cfg).application_status()
-            if ent_status == ApplicationStatus.ENABLED:
+            if ent_status in (
+                ApplicationStatus.ENABLED,
+                ApplicationStatus.WARNING,
+            ):
                 ret.append(service)
 
         return ret


### PR DESCRIPTION
## Why is this needed?
Some of our integration tests are relying on the output of `pro status` to access if the machine is enabled or a specific service is enabled. We already have API features that display which services are enabled. Due to that, we are now updating our tests to rely on the API for this kind of information.

Note that not all `pro status` calls were removed. They were kept if they are evaluating that service status is `n/a` or to see that a change in the system has modified the service description in status (i.e. Livepatch support for an unsupported kernel) 

This PR also includes fixes for the `enabled_services` endpoint:

* `usg` service not being reported there
* services with `warning` status were not show as enabled on the API


## Test Steps
Guarantee that the modified tests are working as expected and the proposed changes are not modifying the original test flow

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
