### PR TITLE
realtime: add raspi variant

### DIFF
--- a/debian/po/pt_BR.po
+++ b/debian/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-05 13:05-0300\n"
+"POT-Creation-Date: 2024-01-17 16:08-0500\n"
 "PO-Revision-Date: 2023-09-25 12:29-0400\n"
 "Last-Translator: Lucas Moura <lucas.moura@canonical.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -2319,7 +2319,7 @@ msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1306
-#: ../../uaclient/messages/__init__.py:1751
+#: ../../uaclient/messages/__init__.py:1755
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
@@ -2501,14 +2501,22 @@ msgid "RT kernel optimized for NVIDIA Tegra platform"
 msgstr "Kernel RT otimizado para a plataforma NVIDIA Tegra"
 
 #: ../../uaclient/messages/__init__.py:1429
-msgid "Real-time Intel IOTG Kernel"
+msgid "Raspberry Pi Real-time for Pi5/Pi4"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1431
+msgid "24.04 Real-time kernel optimised for Raspberry Pi"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1433
+msgid "Real-time Intel IOTG Kernel"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1435
 msgid "RT kernel optimized for Intel IOTG platform"
 msgstr "Kernel RT otimizado para a plataforma Intel IOTG"
 
-#: ../../uaclient/messages/__init__.py:1434
+#: ../../uaclient/messages/__init__.py:1438
 #, python-brace-format
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches "
@@ -2521,7 +2529,7 @@ msgid ""
 "Do you want to continue? [ default = Yes ]: (Y/n) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1445
+#: ../../uaclient/messages/__init__.py:1449
 msgid ""
 "This will remove the boot order preference for the Real-time kernel and\n"
 "disable updates to the Real-time kernel.\n"
@@ -2538,15 +2546,15 @@ msgid ""
 "Are you sure? (y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1461
+#: ../../uaclient/messages/__init__.py:1465
 msgid "ROS ESM Security Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1462
+#: ../../uaclient/messages/__init__.py:1466
 msgid "Security Updates for the Robot Operating System"
 msgstr "Atualizações de Segurança para o Robot Operating System"
 
-#: ../../uaclient/messages/__init__.py:1464
+#: ../../uaclient/messages/__init__.py:1468
 #, python-brace-format
 msgid ""
 "ros provides access to a private PPA which includes security-related "
@@ -2559,15 +2567,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1473
+#: ../../uaclient/messages/__init__.py:1477
 msgid "ROS ESM All Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1475
+#: ../../uaclient/messages/__init__.py:1479
 msgid "All Updates for the Robot Operating System"
 msgstr "Todas as Atualizações para o Robot Operating System"
 
-#: ../../uaclient/messages/__init__.py:1478
+#: ../../uaclient/messages/__init__.py:1482
 #, python-brace-format
 msgid ""
 "ros-updates provides access to a private PPA that includes non-security-"
@@ -2580,14 +2588,14 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1549
+#: ../../uaclient/messages/__init__.py:1553
 msgid ""
 "Unexpected error(s) occurred.\n"
 "For more details, see the log: /var/log/ubuntu-advantage.log\n"
 "To file a bug run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1559
+#: ../../uaclient/messages/__init__.py:1563
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2595,7 +2603,7 @@ msgid ""
 "Please install \"ca-certificates\" and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1569
+#: ../../uaclient/messages/__init__.py:1573
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2603,216 +2611,216 @@ msgid ""
 "Please check your openssl configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1578
+#: ../../uaclient/messages/__init__.py:1582
 #, python-brace-format
 msgid "Ignoring unknown argument '{arg}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1584
+#: ../../uaclient/messages/__init__.py:1588
 #, python-brace-format
 msgid ""
 "A new version of the client is available: {version}. Please upgrade to the "
 "latest version to get the new features and bug fixes."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1591
+#: ../../uaclient/messages/__init__.py:1595
 #, python-brace-format
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1596
+#: ../../uaclient/messages/__init__.py:1600
 #, python-brace-format
 msgid "{title} does not support being disabled with --purge"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1602
+#: ../../uaclient/messages/__init__.py:1606
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1609
+#: ../../uaclient/messages/__init__.py:1613
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1617
+#: ../../uaclient/messages/__init__.py:1621
 #, python-brace-format
 msgid "Cannot disable {entitlement_name} with purge: no origin value defined"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1624
+#: ../../uaclient/messages/__init__.py:1628
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1629
+#: ../../uaclient/messages/__init__.py:1633
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1637
+#: ../../uaclient/messages/__init__.py:1641
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1645
+#: ../../uaclient/messages/__init__.py:1649
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1648
+#: ../../uaclient/messages/__init__.py:1652
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1653
+#: ../../uaclient/messages/__init__.py:1657
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1659
+#: ../../uaclient/messages/__init__.py:1663
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1663
+#: ../../uaclient/messages/__init__.py:1667
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1668
+#: ../../uaclient/messages/__init__.py:1672
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1675
+#: ../../uaclient/messages/__init__.py:1679
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1682
+#: ../../uaclient/messages/__init__.py:1686
 #, python-brace-format
 msgid ""
 "{title} is already enabled.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1689
