### PR TITLE
New name metapackages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,21 @@ Vcs-Git: https://github.com/canonical/ubuntu-pro-client.git
 Vcs-Browser: https://github.com/canonical/ubuntu-pro-client
 Rules-Requires-Root: no
 
+# ubuntu-pro-client is the new name, implemented as a meta package that
+# Depends: ubuntu-advantage-tools. ubuntu-advantage-tools is the package
+# that actually contains the pro-client.
+# Note: Homepage and Description should be kept in sync with ubuntu-advantage-tools
+Package: ubuntu-pro-client
+Homepage: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/
+Architecture: any
+Depends: ubuntu-advantage-tools (=${binary:Version}), ${misc:Depends}
+Description: Management tools for Ubuntu Pro
+ Ubuntu Pro is a suite of additional services provided by Canonical on
+ top of Ubuntu. Whether you're an enterprise customer deploying systems
+ at scale or want security patching for your personal Ubuntu LTS
+ at home, the Ubuntu Pro Client (pro) is the command-line tool that
+ will help you manage the services you need.
+
 Package: ubuntu-advantage-tools
 Homepage: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/
 Architecture: any
@@ -57,6 +72,19 @@ Depends: ${misc:Depends}, ubuntu-advantage-tools (>=30~)
 Description: Translations for Ubuntu Pro Client
  This package delivers translations of Ubuntu Pro Client for various
  languages.
+
+# ubuntu-pro-image-auto-attach is the new name, implemented as a meta package that
+# Depends: ubuntu-advantage-pro. ubuntu-advantage-pro is the package
+# that actually contains the auto-attach systemd service.
+# Note: Homepage and Description should be kept in sync with ubuntu-advantage-pro
+Package: ubuntu-pro-image-auto-attach
+Homepage: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/explanations/what_are_ubuntu_pro_cloud_instances/
+Architecture: all
+Depends: ubuntu-advantage-pro (=${binary:Version}), ${misc:Depends}
+Description: Service to auto-attach Ubuntu Pro cloud images
+ This package delivers an additional service that performs an auto-attach
+ operation for Ubuntu Pro cloud instances. This package should not be manually
+ installed, as it is already present on the cloud instances that require it.
 
 Package: ubuntu-advantage-pro
 Homepage: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/explanations/what_are_ubuntu_pro_cloud_instances/

--- a/debian/control
+++ b/debian/control
@@ -35,6 +35,7 @@ Vcs-Browser: https://github.com/canonical/ubuntu-pro-client
 Rules-Requires-Root: no
 
 Package: ubuntu-advantage-tools
+Homepage: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/
 Architecture: any
 Depends: ${misc:Depends},
          ${python3:Depends},
@@ -43,13 +44,12 @@ Depends: ${misc:Depends},
          python3-pkg-resources,
          ${extra:Depends}
 Recommends: ubuntu-pro-client-l10n
-Description: management tools for Ubuntu Pro
- Ubuntu Pro is the professional package of tooling, technology
- and expertise from Canonical, helping organisations around the world
- manage their Ubuntu deployments.
- .
- Subscribers to Ubuntu Pro will find helpful tools for accessing
- services in this package.
+Description: Management tools for Ubuntu Pro
+ Ubuntu Pro is a suite of additional services provided by Canonical on
+ top of Ubuntu. Whether you're an enterprise customer deploying systems
+ at scale or want security patching for your personal Ubuntu LTS
+ at home, the Ubuntu Pro Client (pro) is the command-line tool that
+ will help you manage the services you need.
 
 Package: ubuntu-pro-client-l10n
 Architecture: any
@@ -59,11 +59,12 @@ Description: Translations for Ubuntu Pro Client
  languages.
 
 Package: ubuntu-advantage-pro
+Homepage: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/explanations/what_are_ubuntu_pro_cloud_instances/
 Architecture: all
 Depends: ${misc:Depends}, ubuntu-advantage-tools (>=20.2)
 Replaces: ubuntu-advantage-tools (<<20.2)
 Breaks: ubuntu-advantage-tools (<<20.2)
-Description: Additional services for Ubuntu Pro images
+Description: Service to auto-attach Ubuntu Pro cloud images
  This package delivers an additional service that performs an auto-attach
  operation for Ubuntu Pro cloud instances. This package should not be manually
  installed, as it is already present on the cloud instances that require it.

--- a/debian/rules
+++ b/debian/rules
@@ -18,10 +18,6 @@ APT_PKG_DEPS="apt (>= 1.2.32), apt-transport-https (>= 1.2.32), apt-utils (>= 1.
 DISTRO_INFO_DEPS="distro-info (>= 0.14ubuntu0.2),"
 else ifeq (${VERSION_ID},"18.04")
 APT_PKG_DEPS="apt (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11),"
-else ifeq (${VERSION_ID},"19.04")
-APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-inst2.0 (>= 1.8.1), libapt-pkg5.0 (>= 1.8.1),"
-else ifeq (${VERSION_ID},"19.10")
-APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1),"
 endif
 
 %:

--- a/features/environment.py
+++ b/features/environment.py
@@ -365,6 +365,21 @@ def before_scenario(context: Context, scenario: Scenario):
         )
         return
 
