### PR TITLE
Improve pro fix docs

### DIFF
--- a/docs/explanations.rst
+++ b/docs/explanations.rst
@@ -28,7 +28,6 @@ selection of some of the commands -- what they do, and how they work.
 
     explanations/how_to_interpret_the_security_status_command.md
     explanations/how_to_interpret_output_of_unattended_upgrades.md
-    explanations/how_to_interpret_output_of_fix_plan_api.md
     explanations/status_columns.md
     explanations/what_refresh_does.md
     explanations/purging_services.md
@@ -45,13 +44,25 @@ tooling: the ``ubuntu-advantage-pro`` package.
     explanations/what_are_ubuntu_pro_cloud_instances.md
     explanations/what_is_the_ubuntu_advantage_pro_package.md
 
+
+Ease handling of CVEs and USNs
+==============================
+
+In this section we explain output and interactions related to CVEs and USNs.
+
+..  toctree::
+    :maxdepth: 1
+
+    explanations/cves_and_usns_explained.md
+    explanations/fix_scenarios.rst
+    explanations/how_to_interpret_output_of_fix_plan_api.md
+
 Other Pro features explained
 ============================
 
 ..  toctree::
     :maxdepth: 1
 
-    explanations/cves_and_usns_explained.md
     explanations/about_esm.md
     explanations/what_are_the_timer_jobs.md
     explanations/using_pro_offline.rst

--- a/docs/explanations.rst
+++ b/docs/explanations.rst
@@ -48,7 +48,8 @@ tooling: the ``ubuntu-advantage-pro`` package.
 Ease handling of CVEs and USNs
 ==============================
 
-In this section we explain output and interactions related to CVEs and USNs.
+In this section we explain the output of ``pro fix`` and its API interface
+as well as some details related to it like CVEs and USNs.
 
 ..  toctree::
     :maxdepth: 1

--- a/docs/explanations.rst
+++ b/docs/explanations.rst
@@ -45,7 +45,7 @@ tooling: the ``ubuntu-advantage-pro`` package.
     explanations/what_is_the_ubuntu_advantage_pro_package.md
 
 
-Ease handling of CVEs and USNs
+Handling CVEs and USNs
 ==============================
 
 In this section we explain the output of ``pro fix`` and its API interface

--- a/docs/explanations/fix_scenarios.rst
+++ b/docs/explanations/fix_scenarios.rst
@@ -15,15 +15,16 @@ encounter using ``pro fix``.
    If instead you look for a simpler guided tutorial to get started with
    ``pro fix`` please start at
    :ref:`Use pro fix to solve a CVE/USN <pro-fix-tutorial>`.
+   You can even use the VM based environment created in that tutorial
+   to recreate the output shown below yourself.
 
 
 Use ``pro fix``
 ===============
 
 First, let's see what happens to your system when ``pro fix`` runs. We will
-choose to fix a CVE that does not affect the VM -- in this case,
-`CVE-2020-15180`_. This CVE addresses security issues for the ``MariaDB``
-package, which is not installed on the system.
+choose to fix a CVE that does not affect the system -- for example if you
+do not have ``MariaDB`` installed `CVE-2020-15180`_.
 
 Let's first confirm that it doesn't affect the system by running this command:
 
@@ -56,8 +57,10 @@ CVE/USN without a released fix
 ==============================
 
 Some CVEs/USNs do not have a fix released yet. When that happens, ``pro fix``
-will let you know! Before we reproduce this scenario, let us first install a
-package that we know has no fix available by running:
+will let you know! This is example output created in the past, there
+might be fixes for it later on. To create this scenario we installed a
+known affected package with no fix at the time and then checked for an
+available fix:
 
 .. code-block:: bash
 
@@ -117,11 +120,11 @@ The command will prompt you for a response, like this:
     subscription.
 
     Choose: [S]ubscribe at ubuntu.com [A]ttach existing token [C]ancel
-    > 
+    >
 
 We can see that the prompt is asking for an Ubuntu Pro subscription token. Any
 user with a Ubuntu One account is entitled to a free personal token to use with
-Ubuntu Pro. 
+Ubuntu Pro.
 
 If you choose the ``Subscribe`` option on the prompt, the command will ask you
 to go to the `Ubuntu Pro portal <Pro_>`_. In the portal, you can get a free