+#: ../../uaclient/messages/__init__.py:1693
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1695
+#: ../../uaclient/messages/__init__.py:1699
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1701
+#: ../../uaclient/messages/__init__.py:1705
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1709
+#: ../../uaclient/messages/__init__.py:1713
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1717
+#: ../../uaclient/messages/__init__.py:1721
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1724
+#: ../../uaclient/messages/__init__.py:1728
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1732
+#: ../../uaclient/messages/__init__.py:1736
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1739
+#: ../../uaclient/messages/__init__.py:1743
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1745
+#: ../../uaclient/messages/__init__.py:1749
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1755
+#: ../../uaclient/messages/__init__.py:1759
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1758
+#: ../../uaclient/messages/__init__.py:1762
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1762
+#: ../../uaclient/messages/__init__.py:1766
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1767
+#: ../../uaclient/messages/__init__.py:1771
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1775
+#: ../../uaclient/messages/__init__.py:1779
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1784
+#: ../../uaclient/messages/__init__.py:1788
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1792
+#: ../../uaclient/messages/__init__.py:1796
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1796
+#: ../../uaclient/messages/__init__.py:1800
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1801
+#: ../../uaclient/messages/__init__.py:1805
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1809
+#: ../../uaclient/messages/__init__.py:1813
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2822,7 +2830,7 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1818
+#: ../../uaclient/messages/__init__.py:1822
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2831,75 +2839,75 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1828
+#: ../../uaclient/messages/__init__.py:1832
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1834
+#: ../../uaclient/messages/__init__.py:1838
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1843
+#: ../../uaclient/messages/__init__.py:1847
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1850
+#: ../../uaclient/messages/__init__.py:1854
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1857
+#: ../../uaclient/messages/__init__.py:1861
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1862
+#: ../../uaclient/messages/__init__.py:1866
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1866
+#: ../../uaclient/messages/__init__.py:1870
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1871
-msgid "apt-daily.timer jobs are not running"
-msgstr ""
-
 #: ../../uaclient/messages/__init__.py:1875
-#, python-brace-format
-msgid "{cfg_name} is empty"
+msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1879
 #, python-brace-format
-msgid "{cfg_name} is turned off"
+msgid "{cfg_name} is empty"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1883
+#, python-brace-format
+msgid "{cfg_name} is turned off"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1887
 msgid "unattended-upgrades package is not installed"
 msgstr "O pacote unattended-upgrades não está instalado"
 
-#: ../../uaclient/messages/__init__.py:1889
+#: ../../uaclient/messages/__init__.py:1893
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1898
+#: ../../uaclient/messages/__init__.py:1902
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1903
+#: ../../uaclient/messages/__init__.py:1907
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1909
+#: ../../uaclient/messages/__init__.py:1913
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2909,28 +2917,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1923
+#: ../../uaclient/messages/__init__.py:1927
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1929
+#: ../../uaclient/messages/__init__.py:1933
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1959
+#: ../../uaclient/messages/__init__.py:1963
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1964
+#: ../../uaclient/messages/__init__.py:1968
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1970
+#: ../../uaclient/messages/__init__.py:1974
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2938,107 +2946,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1980
+#: ../../uaclient/messages/__init__.py:1984
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1987
+#: ../../uaclient/messages/__init__.py:1991
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1992
+#: ../../uaclient/messages/__init__.py:1996
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1996
+#: ../../uaclient/messages/__init__.py:2000
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2000
+#: ../../uaclient/messages/__init__.py:2004
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2005
+#: ../../uaclient/messages/__init__.py:2009
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2010
+#: ../../uaclient/messages/__init__.py:2014
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2015
+#: ../../uaclient/messages/__init__.py:2019
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2021
+#: ../../uaclient/messages/__init__.py:2025
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2027
+#: ../../uaclient/messages/__init__.py:2031
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2031
+#: ../../uaclient/messages/__init__.py:2035
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2037
+#: ../../uaclient/messages/__init__.py:2041
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2045
+#: ../../uaclient/messages/__init__.py:2049
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2051
+#: ../../uaclient/messages/__init__.py:2055
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2060
+#: ../../uaclient/messages/__init__.py:2064
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2067
+#: ../../uaclient/messages/__init__.py:2071
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2074
+#: ../../uaclient/messages/__init__.py:2078
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2079
+#: ../../uaclient/messages/__init__.py:2083
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2085
+#: ../../uaclient/messages/__init__.py:2089
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3046,7 +3054,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2095
+#: ../../uaclient/messages/__init__.py:2099
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3054,7 +3062,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2105
+#: ../../uaclient/messages/__init__.py:2109
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3062,41 +3070,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2115
+#: ../../uaclient/messages/__init__.py:2119
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2122
+#: ../../uaclient/messages/__init__.py:2126
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2128
+#: ../../uaclient/messages/__init__.py:2132
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2134
+#: ../../uaclient/messages/__init__.py:2138
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2139
+#: ../../uaclient/messages/__init__.py:2143
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2145
+#: ../../uaclient/messages/__init__.py:2149
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2153
+#: ../../uaclient/messages/__init__.py:2157
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2162
+#: ../../uaclient/messages/__init__.py:2166
 #, python-brace-format
 msgid ""
 "To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
