### PR TITLE
update logic that checks if a service is enabled

### DIFF
--- a/debian/po/pt_BR.po
+++ b/debian/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-05 11:04-0800\n"
+"POT-Creation-Date: 2024-02-12 21:09-0500\n"
 "PO-Revision-Date: 2023-09-25 12:29-0400\n"
 "Last-Translator: Lucas Moura <lucas.moura@canonical.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -2342,7 +2342,7 @@ msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1323
-#: ../../uaclient/messages/__init__.py:1768
+#: ../../uaclient/messages/__init__.py:1772
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
@@ -2710,133 +2710,138 @@ msgstr ""
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1685
+#: ../../uaclient/messages/__init__.py:1684
+#, python-brace-format
+msgid "{title} does not have a suites directive"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1689
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1692
+#: ../../uaclient/messages/__init__.py:1696
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1699
+#: ../../uaclient/messages/__init__.py:1703
 #, python-brace-format
 msgid ""
 "{title} is already enabled.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1706
+#: ../../uaclient/messages/__init__.py:1710
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1712
+#: ../../uaclient/messages/__init__.py:1716
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1718
+#: ../../uaclient/messages/__init__.py:1722
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1726
+#: ../../uaclient/messages/__init__.py:1730
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1734
+#: ../../uaclient/messages/__init__.py:1738
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1741
+#: ../../uaclient/messages/__init__.py:1745
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1749
+#: ../../uaclient/messages/__init__.py:1753
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1756
+#: ../../uaclient/messages/__init__.py:1760
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1762
+#: ../../uaclient/messages/__init__.py:1766
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1772
+#: ../../uaclient/messages/__init__.py:1776
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1775
+#: ../../uaclient/messages/__init__.py:1779
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1779
+#: ../../uaclient/messages/__init__.py:1783
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1784
+#: ../../uaclient/messages/__init__.py:1788
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1792
+#: ../../uaclient/messages/__init__.py:1796
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1801
+#: ../../uaclient/messages/__init__.py:1805
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1809
+#: ../../uaclient/messages/__init__.py:1813
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1813
+#: ../../uaclient/messages/__init__.py:1817
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1818
+#: ../../uaclient/messages/__init__.py:1822
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1826
+#: ../../uaclient/messages/__init__.py:1830
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2846,7 +2851,7 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1835
+#: ../../uaclient/messages/__init__.py:1839
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2855,75 +2860,75 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1845
+#: ../../uaclient/messages/__init__.py:1849
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1851
+#: ../../uaclient/messages/__init__.py:1855
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1860
+#: ../../uaclient/messages/__init__.py:1864
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1867
+#: ../../uaclient/messages/__init__.py:1871
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1874
+#: ../../uaclient/messages/__init__.py:1878
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1879
+#: ../../uaclient/messages/__init__.py:1883
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1883
+#: ../../uaclient/messages/__init__.py:1887
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1888
-msgid "apt-daily.timer jobs are not running"
-msgstr ""
-
 #: ../../uaclient/messages/__init__.py:1892
-#, python-brace-format
-msgid "{cfg_name} is empty"
+msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1896
 #, python-brace-format
-msgid "{cfg_name} is turned off"
+msgid "{cfg_name} is empty"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1900
+#, python-brace-format
+msgid "{cfg_name} is turned off"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1904
 msgid "unattended-upgrades package is not installed"
 msgstr "O pacote unattended-upgrades não está instalado"
 
-#: ../../uaclient/messages/__init__.py:1906
+#: ../../uaclient/messages/__init__.py:1910
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1915
+#: ../../uaclient/messages/__init__.py:1919
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1920
+#: ../../uaclient/messages/__init__.py:1924
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1926
+#: ../../uaclient/messages/__init__.py:1930
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2933,28 +2938,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1940
+#: ../../uaclient/messages/__init__.py:1944
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1946
+#: ../../uaclient/messages/__init__.py:1950
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1976
+#: ../../uaclient/messages/__init__.py:1980
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1981
+#: ../../uaclient/messages/__init__.py:1985
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1987
+#: ../../uaclient/messages/__init__.py:1991
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2962,107 +2967,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1997
+#: ../../uaclient/messages/__init__.py:2001
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2004
+#: ../../uaclient/messages/__init__.py:2008
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2009
+#: ../../uaclient/messages/__init__.py:2013
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2013
+#: ../../uaclient/messages/__init__.py:2017
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2017
+#: ../../uaclient/messages/__init__.py:2021
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2022
+#: ../../uaclient/messages/__init__.py:2026
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2027
+#: ../../uaclient/messages/__init__.py:2031
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2032
+#: ../../uaclient/messages/__init__.py:2036
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2038
+#: ../../uaclient/messages/__init__.py:2042
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2044
+#: ../../uaclient/messages/__init__.py:2048
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2048
+#: ../../uaclient/messages/__init__.py:2052
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2054
+#: ../../uaclient/messages/__init__.py:2058
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2062
+#: ../../uaclient/messages/__init__.py:2066
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2068
+#: ../../uaclient/messages/__init__.py:2072
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2077
+#: ../../uaclient/messages/__init__.py:2081
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2084
+#: ../../uaclient/messages/__init__.py:2088
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2091
+#: ../../uaclient/messages/__init__.py:2095
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2096
+#: ../../uaclient/messages/__init__.py:2100
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2102
+#: ../../uaclient/messages/__init__.py:2106
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3070,7 +3075,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2112
+#: ../../uaclient/messages/__init__.py:2116
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3078,7 +3083,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2122
+#: ../../uaclient/messages/__init__.py:2126
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3086,41 +3091,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2132
+#: ../../uaclient/messages/__init__.py:2136
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2139
+#: ../../uaclient/messages/__init__.py:2143
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2145
+#: ../../uaclient/messages/__init__.py:2149
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2151
+#: ../../uaclient/messages/__init__.py:2155
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2156
+#: ../../uaclient/messages/__init__.py:2160
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2162
+#: ../../uaclient/messages/__init__.py:2166
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2170
+#: ../../uaclient/messages/__init__.py:2174
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2179
+#: ../../uaclient/messages/__init__.py:2183
 #, python-brace-format
 msgid ""
 "To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
