### PR TITLE
fix: don't include LSN in cve notices list

### DIFF
--- a/uaclient/api/tests/test_api_u_pro_security_fix.py
+++ b/uaclient/api/tests/test_api_u_pro_security_fix.py
@@ -273,8 +273,8 @@ class TestCVE:
             (None, []),
             ([], []),
             (  # USNs are properly sorted by id
-                [{"id": "1"}, {"id": "2"}],
-                [USN(None, {"id": "2"}), USN(None, {"id": "1"})],
+                [{"id": "USN-1"}, {"id": "USN-2"}, {"id": "LSN-3"}],
+                [USN(None, {"id": "USN-2"}), USN(None, {"id": "USN-1"})],
             ),
         ),
     )

--- a/uaclient/api/u/pro/security/fix/_common/__init__.py
+++ b/uaclient/api/u/pro/security/fix/_common/__init__.py
@@ -296,6 +296,7 @@ class CVE:
                 [
                     USN(self.client, notice)
                     for notice in self.response.get("notices", [])
+                    if notice and notice.get("id", "").startswith("USN-")
                 ],
                 key=lambda n: n.id,
                 reverse=True,


### PR DESCRIPTION
## Why is this needed?
When fetching the CVE notices list, we should exclude a LSNs, as they are not supported for the fix operation

## Test Steps
Run the bionic fix test and guarantee that it is passing

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