@@ -3104,59 +3112,59 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2178
+#: ../../uaclient/messages/__init__.py:2182
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2183
+#: ../../uaclient/messages/__init__.py:2187
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2189
+#: ../../uaclient/messages/__init__.py:2193
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2197
+#: ../../uaclient/messages/__init__.py:2201
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2205
+#: ../../uaclient/messages/__init__.py:2209
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2212
+#: ../../uaclient/messages/__init__.py:2216
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2219
+#: ../../uaclient/messages/__init__.py:2223
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2228
+#: ../../uaclient/messages/__init__.py:2232
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2232
+#: ../../uaclient/messages/__init__.py:2236
 #, python-brace-format
 msgid ""
 "Error on Pro Image:\n"
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2238
+#: ../../uaclient/messages/__init__.py:2242
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2245
+#: ../../uaclient/messages/__init__.py:2249
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -3164,16 +3172,16 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2255
+#: ../../uaclient/messages/__init__.py:2259
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2262
+#: ../../uaclient/messages/__init__.py:2266
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2270
+#: ../../uaclient/messages/__init__.py:2274
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
@@ -3182,7 +3190,7 @@ msgstr ""
 "Suporte para auto-attach não está disponível para esta imagem\n"
 "Veja {url}"
 
-#: ../../uaclient/messages/__init__.py:2279
+#: ../../uaclient/messages/__init__.py:2283
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
@@ -3191,18 +3199,18 @@ msgstr ""
 "Suporte para auto-attach não está disponível para {{cloud_type}}\n"
 "Veja: {url}"
 
-#: ../../uaclient/messages/__init__.py:2287
+#: ../../uaclient/messages/__init__.py:2291
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2293
+#: ../../uaclient/messages/__init__.py:2297
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2301
+#: ../../uaclient/messages/__init__.py:2305
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -3213,7 +3221,7 @@ msgstr ""
 "o campo VERSION não tem a informação de versão: {version}\n"
 "e o campo VERSION_CODENAME não está presente"
 
-#: ../../uaclient/messages/__init__.py:2311
+#: ../../uaclient/messages/__init__.py:2315
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -3227,12 +3235,12 @@ msgstr ""
 "\n"
 "$ sudo rm {lock_file_path}"
 
-#: ../../uaclient/messages/__init__.py:2320
+#: ../../uaclient/messages/__init__.py:2324
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr "{source} retornou um json inválido: {out}"
 
-#: ../../uaclient/messages/__init__.py:2326
+#: ../../uaclient/messages/__init__.py:2330
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
@@ -3241,7 +3249,7 @@ msgstr ""
 "Valor inválido para {path_to_value} em /etc/ubuntu-advantage/uaclient.conf."
 "Esperava {expected_value}, mas {value} foi encontrado."
 
-#: ../../uaclient/messages/__init__.py:2335
+#: ../../uaclient/messages/__init__.py:2339
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
@@ -3249,17 +3257,17 @@ msgstr ""
 "Não foi possível associar {key} a {value}: <value> precisa ser um inteiro "
 "positivo."
 
-#: ../../uaclient/messages/__init__.py:2342
+#: ../../uaclient/messages/__init__.py:2346
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr "url inválida no arquivo de configuração. {key}: {value}"
 
-#: ../../uaclient/messages/__init__.py:2347
+#: ../../uaclient/messages/__init__.py:2351
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr "Não foi possível encontrar o arquivo yaml: {filepath}"
 
-#: ../../uaclient/messages/__init__.py:2353
+#: ../../uaclient/messages/__init__.py:2357
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
@@ -3270,27 +3278,27 @@ msgstr ""
 "pro de apt ao mesmo tempo não é suportado.\n"
 "Cancelando o processo de configuração.\n"
 
-#: ../../uaclient/messages/__init__.py:2363
+#: ../../uaclient/messages/__init__.py:2367
 msgid "Can't load the distro-info database."
 msgstr "Não foi possível carregar o banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2368
+#: ../../uaclient/messages/__init__.py:2372
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 "Não foi possível encontrar a série {series} na banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2373
+#: ../../uaclient/messages/__init__.py:2377
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr "Erro: não é possível usar {option1} junto com {option2}"
 
-#: ../../uaclient/messages/__init__.py:2377
+#: ../../uaclient/messages/__init__.py:2381
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr "Ajuda não disponível para '{name}'"
 