@@ -3128,59 +3133,59 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2195
+#: ../../uaclient/messages/__init__.py:2199
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2200
+#: ../../uaclient/messages/__init__.py:2204
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2206
+#: ../../uaclient/messages/__init__.py:2210
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2214
+#: ../../uaclient/messages/__init__.py:2218
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2222
+#: ../../uaclient/messages/__init__.py:2226
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2229
+#: ../../uaclient/messages/__init__.py:2233
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2236
+#: ../../uaclient/messages/__init__.py:2240
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2245
+#: ../../uaclient/messages/__init__.py:2249
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2249
+#: ../../uaclient/messages/__init__.py:2253
 #, python-brace-format
 msgid ""
 "Error on Pro Image:\n"
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2255
+#: ../../uaclient/messages/__init__.py:2259
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2262
+#: ../../uaclient/messages/__init__.py:2266
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -3188,16 +3193,16 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2272
+#: ../../uaclient/messages/__init__.py:2276
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2279
+#: ../../uaclient/messages/__init__.py:2283
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2287
+#: ../../uaclient/messages/__init__.py:2291
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
@@ -3206,7 +3211,7 @@ msgstr ""
 "Suporte para auto-attach não está disponível para esta imagem\n"
 "Veja {url}"
 
-#: ../../uaclient/messages/__init__.py:2296
+#: ../../uaclient/messages/__init__.py:2300
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
@@ -3215,18 +3220,18 @@ msgstr ""
 "Suporte para auto-attach não está disponível para {{cloud_type}}\n"
 "Veja: {url}"
 
-#: ../../uaclient/messages/__init__.py:2304
+#: ../../uaclient/messages/__init__.py:2308
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2310
+#: ../../uaclient/messages/__init__.py:2314
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2318
+#: ../../uaclient/messages/__init__.py:2322
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -3237,7 +3242,7 @@ msgstr ""
 "o campo VERSION não tem a informação de versão: {version}\n"
 "e o campo VERSION_CODENAME não está presente"
 
-#: ../../uaclient/messages/__init__.py:2328
+#: ../../uaclient/messages/__init__.py:2332
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -3251,12 +3256,12 @@ msgstr ""
 "\n"
 "$ sudo rm {lock_file_path}"
 
-#: ../../uaclient/messages/__init__.py:2337
+#: ../../uaclient/messages/__init__.py:2341
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr "{source} retornou um json inválido: {out}"
 
-#: ../../uaclient/messages/__init__.py:2343
+#: ../../uaclient/messages/__init__.py:2347
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
@@ -3265,7 +3270,7 @@ msgstr ""
 "Valor inválido para {path_to_value} em /etc/ubuntu-advantage/uaclient.conf."
 "Esperava {expected_value}, mas {value} foi encontrado."
 
-#: ../../uaclient/messages/__init__.py:2352
+#: ../../uaclient/messages/__init__.py:2356
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
@@ -3273,17 +3278,17 @@ msgstr ""
 "Não foi possível associar {key} a {value}: <value> precisa ser um inteiro "
 "positivo."
 
-#: ../../uaclient/messages/__init__.py:2359
+#: ../../uaclient/messages/__init__.py:2363
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr "url inválida no arquivo de configuração. {key}: {value}"
 
-#: ../../uaclient/messages/__init__.py:2364
+#: ../../uaclient/messages/__init__.py:2368
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr "Não foi possível encontrar o arquivo yaml: {filepath}"
 
-#: ../../uaclient/messages/__init__.py:2370
+#: ../../uaclient/messages/__init__.py:2374
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
@@ -3294,27 +3299,27 @@ msgstr ""
 "pro de apt ao mesmo tempo não é suportado.\n"
 "Cancelando o processo de configuração.\n"
 
