### PR TITLE
fix: update how CVE descriptions are generated

### DIFF
--- a/features/fix.feature
+++ b/features/fix.feature
@@ -248,7 +248,7 @@ Feature: Ua fix command behaviour
         """
         .*WARNING: The option --dry-run is being used.
         No packages will be installed when running this command..*
-        CVE-2017-9233: Coin3D vulnerability
+        CVE-2017-9233: Expat vulnerability
          - https://ubuntu.com/security/CVE-2017-9233
 
         3 affected source packages are installed: expat, matanza, swish-e
@@ -264,7 +264,7 @@ Feature: Ua fix command behaviour
         When I verify that running `pro fix CVE-2017-9233` `with sudo` exits `1`
         Then stdout matches regexp:
         """
-        CVE-2017-9233: Coin3D vulnerability
+        CVE-2017-9233: Expat vulnerability
          - https://ubuntu.com/security/CVE-2017-9233
 
         3 affected source packages are installed: expat, matanza, swish-e

--- a/uaclient/api/tests/test_api_u_pro_security_fix_plan.py
+++ b/uaclient/api/tests/test_api_u_pro_security_fix_plan.py
@@ -31,6 +31,7 @@ from uaclient.api.u.pro.security.fix._common.plan.v1 import (
     PackageCannotBeInstalledData,
     SecurityIssueNotFixedData,
     USNAdditionalData,
+    _get_cve_description,
     fix_plan_cve,
     fix_plan_usn,
 )
@@ -1009,3 +1010,95 @@ class TestSecurityIssueData:
             assert fix_plan.error.msg == expected_message
         else:
             assert fix_plan.target_usn_plan.error.msg == expected_message
+
+
+class TestGetCVEDescription:
+    @pytest.mark.parametrize(
+        "installed_pkgs,notices,cve_description,expected_description",
+        (
+            ({}, [], "cve_description", "cve_description"),
+            (
+                {
+                    "pkg1": {
+                        "bin1": "1.0",
+                        "bin2": "1.1",
+                    },
+                },
+                [
+                    mock.MagicMock(
+                        title="usn2",
+                        release_packages={
+                            "pkg2": {
+                                "libpkg2": {
+                                    "version": "1.0",
+                                    "name": "libpkg2",
+                                },
+                                "source": {"version": "2.0", "name": "pkg2"},
+                            }
+                        },
+                    ),
+                    mock.MagicMock(
+                        title="usn1",
+                        release_packages={
+                            "pkg1": {
+                                "libpkg1": {
+                                    "version": "1.0",
+                                    "name": "libpkg1",
+                                },
+                                "source": {"version": "2.0", "name": "pkg1"},
+                            }
+                        },
+                    ),
+                ],
+                "cve_description",
+                "usn1",
+            ),
+            (
+                {
+                    "pkg3": {
+                        "bin1": "1.0",
+                        "bin2": "1.1",
+                    },
+                },
+                [
+                    mock.MagicMock(
+                        title="usn2",
+                        release_packages={
+                            "pkg2": {
+                                "libpkg2": {
+                                    "version": "1.0",
+                                    "name": "libpkg2",
+                                },
+                                "source": {"version": "2.0", "name": "pkg2"},
+                            }
+                        },
+                    ),
+                    mock.MagicMock(
+                        title="usn1",
+                        release_packages={
+                            "pkg1": {
+                                "libpkg1": {
+                                    "version": "1.0",
+                                    "name": "libpkg1",
+                                },
+                                "source": {"version": "2.0", "name": "pkg1"},
+                            }
+                        },
+                    ),
+                ],
+                "cve_description",
+                "usn2",
+            ),
+        ),
+    )
+    def test_get_cve_description(
+        self,
+        installed_pkgs,
+        notices,
+        cve_description,
+        expected_description,
+    ):
+        cve = mock.MagicMock(notices=notices, description=cve_description)
+        assert expected_description == _get_cve_description(
+            cve, installed_pkgs
+        )


### PR DESCRIPTION
## Why is this needed?
We fetch the CVE description from the USNs associated with the CVE. Before, we picked the first USN title as the CVE description. We are updating that logic to check first if at least one package related to the USN is installed in the system before using its description.

Fixes: #2739

## Test Steps
Run the modified integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