-#: ../../uaclient/messages/__init__.py:2383
+#: ../../uaclient/messages/__init__.py:2387
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
@@ -3299,34 +3307,34 @@ msgstr ""
 "Erro: problema de segurnça \"{issue}\" não foi reconhecido.\n"
 "Use: \"pro fix CVE-yyyy-nnnn\" ou \"pro fix USN-nnnn\""
 
-#: ../../uaclient/messages/__init__.py:2389
+#: ../../uaclient/messages/__init__.py:2393
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr "{arg} precisa ser um de: {choices}"
 
-#: ../../uaclient/messages/__init__.py:2394
+#: ../../uaclient/messages/__init__.py:2398
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr "Esperava {expected} mas encontrou: {actual}"
 
-#: ../../uaclient/messages/__init__.py:2398
+#: ../../uaclient/messages/__init__.py:2402
 msgid "Unable to process uaclient.conf"
 msgstr "Falha ao processar uaclient.conf"
 
-#: ../../uaclient/messages/__init__.py:2403
+#: ../../uaclient/messages/__init__.py:2407
 msgid "Unable to refresh your subscription"
 msgstr "Falha ao atualizar sua assinatura"
 
-#: ../../uaclient/messages/__init__.py:2408
+#: ../../uaclient/messages/__init__.py:2412
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 "Falha ao atualizar as mensagens de APT e MOTD relacioandas ao Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:2414
+#: ../../uaclient/messages/__init__.py:2418
 msgid "json formatted response requires --assume-yes flag."
 msgstr "resposta formatada em json necessita do paramêtro --assume-yes"
 
-#: ../../uaclient/messages/__init__.py:2422
+#: ../../uaclient/messages/__init__.py:2426
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
@@ -3336,50 +3344,50 @@ msgstr ""
 "Ao invés disso, inclua o token no arquivo de attach-config.\n"
 "    "
 
-#: ../../uaclient/messages/__init__.py:2431
+#: ../../uaclient/messages/__init__.py:2435
 msgid "Cannot provide both --args and --data at the same time"
 msgstr "Não é possível usar --args e --data ao mesmo tempo"
 
-#: ../../uaclient/messages/__init__.py:2437
+#: ../../uaclient/messages/__init__.py:2441
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr "Falha ao executar: {lock_request}.\n"
 
-#: ../../uaclient/messages/__init__.py:2446
+#: ../../uaclient/messages/__init__.py:2450
 msgid "This command must be run as root (try using sudo)."
 msgstr "Esse comando precisa ser executado como root (tente usando sudo)."
 
-#: ../../uaclient/messages/__init__.py:2451
+#: ../../uaclient/messages/__init__.py:2455
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr "Metadados para {issue} não são válidos. Erro: {error_msg}."
 
-#: ../../uaclient/messages/__init__.py:2458
+#: ../../uaclient/messages/__init__.py:2462
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr "Erro: {issue_id} não encontrada."
 
-#: ../../uaclient/messages/__init__.py:2462
+#: ../../uaclient/messages/__init__.py:2466
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr "chave GPG '{keyfile}' não foi encontrada"
 
-#: ../../uaclient/messages/__init__.py:2467
+#: ../../uaclient/messages/__init__.py:2471
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr "'{endpoint}' não é um endpoint válido"
 
-#: ../../uaclient/messages/__init__.py:2472
+#: ../../uaclient/messages/__init__.py:2476
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr "'{arg}' está faltando para endpoint {endpoint}"
 
-#: ../../uaclient/messages/__init__.py:2477
+#: ../../uaclient/messages/__init__.py:2481
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr "{endpoint} não aceita paramêtros"
 
-#: ../../uaclient/messages/__init__.py:2482
+#: ../../uaclient/messages/__init__.py:2486
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
@@ -3388,32 +3396,32 @@ msgstr ""
 "Error ao analisar paramêtro data para API json:\n"
 "{data}"
 
-#: ../../uaclient/messages/__init__.py:2487
+#: ../../uaclient/messages/__init__.py:2491
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr "'{arg}' não está formatado como 'chave=valor'"
 
-#: ../../uaclient/messages/__init__.py:2492
+#: ../../uaclient/messages/__init__.py:2496
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr "Não foi possível determinar a versão: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2497
+#: ../../uaclient/messages/__init__.py:2501
 msgid "features.disable_auto_attach set in config"
 msgstr "features.disable_auto_attach definida na configuração"
 
-#: ../../uaclient/messages/__init__.py:2502
+#: ../../uaclient/messages/__init__.py:2506
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 "Não foi possível determinar o status do unattended-upgrades: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2508
+#: ../../uaclient/messages/__init__.py:2512
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr "Esperava valor com tipo {expected_type}, mas recebeu tipo {got_type}"
 
-#: ../../uaclient/messages/__init__.py:2514
+#: ../../uaclient/messages/__init__.py:2518
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
@@ -3422,7 +3430,7 @@ msgstr ""
 "Valor com tipo incorreto na posição {index}:\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2520
