### PR TITLE
daemon: wait for cloud-config.service to complete in python

### DIFF
--- a/features/api_configure_retry_service.feature
+++ b/features/api_configure_retry_service.feature
@@ -7,15 +7,14 @@ Feature: api.u.pro.attach.auto.configure_retry_service
         """
         [Unit]
         Description=test
-        Before=cloud-config.service
-        After=cloud-config.target
+        Before=ubuntu-advantage.service
 
         [Service]
         Type=oneshot
         ExecStart=/usr/bin/pro api u.pro.attach.auto.configure_retry_service.v1
 
         [Install]
-        WantedBy=cloud-config.service multi-user.target
+        WantedBy=multi-user.target
         """
         When I run `systemctl enable apitest.service` with sudo
         When I reboot the machine

--- a/features/environment.py
+++ b/features/environment.py
@@ -256,7 +256,13 @@ class UAClientBehaveConfig:
                 kwargs[key] = bool_value
 
         if "install_from" in kwargs:
-            kwargs["install_from"] = InstallationSource(kwargs["install_from"])
+            if str(kwargs["install_from"]).startswith("ppa:"):
+                kwargs["custom_ppa"] = kwargs["install_from"]
+                kwargs["install_from"] = InstallationSource.CUSTOM
+            else:
+                kwargs["install_from"] = InstallationSource(
+                    kwargs["install_from"]
+                )
 
         return cls(**kwargs)  # type: ignore
 

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -110,3 +110,24 @@ Feature: Pro Install and Uninstall related tests
            | focal   | aws.pro       |
            | jammy   | aws.pro       |
            | jammy   | aws.pro       |
+
+    @skip_local_environment
+    @skip_prebuilt_environment
+    Scenario Outline: Does not cause deadlock when cloud-init installs ubuntu-advantage-tools
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data
+        """
+        <user_data_field>: {}
+        """
+        When I apt remove `ubuntu-advantage-tools ubuntu-pro-client`
+        When I run `cloud-init clean --logs` with sudo
+        When I reboot the machine
+        When I run `cloud-init status --wait` with sudo
+        Then I verify that `ubuntu-advantage-tools` is installed
+
+        Examples: ubuntu release
+           | release | machine_type  | user_data_field  |
+           | xenial  | lxd-container | ubuntu-advantage |
+           | bionic  | lxd-container | ubuntu_advantage |
+           | focal   | lxd-container | ubuntu_advantage |
+           | jammy   | lxd-container | ubuntu_advantage |
+           | mantic  | lxd-container | ubuntu_advantage |

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -169,6 +169,7 @@ Feature: auto-attach retries periodically on failures
         """
         Active: active \(running\)
         """
+        When I wait `20` seconds
         When I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:
         """
@@ -324,6 +325,7 @@ Feature: auto-attach retries periodically on failures
         """
         Active: active \(running\)
         """
+        When I wait `20` seconds
         When I run `run-parts /etc/update-motd.d/` with sudo
         Then stdout matches regexp:
         """

--- a/systemd/ubuntu-advantage.service
+++ b/systemd/ubuntu-advantage.service
@@ -10,7 +10,11 @@
 [Unit]
 Description=Ubuntu Pro Background Auto Attach
 Documentation=man:ubuntu-advantage https://ubuntu.com/advantage
-After=network.target network-online.target systemd-networkd.service ua-auto-attach.service cloud-config.service ubuntu-advantage-cloud-id-shim.service
+# Note: This is NOT After=cloud-config.service to avoid deadlock when
+# cloud-init installs this package.
+# The python script will wait until cloud-config.service is done
+# before doing anything.
+After=network.target network-online.target systemd-networkd.service ua-auto-attach.service ubuntu-advantage-cloud-id-shim.service
 
 # Only run if not already attached
 ConditionPathExists=!/var/lib/ubuntu-advantage/private/machine-token.json

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -747,6 +747,33 @@ def is_systemd_unit_active(service_name: str) -> bool:
     return True
 
 
+def get_systemd_unit_active_state(service_name: str) -> Optional[str]:
+    try:
+        out, _ = subp(
+            [
+                "systemctl",
+                "show",
+                "--property=ActiveState",
+                "--no-pager",
+                service_name,
+            ]
+        )
+        if out and out.startswith("ActiveState="):
+            return out.split("=")[1].strip()
+        else:
+            LOG.warning(
+                "Couldn't find ActiveState in systemctl show output for %s",
+                service_name,
+            )
+    except exceptions.ProcessExecutionError as e:
+        LOG.warning(
+            "Failed to get ActiveState for systemd unit %s",
+            service_name,
+            exc_info=e,
+        )
+    return None
+
+
 def get_user_cache_dir() -> str:
     if util.we_are_currently_root():
         return defaults.UAC_RUN_PATH

