### PR TITLE
logs: fix redaction filter

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -4,6 +4,9 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
     Scenario Outline: Attached refresh in a ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
+        And I verify that `Bearer ` field is redacted in the logs
+        And I verify that `'attach', '` field is redacted in the logs
+        And I verify that `'machineToken': '` field is redacted in the logs
         Then I verify that running `pro refresh` `as non-root` exits `1`
         And stderr matches regexp:
         """
@@ -167,6 +170,9 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
     Scenario Outline: Attached detach in an ubuntu machine
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
+        And I verify that `Bearer ` field is redacted in the logs
+        And I verify that `'attach', '` field is redacted in the logs
+        And I verify that `'machineToken': '` field is redacted in the logs
         And I run `pro api u.pro.status.enabled_services.v1` as non-root
         Then stdout matches regexp:
         """

--- a/features/steps/output.py
+++ b/features/steps/output.py
@@ -156,3 +156,12 @@ def root_vs_nonroot_cmd_comparison(context, cmd):
 
     assert_that(root_status_stdout, nonroot_status_stdout)
     assert root_status_stderr == nonroot_status_stderr
+
+
+@when("I verify that `{field}` field is redacted in the logs")
+def i_verify_field_is_redacted_in_the_logs(context, field):
+    when_i_run_command(
+        context, "cat /var/log/ubuntu-advantage.log", "with sudo"
+    )
+    context.text = field + "<REDACTED>"
+    then_stream_contains_substring(context, "stdout")

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -1671,7 +1671,6 @@ def setup_logging(log_level, log_file=None, logger=None):
     if not logger:
         logger = logging.getLogger("ubuntupro")
     logger.setLevel(log_level)
-    logger.addFilter(pro_log.RedactionFilter())
 
     # Clear all handlers, so they are replaced for this logger
     logger.handlers = []
@@ -1685,6 +1684,7 @@ def setup_logging(log_level, log_file=None, logger=None):
     file_handler.setFormatter(JsonArrayFormatter())
     file_handler.setLevel(log_level)
     file_handler.set_name("upro-file")
+    file_handler.addFilter(pro_log.RedactionFilter())
     logger.addHandler(file_handler)
 
 

--- a/uaclient/log.py
+++ b/uaclient/log.py
@@ -88,8 +88,8 @@ def get_all_user_log_files() -> List[str]:
 
 def setup_journald_logging(log_level, logger):
     logger.setLevel(log_level)
-    logger.addFilter(RedactionFilter())
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(JsonArrayFormatter())
     console_handler.setLevel(log_level)
+    console_handler.addFilter(RedactionFilter())
     logger.addHandler(console_handler)


### PR DESCRIPTION
## Why is this needed?
The redaction filter was not correctly applied to our current logs. We are now fixing this by adding the redaction filter directly in the log file handler

## Test Steps
Run the modified integration tests and also confirm that when performing an attach operation, that all secrets are redacted in the logs

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