+#: ../../uaclient/messages/__init__.py:2524
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
@@ -3431,7 +3439,7 @@ msgstr ""
 "Valor com tipo incorreto para o campo \"{key}\":\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2527
+#: ../../uaclient/messages/__init__.py:2531
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""

--- a/debian/po/ubuntu-pro.pot
+++ b/debian/po/ubuntu-pro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-05 13:05-0300\n"
+"POT-Creation-Date: 2024-01-17 16:08-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1986,7 +1986,7 @@ msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1306
-#: ../../uaclient/messages/__init__.py:1751
+#: ../../uaclient/messages/__init__.py:1755
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
@@ -2165,14 +2165,22 @@ msgid "RT kernel optimized for NVIDIA Tegra platform"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1429
-msgid "Real-time Intel IOTG Kernel"
+msgid "Raspberry Pi Real-time for Pi5/Pi4"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1431
+msgid "24.04 Real-time kernel optimised for Raspberry Pi"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1433
+msgid "Real-time Intel IOTG Kernel"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1435
 msgid "RT kernel optimized for Intel IOTG platform"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1434
+#: ../../uaclient/messages/__init__.py:1438
 #, python-brace-format
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches "
@@ -2185,7 +2193,7 @@ msgid ""
 "Do you want to continue? [ default = Yes ]: (Y/n) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1445
+#: ../../uaclient/messages/__init__.py:1449
 msgid ""
 "This will remove the boot order preference for the Real-time kernel and\n"
 "disable updates to the Real-time kernel.\n"
@@ -2202,15 +2210,15 @@ msgid ""
 "Are you sure? (y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1461
+#: ../../uaclient/messages/__init__.py:1465
 msgid "ROS ESM Security Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1462
+#: ../../uaclient/messages/__init__.py:1466
 msgid "Security Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1464
+#: ../../uaclient/messages/__init__.py:1468
 #, python-brace-format
 msgid ""
 "ros provides access to a private PPA which includes security-related "
@@ -2223,15 +2231,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1473
+#: ../../uaclient/messages/__init__.py:1477
 msgid "ROS ESM All Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1475
+#: ../../uaclient/messages/__init__.py:1479
 msgid "All Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1478
+#: ../../uaclient/messages/__init__.py:1482
 #, python-brace-format
 msgid ""
 "ros-updates provides access to a private PPA that includes non-security-"
@@ -2244,14 +2252,14 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1549
+#: ../../uaclient/messages/__init__.py:1553
 msgid ""
 "Unexpected error(s) occurred.\n"
 "For more details, see the log: /var/log/ubuntu-advantage.log\n"
 "To file a bug run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1559
+#: ../../uaclient/messages/__init__.py:1563
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2259,7 +2267,7 @@ msgid ""
 "Please install \"ca-certificates\" and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1569
+#: ../../uaclient/messages/__init__.py:1573
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2267,216 +2275,216 @@ msgid ""
 "Please check your openssl configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1578
+#: ../../uaclient/messages/__init__.py:1582
 #, python-brace-format
 msgid "Ignoring unknown argument '{arg}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1584
+#: ../../uaclient/messages/__init__.py:1588
 #, python-brace-format
 msgid ""
 "A new version of the client is available: {version}. Please upgrade to the "
 "latest version to get the new features and bug fixes."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1591
+#: ../../uaclient/messages/__init__.py:1595
 #, python-brace-format
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1596
+#: ../../uaclient/messages/__init__.py:1600
 #, python-brace-format
 msgid "{title} does not support being disabled with --purge"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1602
+#: ../../uaclient/messages/__init__.py:1606
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1609
+#: ../../uaclient/messages/__init__.py:1613
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1617
+#: ../../uaclient/messages/__init__.py:1621
 #, python-brace-format
 msgid "Cannot disable {entitlement_name} with purge: no origin value defined"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1624
+#: ../../uaclient/messages/__init__.py:1628
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1629
+#: ../../uaclient/messages/__init__.py:1633
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1637
+#: ../../uaclient/messages/__init__.py:1641
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1645
+#: ../../uaclient/messages/__init__.py:1649
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1648
+#: ../../uaclient/messages/__init__.py:1652
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1653
+#: ../../uaclient/messages/__init__.py:1657
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1659
+#: ../../uaclient/messages/__init__.py:1663
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1663
+#: ../../uaclient/messages/__init__.py:1667
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1668
+#: ../../uaclient/messages/__init__.py:1672
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1675
+#: ../../uaclient/messages/__init__.py:1679
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1682
+#: ../../uaclient/messages/__init__.py:1686
 #, python-brace-format
 msgid ""
 "{title} is already enabled.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1689
