### PR TITLE
tests: remove livepatch test for WSL

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -544,7 +544,6 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
            | release | machine_type | livepatch_status |
            | xenial  | lxd-vm       | warning          |
            | bionic  | lxd-vm       | enabled          |
-           | bionic  | wsl          | enabled          |
 
     Scenario Outline: Attach works when snapd cannot be installed
         Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed


### PR DESCRIPTION
## Why is this needed?
There is no livepatch support for WSL kernels. Because of that, we are removing the WSL machine type from a specific livepatch test

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
Run the modified test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
