### PR TITLE
Updated pro status call in collect-logs

### DIFF
--- a/apport/source_ubuntu-advantage-tools.py
+++ b/apport/source_ubuntu-advantage-tools.py
@@ -17,8 +17,8 @@ def add_info(report, ui=None):
         auto_include_log_files = {
             "cloud-id.txt",
             "cloud-id.txt-error",
-            "ua-status.json",
-            "ua-status.json-error",
+            "pro-status.json",
+            "pro-status.json-error",
             "livepatch-status.txt",
             "livepatch-status.txt-error",
             "pro-journal.txt",

--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -19,6 +19,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         build.info
         cloud-id.txt
         cloud-init-journal.txt
+        environment_vars.json
         esm-cache.service.txt
         jobs-status.json
         livepatch-status.txt-error
@@ -65,6 +66,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         build.info
         cloud-id.txt
         cloud-init-journal.txt
+        environment_vars.json
         esm-cache.service.txt
         jobs-status.json
         livepatch-status.txt-error

--- a/features/collect_logs.feature
+++ b/features/collect_logs.feature
@@ -23,12 +23,12 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         jobs-status.json
         livepatch-status.txt-error
         pro-journal.txt
+        pro-status.json
         systemd-timers.txt
         ua-auto-attach.path.txt(-error)?
         ua-auto-attach.service.txt(-error)?
         uaclient.conf
         ua-reboot-cmds.service.txt
-        ua-status.json
         ua-timer.service.txt
         ua-timer.timer.txt
         ubuntu-advantage.log
@@ -69,12 +69,12 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
         jobs-status.json
         livepatch-status.txt-error
         pro-journal.txt
+        pro-status.json
         systemd-timers.txt
         ua-auto-attach.path.txt(-error)?
         ua-auto-attach.service.txt(-error)?
         uaclient.conf
         ua-reboot-cmds.service.txt
-        ua-status.json
         ua-timer.service.txt
         ua-timer.timer.txt
         ubuntu-advantage.log

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -1,5 +1,6 @@
 import datetime
 import glob
+import json
 import logging
 import os
 import re
@@ -235,9 +236,6 @@ def collect_logs(cfg: config.UAConfig, output_dir: str):
         "cloud-id", "{}/cloud-id.txt".format(output_dir)
     )
     _write_command_output_to_file(
-        "pro status --format json", "{}/ua-status.json".format(output_dir)
-    )
-    _write_command_output_to_file(
         "{} status".format(livepatch.LIVEPATCH_CMD),
         "{}/livepatch-status.txt".format(output_dir),
     )
@@ -268,6 +266,11 @@ def collect_logs(cfg: config.UAConfig, output_dir: str):
             "{}/{}.txt".format(output_dir, service),
             return_codes=[0, 3],
         )
+    pro_status, _ = status(cfg=cfg, show_all=False)
+    system.write_file(
+        "{}/pro-status.json".format(output_dir),
+        json.dumps(pro_status),
+    )
 
     state_files = _get_state_files(cfg)
     user_log_files = (

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -269,7 +269,12 @@ def collect_logs(cfg: config.UAConfig, output_dir: str):
     pro_status, _ = status(cfg=cfg, show_all=False)
     system.write_file(
         "{}/pro-status.json".format(output_dir),
-        json.dumps(pro_status),
+        json.dumps(pro_status, cls=util.DatetimeAwareJSONEncoder),
+    )
+    env_vars = util.get_pro_environment()
+    system.write_file(
+        "{}/environment_vars.json".format(output_dir),
+        json.dumps(env_vars),
     )
 
     state_files = _get_state_files(cfg)

--- a/uaclient/cli/tests/test_cli_collect_logs.py
+++ b/uaclient/cli/tests/test_cli_collect_logs.py
@@ -67,6 +67,7 @@ class TestActionCollectLogs:
     @mock.patch("os.chown")
     @mock.patch("os.path.isfile", return_value=True)
     @mock.patch("shutil.copy")
+    @mock.patch("uaclient.actions.status")
     @mock.patch("uaclient.system.write_file")
     @mock.patch("uaclient.system.load_file")
     @mock.patch("uaclient.system.subp", return_value=(None, None))
@@ -81,6 +82,7 @@ class TestActionCollectLogs:
         m_subp,
         _load_file,
         _write_file,
+        m_status,
         m_shutilcopy,
         m_isfile,
         _chown,
@@ -96,6 +98,7 @@ class TestActionCollectLogs:
         FakeConfig,
         tmpdir,
     ):