+#: ../../uaclient/messages/__init__.py:1693
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1695
+#: ../../uaclient/messages/__init__.py:1699
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1701
+#: ../../uaclient/messages/__init__.py:1705
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1709
+#: ../../uaclient/messages/__init__.py:1713
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1717
+#: ../../uaclient/messages/__init__.py:1721
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1724
+#: ../../uaclient/messages/__init__.py:1728
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1732
+#: ../../uaclient/messages/__init__.py:1736
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1739
+#: ../../uaclient/messages/__init__.py:1743
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1745
+#: ../../uaclient/messages/__init__.py:1749
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1755
+#: ../../uaclient/messages/__init__.py:1759
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1758
+#: ../../uaclient/messages/__init__.py:1762
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1762
+#: ../../uaclient/messages/__init__.py:1766
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1767
+#: ../../uaclient/messages/__init__.py:1771
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1775
+#: ../../uaclient/messages/__init__.py:1779
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1784
+#: ../../uaclient/messages/__init__.py:1788
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1792
+#: ../../uaclient/messages/__init__.py:1796
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1796
+#: ../../uaclient/messages/__init__.py:1800
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1801
+#: ../../uaclient/messages/__init__.py:1805
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1809
+#: ../../uaclient/messages/__init__.py:1813
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2486,7 +2494,7 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1818
+#: ../../uaclient/messages/__init__.py:1822
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2495,75 +2503,75 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1828
+#: ../../uaclient/messages/__init__.py:1832
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1834
+#: ../../uaclient/messages/__init__.py:1838
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1843
+#: ../../uaclient/messages/__init__.py:1847
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1850
+#: ../../uaclient/messages/__init__.py:1854
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1857
+#: ../../uaclient/messages/__init__.py:1861
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1862
+#: ../../uaclient/messages/__init__.py:1866
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1866
+#: ../../uaclient/messages/__init__.py:1870
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1871
-msgid "apt-daily.timer jobs are not running"
-msgstr ""
-
 #: ../../uaclient/messages/__init__.py:1875
-#, python-brace-format
-msgid "{cfg_name} is empty"
+msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1879
 #, python-brace-format
-msgid "{cfg_name} is turned off"
+msgid "{cfg_name} is empty"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1883
+#, python-brace-format
+msgid "{cfg_name} is turned off"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1887
 msgid "unattended-upgrades package is not installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1889
+#: ../../uaclient/messages/__init__.py:1893
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1898
+#: ../../uaclient/messages/__init__.py:1902
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1903
+#: ../../uaclient/messages/__init__.py:1907
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1909
+#: ../../uaclient/messages/__init__.py:1913
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2573,28 +2581,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1923
+#: ../../uaclient/messages/__init__.py:1927
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1929
+#: ../../uaclient/messages/__init__.py:1933
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1959
+#: ../../uaclient/messages/__init__.py:1963
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1964
+#: ../../uaclient/messages/__init__.py:1968
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1970
+#: ../../uaclient/messages/__init__.py:1974
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2602,107 +2610,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1980
+#: ../../uaclient/messages/__init__.py:1984
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1987
+#: ../../uaclient/messages/__init__.py:1991
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1992
+#: ../../uaclient/messages/__init__.py:1996
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1996
+#: ../../uaclient/messages/__init__.py:2000
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2000
+#: ../../uaclient/messages/__init__.py:2004
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2005
+#: ../../uaclient/messages/__init__.py:2009
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2010
+#: ../../uaclient/messages/__init__.py:2014
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2015
+#: ../../uaclient/messages/__init__.py:2019
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2021
+#: ../../uaclient/messages/__init__.py:2025
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2027
+#: ../../uaclient/messages/__init__.py:2031
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2031
+#: ../../uaclient/messages/__init__.py:2035
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2037
+#: ../../uaclient/messages/__init__.py:2041
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2045
+#: ../../uaclient/messages/__init__.py:2049
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2051
+#: ../../uaclient/messages/__init__.py:2055
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2060
+#: ../../uaclient/messages/__init__.py:2064
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2067
+#: ../../uaclient/messages/__init__.py:2071
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2074
+#: ../../uaclient/messages/__init__.py:2078
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2079
+#: ../../uaclient/messages/__init__.py:2083
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2085
+#: ../../uaclient/messages/__init__.py:2089
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2710,7 +2718,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2095
+#: ../../uaclient/messages/__init__.py:2099
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2718,7 +2726,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2105
+#: ../../uaclient/messages/__init__.py:2109
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2726,41 +2734,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2115
+#: ../../uaclient/messages/__init__.py:2119
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2122
+#: ../../uaclient/messages/__init__.py:2126
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2128
+#: ../../uaclient/messages/__init__.py:2132
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2134
+#: ../../uaclient/messages/__init__.py:2138
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2139
+#: ../../uaclient/messages/__init__.py:2143
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2145
+#: ../../uaclient/messages/__init__.py:2149
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2153
+#: ../../uaclient/messages/__init__.py:2157
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2162
+#: ../../uaclient/messages/__init__.py:2166
 #, python-brace-format
 msgid ""
 "To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