@@ -212,7 +215,7 @@ we observe that the USN is indeed fixed, which you can confirm by running the
 
     ✔ USN-5079-2 is resolved.
 
-.. note:: 
+.. note::
 
     Even though we are not covering this scenario here, if you have an expired
     contract, ``pro fix`` will detect that and prompt you to attach a new token
@@ -315,8 +318,8 @@ affected packages. This happens when only a subset of the packages have
 available updates to fix for that CVE/USN.
 
 In this case, ``pro fix`` will tell you which package(s) it can or cannot fix.
-But first, let's install a package so we can run ``pro fix`` to demonstrate
-this scenario.
+In the example, we install a package so we can run ``pro fix`` against to
+demonstrate this scenario.
 
 .. code-block:: bash
 

--- a/docs/explanations/fix_scenarios.rst
+++ b/docs/explanations/fix_scenarios.rst
@@ -6,8 +6,8 @@ Scenarios encountered using ``pro fix`` to solve a CVE/USN
 .. Into "what is pro fix" shared with the related tutorial
 .. include:: ../includes/pro-fix-intro.txt
 
-This howto will go a bit deeper and after introducing the ``pro fix``
-command it will go in more details about the differen scenarios you may
+This page will go a bit deeper and after introducing the ``pro fix``
+command it will go in more details about the different scenarios you may
 encounter using ``pro fix``.
 
 .. note::
@@ -356,7 +356,7 @@ Success!
 ========
 
 Congratulations!  You have learned about the various scenarios that ``pro fix``
-might encounter to be ready to undertand what is happening when using it in a
+might encounter to be ready to understand what is happening when using it in a
 variety of situations.
 
 Next steps

--- a/docs/explanations/fix_scenarios.rst
+++ b/docs/explanations/fix_scenarios.rst
@@ -355,18 +355,12 @@ resolved.
 Success!
 ========
 
-Congratulations! You successfully ran a Multipass VM and used it to encounter
-and resolve the main scenarios that you might find when you run ``pro fix``.
-
-.. Instructions for closing down and deleting the VM
-.. include:: ./common/shutdown-vm.txt
+Congratulations!  You have learned about the various scenarios that ``pro fix``
+might encounter to be ready to undertand what is happening when using it in a
+variety of situations.
 
 Next steps
 ----------
-
-You have learned about the various scenarios that ``pro fix`` might encounter
-to be ready to undertand what is happening when using it in a variety of
-situations.
 
 There are further options to control what exactly will happen when
 running ``pro fix``, read about them in:

--- a/docs/explanations/fix_scenarios.rst
+++ b/docs/explanations/fix_scenarios.rst
@@ -51,6 +51,7 @@ Every ``pro fix`` output has a similar output structure. It:
 .. # The basic case is shared between Howto and Tutorial
 .. include:: ../includes/pro-fix-simple-case.txt
 .. _CVE-no-fix:
+
 CVE/USN without a released fix
 ==============================
 

--- a/docs/explanations/fix_scenarios.rst
+++ b/docs/explanations/fix_scenarios.rst
@@ -1,22 +1,20 @@
 .. _pro-fix-howto:
 
-Scenarios encountered using ``pro fix`` to solve a CVE/USN
+Common scenarios when using ``pro fix`` to solve a CVE/USN
 **********************************************************
 
 .. Into "what is pro fix" shared with the related tutorial
 .. include:: ../includes/pro-fix-intro.txt
 
-This page will go a bit deeper and after introducing the ``pro fix``
-command it will go in more details about the different scenarios you may
-encounter using ``pro fix``.
+In this article we will introduce the ``pro fix`` command, and then go into more details about the different scenarios you may encounter when using ``pro fix`` to resolve CVEs/USNs.
 
 .. note::
 
    If instead you look for a simpler guided tutorial to get started with
    ``pro fix`` please start at
    :ref:`Use pro fix to solve a CVE/USN <pro-fix-tutorial>`.
-   You can even use the VM based environment created in that tutorial
-   to recreate the output shown below yourself.
+   You can use the same VM-based environment created in that tutorial
+   to recreate the output shown below yourself. If you have already completed the tutorial, you may want to :ref:`skip this section <CVE-no-fix>`.
 
 
 Use ``pro fix``