-#: ../../uaclient/messages/__init__.py:2380
+#: ../../uaclient/messages/__init__.py:2384
 msgid "Can't load the distro-info database."
 msgstr "Não foi possível carregar o banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2385
+#: ../../uaclient/messages/__init__.py:2389
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 "Não foi possível encontrar a série {series} na banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2390
+#: ../../uaclient/messages/__init__.py:2394
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr "Erro: não é possível usar {option1} junto com {option2}"
 
-#: ../../uaclient/messages/__init__.py:2394
+#: ../../uaclient/messages/__init__.py:2398
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr "Ajuda não disponível para '{name}'"
 
-#: ../../uaclient/messages/__init__.py:2400
+#: ../../uaclient/messages/__init__.py:2404
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
@@ -3323,34 +3328,34 @@ msgstr ""
 "Erro: problema de segurnça \"{issue}\" não foi reconhecido.\n"
 "Use: \"pro fix CVE-yyyy-nnnn\" ou \"pro fix USN-nnnn\""
 
-#: ../../uaclient/messages/__init__.py:2406
+#: ../../uaclient/messages/__init__.py:2410
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr "{arg} precisa ser um de: {choices}"
 
-#: ../../uaclient/messages/__init__.py:2411
+#: ../../uaclient/messages/__init__.py:2415
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr "Esperava {expected} mas encontrou: {actual}"
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2419
 msgid "Unable to process uaclient.conf"
 msgstr "Falha ao processar uaclient.conf"
 
-#: ../../uaclient/messages/__init__.py:2420
+#: ../../uaclient/messages/__init__.py:2424
 msgid "Unable to refresh your subscription"
 msgstr "Falha ao atualizar sua assinatura"
 
-#: ../../uaclient/messages/__init__.py:2425
+#: ../../uaclient/messages/__init__.py:2429
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 "Falha ao atualizar as mensagens de APT e MOTD relacioandas ao Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:2431
+#: ../../uaclient/messages/__init__.py:2435
 msgid "json formatted response requires --assume-yes flag."
 msgstr "resposta formatada em json necessita do paramêtro --assume-yes"
 
-#: ../../uaclient/messages/__init__.py:2439
+#: ../../uaclient/messages/__init__.py:2443
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
@@ -3360,50 +3365,50 @@ msgstr ""
 "Ao invés disso, inclua o token no arquivo de attach-config.\n"
 "    "
 
-#: ../../uaclient/messages/__init__.py:2448
+#: ../../uaclient/messages/__init__.py:2452
 msgid "Cannot provide both --args and --data at the same time"
 msgstr "Não é possível usar --args e --data ao mesmo tempo"
 
-#: ../../uaclient/messages/__init__.py:2454
+#: ../../uaclient/messages/__init__.py:2458
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr "Falha ao executar: {lock_request}.\n"
 
-#: ../../uaclient/messages/__init__.py:2463
+#: ../../uaclient/messages/__init__.py:2467
 msgid "This command must be run as root (try using sudo)."
 msgstr "Esse comando precisa ser executado como root (tente usando sudo)."
 
-#: ../../uaclient/messages/__init__.py:2468
+#: ../../uaclient/messages/__init__.py:2472
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr "Metadados para {issue} não são válidos. Erro: {error_msg}."
 
-#: ../../uaclient/messages/__init__.py:2475
+#: ../../uaclient/messages/__init__.py:2479
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr "Erro: {issue_id} não encontrada."
 
-#: ../../uaclient/messages/__init__.py:2479
+#: ../../uaclient/messages/__init__.py:2483
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr "chave GPG '{keyfile}' não foi encontrada"
 
-#: ../../uaclient/messages/__init__.py:2484
+#: ../../uaclient/messages/__init__.py:2488
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr "'{endpoint}' não é um endpoint válido"
 
-#: ../../uaclient/messages/__init__.py:2489
+#: ../../uaclient/messages/__init__.py:2493
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr "'{arg}' está faltando para endpoint {endpoint}"
 
-#: ../../uaclient/messages/__init__.py:2494
+#: ../../uaclient/messages/__init__.py:2498
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr "{endpoint} não aceita paramêtros"
 
-#: ../../uaclient/messages/__init__.py:2499
+#: ../../uaclient/messages/__init__.py:2503
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
@@ -3412,32 +3417,32 @@ msgstr ""
 "Error ao analisar paramêtro data para API json:\n"
 "{data}"
 
-#: ../../uaclient/messages/__init__.py:2504
+#: ../../uaclient/messages/__init__.py:2508
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr "'{arg}' não está formatado como 'chave=valor'"
 
-#: ../../uaclient/messages/__init__.py:2509
+#: ../../uaclient/messages/__init__.py:2513
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr "Não foi possível determinar a versão: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2514
+#: ../../uaclient/messages/__init__.py:2518
 msgid "features.disable_auto_attach set in config"
 msgstr "features.disable_auto_attach definida na configuração"
 
