### PR TITLE
tls-in-tls: show auth error for newer pycurl messages

### DIFF
--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -1294,4 +1294,3 @@ Feature: Proxy configuration
            | bionic  | lxd-vm       |
            | focal   | lxd-vm       |
            | jammy   | lxd-vm       |
-           | mantic  | lxd-vm       |

--- a/uaclient/http/__init__.py
+++ b/uaclient/http/__init__.py
@@ -218,11 +218,7 @@ def _handle_pycurl_error(
         code = error.args[0]
     if len(error.args) > 1:
         msg = error.args[1]
-    if (
-        code == authentication_error_code
-        and msg
-        and "HTTP code 407 from proxy" in msg
-    ):
+    if code == authentication_error_code and msg and "407" in msg:
         raise exceptions.ProxyAuthenticationFailed()
     elif code == ca_certificates_error_code:
         raise exceptions.PycurlCACertificatesError(url=url)


### PR DESCRIPTION
## Why is this needed?

Newer versions of curl/pycurl have a slightly different message for 407 http status codes. The new check only looks for "407" anywhere in the message which works for old and new versions of the message, and is hopefully a bit more future proof.

## Test Steps
`tox -e behave -- features/proxy_config.feature:1302` should pass again

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [n/a] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
