### PR TITLE
tests: mock terminal size for terminal-size-dependent tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     - id: isort
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4 # Also stored in dev-requirements.txt; update both together!
+    rev: v0.9.0.6 # Also stored in dev-requirements.txt; update both together!
     hooks:
     - id: shellcheck
       args: ['--severity=warning']

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,4 +3,4 @@
 black==22.3.0
 isort==5.12.0
 pre-commit
-shellcheck-py==0.8.0.4
+shellcheck-py==0.9.0.6

--- a/uaclient/cli/tests/test_cli_security_status.py
+++ b/uaclient/cli/tests/test_cli_security_status.py
@@ -74,7 +74,6 @@ class TestActionSecurityStatus:
                 ):
                     main()
         out, _err = capsys.readouterr()
-        print(out)
         assert re.match(HELP_OUTPUT, out)
 
     @pytest.mark.parametrize("output_format", ("json", "yaml", "text"))

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -1,6 +1,8 @@
 import datetime
 import io
 import logging
+import os
+import shutil
 from enum import Enum
 from typing import Any, Dict
 
@@ -15,6 +17,11 @@ try:
     from uaclient.files.state_files import UserConfigData
 except ImportError:
     raise
+
+
+shutil.get_terminal_size = mock.MagicMock(
+    return_value=os.terminal_size((80, 20))
+)
 
 
 @pytest.yield_fixture(scope="session", autouse=True)


### PR DESCRIPTION
## Why is this needed?
In mantic+ the help output is terminal-size dependent even inside pytest. This mocks the terminal size to 80 columns which is what our tests have always been assuming.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

unit tests should pass on mantic

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
