### PR TITLE
Convert repo files to deb822

### DIFF
--- a/lib/convert_list_to_deb822.py
+++ b/lib/convert_list_to_deb822.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+"""
+This script is called after running do-release-upgrade in a machine.
+This converts list files to deb822 files when upgrading to Noble.
+"""
+
+import logging
+import os
+import sys
+
+from aptsources.sourceslist import SourceEntry  # type: ignore
+
+from uaclient import entitlements
+from uaclient.apt import _get_sources_file_content
+from uaclient.cli import setup_logging
+from uaclient.config import UAConfig
+from uaclient.system import (
+    ensure_file_absent,
+    get_release_info,
+    load_file,
+    write_file,
+)
+from uaclient.util import set_filename_extension
+
+if __name__ == "__main__":
+    series = get_release_info().series
+    if series != "noble":
+        sys.exit(0)
+
+    setup_logging(logging.DEBUG)
+    cfg = UAConfig()
+
+    for entitlement_class in entitlements.ENTITLEMENT_CLASSES:
+        if not issubclass(
+            entitlement_class, entitlements.repo.RepoEntitlement
+        ):
+            continue
+
+        entitlement = entitlement_class(cfg)
+
+        filename = set_filename_extension(entitlement.repo_file, "list")
+        if os.path.exists(filename):
+            # If do-release-upgrade commented out the file, whether the
+            # repository is not reachable or is considered a third party, then
+            # it will be handled in upgrade_lts_contract. This script only
+            # changes services which are enabled, active and reachable.
+            valid_sources = [
+                SourceEntry(line)
+                for line in load_file(filename).strip().split("\n")
+                if line.strip().startswith("deb")
+            ]
+            if valid_sources:
+                # get this information from the file, to avoid interacting with
+                # the entitlement_config
+                suites = list(set(source.dist for source in valid_sources))
+                repo_url = valid_sources[0].uri
+                include_deb_src = any(
+                    source.type == "deb-src" for source in valid_sources
+                )
+                content = _get_sources_file_content(
+                    suites,
+                    series,
+                    True,
+                    repo_url,
+                    entitlement.repo_key_file,
+                    include_deb_src,
+                )
+                write_file(entitlement.repo_file, content)
+
+            ensure_file_absent(filename)

--- a/release-upgrades.d/ubuntu-advantage-upgrades.cfg
+++ b/release-upgrades.d/ubuntu-advantage-upgrades.cfg
@@ -1,4 +1,4 @@
 [Sources]
 Pockets=security,updates,proposed,backports,infra-security,infra-updates,apps-security,apps-updates
 [Distro]
-PostInstallScripts=./xorg_fix_proprietary.py, /usr/lib/ubuntu-advantage/upgrade_lts_contract.py
+PostInstallScripts=./xorg_fix_proprietary.py, /usr/lib/ubuntu-advantage/convert_list_to_deb822.py, /usr/lib/ubuntu-advantage/upgrade_lts_contract.py

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -220,7 +220,7 @@ def _get_state_files(cfg: config.UAConfig):
         timer_jobs_state_file.ua_file.path,
         CLOUD_BUILD_INFO,
         *(
-            entitlement.repo_list_file_tmpl.format(name=entitlement.name)
+            entitlement(cfg).repo_file
             for entitlement in entitlements.ENTITLEMENT_CLASSES
             if issubclass(entitlement, entitlements.repo.RepoEntitlement)
         ),

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -658,6 +658,12 @@ def remove_auth_apt_repo(
 ) -> None:
     """Remove an authenticated apt repo and credentials to the system"""
     system.ensure_file_absent(repo_filename)
+    # Also try to remove old .list files for compatibility with older releases.
+    if repo_filename.endswith(".sources"):
+        system.ensure_file_absent(
+            util.set_filename_extension(repo_filename, "list")
+        )
+
     if keyring_file:
         keyring_file = os.path.join(APT_KEYS_DIR, keyring_file)
         system.ensure_file_absent(keyring_file)

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -63,15 +63,6 @@ Components: main
 Signed-By: {keyrings_dir}/{keyring_file}
 """
 
-ESM_REPO_FILE_CONTENT = """\
-# Written by ubuntu-advantage-tools
-
-deb https://esm.ubuntu.com/{name}/ubuntu {series}-{name}-security main
-# deb-src https://esm.ubuntu.com/{name}/ubuntu {series}-{name}-security main
-
-deb https://esm.ubuntu.com/{name}/ubuntu {series}-{name}-updates main
-# deb-src https://esm.ubuntu.com/{name}/ubuntu {series}-{name}-updates main
-"""
 
 ESM_BASIC_FILE_STRUCTURE = {
     "files": [

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -56,7 +56,7 @@ SERIES_NOT_USING_DEB822 = ("xenial", "bionic", "focal", "jammy", "mantic")
 DEB822_REPO_FILE_CONTENT = """\
 # Written by ubuntu-advantage-tools
 