-#: ../../uaclient/messages/__init__.py:2519
+#: ../../uaclient/messages/__init__.py:2523
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 "Não foi possível determinar o status do unattended-upgrades: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2525
+#: ../../uaclient/messages/__init__.py:2529
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr "Esperava valor com tipo {expected_type}, mas recebeu tipo {got_type}"
 
-#: ../../uaclient/messages/__init__.py:2531
+#: ../../uaclient/messages/__init__.py:2535
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
@@ -3446,7 +3451,7 @@ msgstr ""
 "Valor com tipo incorreto na posição {index}:\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2537
+#: ../../uaclient/messages/__init__.py:2541
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
@@ -3455,16 +3460,26 @@ msgstr ""
 "Valor com tipo incorreto para o campo \"{key}\":\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2544
+#: ../../uaclient/messages/__init__.py:2548
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""
 "Valor fornecido não está presente nos valores permitidos de {enum_class}: "
 "{values}"
 
-#: ../../uaclient/messages/__init__.py:2555
+#: ../../uaclient/messages/__init__.py:2559
 #, python-brace-format
 msgid "Error updating ESM services cache: {error}"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:2565
+#, python-brace-format
+msgid ""
+"There is a problem with the resource directives provided by {url}\n"
+"These entitlements: {names} are sharing the following directives\n"
+" - APT url: {apt_url}\n"
+" - Suite: {suite}\n"
+"These directives need to be unique for every entitlement."
 msgstr ""
 
 #~ msgid "Detach this machine from Ubuntu Pro services."

--- a/debian/po/ubuntu-pro.pot
+++ b/debian/po/ubuntu-pro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-05 11:04-0800\n"
+"POT-Creation-Date: 2024-02-12 21:09-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2009,7 +2009,7 @@ msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1323
-#: ../../uaclient/messages/__init__.py:1768
+#: ../../uaclient/messages/__init__.py:1772
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
@@ -2374,133 +2374,138 @@ msgstr ""
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1685
+#: ../../uaclient/messages/__init__.py:1684
+#, python-brace-format
+msgid "{title} does not have a suites directive"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1689
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1692
+#: ../../uaclient/messages/__init__.py:1696
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1699
+#: ../../uaclient/messages/__init__.py:1703
 #, python-brace-format
 msgid ""
 "{title} is already enabled.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1706
+#: ../../uaclient/messages/__init__.py:1710
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1712
+#: ../../uaclient/messages/__init__.py:1716
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1718
+#: ../../uaclient/messages/__init__.py:1722
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1726
+#: ../../uaclient/messages/__init__.py:1730
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1734
+#: ../../uaclient/messages/__init__.py:1738
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1741
+#: ../../uaclient/messages/__init__.py:1745
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1749
+#: ../../uaclient/messages/__init__.py:1753
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1756
+#: ../../uaclient/messages/__init__.py:1760
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1762
+#: ../../uaclient/messages/__init__.py:1766
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1772
+#: ../../uaclient/messages/__init__.py:1776
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1775
+#: ../../uaclient/messages/__init__.py:1779
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1779
+#: ../../uaclient/messages/__init__.py:1783
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1784
+#: ../../uaclient/messages/__init__.py:1788
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1792
+#: ../../uaclient/messages/__init__.py:1796
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1801
+#: ../../uaclient/messages/__init__.py:1805
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1809
+#: ../../uaclient/messages/__init__.py:1813
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1813
+#: ../../uaclient/messages/__init__.py:1817
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1818
+#: ../../uaclient/messages/__init__.py:1822
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1826
+#: ../../uaclient/messages/__init__.py:1830
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2510,7 +2515,7 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1835
+#: ../../uaclient/messages/__init__.py:1839
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2519,75 +2524,75 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1845
+#: ../../uaclient/messages/__init__.py:1849
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1851
+#: ../../uaclient/messages/__init__.py:1855
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1860
+#: ../../uaclient/messages/__init__.py:1864
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1867
+#: ../../uaclient/messages/__init__.py:1871
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1874
+#: ../../uaclient/messages/__init__.py:1878
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1879
+#: ../../uaclient/messages/__init__.py:1883
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1883
+#: ../../uaclient/messages/__init__.py:1887
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1888
-msgid "apt-daily.timer jobs are not running"
-msgstr ""
-
 #: ../../uaclient/messages/__init__.py:1892
-#, python-brace-format
-msgid "{cfg_name} is empty"
+msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1896
 #, python-brace-format
-msgid "{cfg_name} is turned off"
+msgid "{cfg_name} is empty"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1900
+#, python-brace-format
+msgid "{cfg_name} is turned off"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1904
 msgid "unattended-upgrades package is not installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1906