+        m_status.return_value = {"user-id": ""}, 0
         m_get_release_info.return_value.series = series
         util_we_are_currently_root.return_value = is_root
         m_get_user.return_value = tmpdir.join("user-log").strpath
@@ -116,7 +119,6 @@ class TestActionCollectLogs:
 
         assert m_subp.call_args_list == [
             mock.call(["cloud-id"], rcs=None),
-            mock.call(["pro", "status", "--format", "json"], rcs=None),
             mock.call(["/snap/bin/canonical-livepatch", "status"], rcs=None),
             mock.call(["systemctl", "list-timers", "--all"], rcs=None),
             mock.call(

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -336,6 +336,7 @@ class TestAutoAttach:
 class TestCollectLogs:
     @mock.patch("uaclient.actions.status")
     @mock.patch("uaclient.actions.LOG.warning")
+    @mock.patch("uaclient.util.get_pro_environment")
     @mock.patch("uaclient.util.we_are_currently_root", return_value=False)
     @mock.patch("uaclient.system.write_file")
     @mock.patch("uaclient.system.load_file")
@@ -352,11 +353,13 @@ class TestCollectLogs:
         m_load_file,
         m_write_file,
         m_we_are_currently_root,
+        m_env_vars,
         m_log_warning,
         m_status,
         m_write_cmd,
         tmpdir,
     ):
+        m_env_vars.return_value = {"test": "test"}
         m_status.return_value = ({"test": "test"}, 0)
         log_file = tmpdir.join("user-log").strpath
         m_get_user.return_value = log_file
@@ -373,7 +376,7 @@ class TestCollectLogs:
             mock.call("a"),
             mock.call("b"),
         ] == m_load_file.call_args_list
-        assert 4 == m_write_file.call_count
+        assert 5 == m_write_file.call_count
 
         # apparmor checks
         assert 1 == m_system_subp.call_count
@@ -384,6 +387,7 @@ class TestCollectLogs:
         print(m_write_file.call_args_list)
         assert [
             mock.call("test/pro-status.json", '{"test": "test"}'),
+            mock.call("test/environment_vars.json", '{"test": "test"}'),
             mock.call("test/user0.log", "test"),
             mock.call("test/b", "test"),
             mock.call("test/apparmor_logs.txt", APPARMOR_DENIED),

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -334,6 +334,7 @@ class TestAutoAttach:
 
 @mock.patch("uaclient.actions._write_command_output_to_file")
 class TestCollectLogs:
+    @mock.patch("uaclient.actions.status")
     @mock.patch("uaclient.actions.LOG.warning")
     @mock.patch("uaclient.util.we_are_currently_root", return_value=False)
     @mock.patch("uaclient.system.write_file")
@@ -352,9 +353,11 @@ class TestCollectLogs:
         m_write_file,
         m_we_are_currently_root,
         m_log_warning,
+        m_status,
         m_write_cmd,
         tmpdir,
     ):
+        m_status.return_value = ({"test": "test"}, 0)
         log_file = tmpdir.join("user-log").strpath
         m_get_user.return_value = log_file
         m_get_state_files.return_value = ["a", "b"]
@@ -370,7 +373,7 @@ class TestCollectLogs:
             mock.call("a"),
             mock.call("b"),
         ] == m_load_file.call_args_list
-        assert 3 == m_write_file.call_count
+        assert 4 == m_write_file.call_count
 
         # apparmor checks
         assert 1 == m_system_subp.call_count
@@ -380,6 +383,7 @@ class TestCollectLogs:
 
         print(m_write_file.call_args_list)
         assert [
+            mock.call("test/pro-status.json", '{"test": "test"}'),
             mock.call("test/user0.log", "test"),
             mock.call("test/b", "test"),
             mock.call("test/apparmor_logs.txt", APPARMOR_DENIED),


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief --> 
`pro collect-logs` calls itself by running `pro status` to write the current status into a json file. This avoids that by using internal functions to achieve the same outcome.

Fixes: [#2926]

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

To re-produce behavior and verify changes:

    Launch a VM/Container
    Run sudo pro collect-logs
    look at /var/log/ubuntu-advantage.log

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