@@ -2768,59 +2776,59 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2178
+#: ../../uaclient/messages/__init__.py:2182
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2183
+#: ../../uaclient/messages/__init__.py:2187
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2189
+#: ../../uaclient/messages/__init__.py:2193
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2197
+#: ../../uaclient/messages/__init__.py:2201
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2205
+#: ../../uaclient/messages/__init__.py:2209
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2212
+#: ../../uaclient/messages/__init__.py:2216
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2219
+#: ../../uaclient/messages/__init__.py:2223
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2228
+#: ../../uaclient/messages/__init__.py:2232
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2232
+#: ../../uaclient/messages/__init__.py:2236
 #, python-brace-format
 msgid ""
 "Error on Pro Image:\n"
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2238
+#: ../../uaclient/messages/__init__.py:2242
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2245
+#: ../../uaclient/messages/__init__.py:2249
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -2828,41 +2836,41 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2255
+#: ../../uaclient/messages/__init__.py:2259
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2262
+#: ../../uaclient/messages/__init__.py:2266
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2270
+#: ../../uaclient/messages/__init__.py:2274
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2279
+#: ../../uaclient/messages/__init__.py:2283
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2287
+#: ../../uaclient/messages/__init__.py:2291
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2293
+#: ../../uaclient/messages/__init__.py:2297
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2301
+#: ../../uaclient/messages/__init__.py:2305
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -2870,7 +2878,7 @@ msgid ""
 "and the VERSION_CODENAME information is not present"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2311
+#: ../../uaclient/messages/__init__.py:2315
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -2879,189 +2887,189 @@ msgid ""
 "$ sudo rm {lock_file_path}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2320
+#: ../../uaclient/messages/__init__.py:2324
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2326
+#: ../../uaclient/messages/__init__.py:2330
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
 "Expected {expected_value}, found {value}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2335
+#: ../../uaclient/messages/__init__.py:2339
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2342
+#: ../../uaclient/messages/__init__.py:2346
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2347
+#: ../../uaclient/messages/__init__.py:2351
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2353
+#: ../../uaclient/messages/__init__.py:2357
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
 "Cancelling config process operation.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2363
+#: ../../uaclient/messages/__init__.py:2367
 msgid "Can't load the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2368
+#: ../../uaclient/messages/__init__.py:2372
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2373
+#: ../../uaclient/messages/__init__.py:2377
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2377
+#: ../../uaclient/messages/__init__.py:2381
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2383
+#: ../../uaclient/messages/__init__.py:2387
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
 "Usage: \"pro fix CVE-yyyy-nnnn\" or \"pro fix USN-nnnn\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2389
+#: ../../uaclient/messages/__init__.py:2393
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2394
+#: ../../uaclient/messages/__init__.py:2398
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2398
+#: ../../uaclient/messages/__init__.py:2402
 msgid "Unable to process uaclient.conf"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2403
+#: ../../uaclient/messages/__init__.py:2407
 msgid "Unable to refresh your subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2408
+#: ../../uaclient/messages/__init__.py:2412
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2414
+#: ../../uaclient/messages/__init__.py:2418
 msgid "json formatted response requires --assume-yes flag."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2422
+#: ../../uaclient/messages/__init__.py:2426
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
 "    "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2431
+#: ../../uaclient/messages/__init__.py:2435
 msgid "Cannot provide both --args and --data at the same time"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2437
+#: ../../uaclient/messages/__init__.py:2441
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2446
+#: ../../uaclient/messages/__init__.py:2450
 msgid "This command must be run as root (try using sudo)."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2451
+#: ../../uaclient/messages/__init__.py:2455
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2458
+#: ../../uaclient/messages/__init__.py:2462
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2462
+#: ../../uaclient/messages/__init__.py:2466
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2467
+#: ../../uaclient/messages/__init__.py:2471
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2472
+#: ../../uaclient/messages/__init__.py:2476
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2477
+#: ../../uaclient/messages/__init__.py:2481
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2482
+#: ../../uaclient/messages/__init__.py:2486
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
 "{data}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2487
+#: ../../uaclient/messages/__init__.py:2491
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2492
+#: ../../uaclient/messages/__init__.py:2496
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2497
+#: ../../uaclient/messages/__init__.py:2501
 msgid "features.disable_auto_attach set in config"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2502
+#: ../../uaclient/messages/__init__.py:2506
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2508
+#: ../../uaclient/messages/__init__.py:2512
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2514
+#: ../../uaclient/messages/__init__.py:2518
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2520
+#: ../../uaclient/messages/__init__.py:2524
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2527
+#: ../../uaclient/messages/__init__.py:2531
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -197,11 +197,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
             resourceEntitlements:
               - type: realtime-kernel
                 overrides:
-                  - directives:
+                  - selector:
+                      variant: nvidia-tegra
+                    directives:
                       additionalPackages:
                         - nvidia-prime