@@ -52,14 +50,14 @@ Every ``pro fix`` output has a similar output structure. It:
 
 .. # The basic case is shared between Howto and Tutorial
 .. include:: ../includes/pro-fix-simple-case.txt
-
+.. _CVE-no-fix:
 CVE/USN without a released fix
 ==============================
 
 Some CVEs/USNs do not have a fix released yet. When that happens, ``pro fix``
-will let you know! This is example output created in the past, there
-might be fixes for it later on. To create this scenario we installed a
-known affected package with no fix at the time and then checked for an
+will let you know! This is example output created in the past, for which there
+might be fixes later on. To create this scenario we installed a
+known affected package with no fix (at the time) and then checked for an
 available fix:
 
 .. code-block:: bash
@@ -318,7 +316,7 @@ affected packages. This happens when only a subset of the packages have
 available updates to fix for that CVE/USN.
 
 In this case, ``pro fix`` will tell you which package(s) it can or cannot fix.
-In the example, we install a package so we can run ``pro fix`` against to
+In the example, we install a package so we can run ``pro fix`` against it to
 demonstrate this scenario.
 
 .. code-block:: bash
@@ -368,7 +366,7 @@ Next steps
 There are further options to control what exactly will happen when
 running ``pro fix``, read about them in:
 
-* :ref:`How to know what the fix command would change? <pro-fix-dry-run>`
+* :ref:`How to know what the fix command would change <pro-fix-dry-run>`
 * :ref:`How to skip fixing related USNs <pro-fix-skip-related>`
 
 .. Instructions for how to connect with us

--- a/docs/explanations/fix_scenarios.rst
+++ b/docs/explanations/fix_scenarios.rst
@@ -1,7 +1,7 @@
 .. _pro-fix-howto:
 
-Understand scenarios encountered using ``pro fix`` to solve a CVE/USN
-*********************************************************************
+Scenarios encountered using ``pro fix`` to solve a CVE/USN
+**********************************************************
 
 .. Into "what is pro fix" shared with the related tutorial
 .. include:: ../includes/pro-fix-intro.txt

--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -52,7 +52,6 @@ How to use ``pro`` commands
 .. toctree::
    :maxdepth: 1
 
-   Understand scenarios encountered using `pro fix` to solve a CVE/USN <howtoguides/fix_scenarios>
    How to know what the `fix` command would change? <howtoguides/how_to_know_what_the_fix_command_would_change>
    Skip fixing related USNs <howtoguides/how_to_not_fix_related_usns>
 

--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -52,6 +52,7 @@ How to use ``pro`` commands
 .. toctree::
    :maxdepth: 1
 
+   Understand scenarios encountered using `pro fix` to solve a CVE/USN <howtoguides/fix_scenarios>
    Run `fix` in "dry run" mode <howtoguides/how_to_run_fix_in_dry_run_mode>
    Skip fixing related USNs <howtoguides/how_to_not_fix_related_usns>
 

--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -53,7 +53,7 @@ How to use ``pro`` commands
    :maxdepth: 1
 
    Understand scenarios encountered using `pro fix` to solve a CVE/USN <howtoguides/fix_scenarios>
-   Run `fix` in "dry run" mode <howtoguides/how_to_run_fix_in_dry_run_mode>
+   How to know what the `fix` command would change? <howtoguides/how_to_know_what_the_fix_command_would_change>
    Skip fixing related USNs <howtoguides/how_to_not_fix_related_usns>
 
 ``pro refresh``

--- a/docs/howtoguides/fix_scenarios.rst
+++ b/docs/howtoguides/fix_scenarios.rst
@@ -370,8 +370,9 @@ situations.
 
 There are further options to control what exactly will happen when
 running ``pro fix``, read about them in:
-:ref:`How to know what the fix command would change? <pro-fix-dry-run>`
-:ref:`How to skip fixing related USNs <pro-fix-skip-related>`
+
+* :ref:`How to know what the fix command would change? <pro-fix-dry-run>`
+* :ref:`How to skip fixing related USNs <pro-fix-skip-related>`
 
 .. Instructions for how to connect with us
 .. include:: ../includes/contact.txt

