### PR TITLE
tests: run apt update when creating instances in behave

### DIFF
--- a/features/api_fix_execute.feature
+++ b/features/api_fix_execute.feature
@@ -61,8 +61,7 @@ Feature: Fix execute API endpoints
         """
         {"_schema_version": "v1", "data": {"attributes": {"cves_data": {"cves": \[{"description": "Kerberos vulnerability", "errors": null, "status": "fixed", "title": "CVE-2020-28196", "upgraded_packages": \[\]}, {"description": "Linux kernel vulnerabilities", "errors": null, "status": "not-affected", "title": "CVE-2022-24959", "upgraded_packages": \[\]}\], "status": "fixed"}}, "meta": {"environment_vars": \[\]}, "type": "CVEFixExecute"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
-        When I apt update
-        And I apt install `libawl-php=0.60-1`
+        When I apt install `libawl-php=0.60-1`
         And I run `pro api u.pro.security.fix.usn.execute.v1 --data '{"usns": ["USN-4539-1"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And stdout matches regexp:
@@ -115,8 +114,7 @@ Feature: Fix execute API endpoints
         """
         {"_schema_version": "v1", "data": {"attributes": {"cves_data": {"cves": \[{"description": ".*", "errors": null, "status": "fixed", "title": "CVE-2020-28196", "upgraded_packages": \[\]}\], "status": "fixed"}}, "meta": {"environment_vars": \[\]}, "type": "CVEFixExecute"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
-        When I apt update
-        And I apt install `expat=2.1.0-7 swish-e matanza ghostscript`
+        When I apt install `expat=2.1.0-7 swish-e matanza ghostscript`
         And I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2017-9233"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_execute` schema
@@ -209,8 +207,7 @@ Feature: Fix execute API endpoints
         """
         {"_schema_version": "v1", "data": {"attributes": {"cves_data": {"cves": \[{"description": "Kerberos vulnerability", "errors": null, "status": "fixed", "title": "CVE-2020-28196", "upgraded_packages": \[\]}\], "status": "fixed"}}, "meta": {"environment_vars": \[\]}, "type": "CVEFixExecute"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
-        When I apt update
-        And I apt install `xterm=330-1ubuntu2`
+        When I apt install `xterm=330-1ubuntu2`
         And I run `pro api u.pro.security.fix.cve.execute.v1 --data '{"cves": ["CVE-2021-27135"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_execute` schema

--- a/features/api_fix_plan.feature
+++ b/features/api_fix_plan.feature
@@ -61,8 +61,7 @@ Feature: Fix plan API endpoints
         """
         {"_schema_version": "v1", "data": {"attributes": {"cves_data": {"cves": \[{"additional_data": {}, "affected_packages": \["krb5"\], "description": ".*", "error": null, "expected_status": "fixed", "plan": \[{"data": {"pocket": "standard-updates", "source_packages": \["krb5"\], "status": "cve-already-fixed"}, "operation": "no-op", "order": 1}\], "title": "CVE-2020-28196", "warnings": \[\]}, {"additional_data": {}, "affected_packages": \[\], "description": ".*", "error": null, "expected_status": "not-affected", "plan": \[{"data": {"status": "system-not-affected"}, "operation": "no-op", "order": 1}], "title": "CVE-2022-24959", "warnings": \[\]}\], "expected_status": "fixed"}}, "meta": {"environment_vars": \[\]}, "type": "CVEFixPlan"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
-        When I apt update
-        And I apt install `libawl-php=0.60-1`
+        When I apt install `libawl-php=0.60-1`
         And I run `pro api u.pro.security.fix.usn.plan.v1 --data '{"usns": ["USN-4539-1"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `usn_fix_plan` schema
@@ -106,8 +105,7 @@ Feature: Fix plan API endpoints
         """
         {"_schema_version": "v1", "data": {"attributes": {"cves_data": {"cves": \[{"additional_data": {}, "affected_packages": \["krb5"\], "description": ".*", "error": null, "expected_status": "fixed", "plan": \[{"data": {"pocket": "standard-updates", "source_packages": \["krb5"\], "status": "cve-already-fixed"}, "operation": "no-op", "order": 1}\], "title": "CVE-2020-28196", "warnings": \[\]}\], "expected_status": "fixed"}}, "meta": {"environment_vars": \[\]}, "type": "CVEFixPlan"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
-        When I apt update
-        And I apt install `expat=2.1.0-7 swish-e matanza ghostscript`
+        When I apt install `expat=2.1.0-7 swish-e matanza ghostscript`
         And I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2017-9233"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_plan` schema
@@ -184,8 +182,7 @@ Feature: Fix plan API endpoints
         """
         {"_schema_version": "v1", "data": {"attributes": {"cves_data": {"cves": \[{"additional_data": {}, "affected_packages": \["krb5"\], "description": ".*", "error": null, "expected_status": "fixed", "plan": \[{"data": {"pocket": "standard-updates", "source_packages": \["krb5"\], "status": "cve-already-fixed"}, "operation": "no-op", "order": 1}\], "title": "CVE-2020-28196", "warnings": \[\]}\], "expected_status": "fixed"}}, "meta": {"environment_vars": \[\]}, "type": "CVEFixPlan"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
         """
-        When I apt update
-        And I apt install `xterm=330-1ubuntu2`
+        When I apt install `xterm=330-1ubuntu2`
         And I run `pro api u.pro.security.fix.cve.plan.v1 --data '{"cves": ["CVE-2021-27135"]}'` as non-root
         Then stdout is a json matching the `api_response` schema
         And the json API response data matches the `cve_fix_plan` schema

--- a/features/api_security.feature
+++ b/features/api_security.feature
@@ -19,8 +19,7 @@ Feature: API security/security status tests
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
         Then I verify that `esm-infra` is enabled
-        When I apt update
-        And I apt upgrade
+        When I apt upgrade
         And I apt install `jq bzip2`
         # Install the oscap version 1.3.7 which solved the epoch error message issue
         And I apt install `cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev g++ libapt-pkg-dev libyaml-dev libxmlsec1-dev libxmlsec1-openssl`

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -4,7 +4,6 @@ Feature: APT Messages
     Scenario Outline: APT JSON Hook prints package counts correctly on xenial
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        When I apt update
         When I apt upgrade
         When I apt install `<standard-pkg>`
         When I apt upgrade
@@ -94,7 +93,6 @@ Feature: APT Messages
     @uses.config.contract_token
     Scenario Outline: APT Hook advertises esm-infra on upgrade
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
         When I apt upgrade
         When I apt autoremove
         When I run `pro config set apt_news=false` with sudo
@@ -151,7 +149,6 @@ Feature: APT Messages
     @uses.config.contract_token
     Scenario Outline: APT Hook advertises esm-apps on upgrade
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
         When I apt upgrade including phased updates
         When I apt autoremove
         When I apt install `<package>`
@@ -212,15 +209,12 @@ Feature: APT Messages
     Scenario Outline: APT News
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        # On interim releases we will not enable any service, so we need a manual apt update
-        When I apt update
         When I apt upgrade including phased updates
         When I apt autoremove
         When I apt install `jq`
         When I run `pro detach --assume-yes` with sudo
 
         Given a `focal` `<machine_type>` machine named `apt-news-server`
-        When I apt update on the `apt-news-server` machine
         When I apt install `nginx` on the `apt-news-server` machine
         When I run `sed -i "s/gzip on;/gzip on;\n\tgzip_min_length 1;\n\tgzip_types application\/json;\n/" /etc/nginx/nginx.conf` `with sudo` on the `apt-news-server` machine
         When I run `systemctl restart nginx` `with sudo` on the `apt-news-server` machine
@@ -678,7 +672,6 @@ Feature: APT Messages
 
     Scenario Outline: Cloud and series-specific URLs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
         When I apt install `ansible`
         # Update after installing to make sure messages are there
         When I apt update
@@ -702,7 +695,6 @@ Feature: APT Messages
     @uses.config.contract_token
     Scenario Outline: APT Hook do not advertises esm-apps on upgrade for interim releases
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
         When I apt upgrade including phased updates
         When I apt autoremove
         When I apt install `hello`

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -40,8 +40,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
 
     Scenario Outline: Attach command in a ubuntu lxd container
        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
-        And I apt install `update-motd`
+        When I apt install `update-motd`
         And I apt install `<downrev_pkg>`
         And I run `pro refresh messages` with sudo
         Then stdout matches regexp:

--- a/features/cloud_pro_clone.feature
+++ b/features/cloud_pro_clone.feature
@@ -11,7 +11,6 @@ Feature: Creating golden images based on Cloud Ubuntu Pro instances
         """
         When I run `pro auto-attach` with sudo
         Then the machine is attached
-        When I apt update
         When I apt install `jq`
         When I save the `activityInfo.activityToken` value from the contract
         When I save the `activityInfo.activityID` value from the contract

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -2,7 +2,6 @@ Feature: Ua fix command behaviour
 
     Scenario Outline: Useful SSL failure message when there aren't any ca-certs
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
         When I apt remove `ca-certificates`
         When I run `rm -f /etc/ssl/certs/ca-certificates.crt` with sudo
         When I verify that running `ua fix CVE-1800-123456` `as non-root` exits `1`
@@ -31,7 +30,6 @@ Feature: Ua fix command behaviour
 
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
         Then I will see the following on stderr:
         """
@@ -204,7 +202,11 @@ Feature: Ua fix command behaviour
         """
         Error: USN-12345-12 not found.
         """
-        When I verify that running `pro fix USN-5079-2 --dry-run` `as non-root` exits `1`
+        # Make sure esm cache is empty
+        # Technically a folder right, but this works
+        When I delete the file `/var/lib/ubuntu-advantage/apt-esm/`
+        When I delete the file `/var/lib/apt/periodic/update-success-stamp`
+        And I verify that running `pro fix USN-5079-2 --dry-run` `as non-root` exits `1`
         Then stdout matches regexp:
         """
         .*WARNING: The option --dry-run is being used.
@@ -575,7 +577,6 @@ Feature: Ua fix command behaviour
 
     Scenario Outline: Fix command on an unattached machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
         When I verify that running `pro fix CVE-1800-123456` `as non-root` exits `1`
         Then I will see the following on stderr:
         """

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -16,8 +16,7 @@ Feature: Pro supports multiple languages
         """
         não
         """
-        When I apt update
-        And I apt install `jq`
+        When I apt install `jq`
         And I run shell command `LANGUAGE=pt_BR.UTF-8 pro status --format json | jq .services[0].available` as non-root
         Then I will see the following on stdout:
         """
@@ -47,8 +46,7 @@ Feature: Pro supports multiple languages
         """
         não
         """
-        When I apt update
-        And I apt install `jq`
+        When I apt install `jq`
         And I run shell command `LANGUAGE=pt_BR.UTF-8 pro status --format json | jq .result` as non-root
         Then I will see the following on stdout:
         """
@@ -85,7 +83,6 @@ Feature: Pro supports multiple languages
     Scenario Outline: apt-hook translations work
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        When I apt update
         When I apt upgrade
         When I run `pro detach --assume-yes` with sudo
         When I apt update

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -47,8 +47,7 @@ Feature: Pro Install and Uninstall related tests
     Scenario Outline: Do not fail during postinst with nonstandard python setup
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         # Works when in a python virtualenv
-        When I apt update
-        And I apt install `python3-venv`
+        When I apt install `python3-venv`
         And I run `python3 -m venv env` with sudo
         Then I verify that running `bash -c ". env/bin/activate && python3 -c 'import uaclient'"` `with sudo` exits `1`
         Then stderr matches regexp:

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -159,7 +159,6 @@ Feature: Livepatch
         # It should be kept up to date so that it runs on the latest LTS and installs the latest
         # HWE kernel for that release.
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
         When I apt install `linux-generic-hwe-<release_num>`
         When I apt remove `linux-image*-kvm`
         When I run `update-grub` with sudo

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -3,8 +3,7 @@ Feature: Logs in Json Array Formatter
     @uses.config.contract_token
     Scenario Outline: The log file can be successfully parsed as json array
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
-        And I apt install `jq`
+        When I apt install `jq`
         And I verify that running `pro status` `with sudo` exits `0`
         And I verify that running `pro enable test_entitlement` `with sudo` exits `1`
         And I run shell command `tail /var/log/ubuntu-advantage.log | jq -r .` as non-root

--- a/features/motd_messages.feature
+++ b/features/motd_messages.feature
@@ -3,7 +3,6 @@ Feature: MOTD Messages
     @uses.config.contract_token
     Scenario Outline: Contract update prevents contract expiration messages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
         When I attach `contract_token` with sudo
         When I update contract to use `effectiveTo` as `$behave_var{today +2}`
         When I run `pro refresh messages` with sudo
@@ -54,8 +53,7 @@ Feature: MOTD Messages
 
     Scenario Outline: Contract Expiration Messages
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
-        And I apt install `ansible`
+        When I apt install `ansible`
         And I attach `contract_token` with sudo
         And I set the machine token overlay to the following yaml
         """

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -253,8 +253,7 @@ Feature: Proxy configuration
     Scenario Outline: Attach command when authenticated proxy is configured for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `lxd-container` machine named `proxy`
-        When I apt update on the `proxy` machine
-        And I apt install `squid apache2-utils` on the `proxy` machine
+        When I apt install `squid apache2-utils` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
         """
@@ -347,8 +346,7 @@ Feature: Proxy configuration
     Scenario Outline: Attach command when authenticated proxy is configured
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `lxd-container` machine named `proxy`
-        When I apt update on the `proxy` machine
-        And I apt install `squid apache2-utils` on the `proxy` machine
+        When I apt install `squid apache2-utils` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
         """
@@ -535,8 +533,7 @@ Feature: Proxy configuration
     Scenario Outline: Attach command when authenticated proxy is configured manually for uaclient
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `lxd-container` machine named `proxy`
-        When I apt update on the `proxy` machine
-        And I apt install `squid apache2-utils` on the `proxy` machine
+        When I apt install `squid apache2-utils` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
         """
@@ -768,8 +765,7 @@ Feature: Proxy configuration
     Scenario Outline: Attach command when authenticated proxy is configured globally
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         Given a `focal` `lxd-container` machine named `proxy`
-        When I apt update on the `proxy` machine
-        And I apt install `squid apache2-utils` on the `proxy` machine
+        When I apt install `squid apache2-utils` on the `proxy` machine
         And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
         And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
         """
@@ -1180,8 +1176,7 @@ Feature: Proxy configuration
 
         # set up a HTTPS proxy
         Given a `jammy` `<machine_type>` machine named `proxy`
-        When I apt update on the `proxy` machine
-        And I apt install `openssl libssl-dev ssl-cert squid-openssl apache2-utils` on the `proxy` machine
+        When I apt install `openssl libssl-dev ssl-cert squid-openssl apache2-utils` on the `proxy` machine
         And I run `openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes -out ca.crt -keyout ca.key -subj "/C=CN/ST=BJ/O=STS/CN=CA"` `with sudo` on the `proxy` machine
         And I run `openssl genrsa -out $behave_var{machine-name proxy}.lxd.key` `with sudo` on the `proxy` machine
         And I run `openssl req -new -key $behave_var{machine-name proxy}.lxd.key -out $behave_var{machine-name proxy}.lxd.csr -subj "/C=CN/ST=BJ/O=STS/CN=$behave_var{machine-name proxy}.lxd"` `with sudo` on the `proxy` machine

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -3,8 +3,7 @@ Feature: Security status command behavior
     @uses.config.contract_token
     Scenario Outline: Run security status with JSON/YAML format
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
-        And I apt install `ansible`
+        When I apt install `ansible`
         And I run `pro security-status --format json` as non-root
         Then stdout is a json matching the `ua_security_status` schema
         And stdout matches regexp:

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 from behave import given, when
 from pycloudlib.instance import BaseInstance  # type: ignore
 
+from features.steps.packages import when_i_apt_update
 from features.steps.shell import when_i_run_command
 from features.steps.ubuntu_advantage_tools import when_i_install_uat
 from features.util import (
@@ -105,6 +106,9 @@ def given_a_machine(
             "with sudo",
             machine_name=machine_name,
         )
+
+    # make sure the machine has up-to-date apt data
+    when_i_apt_update(context, machine_name=machine_name)
 
     if cleanup:
 

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -20,7 +20,6 @@ def when_i_install_uat(context, machine_name=SUT):
     series = context.machines[machine_name].series
     is_pro = "pro" in context.machines[machine_name].machine_type
     if context.pro_config.install_from is InstallationSource.ARCHIVE:
-        instance.execute("sudo apt update")
         when_i_apt_install(
             context, "ubuntu-advantage-tools", machine_name=machine_name
         )

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -365,8 +365,7 @@ Feature: Command behaviour when unattached
     # Services fail, degraded systemctl, but no crashes.
     Scenario Outline: services fail gracefully when yaml is broken/absent
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-        When I apt update
-        And I run `rm -rf /usr/lib/python3/dist-packages/yaml` with sudo
+        When I run `rm -rf /usr/lib/python3/dist-packages/yaml` with sudo
         And I verify that running `pro status` `with sudo` exits `1`
         Then stderr matches regexp:
         """


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because now we don't need explicit steps to update the apt data, making the apt update calls in behave tests happen only when really testing something.

Also
Fixes: #2859

## Test Steps
All behave should behave the same.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly AHA
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