+#: ../../uaclient/messages/__init__.py:1910
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1915
+#: ../../uaclient/messages/__init__.py:1919
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1920
+#: ../../uaclient/messages/__init__.py:1924
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1926
+#: ../../uaclient/messages/__init__.py:1930
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2597,28 +2602,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1940
+#: ../../uaclient/messages/__init__.py:1944
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1946
+#: ../../uaclient/messages/__init__.py:1950
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1976
+#: ../../uaclient/messages/__init__.py:1980
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1981
+#: ../../uaclient/messages/__init__.py:1985
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1987
+#: ../../uaclient/messages/__init__.py:1991
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2626,107 +2631,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1997
+#: ../../uaclient/messages/__init__.py:2001
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2004
+#: ../../uaclient/messages/__init__.py:2008
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2009
+#: ../../uaclient/messages/__init__.py:2013
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2013
+#: ../../uaclient/messages/__init__.py:2017
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2017
+#: ../../uaclient/messages/__init__.py:2021
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2022
+#: ../../uaclient/messages/__init__.py:2026
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2027
+#: ../../uaclient/messages/__init__.py:2031
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2032
+#: ../../uaclient/messages/__init__.py:2036
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2038
+#: ../../uaclient/messages/__init__.py:2042
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2044
+#: ../../uaclient/messages/__init__.py:2048
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2048
+#: ../../uaclient/messages/__init__.py:2052
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2054
+#: ../../uaclient/messages/__init__.py:2058
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2062
+#: ../../uaclient/messages/__init__.py:2066
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2068
+#: ../../uaclient/messages/__init__.py:2072
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2077
+#: ../../uaclient/messages/__init__.py:2081
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2084
+#: ../../uaclient/messages/__init__.py:2088
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2091
+#: ../../uaclient/messages/__init__.py:2095
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2096
+#: ../../uaclient/messages/__init__.py:2100
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2102
+#: ../../uaclient/messages/__init__.py:2106
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2734,7 +2739,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2112
+#: ../../uaclient/messages/__init__.py:2116
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2742,7 +2747,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2122
+#: ../../uaclient/messages/__init__.py:2126
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2750,41 +2755,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2132
+#: ../../uaclient/messages/__init__.py:2136
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2139
+#: ../../uaclient/messages/__init__.py:2143
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2145
+#: ../../uaclient/messages/__init__.py:2149
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2151
+#: ../../uaclient/messages/__init__.py:2155
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2156
+#: ../../uaclient/messages/__init__.py:2160
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2162
+#: ../../uaclient/messages/__init__.py:2166
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2170
+#: ../../uaclient/messages/__init__.py:2174
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2179
+#: ../../uaclient/messages/__init__.py:2183
 #, python-brace-format
 msgid ""
 "To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
@@ -2792,59 +2797,59 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2195
+#: ../../uaclient/messages/__init__.py:2199
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2200
+#: ../../uaclient/messages/__init__.py:2204
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2206
+#: ../../uaclient/messages/__init__.py:2210
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2214
+#: ../../uaclient/messages/__init__.py:2218
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2222
+#: ../../uaclient/messages/__init__.py:2226
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2229
+#: ../../uaclient/messages/__init__.py:2233
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2236
+#: ../../uaclient/messages/__init__.py:2240
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2245
+#: ../../uaclient/messages/__init__.py:2249
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2249
+#: ../../uaclient/messages/__init__.py:2253
 #, python-brace-format
 msgid ""
 "Error on Pro Image:\n"
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2255
+#: ../../uaclient/messages/__init__.py:2259
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2262
+#: ../../uaclient/messages/__init__.py:2266
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -2852,41 +2857,41 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2272
+#: ../../uaclient/messages/__init__.py:2276
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2279
+#: ../../uaclient/messages/__init__.py:2283
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2287
+#: ../../uaclient/messages/__init__.py:2291
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2296
+#: ../../uaclient/messages/__init__.py:2300
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2304
+#: ../../uaclient/messages/__init__.py:2308
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2310
+#: ../../uaclient/messages/__init__.py:2314
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2318
+#: ../../uaclient/messages/__init__.py:2322
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -2894,7 +2899,7 @@ msgid ""
 "and the VERSION_CODENAME information is not present"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2328
+#: ../../uaclient/messages/__init__.py:2332
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -2903,194 +2908,204 @@ msgid ""
 "$ sudo rm {lock_file_path}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2337
+#: ../../uaclient/messages/__init__.py:2341
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2343
+#: ../../uaclient/messages/__init__.py:2347
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
 "Expected {expected_value}, found {value}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2352
+#: ../../uaclient/messages/__init__.py:2356
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2359
+#: ../../uaclient/messages/__init__.py:2363
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2364
+#: ../../uaclient/messages/__init__.py:2368
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2370
+#: ../../uaclient/messages/__init__.py:2374
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
 "Cancelling config process operation.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2380
+#: ../../uaclient/messages/__init__.py:2384
 msgid "Can't load the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2385
+#: ../../uaclient/messages/__init__.py:2389
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2390
+#: ../../uaclient/messages/__init__.py:2394
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2394
+#: ../../uaclient/messages/__init__.py:2398
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2400
+#: ../../uaclient/messages/__init__.py:2404
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
 "Usage: \"pro fix CVE-yyyy-nnnn\" or \"pro fix USN-nnnn\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2406
