### PR TITLE
ci: run custom pr checks on next-* branch PRs

### DIFF
--- a/.github/workflows/custom-pr-checks.yaml
+++ b/.github/workflows/custom-pr-checks.yaml
@@ -11,6 +11,7 @@ on:
       - edited
     branches:
       - main
+      - next-*
 
 jobs:
   bug-refs:


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because Custom PR Checks weren't running on PRs to `next-v32`