### PR TITLE
chore: use os.path.join instead of concatenating paths

### DIFF
--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -5,35 +5,54 @@ These are in their own file so they can be imported by setup.py before we have
 any of our dependencies installed.
 """
 
-UAC_ETC_PATH = "/etc/ubuntu-advantage/"
-UAC_RUN_PATH = "/run/ubuntu-advantage/"
+import os
+
+# Base directories
+UAC_ETC_PATH = "/etc/ubuntu-advantage"
+UAC_RUN_PATH = "/run/ubuntu-advantage"
 DEFAULT_DATA_DIR = "/var/lib/ubuntu-advantage"
+DEFAULT_LOG_DIR = "/var/log"
+
+
+# Relative paths
 MACHINE_TOKEN_FILE = "machine-token.json"
+CONFIG_FILE = "uaclient.conf"
+USER_CONFIG_FILE = "user-config.json"
+CANDIDATE_VERSION_FILE = "candidate-version"
+DEFAULT_LOG_FILE_BASE_NAME = "ubuntu-advantage"
 PRIVATE_SUBDIR = "private"
-DEFAULT_PRIVATE_MACHINE_TOKEN_PATH = (
-    DEFAULT_DATA_DIR + "/" + PRIVATE_SUBDIR + "/" + MACHINE_TOKEN_FILE
+MESSAGES_SUBDIR = "messages"
+USER_CACHE_SUBDIR = "ubuntu-pro"
+NOTICES_SUBDIR = "notices"
+PRIVATE_ESM_CACHE_SUBDIR = "apt-esm"
+
+DEFAULT_PRIVATE_MACHINE_TOKEN_PATH = os.path.join(
+    DEFAULT_DATA_DIR, PRIVATE_SUBDIR, MACHINE_TOKEN_FILE
 )
-DEFAULT_PRIVATE_DATA_DIR = DEFAULT_DATA_DIR + "/" + PRIVATE_SUBDIR
-MESSAGES_SUBDIR = "/messages"
-MESSAGES_DIR = DEFAULT_DATA_DIR + MESSAGES_SUBDIR
-CANDIDATE_CACHE_PATH = UAC_RUN_PATH + "candidate-version"
-DEFAULT_CONFIG_FILE = UAC_ETC_PATH + "uaclient.conf"
-DEFAULT_USER_CONFIG_JSON_FILE = DEFAULT_DATA_DIR + "/user-config.json"
-DEFAULT_UPGRADE_CONTRACT_FLAG_FILE = UAC_ETC_PATH + "request-update-contract"
+DEFAULT_PRIVATE_DATA_DIR = os.path.join(DEFAULT_DATA_DIR, PRIVATE_SUBDIR)
+MESSAGES_DIR = os.path.join(DEFAULT_DATA_DIR, MESSAGES_SUBDIR)
+DEFAULT_CONFIG_FILE = os.path.join(UAC_ETC_PATH, CONFIG_FILE)
+CANDIDATE_CACHE_PATH = os.path.join(UAC_RUN_PATH, CANDIDATE_VERSION_FILE)
+DEFAULT_USER_CONFIG_JSON_FILE = os.path.join(
+    DEFAULT_DATA_DIR, USER_CONFIG_FILE
+)
+DEFAULT_LOG_PREFIX = os.path.join(DEFAULT_LOG_DIR, DEFAULT_LOG_FILE_BASE_NAME)
+ESM_APT_ROOTDIR = os.path.join(DEFAULT_DATA_DIR, PRIVATE_ESM_CACHE_SUBDIR)
+NOTICES_PERMANENT_DIRECTORY = os.path.join(DEFAULT_DATA_DIR, NOTICES_SUBDIR)
+NOTICES_TEMPORARY_DIRECTORY = os.path.join(UAC_RUN_PATH, NOTICES_SUBDIR)
+
+
+# URLs
 BASE_CONTRACT_URL = "https://contracts.canonical.com"
 BASE_SECURITY_URL = "https://ubuntu.com/security"
 BASE_LIVEPATCH_URL = "https://livepatch.canonical.com"
 APT_NEWS_URL = "https://motd.ubuntu.com/aptnews.json"
-CLOUD_BUILD_INFO = "/etc/cloud/build.info"
-ESM_APT_ROOTDIR = DEFAULT_DATA_DIR + "/apt-esm/"
 
 PRINT_WRAP_WIDTH = 80
 CONTRACT_EXPIRY_GRACE_PERIOD_DAYS = 14
 CONTRACT_EXPIRY_PENDING_DAYS = 20
 ATTACH_FAIL_DATE_FORMAT = "%B %d, %Y"
-DEFAULT_LOG_DIR = "/var/log"
-DEFAULT_LOG_FILE_BASE_NAME = "ubuntu-advantage"
-DEFAULT_LOG_PREFIX = DEFAULT_LOG_DIR + "/" + DEFAULT_LOG_FILE_BASE_NAME
+
 DEFAULT_LOG_FORMAT = (
     "%(asctime)s - %(filename)s:(%(lineno)d) [%(levelname)s]: %(message)s"
 )
@@ -43,7 +62,7 @@ CONFIG_DEFAULTS = {
     "security_url": BASE_SECURITY_URL,
     "data_dir": DEFAULT_DATA_DIR,
     "log_level": "debug",
-    "log_file": "/var/log/ubuntu-advantage.log",
+    "log_file": "{}.log".format(DEFAULT_LOG_PREFIX),
 }
 
 CONFIG_FIELD_ENVVAR_ALLOWLIST = [
@@ -55,10 +74,8 @@ CONFIG_FIELD_ENVVAR_ALLOWLIST = [
 
 ROOT_READABLE_MODE = 0o600
 WORLD_READABLE_MODE = 0o644
-NOTICES_PERMANENT_DIRECTORY = DEFAULT_DATA_DIR + "/notices/"
-NOTICES_TEMPORARY_DIRECTORY = UAC_RUN_PATH + "notices/"
-USER_CACHE_SUBDIR = "ubuntu-pro"
 
+CLOUD_BUILD_INFO = "/etc/cloud/build.info"
 SSL_CERTS_PATH = "/etc/ssl/certs/ca-certificates.crt"
 
 # used by apport, collect-logs, and tests

--- a/uaclient/files/files.py
+++ b/uaclient/files/files.py
@@ -79,7 +79,7 @@ class MachineTokenFile:
     ):
         file_name = defaults.MACHINE_TOKEN_FILE
         self.private_file = UAFile(
-            file_name, directory + "/" + defaults.PRIVATE_SUBDIR
+            file_name, os.path.join(directory, defaults.PRIVATE_SUBDIR)
         )
         self.public_file = UAFile(file_name, directory, False)
         self.machine_token_overlay_path = machine_token_overlay_path

--- a/uaclient/log.py
+++ b/uaclient/log.py
@@ -63,7 +63,7 @@ class JsonArrayFormatter(logging.Formatter):
 
 def get_user_log_file() -> str:
     """Gets the correct user log_file storage location"""
-    return system.get_user_cache_dir() + "/ubuntu-pro.log"
+    return os.path.join(system.get_user_cache_dir(), "ubuntu-pro.log")
 
 
 def get_all_user_log_files() -> List[str]:
@@ -74,12 +74,12 @@ def get_all_user_log_files() -> List[str]:
     user_directories = os.listdir("/home")
     log_files = []
     for user_directory in user_directories:
-        user_path = (
-            "/home/"
-            + user_directory
-            + "/.cache/"
-            + defaults.USER_CACHE_SUBDIR
-            + "/ubuntu-pro.log"
+        user_path = os.path.join(
+            "/home",
+            user_directory,
+            ".cache",
+            defaults.USER_CACHE_SUBDIR,
+            "ubuntu-pro.log",
         )
         if os.path.isfile(user_path):
             log_files.append(user_path)

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -753,9 +753,11 @@ def get_user_cache_dir() -> str:
 
     xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
     if xdg_cache_home:
-        return xdg_cache_home + "/" + defaults.USER_CACHE_SUBDIR
+        return os.path.join(xdg_cache_home, defaults.USER_CACHE_SUBDIR)
 
-    return os.path.expanduser("~") + "/.cache/" + defaults.USER_CACHE_SUBDIR
+    return os.path.join(
+        os.path.expanduser("~"), ".cache", defaults.USER_CACHE_SUBDIR
+    )
 
 
 def get_reboot_required_pkgs() -> Optional[RebootRequiredPkgs]:

--- a/uaclient/tests/test_system.py
+++ b/uaclient/tests/test_system.py
@@ -1418,7 +1418,7 @@ class TestGetUserCacheDir:
             "expected",
         ],
         (
-            (True, None, None, "/run/ubuntu-advantage/"),
+            (True, None, None, "/run/ubuntu-advantage"),
             (False, None, "/home/user", "/home/user/.cache/ubuntu-pro"),
             (False, "/something", "/home/user", "/something/ubuntu-pro"),
         ),


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we are trying not to concatenate paths manually.
Removes trailing and connection slashes from paths, and everything reads more pythonic.

Fixes: #2799

## Test Steps
It is a refactor, assert nothing breaks.

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