+#: ../../uaclient/messages/__init__.py:2410
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2411
+#: ../../uaclient/messages/__init__.py:2415
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2419
 msgid "Unable to process uaclient.conf"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2420
+#: ../../uaclient/messages/__init__.py:2424
 msgid "Unable to refresh your subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2425
+#: ../../uaclient/messages/__init__.py:2429
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2431
+#: ../../uaclient/messages/__init__.py:2435
 msgid "json formatted response requires --assume-yes flag."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2439
+#: ../../uaclient/messages/__init__.py:2443
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
 "    "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2448
+#: ../../uaclient/messages/__init__.py:2452
 msgid "Cannot provide both --args and --data at the same time"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2454
+#: ../../uaclient/messages/__init__.py:2458
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2463
+#: ../../uaclient/messages/__init__.py:2467
 msgid "This command must be run as root (try using sudo)."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2468
+#: ../../uaclient/messages/__init__.py:2472
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2475
+#: ../../uaclient/messages/__init__.py:2479
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2479
+#: ../../uaclient/messages/__init__.py:2483
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2484
+#: ../../uaclient/messages/__init__.py:2488
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2489
+#: ../../uaclient/messages/__init__.py:2493
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2494
+#: ../../uaclient/messages/__init__.py:2498
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2499
+#: ../../uaclient/messages/__init__.py:2503
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
 "{data}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2504
+#: ../../uaclient/messages/__init__.py:2508
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2509
+#: ../../uaclient/messages/__init__.py:2513
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2514
+#: ../../uaclient/messages/__init__.py:2518
 msgid "features.disable_auto_attach set in config"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2519
+#: ../../uaclient/messages/__init__.py:2523
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2525
+#: ../../uaclient/messages/__init__.py:2529
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2531
+#: ../../uaclient/messages/__init__.py:2535
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2537
+#: ../../uaclient/messages/__init__.py:2541
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2544
+#: ../../uaclient/messages/__init__.py:2548
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2555
+#: ../../uaclient/messages/__init__.py:2559
 #, python-brace-format
 msgid "Error updating ESM services cache: {error}"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:2565
+#, python-brace-format
+msgid ""
+"There is a problem with the resource directives provided by {url}\n"
+"These entitlements: {names} are sharing the following directives\n"
+" - APT url: {apt_url}\n"
+" - Suite: {suite}\n"
+"These directives need to be unique for every entitlement."
 msgstr ""

--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -47,3 +47,53 @@ Feature: Performing attach using ua-airgapped
         Examples: ubuntu release
             | release | machine_type  |
             | jammy   | lxd-container |