-Types: deb
+Types: deb{deb_src}
 URIs: {url}
 Suites: {suites}
 Components: main
@@ -506,6 +506,7 @@ def _get_sources_file_content(
     updates_enabled: bool,
     repo_url: str,
     keyring_file: str,
+    include_deb_src: bool = False,
 ) -> str:
     appliable_suites = [suite for suite in suites if series in suite]
     if not updates_enabled:
@@ -518,11 +519,14 @@ def _get_sources_file_content(
             suite for suite in appliable_suites if "-updates" not in suite
         ]
 
+    deb_src = " deb-src" if include_deb_src else ""
+
     content = DEB822_REPO_FILE_CONTENT.format(
         url=repo_url,
         suites=" ".join(appliable_suites),
         keyrings_dir=KEYRINGS_DIR,
         keyring_file=keyring_file,
+        deb_src=deb_src,
     )
 
     return content

--- a/uaclient/cli/tests/test_cli_collect_logs.py
+++ b/uaclient/cli/tests/test_cli_collect_logs.py
@@ -47,6 +47,9 @@ class TestActionCollectLogs:
         out, _err = capsys.readouterr()
         assert re.match(HELP_OUTPUT, out)
 
+    @pytest.mark.parametrize(
+        "series,extension", (("jammy", "list"), ("noble", "sources"))
+    )
     @pytest.mark.parametrize("is_root", ((True), (False)))
     @mock.patch("uaclient.util.we_are_currently_root")
     @mock.patch(
@@ -69,8 +72,10 @@ class TestActionCollectLogs:
     @mock.patch("uaclient.system.subp", return_value=(None, None))
     @mock.patch("uaclient.log.get_user_log_file")
     @mock.patch("uaclient.log.get_all_user_log_files")
+    @mock.patch("uaclient.system.get_release_info")
     def test_collect_logs(
         self,
+        m_get_release_info,
         m_get_users,
         m_get_user,
         m_subp,
@@ -86,9 +91,12 @@ class TestActionCollectLogs:
         _glob,
         util_we_are_currently_root,
         is_root,
+        series,
+        extension,
         FakeConfig,
         tmpdir,
     ):
+        m_get_release_info.return_value.series = series
         util_we_are_currently_root.return_value = is_root
         m_get_user.return_value = tmpdir.join("user-log").strpath
         m_get_users.return_value = [
@@ -173,17 +181,49 @@ class TestActionCollectLogs:
             mock.call(cfg.log_file),
             mock.call("/var/lib/ubuntu-advantage/jobs-status.json"),
             mock.call("/etc/cloud/build.info"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-anbox-cloud.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-cc-eal.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-cis.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-esm-apps.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-esm-infra.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-fips.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-fips-updates.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-fips-preview.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-realtime-kernel.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-ros.list"),
-            mock.call("/etc/apt/sources.list.d/ubuntu-ros-updates.list"),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-anbox-cloud.{}".format(
+                    extension
+                )
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-cc-eal.{}".format(extension)
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-cis.{}".format(extension)
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-esm-apps.{}".format(extension)
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-esm-infra.{}".format(extension)
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-fips.{}".format(extension)
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-fips-updates.{}".format(
+                    extension
+                )
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-fips-preview.{}".format(
+                    extension
+                )
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-realtime-kernel.{}".format(
+                    extension
+                )
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-ros.{}".format(extension)
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-ros-updates.{}".format(
+                    extension
+                )
+            ),
             mock.call("/var/log/ubuntu-advantage.log"),
             mock.call("/var/log/ubuntu-advantage.log.1"),
             *[mock.call(f) for f in APPARMOR_PROFILES],

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -68,6 +68,7 @@ class ESMBaseEntitlement(repo.RepoEntitlement):
                 suites=suites,
                 keyrings_dir=KEYRINGS_DIR,
                 keyring_file=self.repo_key_file,
+                deb_src="",
             ),
         )
 

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -36,7 +36,7 @@ class ESMBaseEntitlement(repo.RepoEntitlement):
         assert self.name.startswith("esm-")
         esm_name = self.name[len("esm-") :]
         repo_filename = os.path.normpath(
-            ESM_APT_ROOTDIR + self.repo_list_file_tmpl.format(name=self.name),
+            ESM_APT_ROOTDIR + self.repo_file,
         )
         keyring_file = self.repo_key_file
 