--- a/uaclient/tests/test_lib_daemon.py
+++ b/uaclient/tests/test_lib_daemon.py
@@ -1,0 +1,59 @@
+import mock
+import pytest
+
+from lib.daemon import (
+    WAIT_FOR_CLOUD_CONFIG_POLL_TIMES,
+    WAIT_FOR_CLOUD_CONFIG_SLEEP_TIME,
+    _wait_for_cloud_config,
+)
+
+
+class TestWaitForCloudConfig:
+    @pytest.mark.parametrize(
+        [
+            "active_state_side_effect",
+            "expected_sleep_calls",
+        ],
+        (
+            # not activating
+            (
+                ["active"],
+                [],
+            ),
+            (
+                ["inactive"],
+                [],
+            ),
+            (
+                [None],
+                [],
+            ),
+            # activating, then finishes
+            (
+                (["activating"] * 11) + ["active"],
+                [mock.call(WAIT_FOR_CLOUD_CONFIG_SLEEP_TIME)] * 11,
+            ),
+            (
+                (["activating"] * 11) + ["failed"],
+                [mock.call(WAIT_FOR_CLOUD_CONFIG_SLEEP_TIME)] * 11,
+            ),
+            # still activating after polling maximum times
+            (
+                ["activating"] * (WAIT_FOR_CLOUD_CONFIG_POLL_TIMES + 1000),
+                [mock.call(WAIT_FOR_CLOUD_CONFIG_SLEEP_TIME)]
+                * WAIT_FOR_CLOUD_CONFIG_POLL_TIMES,
+            ),
+        ),
+    )
+    @mock.patch("lib.daemon.time.sleep")
+    @mock.patch("lib.daemon.system.get_systemd_unit_active_state")
+    def test_wait_for_cloud_config(
+        self,
+        m_get_systemd_unit_active_state,
+        m_sleep,
+        active_state_side_effect,
+        expected_sleep_calls,
+    ):
+        m_get_systemd_unit_active_state.side_effect = active_state_side_effect
+        _wait_for_cloud_config()
+        assert m_sleep.call_args_list == expected_sleep_calls

--- a/uaclient/tests/test_system.py
+++ b/uaclient/tests/test_system.py
@@ -1336,6 +1336,31 @@ class TestIsSystemdServiceActive:
         assert expected_return == system.is_systemd_unit_active("test")
 
 
+class TestGetSystemdUnitActiveState:
+    @pytest.mark.parametrize(
+        [
+            "subp_side_effect",
+            "expected",
+        ],
+        (
+            ([("ActiveState=active\n", "")], "active"),
+            ([("ActiveState=activating\n", "")], "activating"),
+            ([("", "")], None),
+            ([("anything=anything", "")], None),
+            (exceptions.ProcessExecutionError("test"), None),
+        ),
+    )
+    @mock.patch("uaclient.system.subp")
+    def test_get_systemd_unit_active_state(
+        self,
+        m_subp,
+        subp_side_effect,
+        expected,
+    ):
+        m_subp.side_effect = subp_side_effect
+        assert expected == system.get_systemd_unit_active_state("test.service")
+
+
 class TestGetCpuInfo:
     @pytest.mark.parametrize(
         "cpuinfo,vendor_id,model,stepping",


### PR DESCRIPTION
currently based on https://github.com/canonical/ubuntu-pro-client/pull/2887 so only look at the last two commit

## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
When cloud-init gets "ubuntu_advantage" user-data, it may need to
install or upgrade ubuntu-advantage-tools. This happens during
cloud-config.service. The install/upgrade of ubuntu-advantage-tools
triggers a "systemctl start ubuntu-advantage.service".
ubuntu-advantage.service is configured with an
"After=cloud-config.service", so it waits to start until
cloud-config.service becomes "active". In this scenario,
cloud-config.service cannot continue until ubuntu-advantage.service
starts, creating deadlock.

We get around this deadlock by removing the "After=cloud-config.service"
from ubuntu-advantage.service. Instead we are moving the ordering dependency
enforcement into the python code called by the service. This allows
systemd to go ahead and start the service allowing the install of
ubuntu-advantage-tools to finish and cloud-init to continue.
ubuntu-advantage.service will wait until cloud-config.service is
"active" to actually do anything.

LP: #2050022


## Test Steps
Run the added behave tests with `-D install_from=ppa:orndorffgrant/proclient-cloudinit-deadlock-test`

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
