### PR TITLE
tests: add dependency to libapt-pkg-dev

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,7 @@ pycodestyle
 mock
 pytest
 pytest-cov
+libapt-pkg-dev
 
 # python3-apt
 # We know it is in the distro, but for testing in venvs we need to install it


### PR DESCRIPTION
Without this being available in the host or tox env tests would fail at:

```
...
  building 'apt_pkg' extension
  creating build/temp.linux-x86_64-3.10
  creating build/temp.linux-x86_64-3.10/python
  x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv ...
  In file included from python/acquire-item.cc:24:
  python/apt_pkgmodule.h:14:10: fatal error: apt-pkg/hashes.h: No such file ...
     14 | #include <apt-pkg/hashes.h>
        |          ^~~~~~~~~~~~~~~~~~
  compilation terminated.
  error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
  [end of output]
...
ERROR: could not install deps
```

## Why is this needed?

This PR allows to run tox in an otherwise unprepared system.

> P.S. I feel you'd have fixed that issue long ago if it was so easy, but I'm happy to learn why we would not need it when being rejected :-) OTOH if you consider this too trivial, consider automatically converting d/control Build-Depends into tox deps - then we'd only need to maintain this once :-)


## Test Steps

On Ubuntu jammy, get a clone of this repo and run `tox`.

## Checklist
 - I have not updated or added any unit tests accordingly (no new functionality)
 - I have not updated or added any integration tests accordingly (no new functionality)
 - Changes here do not need to be documented (no new functionality, nor new test behavior)

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No