@@ -62,7 +62,7 @@ class ESMBaseEntitlement(repo.RepoEntitlement):
             ESM_APT_ROOTDIR + APT_KEYS_DIR + self.repo_key_file
         )
         repo_filename = os.path.normpath(
-            ESM_APT_ROOTDIR + self.repo_list_file_tmpl.format(name=self.name),
+            ESM_APT_ROOTDIR + self.repo_file,
         )
         system.ensure_file_absent(repo_filename)
         system.ensure_file_absent(keyring_file)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -31,7 +31,7 @@ RE_KERNEL_PKG = r"^linux-image-([\d]+[.-][\d]+[.-][\d]+-[\d]+-[A-Za-z0-9_-]+)$"
 
 
 class RepoEntitlement(base.UAEntitlement):
-    repo_file_tmpl = "/etc/apt/sources.list.d/ubuntu-{name}.list"
+    repo_file_tmpl = "/etc/apt/sources.list.d/ubuntu-{name}.{extension}"
     repo_pref_file_tmpl = "/etc/apt/preferences.d/ubuntu-{name}"
     repo_url_tmpl = "{}/ubuntu"
 
@@ -55,7 +55,11 @@ class RepoEntitlement(base.UAEntitlement):
 
     @property
     def repo_file(self) -> str:
-        return self.repo_file_tmpl.format(name=self.name)
+        extension = "sources"
+        series = system.get_release_info().series
+        if series in apt.SERIES_NOT_USING_DEB822:
+            extension = "list"
+        return self.repo_file_tmpl.format(name=self.name, extension=extension)
 
     @property
     def packages(self) -> List[str]:

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -134,6 +134,7 @@ class TestUpdateESMCaches:
                         suites=suites,
                         keyrings_dir=apt.KEYRINGS_DIR,
                         keyring_file=entitlement.repo_key_file,
+                        deb_src="",
                     ),
                 )
             ]

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -124,10 +124,7 @@ class TestUpdateESMCaches:
             assert m_write_file.call_args_list == [
                 mock.call(
                     os.path.normpath(
-                        apt.ESM_APT_ROOTDIR
-                        + entitlement.repo_list_file_tmpl.format(
-                            name=entitlement.name
-                        ),
+                        apt.ESM_APT_ROOTDIR + entitlement.repo_file,
                     ),
                     apt.ESM_REPO_FILE_CONTENT.format(
                         name=entitlement.name[4:], series="example"
@@ -165,8 +162,7 @@ class TestUpdateESMCaches:
         assert m_ensure_file_absent.call_args_list == [
             mock.call(
                 os.path.normpath(
-                    apt.ESM_APT_ROOTDIR
-                    + self.repo_list_file_tmpl.format(name=self.name),
+                    apt.ESM_APT_ROOTDIR + self.repo_file,
                 )
             ),
             mock.call(

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -639,7 +639,7 @@ class TestCleanAptFiles:
 
         class TestRepo(request.param):
             name = entitlement_name
-            repo_list_file_tmpl = repo_tmpl
+            repo_file_tmpl = repo_tmpl
             repo_pref_file_tmpl = pref_tmpl
             is_repo = request.param == RepoEntitlement
 

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -468,3 +468,33 @@ class TestReplaceLoggerName:
         assert (
             util.replace_top_level_logger_name(logger_name) == new_logger_name
         )
+
+
+class TestSetFilenameExtension:
+    @pytest.mark.parametrize(
+        "input_string,extension,output_string",
+        (
+            ("virus.exe", "test", "virus.test"),
+            (
+                "/many/dots.and.slashes/in/this.file",
+                "test",
+                "/many/dots.and.slashes/in/this.test",
+            ),
+            ("/no/change/when.same", "same", "/no/change/when.same"),
+            ("no_extension", "test", "no_extension.test"),
+            (
+                "/with.previous.dots/no_extension",
+                "test",
+                "/with.previous.dots/no_extension.test",
+            ),
+            ("d.o.t.s", "test", "d.o.t.test"),
+            (".dotfile", "test", ".dotfile.test"),
+        ),
+    )
+    def test_set_filename_extension(
+        self, input_string, extension, output_string
+    ):
+        assert (
+            util.set_filename_extension(input_string, extension)
+            == output_string
+        )

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -461,6 +461,11 @@ def we_are_currently_root() -> bool:
     return os.getuid() == 0
 
 
+def set_filename_extension(filename: str, new_extension: str) -> str:
+    name, _extension = os.path.splitext(filename)
+    return name + "." + new_extension
+
+
 def print_package_list(
     package_list: List[str],
 ):


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because Ubuntu itself will change to deb822 sources by default, and the Client should follow. Not changing means warnings in the future, and adapting early gives us room to facilitate integration when the shift actually happens.

## Test Steps
Except from the file format, everything should work exactly the same. CI should cover all cases.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [x] Yes - SRU people + Julian would be nice
 - [ ] No