### PR TITLE
feat(cloud-init): support ubuntu_pro user-data (SC-1555)

### DIFF
--- a/lib/auto_attach.py
+++ b/lib/auto_attach.py
@@ -33,6 +33,11 @@ from uaclient.files import state_files
 
 LOG = logging.getLogger("ubuntupro.lib.auto_attach")
 
+# All known cloud-config keys which provide ubuntu pro configuration directives
+CLOUD_INIT_UA_KEYS = set(
+    ["ubuntu-advantage", "ubuntu_advantage", "ubuntu_pro"]
+)
+
 try:
     import cloudinit.stages as ci_stages  # type: ignore
 except ImportError:
@@ -54,10 +59,7 @@ def check_cloudinit_userdata_for_ua_info():
     if init is None:
         return False
 
-    if init.cfg and (
-        "ubuntu_advantage" in init.cfg.keys()
-        or "ubuntu-advantage" in init.cfg.keys()
-    ):
+    if init.cfg and CLOUD_INIT_UA_KEYS.intersection(init.cfg):
         return True
 
     return False

--- a/uaclient/tests/test_lib_auto_attach.py
+++ b/uaclient/tests/test_lib_auto_attach.py
@@ -41,6 +41,20 @@ class TestCheckCloudinitUserdataForUAInfo:
                     "cloud_config_modules": ["ubuntu-advantage", "test"],
                 },
             ),
+            (
+                True,
+                {
+                    "ubuntu_pro": {"token": "TOKEN"},
+                    "cloud_config_modules": ["ubuntu-advantage", "test"],
+                },
+            ),
+            (
+                True,
+                {
+                    "ubuntu-advantage": {"token": "TOKEN"},
+                    "cloud_config_modules": ["ubuntu-advantage", "test"],
+                },
+            ),
         ),
     )
     @mock.patch("lib.auto_attach.get_cloudinit_init_stage")


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
cloud-init upstream is looking to better align with product naming changes the Ubuntu Pro instead of the former Ubuntu Advantage product name.  As a result, even cloud-config userdata will now deprecate `ubuntu_advantage` configuration key from user-data and prefer `ubuntu_pro` key instead. This changset is needed pro client because the client initially checks and cloud-init userdata for keys that will operate on Ubuntu Pro. When such keys are present, Ubuntu Pro will avoid autoattaching those VMs on launch and leave that resposibility to cloud-init.

This change is part of a planning epic [SC-1555](https://warthogs.atlassian.net/browse/SC-1555) to align Pro naming in docs and potentially backport this feature to bionic/xenial if needed. That being said, the approach taken here is flexible and honors either the deprecated key ubuntu_advantage and the new key ubuntu_pro because we don't want ubuntu-advantage-tools to be tightly coupled to any cloud-init release changing this feature via cloud-init's own SRU schedule.
 
Note there is a [corresponding cloud-init PR](https://github.com/canonical/cloud-init/pull/4865) that needs to land to enable this ubuntu_pro support in #cloud-config.  At that point it may may sense to update `features/ubuntu_pro.feature` for noble and newer to provide `ubuntu_pro:` in user-data instead of `ubuntu_advantage:`

## Please Squash this PR with this commit message

```
    feat(cloud-init): support ubuntu_pro user-data (SC-1555)
    
    In #cloud-config user-data, cloud-init will be deprecating the
    ubuntu_advantage key in favor of ubuntu_pro to align with the
    current product naming and branding.
    
    To avoid tightly coupling ubuntu-pro-client with cloud-init
    releases, add support for the new 'ubuntu_pro' config key and
    retain support for the deprecated keys:
     - ubuntu-advantage
     - ubuntu_advantage
    
    Since cloud-init doesn't target Ubuntu Xenial for stable release
    updates (SRUs), the ubuntu-advantage/ubuntu_advantage keys must be
    supported by cloud-init and ubuntu-pro-client in Xenial unless a
    backport of latest cloud-init cc_ubuntu_advantage.py module is
    published to Xenial.
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
A manual integration test could be run installing ppa:cloud-init-dev/daily once the related cloud-init PR merges:
https://github.com/canonical/cloud-init/pull/4865 which will honor the new ubuntu_pro: config key.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No


[SC-1555]: https://warthogs.atlassian.net/browse/SC-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