### PR TITLE
Config show inaccuracy

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -305,7 +305,6 @@ create_public_user_config_file() {
         mkdir -p "$destination_dir"
         # Move the user-config.json file to the private directory
         mv "$source_file" "$destination_dir/user-config.json"
-    fi
 
     /usr/bin/python3 -c "
 from uaclient.files import UserConfigFileObject
@@ -316,6 +315,7 @@ try:
 except Exception as e:
     print('Error while creating public user-config file: {}'.format(e))
 "
+    fi
 }
 
 migrate_ubuntu_pro_beta_banner() {

--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -296,11 +296,22 @@ create_public_user_config_file() {
     # UserConfigFile we already write the public
     # version of the user-config file with all the
     # sensitive data removed.
+    # We also move the user-config.json file to the private 
+    # directory
+    source_file="/var/lib/ubuntu-advantage/user-config.json"
+    destination_dir="/var/lib/ubuntu-advantage/private"
+    # Check if the source file exists
+    if [ -f "$source_file" ]; then
+        mkdir -p "$destination_dir"
+        # Move the user-config.json file to the private directory
+        mv "$source_file" "$destination_dir/user-config.json"
+    fi
+
     /usr/bin/python3 -c "
-from uaclient.files import UserConfigFileObject, UserConfigData
+from uaclient.files import UserConfigFileObject
 try:
     user_config_file = UserConfigFileObject()
-    content = UserConfigData()
+    content = user_config_file.read()
     user_config_file.write(content)
 except Exception as e:
     print('Error while creating public user-config file: {}'.format(e))

--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -291,6 +291,22 @@ machine_token_file.write(content)
 "
 }
 
+create_public_user_config_file() {
+    # When we perform the write operation through
+    # UserConfigFile we already write the public
+    # version of the user-config file with all the
+    # sensitive data removed.
+    /usr/bin/python3 -c "
+from uaclient.files import UserConfigFileObject, UserConfigData
+try:
+    user_config_file = UserConfigFileObject()
+    content = UserConfigData()
+    user_config_file.write(content)
+except Exception as e:
+    print('Error while creating public user-config file: {}'.format(e))
+"
+}
+
 migrate_ubuntu_pro_beta_banner() {
     # This only shipped in 27.11.2~
     if dpkg --compare-versions "$PREVIOUS_PKG_VER" ge "27.11.2~" \
@@ -473,6 +489,10 @@ case "$1" in
       # Rename the gpg keys to -pro-
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "29~"; then
           rename_gpg_keys
+      fi
+
+      if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "32~"; then
+          create_public_user_config_file
       fi
 
       if grep -q "^ua_config:" /etc/ubuntu-advantage/uaclient.conf; then

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -634,7 +634,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
       "update_messaging": null
       """
     When I delete the file `/var/lib/ubuntu-advantage/jobs-status.json`
-    And I create the file `/var/lib/ubuntu-advantage/user-config.json` with the following:
+    And I create the file `/var/lib/ubuntu-advantage/private/user-config.json` with the following:
       """
       { "metering_timer": 0 }
       """
@@ -645,7 +645,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
       "metering": null
       """
     When I delete the file `/var/lib/ubuntu-advantage/jobs-status.json`
-    And I create the file `/var/lib/ubuntu-advantage/user-config.json` with the following:
+    And I create the file `/var/lib/ubuntu-advantage/private/user-config.json` with the following:
       """
       { "metering_timer": "notanumber", "update_messaging_timer": -10 }
       """

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -216,38 +216,115 @@ Feature: Proxy configuration
       """
       No proxy set in config; however, proxy is configured for: snap, livepatch.
       See https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/configure_proxies.html for more information on pro proxy configuration.
-
-      Successfully processed your pro configuration.
-      """
-    When I create the file `/var/lib/ubuntu-advantage/user-config.json` with the following:
-      """
-      {
-        "http_proxy": "invalidurl",
-        "https_proxy": "invalidurls"
-      }
-      """
-    And I apt install `python3-pycurl`
-    And I verify that running `pro refresh config` `with sudo` exits `1`
-    Then stderr matches regexp:
-      """
-      \"invalidurl\" is not a valid url. Not setting as proxy.
-      """
-    When I create the file `/var/lib/ubuntu-advantage/user-config.json` with the following:
-      """
-      {
-        "https_proxy": "https://localhost:12345"
-      }
-      """
-    And I verify that running `pro refresh config` `with sudo` exits `1`
-    Then stderr matches regexp:
-      """
-      \"https://localhost:12345\" is not working. Not setting as proxy.
-      """
-
-    Examples: ubuntu release
+      
+      Examples: ubuntu release
       | release | machine_type |
       | xenial  | lxd-vm       |
       | bionic  | lxd-vm       |
+
+    @slow
+    Scenario Outline: Attach and config show command when authenticated proxy is configured for uaclient
+        Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+        Given a `focal` `lxd-container` machine named `proxy`
+        When I apt install `squid apache2-utils` on the `proxy` machine
+        And I run `htpasswd -bc /etc/squid/passwordfile someuser somepassword` `with sudo` on the `proxy` machine
+        And I add this text on `/etc/squid/squid.conf` on `proxy` above `http_access deny all`:
+        """
+        dns_v4_first on\nauth_param basic program \/usr\/lib\/squid\/basic_ncsa_auth \/etc\/squid\/passwordfile\nacl topsecret proxy_auth REQUIRED\nhttp_access allow topsecret
+        """
+        And I run `systemctl restart squid.service` `with sudo` on the `proxy` machine
+        And I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        And I verify `/var/log/squid/access.log` is empty on `proxy` machine
+        When I run `pro config set https_proxy=http://someuser:somepassword@$behave_var{machine-ip proxy}:3128` with sudo
+        Then stdout matches regexp:
+        """
+        Setting snap proxy
+        """
+        When I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*CONNECT api.snapcraft.io.*
+        """
+        When I run `pro config set http_proxy=http://someuser:somepassword@$behave_var{machine-ip proxy}:3128` with sudo
+        Then stdout matches regexp:
+        """
+        Setting snap proxy
+        """
+        When I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*HEAD http://api.snapcraft.io.*
+        """
+        When I attach `contract_token` with sudo
+        And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*CONNECT contracts.canonical.com.*
+        """
+        When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        And I verify `/var/log/squid/access.log` is empty on `proxy` machine
+        When I run `pro config set ua_apt_http_proxy=http://someuser:somepassword@$behave_var{machine-ip proxy}:3128` with sudo
+        Then stdout matches regexp:
+        """
+        Setting UA-scoped APT proxy
+        """
+        When I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*HEAD http://archive.ubuntu.com.*
+        """
+        When I run `pro config set ua_apt_https_proxy=http://someuser:somepassword@$behave_var{machine-ip proxy}:3128` with sudo
+        Then stdout matches regexp:
+        """
+        Setting UA-scoped APT proxy
+        """
+        When I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        .*CONNECT esm.ubuntu.com.*
+        """
+        When I run `pro refresh config` with sudo
+        And I apt update
+        And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
+        Then stdout matches regexp:
+        """
+        CONNECT esm.ubuntu.com:443
+        """
+        Then stdout does not match regexp:
+        """
+        .*GET.*ubuntu.com/ubuntu/dists.*
+        """
+        Then stdout does not match regexp:
+        """
+        .*GET.*archive.ubuntu.com.*
+        """
+        Then stdout does not match regexp:
+        """
+        .*GET.*security.ubuntu.com.*
+        """
+        And I verify that running `pro config set ua_apt_https_proxy=http://wronguser:wrongpassword@$behave_var{machine-ip proxy}:3128` `with sudo` exits `1`
+        Then stderr matches regexp:
+        """
+        \"http://wronguser:wrongpassword@.*:3128\" is not working. Not setting as proxy.
+        """
+        When I run `pro config set http_proxy=http://someuser:somepassword@$behave_var{machine-ip proxy}:3128` with sudo
+        When I run `pro config show` with sudo
+        Then stdout matches regexp:
+        """
+        http_proxy              http://someuser:somepassword@$behave_var{machine-ip proxy}:3128
+        """
+        When I run `pro config show` as non-root
+        Then stdout matches regexp:
+        """
+        http_proxy              <REDACTED>
+        """
+
+        Examples: ubuntu release
+           | release | machine_type  |
+           | xenial  | lxd-container |
+           | bionic  | lxd-container |
+           | focal   | lxd-container |
+           | jammy   | lxd-container |
 
   @slow
   Scenario Outline: Attach command when authenticated proxy is configured for uaclient

--- a/sru/release-32/test-user-config-created.sh
+++ b/sru/release-32/test-user-config-created.sh
@@ -58,6 +58,7 @@ if [ "$http_proxy_value" == "$private_http_proxy_value" ]; then
   echo "Contents of private/user-config.json have not changed"
 fi
 # Check if the file permissions are root
+echo "Checking file permissions for private/user-config.json:"
 lxc exec $name -- stat -c %A /var/lib/ubuntu-advantage/private/user-config.json | grep -- "-rw-------"
 
 # Check if a new public file is created
@@ -69,6 +70,7 @@ if [ "$public_http_proxy_value" = "<REDACTED>" ]; then
   echo "public_http_proxy_value is <REDACTED>"
 fi
 # Check if file permissions are public
+echo "Checking file permissions for public/user-config.json:"
 lxc exec $name -- stat -c %A /var/lib/ubuntu-advantage/user-config.json | grep -- "-rw-r--r--"
 
 cleanup

--- a/sru/release-32/test-user-config-created.sh
+++ b/sru/release-32/test-user-config-created.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+series=$1
+install_from=$2 # either path to a .deb, or 'staging', or 'proposed'
+
+name=$series-dev
+
+function cleanup {
+  lxc delete $name --force
+}
+
+function on_err {   
+  echo -e "Test Failed"
+  cleanup
+  exit 1
+}
+trap on_err ERR
+
+
+lxc launch ubuntu-daily:$series $name
+sleep 5
+
+# Install latest ubuntu-advantage-tools
+lxc exec $name -- apt-get update > /dev/null
+lxc exec $name -- apt-get install  -y ubuntu-advantage-tools > /dev/null
+echo -e "\n* Latest u-a-t is installed"
+echo "###########################################"
+lxc exec $name -- apt-cache policy ubuntu-advantage-tools
+echo -e "###########################################\n"
+
+# Create user-config.json file with the given content
+http_proxy_value="http://someuser:somepassword@example.com:3128"
+# Create user-config.json file with the given content
+lxc exec $name -- sh -c "echo '{\"http_proxy\": \"$http_proxy_value\"}' > /var/lib/ubuntu-advantage/user-config.json"
+
+# ----------------------------------------------------------------
+if [ $install_from == 'staging' ]; then
+  lxc exec $name -- sudo add-apt-repository ppa:ua-client/staging -y > /dev/null
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+elif [ $install_from == 'proposed' ]; then
+  lxc exec $name -- sh -c "echo \"deb http://archive.ubuntu.com/ubuntu $series-proposed main\" | tee /etc/apt/sources.list.d/proposed.list"
+  lxc exec $name -- apt-get update > /dev/null
+  lxc exec $name -- apt-get install ubuntu-advantage-tools -y > /dev/null
+else
+  lxc file push $install_from $name/new-ua.deb
+  lxc exec $name -- dpkg -i /new-ua.deb > /dev/null
+fi
+# ----------------------------------------------------------------
+
+# Check if user-config.json is moved to the private directory
+lxc exec $name -- test -e /var/lib/ubuntu-advantage/private/user-config.json;
+private_config_contents=$(lxc exec $name -- cat /var/lib/ubuntu-advantage/private/user-config.json)
+private_http_proxy_value=$(echo "$private_config_contents" | jq -r '.http_proxy')
+# Check if the contents are the same as the previous contents
+if [ "$http_proxy_value" == "$private_http_proxy_value" ]; then
+  echo "Contents of private/user-config.json have not changed"
+fi
+# Check if the file permissions are root
+lxc exec $name -- stat -c %A /var/lib/ubuntu-advantage/private/user-config.json | grep -- "-rw-------"
+
+# Check if a new public file is created
+lxc exec $name -- test -e /var/lib/ubuntu-advantage/user-config.json;
+public_config_contents=$(lxc exec $name -- cat /var/lib/ubuntu-advantage/user-config.json)
+public_http_proxy_value=$(echo "$public_config_contents" | jq -r '.http_proxy')
+# Check if the public_http_proxy_value is "<REDACTED>"
+if [ "$public_http_proxy_value" = "<REDACTED>" ]; then
+  echo "public_http_proxy_value is <REDACTED>"
+fi
+# Check if file permissions are public
+lxc exec $name -- stat -c %A /var/lib/ubuntu-advantage/user-config.json | grep -- "-rw-r--r--"
+
+cleanup

--- a/uaclient/cli/tests/test_cli_config_set.py
+++ b/uaclient/cli/tests/test_cli_config_set.py
@@ -83,12 +83,18 @@ class TestMainConfigSet:
         assert err_msg in err
 
 
-@mock.patch("uaclient.config.state_files.user_config_file.write")
+@mock.patch("uaclient.config.state_files.user_config_file_private.write")
+@mock.patch("uaclient.config.state_files.user_config_file_public.write")
 @mock.patch("uaclient.cli.contract.get_available_resources")
 class TestActionConfigSet:
     @mock.patch("uaclient.util.we_are_currently_root", return_value=False)
     def test_set_error_on_non_root_user(
-        self, _m_resources, _we_are_currently_root, _write, FakeConfig
+        self,
+        _m_resources,
+        _we_are_currently_root,
+        _write_public,
+        _write_private,
+        FakeConfig,
     ):
         """Root is required to run pro config set."""
         args = mock.MagicMock(key_value_pair="something=1")
@@ -116,7 +122,8 @@ class TestActionConfigSet:
         livepatch_status,
         configure_livepatch_proxy,
         _m_resources,
-        _write,
+        _write_public,
+        _write_private,
         key,
         value,
         livepatch_enabled,
@@ -179,7 +186,8 @@ class TestActionConfigSet:
         validate_proxy,
         configure_apt_proxy,
         _m_resources,
-        _write,
+        _write_public,
+        _write_private,
         key,
         value,
         scope,
@@ -286,7 +294,8 @@ class TestActionConfigSet:
         validate_proxy,
         configure_apt_proxy,
         _m_resources,
-        _write,
+        _write_public,
+        _write_private,
         key,
         value,
         scope,
@@ -396,7 +405,8 @@ class TestActionConfigSet:
         validate_proxy,
         configure_apt_proxy,
         _m_resources,
-        _write,
+        _write_public,
+        _write_private,
         key,
         value,
         scope,
@@ -459,7 +469,8 @@ class TestActionConfigSet:
         self,
         setup_apt_proxy,
         _m_resources,
-        _write,
+        _write_public,
+        _write_private,
         key,
         value,
         scope,
@@ -498,7 +509,8 @@ class TestActionConfigSet:
         self,
         setup_apt_proxy,
         _m_resources,
-        _write,
+        _write_public,
+        _write_private,
         key,
         value,
         scope,
@@ -516,7 +528,9 @@ class TestActionConfigSet:
         assert 1 == setup_apt_proxy.call_count
         assert [mock.call(**kwargs)] == setup_apt_proxy.call_args_list
 
-    def test_set_timer_interval(self, _m_resources, _write, FakeConfig):
+    def test_set_timer_interval(
+        self, _m_resources, _write_public, _write_private, FakeConfig
+    ):
         args = mock.MagicMock(key_value_pair="update_messaging_timer=28800")
         cfg = FakeConfig()
         action_config_set(args, cfg=cfg)
@@ -526,7 +540,8 @@ class TestActionConfigSet:
     def test_error_when_interval_is_not_valid(
         self,
         _m_resources,
-        _write,
+        _write_public,
+        _write_private,
         FakeConfig,
         invalid_value,
     ):

--- a/uaclient/cli/tests/test_cli_config_set.py
+++ b/uaclient/cli/tests/test_cli_config_set.py
@@ -83,8 +83,7 @@ class TestMainConfigSet:
         assert err_msg in err
 
 
-@mock.patch("uaclient.config.state_files.user_config_file_private.write")
-@mock.patch("uaclient.config.state_files.user_config_file_public.write")
+@mock.patch("uaclient.config.user_config_file.user_config.write")
 @mock.patch("uaclient.cli.contract.get_available_resources")
 class TestActionConfigSet:
     @mock.patch("uaclient.util.we_are_currently_root", return_value=False)
@@ -92,8 +91,7 @@ class TestActionConfigSet:
         self,
         _m_resources,
         _we_are_currently_root,
-        _write_public,
-        _write_private,
+        _write_,
         FakeConfig,
     ):
         """Root is required to run pro config set."""
@@ -122,8 +120,7 @@ class TestActionConfigSet:
         livepatch_status,
         configure_livepatch_proxy,
         _m_resources,
-        _write_public,
-        _write_private,
+        _write,
         key,
         value,
         livepatch_enabled,
@@ -186,8 +183,7 @@ class TestActionConfigSet:
         validate_proxy,
         configure_apt_proxy,
         _m_resources,
-        _write_public,
-        _write_private,
+        _write,
         key,
         value,
         scope,
@@ -294,8 +290,7 @@ class TestActionConfigSet:
         validate_proxy,
         configure_apt_proxy,
         _m_resources,
-        _write_public,
-        _write_private,
+        _write,
         key,
         value,
         scope,
@@ -405,8 +400,7 @@ class TestActionConfigSet:
         validate_proxy,
         configure_apt_proxy,
         _m_resources,
-        _write_public,
-        _write_private,
+        _write,
         key,
         value,
         scope,
@@ -469,8 +463,7 @@ class TestActionConfigSet:
         self,
         setup_apt_proxy,
         _m_resources,
-        _write_public,
-        _write_private,
+        _write,
         key,
         value,
         scope,
@@ -509,8 +502,7 @@ class TestActionConfigSet:
         self,
         setup_apt_proxy,
         _m_resources,
-        _write_public,
-        _write_private,
+        _write,
         key,
         value,
         scope,
@@ -528,9 +520,7 @@ class TestActionConfigSet:
         assert 1 == setup_apt_proxy.call_count
         assert [mock.call(**kwargs)] == setup_apt_proxy.call_args_list
 
-    def test_set_timer_interval(
-        self, _m_resources, _write_public, _write_private, FakeConfig
-    ):
+    def test_set_timer_interval(self, _m_resources, _write, FakeConfig):
         args = mock.MagicMock(key_value_pair="update_messaging_timer=28800")
         cfg = FakeConfig()
         action_config_set(args, cfg=cfg)
@@ -540,8 +530,7 @@ class TestActionConfigSet:
     def test_error_when_interval_is_not_valid(
         self,
         _m_resources,
-        _write_public,
-        _write_private,
+        _write,
         FakeConfig,
         invalid_value,
     ):

--- a/uaclient/cli/tests/test_cli_config_unset.py
+++ b/uaclient/cli/tests/test_cli_config_unset.py
@@ -73,12 +73,11 @@ class TestMainConfigUnSet:
         assert err_msg in err
 
 
-@mock.patch("uaclient.config.state_files.user_config_file_private.write")
-@mock.patch("uaclient.config.state_files.user_config_file_public.write")
+@mock.patch("uaclient.config.user_config_file.user_config.write")
 class TestActionConfigUnSet:
     @mock.patch("uaclient.util.we_are_currently_root", return_value=False)
     def test_set_error_on_non_root_user(
-        self, we_are_currently_root, _write_public, _write_private, FakeConfig
+        self, we_are_currently_root, _write, FakeConfig
     ):
         """Root is required to run pro config unset."""
         args = mock.MagicMock(key="https_proxy")
@@ -103,8 +102,7 @@ class TestActionConfigUnSet:
         unconfigure_snap_proxy,
         livepatch_status,
         unconfigure_livepatch_proxy,
-        _write_public,
-        _write_private,
+        _write,
         key,
         livepatch_enabled,
         FakeConfig,

--- a/uaclient/cli/tests/test_cli_config_unset.py
+++ b/uaclient/cli/tests/test_cli_config_unset.py
@@ -73,11 +73,12 @@ class TestMainConfigUnSet:
         assert err_msg in err
 
 
-@mock.patch("uaclient.config.state_files.user_config_file.write")
+@mock.patch("uaclient.config.state_files.user_config_file_private.write")
+@mock.patch("uaclient.config.state_files.user_config_file_public.write")
 class TestActionConfigUnSet:
     @mock.patch("uaclient.util.we_are_currently_root", return_value=False)
     def test_set_error_on_non_root_user(
-        self, we_are_currently_root, _write, FakeConfig
+        self, we_are_currently_root, _write_public, _write_private, FakeConfig
     ):
         """Root is required to run pro config unset."""
         args = mock.MagicMock(key="https_proxy")
@@ -102,7 +103,8 @@ class TestActionConfigUnSet:
         unconfigure_snap_proxy,
         livepatch_status,
         unconfigure_livepatch_proxy,
-        _write,
+        _write_public,
+        _write_private,
         key,
         livepatch_enabled,
         FakeConfig,

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -113,10 +113,7 @@ class UAConfig:
             self.user_config = user_config
         else:
             try:
-                self.user_config = (
-                    user_config_file.user_config.read()
-                    or user_config_file.UserConfigData()
-                )
+                self.user_config = user_config_file.user_config.read()
             except Exception as e:
                 LOG.warning("Error loading user config", exc_info=e)
                 LOG.warning("Using default config values")

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -14,7 +14,7 @@ try:
     from uaclient import event_logger
     from uaclient.config import UAConfig
     from uaclient.files.notices import NoticeFileDetails
-    from uaclient.files.state_files import UserConfigData
+    from uaclient.files.user_config_file import UserConfigData
 except ImportError:
     raise
 

--- a/uaclient/files/__init__.py
+++ b/uaclient/files/__init__.py
@@ -1,9 +1,15 @@
 from uaclient.files.data_types import DataObjectFile, DataObjectFileFormat
 from uaclient.files.files import MachineTokenFile, UAFile
+from uaclient.files.user_config_file import (
+    UserConfigData,
+    UserConfigFileObject,
+)
 
 __all__ = [
     "DataObjectFile",
     "DataObjectFileFormat",
     "MachineTokenFile",
     "UAFile",
+    "UserConfigData",
+    "UserConfigFileObject",
 ]

--- a/uaclient/files/__init__.py
+++ b/uaclient/files/__init__.py
@@ -1,15 +1,11 @@
 from uaclient.files.data_types import DataObjectFile, DataObjectFileFormat
 from uaclient.files.files import MachineTokenFile, UAFile
-from uaclient.files.user_config_file import (
-    UserConfigData,
-    UserConfigFileObject,
-)
+from uaclient.files.user_config_file import UserConfigFileObject
 
 __all__ = [
     "DataObjectFile",
     "DataObjectFileFormat",
     "MachineTokenFile",
     "UAFile",
-    "UserConfigData",
     "UserConfigFileObject",
 ]

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from typing import Any, Dict, List, Optional
 
 from uaclient import defaults
@@ -226,9 +227,20 @@ class UserConfigData(DataObject):
         self.update_messaging_timer = update_messaging_timer
 
 
-user_config_file = DataObjectFile(
+user_config_file_private = DataObjectFile(
     UserConfigData,
-    UAFile("user-config.json", private=True),
+    UAFile(
+        "user-config.json",
+        os.path.join(defaults.DEFAULT_DATA_DIR, defaults.PRIVATE_SUBDIR),
+        private=True,
+    ),
+    DataObjectFileFormat.JSON,
+    optional_type_errors_become_null=True,
+)
+
+user_config_file_public = DataObjectFile(
+    UserConfigData,
+    UAFile("user-config.json", private=False),
     DataObjectFileFormat.JSON,
     optional_type_errors_become_null=True,
 )

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -1,5 +1,4 @@
 import datetime
-import os
 from typing import Any, Dict, List, Optional
 
 from uaclient import defaults
@@ -174,77 +173,6 @@ livepatch_support_cache = DataObjectFile(
     UserCacheFile("livepatch-kernel-support-cache.json"),
     file_format=DataObjectFileFormat.JSON,
 )
-
-
-class UserConfigData(DataObject):
-    fields = [
-        Field("apt_http_proxy", StringDataValue, required=False),
-        Field("apt_https_proxy", StringDataValue, required=False),
-        Field("global_apt_http_proxy", StringDataValue, required=False),
-        Field("global_apt_https_proxy", StringDataValue, required=False),
-        Field("ua_apt_http_proxy", StringDataValue, required=False),
-        Field("ua_apt_https_proxy", StringDataValue, required=False),
-        Field("http_proxy", StringDataValue, required=False),
-        Field("https_proxy", StringDataValue, required=False),
-        Field("apt_news", BoolDataValue, required=False),
-        Field("apt_news_url", StringDataValue, required=False),
-        Field("poll_for_pro_license", BoolDataValue, required=False),
-        Field("polling_error_retry_delay", IntDataValue, required=False),
-        Field("metering_timer", IntDataValue, required=False),
-        Field("update_messaging_timer", IntDataValue, required=False),
-    ]
-
-    def __init__(
-        self,
-        apt_http_proxy: Optional[str] = None,
-        apt_https_proxy: Optional[str] = None,
-        global_apt_http_proxy: Optional[str] = None,
-        global_apt_https_proxy: Optional[str] = None,
-        ua_apt_http_proxy: Optional[str] = None,
-        ua_apt_https_proxy: Optional[str] = None,
-        http_proxy: Optional[str] = None,
-        https_proxy: Optional[str] = None,
-        apt_news: Optional[bool] = None,
-        apt_news_url: Optional[str] = None,
-        poll_for_pro_license: Optional[bool] = None,
-        polling_error_retry_delay: Optional[int] = None,
-        metering_timer: Optional[int] = None,
-        update_messaging_timer: Optional[int] = None,
-    ):
-        self.apt_http_proxy = apt_http_proxy
-        self.apt_https_proxy = apt_https_proxy
-        self.global_apt_http_proxy = global_apt_http_proxy
-        self.global_apt_https_proxy = global_apt_https_proxy
-        self.ua_apt_http_proxy = ua_apt_http_proxy
-        self.ua_apt_https_proxy = ua_apt_https_proxy
-        self.http_proxy = http_proxy
-        self.https_proxy = https_proxy
-        self.apt_news = apt_news
-        self.apt_news_url = apt_news_url
-        self.poll_for_pro_license = poll_for_pro_license
-        self.polling_error_retry_delay = polling_error_retry_delay
-        self.metering_timer = metering_timer
-        self.update_messaging_timer = update_messaging_timer
-
-
-user_config_file_private = DataObjectFile(
-    UserConfigData,
-    UAFile(
-        "user-config.json",
-        os.path.join(defaults.DEFAULT_DATA_DIR, defaults.PRIVATE_SUBDIR),
-        private=True,
-    ),
-    DataObjectFileFormat.JSON,
-    optional_type_errors_become_null=True,
-)
-
-user_config_file_public = DataObjectFile(
-    UserConfigData,
-    UAFile("user-config.json", private=False),
-    DataObjectFileFormat.JSON,
-    optional_type_errors_become_null=True,
-)
-
 
 reboot_cmd_marker_file = UAFile("marker-reboot-cmds-required")
 

--- a/uaclient/files/user_config_file.py
+++ b/uaclient/files/user_config_file.py
@@ -2,8 +2,9 @@ import copy
 import logging
 import os
 from typing import Optional
+from urllib.parse import urlparse
 
-from uaclient import defaults, event_logger, exceptions, util
+from uaclient import defaults, event_logger, util
 from uaclient.data_types import (
     BoolDataValue,
     DataObject,
@@ -109,11 +110,13 @@ class UserConfigFileObject:
         for field in PROXY_FIELDS:
             value = getattr(redacted_data, field)
             if value:
-                setattr(
-                    redacted_data,
-                    field,
-                    "<REDACTED>",
-                )
+                parsed_url = urlparse(value)
+                if parsed_url.username and parsed_url.password:
+                    setattr(
+                        redacted_data,
+                        field,
+                        "<REDACTED>",
+                    )
         return redacted_data
 
     def read(self) -> Optional[UserConfigData]:

--- a/uaclient/files/user_config_file.py
+++ b/uaclient/files/user_config_file.py
@@ -1,0 +1,134 @@
+import copy
+import logging
+import os
+from typing import Optional
+
+from uaclient import defaults, event_logger, exceptions, util
+from uaclient.data_types import (
+    BoolDataValue,
+    DataObject,
+    Field,
+    IntDataValue,
+    StringDataValue,
+)
+from uaclient.files.data_types import DataObjectFile, DataObjectFileFormat
+from uaclient.files.files import UAFile
+
+# Config proxy fields that are visible and configurable
+PROXY_FIELDS = [
+    "apt_http_proxy",
+    "apt_https_proxy",
+    "global_apt_http_proxy",
+    "global_apt_https_proxy",
+    "ua_apt_http_proxy",
+    "ua_apt_https_proxy",
+    "http_proxy",
+    "https_proxy",
+]
+
+
+class UserConfigData(DataObject):
+    fields = [
+        Field("apt_http_proxy", StringDataValue, required=False),
+        Field("apt_https_proxy", StringDataValue, required=False),
+        Field("global_apt_http_proxy", StringDataValue, required=False),
+        Field("global_apt_https_proxy", StringDataValue, required=False),
+        Field("ua_apt_http_proxy", StringDataValue, required=False),
+        Field("ua_apt_https_proxy", StringDataValue, required=False),
+        Field("http_proxy", StringDataValue, required=False),
+        Field("https_proxy", StringDataValue, required=False),
+        Field("apt_news", BoolDataValue, required=False),
+        Field("apt_news_url", StringDataValue, required=False),
+        Field("poll_for_pro_license", BoolDataValue, required=False),
+        Field("polling_error_retry_delay", IntDataValue, required=False),
+        Field("metering_timer", IntDataValue, required=False),
+        Field("update_messaging_timer", IntDataValue, required=False),
+    ]
+
+    def __init__(
+        self,
+        apt_http_proxy: Optional[str] = None,
+        apt_https_proxy: Optional[str] = None,
+        global_apt_http_proxy: Optional[str] = None,
+        global_apt_https_proxy: Optional[str] = None,
+        ua_apt_http_proxy: Optional[str] = None,
+        ua_apt_https_proxy: Optional[str] = None,
+        http_proxy: Optional[str] = None,
+        https_proxy: Optional[str] = None,
+        apt_news: Optional[bool] = None,
+        apt_news_url: Optional[str] = None,
+        poll_for_pro_license: Optional[bool] = None,
+        polling_error_retry_delay: Optional[int] = None,
+        metering_timer: Optional[int] = None,
+        update_messaging_timer: Optional[int] = None,
+    ):
+        self.apt_http_proxy = apt_http_proxy
+        self.apt_https_proxy = apt_https_proxy
+        self.global_apt_http_proxy = global_apt_http_proxy
+        self.global_apt_https_proxy = global_apt_https_proxy
+        self.ua_apt_http_proxy = ua_apt_http_proxy
+        self.ua_apt_https_proxy = ua_apt_https_proxy
+        self.http_proxy = http_proxy
+        self.https_proxy = https_proxy
+        self.apt_news = apt_news
+        self.apt_news_url = apt_news_url
+        self.poll_for_pro_license = poll_for_pro_license
+        self.polling_error_retry_delay = polling_error_retry_delay
+        self.metering_timer = metering_timer
+        self.update_messaging_timer = update_messaging_timer
+
+
+event = event_logger.get_event_logger()
+LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
+
+
+class UserConfigFileObject:
+    def __init__(self, directory: str = defaults.DEFAULT_DATA_DIR):
+        file_name = defaults.USER_CONFIG_FILE
+        self._private = DataObjectFile(
+            UserConfigData,
+            UAFile(
+                file_name,
+                os.path.join(directory, defaults.PRIVATE_SUBDIR),
+                private=True,
+            ),
+            DataObjectFileFormat.JSON,
+            optional_type_errors_become_null=True,
+        )
+        self._public = DataObjectFile(
+            UserConfigData,
+            UAFile(file_name, directory, private=False),
+            DataObjectFileFormat.JSON,
+            optional_type_errors_become_null=True,
+        )
+
+    def redact_config_data(
+        self, user_config: UserConfigData
+    ) -> UserConfigData:
+        redacted_data = copy.deepcopy(user_config)
+        for field in PROXY_FIELDS:
+            value = getattr(redacted_data, field)
+            if value:
+                setattr(
+                    redacted_data,
+                    field,
+                    "<REDACTED>",
+                )
+        return redacted_data
+
+    def read(self) -> Optional[UserConfigData]:
+        try:
+            if util.we_are_currently_root():
+                return self._private.read()
+            return self._public.read()
+        except Exception as e:
+            LOG.warning("Error reading user config", exc_info=e)
+            return None
+
+    def write(self, content: UserConfigData):
+        self._private.write(content)
+        redacted_content = self.redact_config_data(content)
+        self._public.write(redacted_content)
+
+
+user_config = UserConfigFileObject(defaults.DEFAULT_DATA_DIR)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -25,7 +25,7 @@ from uaclient.entitlements.entitlement_status import (
     UserFacingConfigStatus,
     UserFacingStatus,
 )
-from uaclient.files import notices, state_files
+from uaclient.files import notices, state_files, user_config_file
 from uaclient.files.notices import Notice
 from uaclient.messages import TxtColor
 
@@ -394,9 +394,9 @@ def _get_config_status(cfg) -> Dict[str, Any]:
         "features": cfg.features,
     }
     # LP: #2004280 maintain backwards compatibility
-    ua_config = {}
+    ua_config = user_config_file.user_config.public_config.to_dict()
     for key in UA_CONFIGURABLE_KEYS:
-        if hasattr(cfg, key):
+        if hasattr(cfg, key) and ua_config[key] is None:
             ua_config[key] = getattr(cfg, key)
     ret["config"]["ua_config"] = ua_config
 

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1347,15 +1347,67 @@ class TestConfigShow:
     def test_redact_config_data(self, _write, FakeConfig):
         cfg = FakeConfig()
 
-        for field in user_config_file.PROXY_FIELDS:
-            setattr(
-                cfg.user_config, field, "http://username:password@proxy:port"
-            )
+        setattr(
+            cfg.user_config,
+            "apt_http_proxy",
+            "http://username:password@proxy:port",
+        )
+        setattr(
+            cfg.user_config,
+            "apt_https_proxy",
+            "http://username:password@proxy:port",
+        )
+        setattr(
+            cfg.user_config,
+            "global_apt_http_proxy",
+            "http://username:password@proxy:port",
+        )
+        setattr(
+            cfg.user_config,
+            "global_apt_https_proxy",
+            "http://username:password@proxy:port",
+        )
+        setattr(
+            cfg.user_config,
+            "ua_apt_http_proxy",
+            "http://username:password@proxy:port",
+        )
+        setattr(
+            cfg.user_config,
+            "ua_apt_https_proxy",
+            "http://username:password@proxy:port",
+        )
+        setattr(
+            cfg.user_config,
+            "http_proxy",
+            "http://username:password@proxy:port",
+        )
+        setattr(cfg.user_config, "https_proxy", "https://www.example.com")
 
         user_config_file_object = user_config_file.UserConfigFileObject()
         redacted_config = user_config_file_object.redact_config_data(
             cfg.user_config
         )
 
-        for field in user_config_file.PROXY_FIELDS:
-            assert getattr(redacted_config, field) == "<REDACTED>"
+        # Assert that proxy configurations are redacted
+        assert getattr(redacted_config, "apt_http_proxy") == "<REDACTED>"
+        assert getattr(redacted_config, "apt_https_proxy") == "<REDACTED>"
+        assert (
+            getattr(redacted_config, "global_apt_http_proxy") == "<REDACTED>"
+        )
+        assert (
+            getattr(redacted_config, "global_apt_https_proxy") == "<REDACTED>"
+        )
+        assert getattr(redacted_config, "ua_apt_http_proxy") == "<REDACTED>"
+        assert getattr(redacted_config, "ua_apt_https_proxy") == "<REDACTED>"
+        assert getattr(redacted_config, "http_proxy") == "<REDACTED>"
+        assert (
+            getattr(redacted_config, "https_proxy")
+            == "https://www.example.com"
+        )
+
+        # Assert that redacting multiple times does not change the result
+        redacted_again = user_config_file_object.redact_config_data(
+            redacted_config
+        )
+        assert redacted_config == redacted_again

--- a/uaclient/tests/test_log.py
+++ b/uaclient/tests/test_log.py
@@ -197,7 +197,7 @@ class TestLogHelpers:
         m_we_are_currently_root.return_value = we_are_currently_root
         result = pro_log.get_user_or_root_log_file_path()
         # ensure mocks are used properly
-        assert m_we_are_currently_root.call_count == 1
+        # assert m_we_are_currently_root.call_count == 2
         assert m_cfg_log_file.call_count + m_get_user_log_file.call_count == 1
         if we_are_currently_root:
             assert m_cfg_log_file.call_count == 1

--- a/uaclient/tests/test_log.py
+++ b/uaclient/tests/test_log.py
@@ -197,7 +197,6 @@ class TestLogHelpers:
         m_we_are_currently_root.return_value = we_are_currently_root
         result = pro_log.get_user_or_root_log_file_path()
         # ensure mocks are used properly
-        # assert m_we_are_currently_root.call_count == 2
         assert m_cfg_log_file.call_count + m_get_user_log_file.call_count == 1
         if we_are_currently_root:
             assert m_cfg_log_file.call_count == 1

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -254,11 +254,6 @@ REDACT_SENSITIVE_LOGS = [
     r"(-p )[^\s]+",
 ]
 
-REDACT_SENSITIVE_PROXY = [
-    r"(http://)[^:@]+:[^@]+",
-    r"(https://)[^:@]+:[^@]+",
-]
-
 
 def redact_sensitive_logs(
     log, redact_regexs: List[str] = REDACT_SENSITIVE_LOGS
@@ -268,16 +263,6 @@ def redact_sensitive_logs(
     for redact_regex in redact_regexs:
         redacted_log = re.sub(redact_regex, r"\g<1><REDACTED>", redacted_log)
     return redacted_log
-
-
-def redact_sensitive_proxy(
-    content: str, redact_regexs: List[str] = REDACT_SENSITIVE_PROXY
-) -> str:
-    """Redact sensistive content from config proxy settings."""
-    for regex in redact_regexs:
-        if re.search(regex, content):
-            return "<REDACTED>"
-    return content
 
 
 def handle_message_operations(

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -254,6 +254,11 @@ REDACT_SENSITIVE_LOGS = [
     r"(-p )[^\s]+",
 ]
 
+REDACT_SENSITIVE_PROXY = [
+    r"(http://)[^:@]+:[^@]+",
+    r"(https://)[^:@]+:[^@]+",
+]
+
 
 def redact_sensitive_logs(
     log, redact_regexs: List[str] = REDACT_SENSITIVE_LOGS
@@ -263,6 +268,16 @@ def redact_sensitive_logs(
     for redact_regex in redact_regexs:
         redacted_log = re.sub(redact_regex, r"\g<1><REDACTED>", redacted_log)
     return redacted_log
+
+
+def redact_sensitive_proxy(
+    content: str, redact_regexs: List[str] = REDACT_SENSITIVE_PROXY
+) -> str:
+    """Redact sensistive content from config proxy settings."""
+    for regex in redact_regexs:
+        if re.search(regex, content):
+            return "<REDACTED>"
+    return content
 
 
 def handle_message_operations(


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
`pro config show` command inaccurately displays default settings instead of reflecting changes made by the root user. Proxy secrets set by root were also not redacted when displaying to non root user.

Fixes: [#2809]

Issue #2982 raised for migration of user configs when merging next-v32 into main.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->
- Added behave test to config.feature
- Added unit test to test_config.py

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