+
+    Scenario Outline: airgapped environment with same apt url for different services
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        # set up the apt mirror configuration
+        Given a `jammy` `<machine_type>` machine named `mirror`
+        When I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `mirror` machine
+        And I run `apt-get update` `with sudo` on the `mirror` machine
+        And I run `apt-get install apt-mirror get-resource-tokens ua-airgapped -yq` `with sudo` on the `mirror` machine
+        And I download the service credentials on the `mirror` machine
+        And I extract the `esm-infra` credentials from the `mirror` machine
+        And I extract the `esm-apps` credentials from the `mirror` machine
+        And I set the apt-mirror file for `<release>` with the `esm-infra,esm-apps` credentials on the `mirror` machine
+        And I run `apt-mirror` `with sudo` on the `mirror` machine
+        And I consolidate `esm-infra,esm-apps` on a single mirror on the `mirror` machine
+        And I serve the `all-mirrors` mirror using port `8000` on the `mirror` machine
+        # set up the ua-airgapped configuration
+        And I create the contract config overrides file for `esm-infra,esm-apps` on the `mirror` machine
+        And I generate the contracts-airgapped configuration on the `mirror` machine
+        # set up the contracts-airgapped configuration
+        Given a `jammy` `<machine_type>` machine named `contracts`
+        When I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `contracts` machine
+        And I run `apt-get update` `with sudo` on the `contracts` machine
+        And I run `apt-get install contracts-airgapped -yq` `with sudo` on the `contracts` machine
+        And I run `apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4067E40313CB4B13` `with sudo` on the `contracts` machine
+        And I disable any internet connection on the `contracts` machine
+        And I send the contracts-airgapped config from the `mirror` machine to the `contracts` machine
+        And I start the contracts-airgapped service on the `contracts` machine
+        # attach an airgapped machine to the contracts-airgapped server
+        And I disable any internet connection on the machine
+        And I change config key `contract_url` to use value `http://$behave_var{machine-ip contracts}:8484`
+        And I attach `contract_token` with sudo
+        Then stdout matches regexp:
+        """
+        esm-apps     +yes      +enabled .*
+        esm-infra    +yes      +enabled .*
+        """
+        When I run `apt-cache policy hello` with sudo
+        Then stdout matches regexp:
+        """
+        510 .*:8000/ubuntu jammy-apps-security/main
+        """
+        And stdout matches regexp:
+        """
+        510 .*:8000/ubuntu jammy-infra-security/main
+        """
+        Then I verify that running `pro refresh` `with sudo` exits `0`
+
+        Examples: ubuntu release
+            | release | machine_type  |
+            | jammy   | lxd-container |

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -58,6 +58,9 @@ def attach_with_token(
     :raise ContractAPIError: On unexpected errors when talking to the contract
         server.
     """
+    from uaclient.entitlements import (
+        check_entitlement_apt_directives_are_unique,
+    )
     from uaclient.timer.update_messaging import update_motd_messages
 
     contract_client = contract.UAContractClient(cfg)
@@ -67,6 +70,12 @@ def attach_with_token(
     )
 
     cfg.machine_token_file.write(new_machine_token)
+
+    try:
+        check_entitlement_apt_directives_are_unique(cfg)
+    except exceptions.EntitlementsAPTDirectivesAreNotUnique as e:
+        cfg.machine_token_file.delete()
+        raise e
 
     system.get_machine_id.cache_clear()
     machine_id = new_machine_token.get("machineTokenInfo", {}).get(

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -254,6 +254,10 @@ class TestActionAttach:
         assert "mock_tabular_status" in out
 
     @mock.patch(
+        "uaclient.entitlements.check_entitlement_apt_directives_are_unique",
+        return_value=True,
+    )
+    @mock.patch(
         M_PATH + "contract.UAContractClient.update_activity_token",
     )
     @mock.patch("uaclient.files.state_files.attachment_data_file.write")
@@ -271,6 +275,7 @@ class TestActionAttach:
         _m_should_reboot,
         _m_attachment_data_file_write,
         m_update_activity_token,
+        _m_check_ent_apt_directives,
         FakeConfig,
         event,
     ):
@@ -523,6 +528,10 @@ class TestActionAttach:
             ),
         ),
     )
+    @mock.patch(
+        "uaclient.entitlements.check_entitlement_apt_directives_are_unique",
+        return_value=True,
+    )
     @mock.patch("uaclient.files.state_files.attachment_data_file.write")
     @mock.patch("uaclient.entitlements.entitlements_enable_order")
     @mock.patch("uaclient.contract.process_entitlement_delta")
@@ -537,6 +546,7 @@ class TestActionAttach:
         m_process_entitlement_delta,
         m_enable_order,
         _m_attachment_data_file_write,
+        _m_check_ent_apt_directives,
         expected_exception,
         expected_msg,
         expected_outer_msg,

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -79,6 +79,22 @@ class RepoEntitlement(base.UAEntitlement):
 
         return packages
 
+    @property
+    def apt_url(self) -> Optional[str]:
+        return (
+            self.entitlement_cfg.get("entitlement", {})
+            .get("directives", {})
+            .get("aptURL")
+        )
+
+    @property
+    def apt_suites(self) -> Optional[str]:
+        return (
+            self.entitlement_cfg.get("entitlement", {})
+            .get("directives", {})
+            .get("suites")
+        )
+
     def _check_for_reboot(self) -> bool:
         """Check if system needs to be rebooted."""
         reboot_required = system.should_reboot(

--- a/uaclient/entitlements/tests/test_entitlements.py
+++ b/uaclient/entitlements/tests/test_entitlements.py
@@ -3,6 +3,7 @@ import mock
 import pytest
 
 from uaclient import entitlements, exceptions, messages
+from uaclient.entitlements.entitlement_status import ApplicabilityStatus
 
 
 class TestValidServices:
@@ -262,3 +263,113 @@ class TestSortEntitlements:
                 cfg=FakeConfig(),
                 ents=["ent4", "notthere", "ent2", "ent6typo", "ent5"],
             )
+
+
+class TestCheckEntitlementAPTDefinitionsAreUnique:
+    @pytest.mark.parametrize(
+        (
+            "applicability_status1,applicability_status2,"
+            "apt_url1,suite1,apt_url2,suite2,expected"
+        ),
+        (
+            (
+                (ApplicabilityStatus.APPLICABLE, None),
+                (ApplicabilityStatus.APPLICABLE, None),
+                "test",
+                ("release",),
+                "test",
+                ("release",),
+                exceptions.EntitlementsAPTDirectivesAreNotUnique(
+                    url="test_url",
+                    names="ent1, ent2",
+                    apt_url="test",
+                    suite="release",
+                ),
+            ),
+            (
+                (ApplicabilityStatus.APPLICABLE, None),
+                (ApplicabilityStatus.INAPPLICABLE, None),
+                "test",
+                ("release",),
+                "test",
+                ("release",),
+                True,
+            ),
+            (
+                (ApplicabilityStatus.APPLICABLE, None),
+                (ApplicabilityStatus.APPLICABLE, None),
+                "test1",
+                ("release1",),
+                "test2",
+                ("release2",),
+                True,
+            ),
+            (
+                (ApplicabilityStatus.APPLICABLE, None),
+                (ApplicabilityStatus.APPLICABLE, None),
+                "test1",
+                ("release",),
+                "test1",
+                ("release2",),
+                True,
+            ),
+            (
+                (ApplicabilityStatus.APPLICABLE, None),
+                (ApplicabilityStatus.APPLICABLE, None),
+                "test1",
+                ("release",),
+                "test2",
+                ("release",),
+                True,
+            ),
+        ),
+    )
+    @mock.patch(
+        "uaclient.entitlements._is_repo_entitlement", return_value=True
+    )
+    @mock.patch("uaclient.entitlements.entitlement_factory")
+    @mock.patch("uaclient.entitlements.valid_services")
+    def test_check_entitlement_definitions_are_unique(
+        self,
+        m_valid_services,
+        m_ent_factory,
+        _m_is_repo_ent,
+        applicability_status1,
+        applicability_status2,
+        apt_url1,
+        suite1,
+        apt_url2,
+        suite2,
+        expected,
+    ):
+        m_valid_services.return_value = ["ent1", "ent2"]
+
+        m_ent1 = mock.MagicMock()
+        m_ent1_obj = mock.MagicMock()
+        m_ent1_obj.applicability_status.return_value = applicability_status1
+        type(m_ent1_obj).apt_url = apt_url1
+        type(m_ent1_obj).apt_suites = suite1
+        type(m_ent1_obj).repo_policy_check_tmpl = "{}/ubuntu {}"
+        m_ent1.return_value = m_ent1_obj
+
+        m_ent2 = mock.MagicMock()
+        m_ent2_obj = mock.MagicMock()
+        m_ent2_obj.applicability_status.return_value = applicability_status2
+        type(m_ent2_obj).apt_url = apt_url2
+        type(m_ent2_obj).apt_suites = suite2
+        type(m_ent2_obj).repo_policy_check_tmpl = "{}/ubuntu {}"
+        m_ent2.return_value = m_ent2_obj
+
+        m_ent_factory.side_effect = [m_ent1, m_ent2]
+
+        if expected is True:
+            assert entitlements.check_entitlement_apt_directives_are_unique(
+                mock.MagicMock()
+            )
+        else:
+            with pytest.raises(
+                exceptions.EntitlementsAPTDirectivesAreNotUnique
+            ):
+                entitlements.check_entitlement_apt_directives_are_unique(
+                    mock.MagicMock(url="test_url")
+                )

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -1290,7 +1290,10 @@ class TestApplicationStatus:
         """Report ENABLED when apt-policy lists specific aptURL."""
         entitlement = entitlement_factory(
             RepoTestEntitlement,
-            directives={"aptURL": "https://esm.ubuntu.com"},
+            directives={
+                "aptURL": "https://esm.ubuntu.com",
+                "suites": ["bionic-updates", "bionic-security"],
+            },
         )
 
         policy_lines = [

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -375,6 +375,10 @@ class InvalidContractDeltasServiceType(UbuntuProError):
     _formatted_msg = messages.E_INVALID_CONTRACT_DELTAS_SERVICE_TYPE
 
 
+class EntitlementsAPTDirectivesAreNotUnique(UbuntuProError):
+    _formatted_msg = messages.E_ENTITLEMENTS_APT_DIRECTIVES_ARE_NOT_UNIQUE
+
+
 ###############################################################################
 #                              CLOUD PRO                                      #
 ###############################################################################

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1679,6 +1679,10 @@ NO_APT_URL_FOR_SERVICE = FormattedNamedMessage(
     "no-apt-url-for-service",
     t.gettext("{title} does not have an aptURL directive"),
 )
+NO_SUITES_FOR_SERVICE = FormattedNamedMessage(
+    "no-suites-for-service",
+    t.gettext("{title} does not have a suites directive"),
+)
 ALREADY_DISABLED = FormattedNamedMessage(
     "service-already-disabled",
     t.gettext(

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -2558,3 +2558,13 @@ E_UPDATING_ESM_CACHE = FormattedNamedMessage(
     "error-updating-esm-cache",
     t.gettext("Error updating ESM services cache: {error}"),
 )
+
+E_ENTITLEMENTS_APT_DIRECTIVES_ARE_NOT_UNIQUE = FormattedNamedMessage(
+    "entitlements-apt-directives-are-not-unique",
+    t.gettext(
+        "There is a problem with the resource directives provided by {url}\n"
+        "These entitlements: {names} are sharing the following directives\n"
+        " - APT url: {apt_url}\n - Suite: {suite}\n"
+        "These directives need to be unique for every entitlement."
+    ),
+)


### PR DESCRIPTION
## Why is this needed?
When enabling a repo service, we check to see if it apt url is present at the output of apt-cache policy. We are updating this check to also check if any suite of the service also appear together with the apt url. We need this for some setups where the service share the same apt url.

LP: #2031192

## Test Steps
Run the new integration test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