--- a/docs/howtoguides/fix_scenarios.rst
+++ b/docs/howtoguides/fix_scenarios.rst
@@ -368,12 +368,8 @@ You have learned about the various scenarios that ``pro fix`` might encounter
 to be ready to undertand what is happening when using it in a variety of
 situations.
 
-If you need more information about this command, please feel free to reach out
-to the Ubuntu Pro Client team on ``#ubuntu-server`` on
-`Libera IRC <pro_IRC_>`_ -- we're happy to help! 
-
-Alternatively, if you have a GitHub account, click on the "Give feedback"
-link at the top of this page to leave us a message. We'd love to hear from you!
+.. Instructions for how to connect with us
+.. include:: ../includes/contact.txt
 
 .. LINKS
 

--- a/docs/howtoguides/fix_scenarios.rst
+++ b/docs/howtoguides/fix_scenarios.rst
@@ -368,6 +368,11 @@ You have learned about the various scenarios that ``pro fix`` might encounter
 to be ready to undertand what is happening when using it in a variety of
 situations.
 
+There are further options to control what exactly will happen when
+running ``pro fix``, read about them in:
+:ref:`How to know what the fix command would change? <pro-fix-dry-run>`
+:ref:`How to skip fixing related USNs <pro-fix-skip-related>`
+
 .. Instructions for how to connect with us
 .. include:: ../includes/contact.txt
 

--- a/docs/howtoguides/fix_scenarios.rst
+++ b/docs/howtoguides/fix_scenarios.rst
@@ -1,23 +1,20 @@
-Use ``pro fix`` to solve a CVE/USN
-**********************************
+.. _pro-fix-howto:
 
-The Ubuntu Pro Client (``pro``) can be used to inspect and resolve
-`Common Vulnerabilities and Exposures <cve_>`_ (CVEs) and
-`Ubuntu Security Notices <usn_>`_ (USNs) on your machine.
+Understand scenarios encountered using ``pro fix`` to solve a CVE/USN
+*********************************************************************
 
-Every CVE/USN is fixed by trying to upgrade all of the affected packages
-described by the CVE or USN. Sometimes, the package fixes can only be applied
-if an Ubuntu Pro service is already enabled on your machine.
+.. Into "what is pro fix" shared with the related tutorial
+.. include:: ../includes/pro-fix-intro.txt
 
-In this tutorial, we will introduce the ``pro fix`` command and test some
-common scenarios you may encounter.
+This howto will go a bit deeper and after introducing the ``pro fix``
+command it will go in more details about the differen scenarios you may
+encounter using ``pro fix``.
 
-.. Why we use Multipass + command to install it
-.. include:: ./common/install-multipass.txt
+.. note::
 
-.. Commands for launching and updating a Xenial VM
-.. include:: ./common/create-vm.txt
-
+   If instead you look for a simpler guided tutorial to get started with
+   ``pro fix`` please start at
+   :ref:`Use pro fix to solve a CVE/USN <pro-fix-tutorial>`.
 
 
 Use ``pro fix``
@@ -52,64 +49,8 @@ Every ``pro fix`` output has a similar output structure. It:
 * fixes the affected packages; and
 * at the end, shows if the CVE/USN is fully fixed in the machine.
 
-This is better demonstrated in a ``pro fix`` call that *does* fix a package!
-
-Let's install a package on the VM that we know is associated with
-`CVE-2020-25686`_. You can install the package by running these commands:
-
-.. code-block:: bash
-
-    $ sudo apt update
-    $ sudo apt install dnsmasq=2.75-1
-
-Now, let's run ``pro fix`` on the package:
-
-.. code-block:: bash
-
-    $ sudo pro fix CVE-2020-25686
-
-You will then see the following output:
-
-.. code-block:: text
-
-    CVE-2020-25686: Dnsmasq vulnerabilities
-    https://ubuntu.com/security/CVE-2020-25686
-
-    1 affected package is installed: dnsmasq
-    (1/1) dnsmasq:
-    A fix is available in Ubuntu standard updates.
-    { apt update && apt install --only-upgrade -y dnsmasq }
-
-    ✔ CVE-2020-25686 is resolved.
-
-.. note::
-
-    We need to run the command with ``sudo`` because we are now installing a
-    package on the system.
-
-Whenever ``pro fix`` has a package to upgrade, it follows a consistent
-structure and displays the following, in this order:
-
-1. The affected package
-2. The availability of a fix
-3. The location of the fix, if one is available
-4. The command that will fix the issue
-
-Also, at the end of the output you can see confirmation that the CVE was fixed
-by the command. Just to confirm that the fix was successfully applied, let's
-run the ``pro fix`` command again, and we should now see the following:
-
-.. code-block:: text
-
-    CVE-2020-25686: Dnsmasq vulnerabilities
-    https://ubuntu.com/security/CVE-2020-25686
-
-    1 affected package is installed: dnsmasq
-    (1/1) dnsmasq:
-    A fix is available in Ubuntu standard updates.
-    The update is already installed.
-
-    ✔ CVE-2020-25686 is resolved.
+.. # The basic case is shared between Howto and Tutorial
+.. include:: ../includes/pro-fix-simple-case.txt
 
 CVE/USN without a released fix
 ==============================