+    # skip scenario based on install_from value
+    for tag in scenario.effective_tags:
+        parts = tag.split(".")
+        if all(
+            [len(parts) == 3, parts[0] == "skip", parts[1] == "install_from"]
+        ):
+            to_skip = InstallationSource(parts[2])
+            if context.pro_config.install_from == to_skip:
+                scenario.skip(
+                    reason="Scenario does not support install_from={}".format(
+                        to_skip.value
+                    )
+                )
+                return
+
     # before_step doesn't execute early enough to modify the step
     # so we perform step text surgery here
     # Also, logging capture is not set up when before_scenario is called,

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -82,3 +82,33 @@ Feature: Pro Install and Uninstall related tests
            | bionic  | lxd-container |
            | focal   | lxd-container |
            | jammy   | lxd-container |
+
+    @skip.install_from.local
+    @skip.install_from.prebuilt
+    Scenario Outline: ubuntu-pro-client brings up-to-date ubuntu-advantage-tools
+        Given a `<release>` `<machine_type>` machine
+        When I set up the apt source for ubuntu-advantage-tools
+        When I apt install `ubuntu-pro-client`
+        Then I verify that the version of `ubuntu-pro-client` equals the version of `ubuntu-advantage-tools`
+        Examples: ubuntu release
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
+           | mantic  | lxd-container |
+
+    @skip.install_from.local
+    @skip.install_from.prebuilt
+    Scenario Outline: ubuntu-pro-image-auto-attach brings up-to-date ubuntu-advantage-pro
+        Given a `<release>` `<machine_type>` machine
+        When I set up the apt source for ubuntu-advantage-tools
+        When I apt install `ubuntu-pro-image-auto-attach`
+        Then I verify that the version of `ubuntu-pro-image-auto-attach` equals the version of `ubuntu-advantage-pro`
+        Examples: ubuntu release
+           | release | machine_type  |
+           | xenial  | aws.pro       |
+           | bionic  | aws.pro       |
+           | focal   | aws.pro       |
+           | jammy   | aws.pro       |
+           | mantic  | aws.pro       |

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -7,7 +7,10 @@ from behave import given, when
 from pycloudlib.instance import BaseInstance  # type: ignore
 
 from features.steps.shell import when_i_run_command
-from features.steps.ubuntu_advantage_tools import when_i_install_uat
+from features.steps.ubuntu_advantage_tools import (
+    when_i_install_uat,
+    when_i_setup_uat_source,
+)
 from features.util import (
     BUILDER_NAME_PREFIX,
     SUT,
@@ -190,6 +193,7 @@ def given_a_sut_machine(context, series, machine_type):
                 machine_name=builder_name,
                 cleanup=False,
             )
+            when_i_setup_uat_source(context, machine_name=builder_name)
             when_i_install_uat(context, machine_name=builder_name)
             when_i_take_a_snapshot(
                 context,
@@ -205,6 +209,7 @@ def given_a_sut_machine(context, series, machine_type):
         )
     else:
         given_a_machine(context, series, machine_type=machine_type)
+        when_i_setup_uat_source(context)
         when_i_install_uat(context)
 
     logging.info(
@@ -219,6 +224,7 @@ def given_a_sut_machine_with_user_data(context, series, machine_type):
     # doesn't support snapshot strategy because the test depends on
     # custom user data
     given_a_machine(context, series, machine_type, user_data=context.text)
+    when_i_setup_uat_source(context)
     when_i_install_uat(context)
 
 

--- a/features/steps/packages.py
+++ b/features/steps/packages.py
@@ -1,7 +1,7 @@
 import re
 
 from behave import then, when
-from hamcrest import assert_that, contains_string, matches_regexp
+from hamcrest import assert_that, contains_string, equal_to, matches_regexp
 
 from features.steps.shell import when_i_retry_run_command, when_i_run_command
 from features.util import SUT
@@ -254,3 +254,23 @@ def store_candidate_version(context, package):
         context.stored_vars["candidate"] = candidate_version_match.group(
             1
         ).strip()
+
+
+@then(
+    "I verify that the version of `{package1}` equals the version of `{package2}`"  # noqa: E501
+)
+def verify_package_version_equality(context, package1, package2):
+    when_i_run_command(
+        context,
+        "dpkg-query --showformat='${{Version}}' --show {}".format(package1),
+        "as non-root",
+    )
+    package1_version_str = context.process.stdout.strip()
+    when_i_run_command(
+        context,
+        "dpkg-query --showformat='${{Version}}' --show {}".format(package2),
+        "as non-root",
+    )
+    package2_version_str = context.process.stdout.strip()
+
+    assert_that(package1_version_str, equal_to(package2_version_str))

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -100,7 +100,11 @@ def when_i_install_uat(context, machine_name=SUT):
         )
         logging.info("using debs: {}".format(deb_paths))
         for deb_path in deb_paths:
-            if "advantage-pro" not in deb_path or is_pro:
+            if (
+                "ubuntu-pro-client-l10n" in deb_path
+                or "ubuntu-advantage-tools" in deb_path
+                or ("ubuntu-advantage-pro" in deb_path and is_pro)
+            ):
                 instance.push_file(deb_path, "/tmp/behave_ua.deb")
                 when_i_apt_install(
                     context, "/tmp/behave_ua.deb", machine_name=machine_name


### PR DESCRIPTION
## Why is this needed?
This is a (preferred) alternative to #2887 

This introduces meta  packages with new names that Depend on the old names. 

## Test Steps
I uploaded to ppa:orndorffgrant/proclient-newname-test

Try upgrading and `apt install ubuntu-pro-client`-ing with that ppa

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [x] Yes
 - [ ] No