-                    selector:
-                      variant: nvidia-tegra
+                  - selector:
+                      variant: rpi
+                    directives:
+                      additionalPackages:
+                        - raspi-config
         """
         When I run `pro enable realtime-kernel --variant nvidia-tegra` `with sudo` and stdin `y`
         Then stdout matches regexp:
@@ -235,7 +240,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
         ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-        └ nvidia-tegra   yes +enabled   +RT kernel optimized for NVIDIA Tegra platform
+        ├ nvidia-tegra   yes +enabled   +RT kernel optimized for NVIDIA Tegra platform
+        └ rpi            yes +disabled  +24.04 Real-time kernel optimised for Raspberry Pi
         """
         When I verify that running `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `N` exits `1`
         Then stdout matches regexp:
@@ -246,6 +252,16 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         And stdout matches regexp:
         """
         Cannot enable Real-time Intel IOTG Kernel when Real-time NVIDIA Tegra Kernel is enabled.
+        """
+        When I run `pro enable realtime-kernel --variant rpi --assume-yes` with sudo
+        When I run `pro status --all` as non-root
+        Then stdout matches regexp:
+        """
+        realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
+        ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
+        ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+        ├ nvidia-tegra   yes +disabled  +RT kernel optimized for NVIDIA Tegra platform
+        └ rpi            yes +enabled   +24.04 Real-time kernel optimised for Raspberry Pi
         """
         When I run `pro help realtime-kernel` as non-root
         Then I will see the following on stdout:
@@ -272,6 +288,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
           * generic: Generic version of the RT kernel (default)
           * intel-iotg: RT kernel optimized for Intel IOTG platform
           * nvidia-tegra: RT kernel optimized for NVIDIA Tegra platform
+          * rpi: 24.04 Real-time kernel optimised for Raspberry Pi
         """
         When I run `pro disable realtime-kernel` `with sudo` and stdin `y`
         Then stdout matches regexp:
@@ -299,7 +316,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
         realtime-kernel  yes +disabled   +Ubuntu kernel with PREEMPT_RT patches integrated
         ├ generic        yes +disabled  +Generic version of the RT kernel \(default\)
         ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
-        └ nvidia-tegra   yes +disabled   +RT kernel optimized for NVIDIA Tegra platform
+        ├ nvidia-tegra   yes +disabled  +RT kernel optimized for NVIDIA Tegra platform
+        └ rpi            yes +disabled  +24.04 Real-time kernel optimised for Raspberry Pi
         """
         When I verify that running `pro enable realtime-kernel --variant nonexistent` `with sudo` exits `1`
         Then I will see the following on stdout:

--- a/tools/spellcheck-allowed-words.txt
+++ b/tools/spellcheck-allowed-words.txt
@@ -109,12 +109,15 @@ num
 OKGREEN
 openssl
 OPENSSL
+optimised
 option1
 option2
 param
 PARAM
 params
 PCI
+Pi4
+Pi5
 pid
 pkgs
 PKGS
@@ -128,6 +131,7 @@ PycURL
 PYCURL
 python3
 PYTHONPATH
+RASPI
 realtime
 Realtime
 REALTIME

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -37,6 +37,7 @@ class RealtimeKernelEntitlement(repo.RepoEntitlement):
         return {
             GenericRealtime.variant_name: GenericRealtime,
             NvidiaTegraRealtime.variant_name: NvidiaTegraRealtime,
+            RaspberryPiRealtime.variant_name: RaspberryPiRealtime,
             IntelIotgRealtime.variant_name: IntelIotgRealtime,
         }
 
@@ -145,6 +146,14 @@ class NvidiaTegraRealtime(RealtimeVariant):
     variant_name = "nvidia-tegra"
     title = messages.REALTIME_NVIDIA_TITLE
     description = messages.REALTIME_NVIDIA_DESCRIPTION
+    is_variant = True
+    check_packages_are_installed = True
+
+
+class RaspberryPiRealtime(RealtimeVariant):
+    variant_name = "rpi"
+    title = messages.REALTIME_RASPI_TITLE
+    description = messages.REALTIME_RASPI_DESCRIPTION
     is_variant = True
     check_packages_are_installed = True
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1426,6 +1426,10 @@ REALTIME_NVIDIA_TITLE = t.gettext("Real-time NVIDIA Tegra Kernel")
 REALTIME_NVIDIA_DESCRIPTION = t.gettext(
     "RT kernel optimized for NVIDIA Tegra platform"
 )
+REALTIME_RASPI_TITLE = t.gettext("Raspberry Pi Real-time for Pi5/Pi4")
+REALTIME_RASPI_DESCRIPTION = t.gettext(
+    "24.04 Real-time kernel optimised for Raspberry Pi"
+)
 REALTIME_INTEL_TITLE = t.gettext("Real-time Intel IOTG Kernel")
 REALTIME_INTEL_DESCRIPTION = t.gettext(
     "RT kernel optimized for Intel IOTG platform"


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
A raspberry pi variant of realtime-kernel may become available in time for noble. This sets up the variant on our side.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

run the edited lxd-vm behave test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [x] Yes from realtime-team
 - [ ] No