@@ -423,8 +364,9 @@ and resolve the main scenarios that you might find when you run ``pro fix``.
 Next steps
 ----------
 
-We have successfully encountered and resolved the main scenarios that you might
-find when you run ``pro fix``.
+You have learned about the various scenarios that ``pro fix`` might encounter
+to be ready to undertand what is happening when using it in a variety of
+situations.
 
 If you need more information about this command, please feel free to reach out
 to the Ubuntu Pro Client team on ``#ubuntu-server`` on

--- a/docs/howtoguides/how_to_know_what_the_fix_command_would_change.rst
+++ b/docs/howtoguides/how_to_know_what_the_fix_command_would_change.rst
@@ -3,12 +3,12 @@
 How to know what the ``fix`` command would change?
 **************************************************
 
-As outlined in
-:ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`
+As outlined in our explanation of the different scenarios encountered when
+:ref:`using pro fix to solve a CVE/USN <pro-fix-howto>`,
 ``pro fix`` can encounter many conditions
 and running it might or might not lead to upgrades of packages on your system.
 
-If you are unsure what changes will happen to your system when you run
+If you are unsure and want to check what changes will happen to your system when you run
 ``pro fix`` to address a CVE/USN, you can simulate a run using the
 ``--dry-run`` flag to see which packages will be installed on the system. For
 example, this is the output of running ``pro fix USN-5079-2 --dry-run``:

--- a/docs/howtoguides/how_to_know_what_the_fix_command_would_change.rst
+++ b/docs/howtoguides/how_to_know_what_the_fix_command_would_change.rst
@@ -1,3 +1,5 @@
+.. _pro-fix-dry-run:
+
 How to know what the ``fix`` command would change?
 **************************************************
 

--- a/docs/howtoguides/how_to_know_what_the_fix_command_would_change.rst
+++ b/docs/howtoguides/how_to_know_what_the_fix_command_would_change.rst
@@ -1,7 +1,12 @@
-How to run the ``fix`` command in "dry run" mode
-************************************************
+How to know what the ``fix`` command would change?
+**************************************************
 
-If you are unsure what changes will happen to your system after you run
+As outlined in
+:ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`
+``pro fix`` can encounter many conditions
+and running it might or might not lead to upgrades of packages on your system.
+
+If you are unsure what changes will happen to your system when you run
 ``pro fix`` to address a CVE/USN, you can simulate a run using the
 ``--dry-run`` flag to see which packages will be installed on the system. For
 example, this is the output of running ``pro fix USN-5079-2 --dry-run``:

--- a/docs/howtoguides/how_to_not_fix_related_usns.rst
+++ b/docs/howtoguides/how_to_not_fix_related_usns.rst
@@ -1,5 +1,11 @@
+.. _pro-fix-skip-related:
+
 How to skip fixing related USNs
 *******************************
+
+The general scenarios you might encounter when running ``pro fix`` are
+outlined in
+:ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`
 
 When running the ``pro fix`` command for a USN, by default we also try to fix
 any related USNs as well. To better understand the concept of related USNs,

--- a/docs/howtoguides/how_to_not_fix_related_usns.rst
+++ b/docs/howtoguides/how_to_not_fix_related_usns.rst
@@ -4,8 +4,8 @@ How to skip fixing related USNs
 *******************************
 
 The general scenarios you might encounter when running ``pro fix`` are
-outlined in
-:ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`
+outlined in our explanation of
+:ref:`using pro fix to solve a CVE/USN <pro-fix-howto>`.
 
 When running the ``pro fix`` command for a USN, by default we also try to fix
 any related USNs as well. To better understand the concept of related USNs,

