### PR TITLE
fix: ignore LSNs when fetching CVE related USNs

### DIFF
--- a/features/fix.feature
+++ b/features/fix.feature
@@ -824,6 +824,16 @@ Feature: Ua fix command behaviour
         .*✔.* USN-6385-1 \[related\] does not affect your system.
         .*✔.* USN-6460-1 \[related\] does not affect your system.
         """
+        When I run `pro fix CVE-2023-42752` with sudo
+        Then stdout matches regexp:
+        """
+        CVE-2023-42752: Linux kernel \(NVIDIA\) vulnerabilities
+         - https://ubuntu.com/security/CVE-2023-42752
+
+        No affected source packages are installed.
+
+        .*✔.* CVE-2023-42752 does not affect your system.
+        """
 
     Scenario: Fix command on a machine without security/updates source lists
         Given a `bionic` `lxd-container` machine with ubuntu-advantage-tools installed

--- a/uaclient/api/tests/test_api_u_pro_security_fix.py
+++ b/uaclient/api/tests/test_api_u_pro_security_fix.py
@@ -674,8 +674,9 @@ class TestUASecurityClient:
                 body="",
                 json_dict={
                     "notices": [
-                        {"id": "2", "cves_ids": ["cve"]},
-                        {"id": "1", "cves_ids": ["cve"]},
+                        {"id": "USN-2", "cves_ids": ["cve"]},
+                        {"id": "USN-1", "cves_ids": ["cve"]},
+                        {"id": "LSN-3", "cves_ids": ["cve"]},
                     ]
                 },
                 json_list=[],
@@ -683,8 +684,8 @@ class TestUASecurityClient:
             [usn1, usn2] = client.get_notices(**m_kwargs)
             assert isinstance(usn1, USN)
             assert isinstance(usn2, USN)
-            assert "1" == usn1.id
-            assert "2" == usn2.id
+            assert "USN-1" == usn1.id
+            assert "USN-2" == usn2.id
             assert [
                 mock.call(API_V1_NOTICES, query_params=m_kwargs)
             ] == request_url.call_args_list
@@ -702,8 +703,9 @@ class TestUASecurityClient:
             body="",
             json_dict={
                 "notices": [
-                    {"id": "2", "cves_ids": ["cve1"]},
-                    {"id": "1", "cves_ids": ["cve12"]},
+                    {"id": "USN-2", "cves_ids": ["cve2"]},
+                    {"id": "USN-1", "cves_ids": ["cve1"]},
+                    {"id": "LSN-3", "cves_ids": ["cve3"]},
                 ]
             },
             json_list=[],
@@ -712,11 +714,11 @@ class TestUASecurityClient:
 
         if details:
             assert len(usns) == 1
-            assert usns[0].id == "2"
+            assert usns[0].id == "USN-1"
         else:
             assert len(usns) == 2
-            assert usns[0].id == "1"
-            assert usns[1].id == "2"
+            assert usns[0].id == "USN-1"
+            assert usns[1].id == "USN-2"
 
     @pytest.mark.parametrize(
         "m_kwargs,expected_error, extra_security_params",

--- a/uaclient/api/u/pro/security/fix/_common/__init__.py
+++ b/uaclient/api/u/pro/security/fix/_common/__init__.py
@@ -167,11 +167,13 @@ class UASecurityClient(serviceclient.UAServiceClient):
             raise exceptions.SecurityAPIError(
                 url=API_V1_NOTICES, code=response.code, body=response.body
             )
+
         return sorted(
             [
                 USN(client=self, response=usn_md)
                 for usn_md in response.json_dict.get("notices", [])
-                if details is None or details in usn_md.get("cves_ids", [])
+                if (details is None or details in usn_md.get("cves_ids", []))
+                and usn_md.get("id", "").startswith("USN-")
             ],
             key=lambda x: x.id,
         )


### PR DESCRIPTION
## Why is this needed?
When fixing a CVE, we also fetch the related USNs tied to it. When doing that, we need to discard LSNs since they are not supported at the moment.

## Test Steps
Run the modified integration test to assert that LSNs are being ignore now when fixing CVEs

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