--- a/docs/includes/contact.txt
+++ b/docs/includes/contact.txt
@@ -1,0 +1,6 @@
+If you need more information about this, please feel free to reach out
+to the Ubuntu Pro Client team on ``#ubuntu-server`` on
+`Libera IRC <pro_IRC_>`_ -- we're happy to help!
+
+Alternatively, if you have a GitHub account, click on the "Give feedback"
+link at the top of this page to leave us a message. We'd love to hear from you!

--- a/docs/includes/pro-fix-intro.txt
+++ b/docs/includes/pro-fix-intro.txt
@@ -1,0 +1,7 @@
+The Ubuntu Pro Client (``pro``) can be used to inspect and resolve
+`Common Vulnerabilities and Exposures <cve_>`_ (CVEs) and
+`Ubuntu Security Notices <usn_>`_ (USNs) on your machine.
+
+Every CVE/USN is fixed by trying to upgrade all of the affected packages
+described by the CVE or USN. Sometimes, the package fixes can only be applied
+if an Ubuntu Pro service is already enabled on your machine.

--- a/docs/includes/pro-fix-simple-case.txt
+++ b/docs/includes/pro-fix-simple-case.txt
@@ -1,0 +1,60 @@
+This is best demonstrated in a ``pro fix`` call that *does* fix a package.
+
+Therefore let us install an older package on the VM that we know is associated
+with `CVE-2020-25686`_. You can install the package by running these commands:
+
+.. code-block:: bash
+
+    $ sudo apt update
+    $ sudo apt install dnsmasq=2.75-1
+
+Now, let's run ``pro fix`` on the CVE:
+
+.. code-block:: bash
+
+    $ sudo pro fix CVE-2020-25686
+
+You will then see the following output:
+
+.. code-block:: text
+
+    CVE-2020-25686: Dnsmasq vulnerabilities
+    https://ubuntu.com/security/CVE-2020-25686
+
+    1 affected package is installed: dnsmasq
+    (1/1) dnsmasq:
+    A fix is available in Ubuntu standard updates.
+    { apt update && apt install --only-upgrade -y dnsmasq }
+
+    ✔ CVE-2020-25686 is resolved.
+
+.. note::
+
+    We need to run the command with ``sudo`` because it will be installing a
+    package on the system.
+
+Whenever ``pro fix`` has a package to upgrade, it follows a consistent
+structure and displays the following, in this order:
+
+1. The affected package
+2. The availability of a fix
+3. The location of the fix, if one is available
+4. The command that will fix the issue
+
+Also, at the end of the output you can see confirmation that the CVE was fixed
+by the command. Just to confirm that the fix was successfully applied, let's
+run the ``pro fix`` command again, and we should now see the following:
+
+.. code-block:: text
+
+    CVE-2020-25686: Dnsmasq vulnerabilities
+    https://ubuntu.com/security/CVE-2020-25686
+
+    1 affected package is installed: dnsmasq
+    (1/1) dnsmasq:
+    A fix is available in Ubuntu standard updates.
+    The update is already installed.
+
+    ✔ CVE-2020-25686 is resolved.
+
+

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -37,5 +37,5 @@ start. They are not sequential, so you can approach them in any order you like!
 ..  toctree::
     :maxdepth: 1
 
-    tutorials/fix_scenarios.rst
+    tutorials/fix_intro.rst
     tutorials/create_a_fips_docker_image.rst

--- a/docs/tutorials/fix_intro.rst
+++ b/docs/tutorials/fix_intro.rst
@@ -50,8 +50,11 @@ We have successfully encountered and resolved the main scenarios that you might
 find when you run ``pro fix``.
 
 As mentioned at the beginning, there might be more scenarios that you may
-encounter using ``pro fix``, those are covered in detail in
-:ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`.
+encounter using ``pro fix`` as well as options to control what exactly will
+happen, those are covered in detail in:
+:ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`
+:ref:`How to know what the fix command would change? <pro-fix-dry-run>`
+:ref:`How to skip fixing related USNs <pro-fix-skip-related>`
 
 .. Instructions for how to connect with us
 .. include:: ../includes/contact.txt

--- a/docs/tutorials/fix_intro.rst
+++ b/docs/tutorials/fix_intro.rst
@@ -52,9 +52,10 @@ find when you run ``pro fix``.
 As mentioned at the beginning, there might be more scenarios that you may
 encounter using ``pro fix`` as well as options to control what exactly will
 happen, those are covered in detail in:
-:ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`
-:ref:`How to know what the fix command would change? <pro-fix-dry-run>`
-:ref:`How to skip fixing related USNs <pro-fix-skip-related>`
+
+* :ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`
+* :ref:`How to know what the fix command would change? <pro-fix-dry-run>`
+* :ref:`How to skip fixing related USNs <pro-fix-skip-related>`
 
 .. Instructions for how to connect with us
 .. include:: ../includes/contact.txt

--- a/docs/tutorials/fix_intro.rst
+++ b/docs/tutorials/fix_intro.rst
@@ -53,12 +53,8 @@ As mentioned at the beginning, there might be more scenarios that you may
 encounter using ``pro fix``, those are covered in detail in
 :ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`.
 
-If you need more information about this command, please feel free to reach out
-to the Ubuntu Pro Client team on ``#ubuntu-server`` on
-`Libera IRC <pro_IRC_>`_ -- we're happy to help! 
-
-Alternatively, if you have a GitHub account, click on the "Give feedback"
-link at the top of this page to leave us a message. We'd love to hear from you!
+.. Instructions for how to connect with us
+.. include:: ../includes/contact.txt
 
 .. LINKS
 

--- a/docs/tutorials/fix_intro.rst
+++ b/docs/tutorials/fix_intro.rst
@@ -53,7 +53,7 @@ As mentioned at the beginning, there might be more scenarios that you may
 encounter using ``pro fix`` as well as options to control what exactly will
 happen, those are covered in detail in:
 
-* :ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`
+* In :ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>` you can continue using your test environment created here to explore difference scenarios you might encounter.
 * :ref:`How to know what the fix command would change? <pro-fix-dry-run>`
 * :ref:`How to skip fixing related USNs <pro-fix-skip-related>`
 

--- a/docs/tutorials/fix_intro.rst
+++ b/docs/tutorials/fix_intro.rst
@@ -1,0 +1,68 @@
+.. _pro-fix-tutorial:
+
+Use ``pro fix`` to solve a CVE/USN
+**********************************
+
+.. Why we use Multipass + command to install it
+.. include:: ../includes/pro-fix-intro.txt
+
+In this tutorial, we will introduce the ``pro fix`` command and guide
+you to a simple example of using it to solve a CVE/USN.
+
+There might be more scenarios that you may encounter using ``pro fix``,
+but those are distracting from this tutorial and therefore available
+in the separate
+:ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`.
+
+.. Why we use Multipass + command to install it
+.. include:: ./common/install-multipass.txt
+
+.. Commands for launching and updating a Xenial VM
+.. include:: ./common/create-vm.txt
+
+
+Use ``pro fix``
+===============
+
+Every ``pro fix`` output has a similar output structure. It:
+
+* describes the CVE/USN;
+* displays the affected packages;
+* fixes the affected packages; and
+* at the end, shows if the CVE/USN is fully fixed in the machine.
+
+.. # The basic case is shared between Howto and Tutorial
+.. include:: ../includes/pro-fix-simple-case.txt
+
+Success!
+========
+
+Congratulations! You successfully ran a Multipass VM and used it to encounter
+and resolve a CVE by using ``pro fix``.
+
+.. Instructions for closing down and deleting the VM
+.. include:: ./common/shutdown-vm.txt
+
+Next steps
+----------
+
+We have successfully encountered and resolved the main scenarios that you might
+find when you run ``pro fix``.
+
+As mentioned at the beginning, there might be more scenarios that you may
+encounter using ``pro fix``, those are covered in detail in
+:ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>`.
+
+If you need more information about this command, please feel free to reach out
+to the Ubuntu Pro Client team on ``#ubuntu-server`` on
+`Libera IRC <pro_IRC_>`_ -- we're happy to help! 
+
+Alternatively, if you have a GitHub account, click on the "Give feedback"
+link at the top of this page to leave us a message. We'd love to hear from you!
+
+.. LINKS
+
+.. include:: ../links.txt
+
+.. _CVE-2020-15180: https://ubuntu.com/security/CVE-2020-15180
+.. _CVE-2020-25686: https://ubuntu.com/security/CVE-2020-25686

--- a/docs/tutorials/fix_intro.rst
+++ b/docs/tutorials/fix_intro.rst
@@ -7,7 +7,7 @@ Use ``pro fix`` to solve a CVE/USN
 .. include:: ../includes/pro-fix-intro.txt
 
 In this tutorial, we will introduce the ``pro fix`` command and guide
-you to a simple example of using it to solve a CVE/USN.
+you through a simple example of using it to solve a CVE/USN.
 
 There might be more scenarios that you may encounter using ``pro fix``,
 but those are distracting from this tutorial and therefore available
@@ -31,7 +31,7 @@ Every ``pro fix`` output has a similar output structure. It:
 * fixes the affected packages; and
 * at the end, shows if the CVE/USN is fully fixed in the machine.
 
-.. # The basic case is shared between Howto and Tutorial
+.. # The basic case is shared between Explanation and Tutorial
 .. include:: ../includes/pro-fix-simple-case.txt
 
 Success!
@@ -49,13 +49,11 @@ Next steps
 We have successfully encountered and resolved the main scenarios that you might
 find when you run ``pro fix``.
 
-As mentioned at the beginning, there might be more scenarios that you may
-encounter using ``pro fix`` as well as options to control what exactly will
-happen, those are covered in detail in:
+This is not the only scenario where you might want to use ``pro fix``. To find out about the other situations where it can be useful, as well as which options can be used to give you greater control over the command, you can refer to the following guides: 
 
-* In :ref:`How to Understand scenarios encountered using pro fix to solve a CVE/USN <pro-fix-howto>` you can continue using your test environment created here to explore difference scenarios you might encounter.
-* :ref:`How to know what the fix command would change? <pro-fix-dry-run>`
-* :ref:`How to skip fixing related USNs <pro-fix-skip-related>`
+* In :ref:`Understanding scenarios encountered when using pro fix to solve a CVE/USN <pro-fix-howto>` you can continue using the test environment you created here to explore different scenarios you might encounter and understand the different outputs you will find.
+* :ref:`How do I know what the pro fix command would change? <pro-fix-dry-run>` will show you how to use ``pro fix`` in ``--dry-run`` mode to safely simulate the changes before they're applied.
+* :ref:`How to skip fixing related USNs <pro-fix-skip-related>` will show you how to only fix a single USN, even if other fixes are available.
 
 .. Instructions for how to connect with us
 .. include:: ../includes/contact.txt


### PR DESCRIPTION
## Why is this needed?

This is based on requests I got in regard to pro fix and on searches in our docs not leading me to the answer :-)

I love that these exist
- https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/tutorials/fix_scenarios
- https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/how_to_run_fix_in_dry_run_mode

But while looking for documentation I realized we could help users a bit more.
Right now a lot is written well but organized for people that know what to look for.

- the tutorial on fix is overloaded with special cases
- the title of fix --dry-run assumed that people would know they look for --dry-run
- when someone just wants the explanation for the conditions encountered on fix they need to not look at the multipass/vm things in the tutorial to not be distracted
- ...

To resolve that I propose:
- Split A) fix tutorial to have much less special cases
- Split B) New explanation (based on the extended tutorial) and with a title users look for
- Modify the dry-run howto with a better title
- Better cross link between all of them
- move re-used text blocks to includes



## Test Steps

I've run the doc build locally until I got no warnings due to my changes and the resulting output looked good.
I'd suggest doing the same to be sure this meets your needs as well.


## Checklist
 - [n/a] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [n/a] Changes here need to be documented

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No


## Bonus
I've seen that just those pages have "contact us on IRC or via GH", I've not changed that yet, but I think that is an artifact of the past. On the documentation side we have the "Give Feedback" button and the other bit should be part of the community landing right @s-makin ?
