### PR TITLE
Remove lock from the config module

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -114,15 +114,16 @@ redact_ubuntu_release_from_ua_apt_filenames() {
 check_service_is_enabled() {
     service_name=$1
     _RET=$(/usr/bin/python3 -c "
-import os
-import json
-from uaclient.config import UAConfig
-cfg = UAConfig()
-status = cfg.read_cache('status-cache')
-if status:
-    for service in status.get('services', []):
-       if service.get('name', '') == '${service_name}':
-           print(service.get('status', ''))
+from uaclient.files.state_files import status_cache_file
+try:
+    status = status_cache_file.read()
+    if status:
+        for service in status.get('services', []):
+            if service.get('name', '') == '${service_name}':
+                print(service.get('status', ''))
+except Exception:
+    # Assume not enabled
+    pass
 ")
    if [ "${_RET}" = "enabled" ]; then
        return  0

--- a/features/api_fix_execute.feature
+++ b/features/api_fix_execute.feature
@@ -1427,6 +1427,13 @@ Feature: Fix execute API endpoints
                     "status": "not-affected",
                     "title": "USN-6460-1",
                     "upgraded_packages": []
+                  },
+                  {
+                    "description": "Linux kernel vulnerabilities",
+                    "errors": null,
+                    "status": "not-affected",
+                    "title": "USN-6699-1",
+                    "upgraded_packages": []
                   }
                 ],
                 "target_usn": {

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -83,6 +83,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
       This machine is already attached to '.+'
       To use a different subscription first run: sudo pro detach.
       """
+    And I verify that `/var/lib/ubuntu-advantage/status.json` is owned by `root:root` with permission `644`
 
     Examples: ubuntu release packages
       | release | machine_type  | downrev_pkg            | cc_status | cis_or_usg | cis      | fips     | livepatch_desc              |

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -747,6 +747,7 @@ Feature: Ua fix command behaviour
       - USN-6256-1
       - USN-6385-1
       - USN-6460-1
+      - USN-6699-1
 
       Fixing related USNs:
       - USN-6033-1
@@ -839,6 +840,11 @@ Feature: Ua fix command behaviour
 
       .*✔.* USN-6460-1 does not affect your system.
 
+      - USN-6699-1
+      No affected source packages are installed.
+
+      .*✔.* USN-6699-1 does not affect your system.
+
       Summary:
       .*✔.* USN-6130-1 \[requested\] does not affect your system.
       .*✔.* USN-6033-1 \[related\] does not affect your system.
@@ -859,6 +865,7 @@ Feature: Ua fix command behaviour
       .*✔.* USN-6256-1 \[related\] does not affect your system.
       .*✔.* USN-6385-1 \[related\] does not affect your system.
       .*✔.* USN-6460-1 \[related\] does not affect your system.
+      .*✔.* USN-6699-1 \[related\] does not affect your system.
       """
     When I run `pro fix CVE-2023-42752` with sudo
     Then stdout matches regexp:
@@ -873,7 +880,7 @@ Feature: Ua fix command behaviour
 
     Examples: ubuntu release details
       | release | machine_type  |
-      | bionix  | lxd-container |
+      | bionic  | lxd-container |
       | bionic  | wsl           |
 
   Scenario Outline: Fix command on a machine without security/updates source lists

--- a/features/steps/files.py
+++ b/features/steps/files.py
@@ -4,7 +4,7 @@ import tempfile
 
 import yaml
 from behave import then, when
-from hamcrest import assert_that, matches_regexp
+from hamcrest import assert_that, equal_to, matches_regexp
 
 from features.steps.shell import when_i_run_command
 from features.util import SUT, process_template_vars
@@ -160,3 +160,27 @@ def when_i_move_file_from_one_machine_to_another(
     when_i_create_file_with_content(
         context, dest_path, machine_name=dest_machine, text=content
     )
+
+
+@then(
+    "I verify that `{file_path}` is owned by `{owner}` with permission `{permission}`"  # noqa
+)
+def then_i_verify_that_file_is_world_readable(
+    context, file_path, owner, permission, machine_name=SUT
+):
+    when_i_run_command(
+        context,
+        "stat -c '%U:%G' {}".format(file_path),
+        "as non-root",
+        machine_name=machine_name,
+    )
+    assert_that(context.process.stdout.strip(), equal_to(owner))
+
+    when_i_run_command(
+        context,
+        "stat -c '%a' {}".format(file_path),
+        "as non-root",
+        machine_name=machine_name,
+    )
+
+    assert_that(context.process.stdout.strip(), equal_to(permission))

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -35,7 +35,7 @@ LOG = logging.getLogger("ubuntupro.lib.reboot_cmds")
 
 
 def fix_pro_pkg_holds(cfg: config.UAConfig):
-    status_cache = cfg.read_cache("status-cache")
+    status_cache = state_files.status_cache_file.read()
     if not status_cache:
         return
     for service in status_cache.get("services", []):

--- a/lib/reboot_cmds.py
+++ b/lib/reboot_cmds.py
@@ -85,7 +85,7 @@ def main(cfg: config.UAConfig) -> int:
 
     LOG.debug("Running reboot commands...")
     try:
-        with lock.RetryLock(cfg=cfg, lock_holder="pro-reboot-cmds"):
+        with lock.RetryLock(lock_holder="pro-reboot-cmds"):
             fix_pro_pkg_holds(cfg)
             refresh_contract(cfg)
             upgrade_lts_contract.process_contract_delta_after_apt_lock(cfg)

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -19,7 +19,6 @@ from uaclient import log as pro_log
 from uaclient import status as ua_status
 from uaclient import system, timer, util
 from uaclient.clouds import AutoAttachCloudInstance  # noqa: F401
-from uaclient.clouds import identity
 from uaclient.defaults import (
     APPARMOR_PROFILES,
     CLOUD_BUILD_INFO,
@@ -101,10 +100,6 @@ def attach_with_token(
         update_motd_messages(cfg)
         contract_client.update_activity_token()
         raise exc
-
-    current_iid = identity.get_instance_id()
-    if current_iid:
-        cfg.write_cache("instance-id", current_iid)
 
     attachment_data_file.write(AttachmentData(attached_at=attached_at))
     update_motd_messages(cfg)

--- a/uaclient/api/tests/test_api_u_pro_attach_auto_full_auto_attach_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_attach_auto_full_auto_attach_v1.py
@@ -168,6 +168,7 @@ class TestEnableServicesByName:
 @mock.patch("uaclient.files.notices.add")
 @mock.patch("uaclient.files.notices.remove")
 class TestFullAutoAttachV1:
+    @mock.patch("uaclient.lock.RetryLock.__enter__")
     @mock.patch(
         M_PATH + "contract.UAContractClient.update_activity_token",
     )
@@ -182,6 +183,7 @@ class TestFullAutoAttachV1:
         _cloud_instance_factory,
         m_enable_ent_by_name,
         _m_update_activity_token,
+        _m_lock_enter,
         _notice_remove,
         _notice_add,
         FakeConfig,
@@ -204,6 +206,7 @@ class TestFullAutoAttachV1:
 
         assert 5 == m_enable_ent_by_name.call_count
 
+    @mock.patch("uaclient.lock.RetryLock.__enter__")
     @mock.patch(
         M_PATH + "contract.UAContractClient.update_activity_token",
     )
@@ -219,6 +222,7 @@ class TestFullAutoAttachV1:
         _cloud_instance_factory,
         enable_ent_by_name,
         _m_update_activity_token,
+        _m_lock_enter,
         _notice_remove,
         _notice_add,
         FakeConfig,

--- a/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
@@ -79,7 +79,6 @@ def _full_auto_attach(
 ) -> FullAutoAttachResult:
     try:
         with lock.RetryLock(
-            cfg=cfg,
             lock_holder="pro.api.u.pro.attach.auto.full_auto_attach.v1",
         ):
             ret = _full_auto_attach_in_lock(options, cfg, mode=mode)

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -15,6 +15,7 @@ from apt.progress.base import AcquireProgress  # type: ignore
 
 from uaclient import event_logger, exceptions, gpg, messages, system, util
 from uaclient.defaults import ESM_APT_ROOTDIR
+from uaclient.files.state_files import status_cache_file
 
 APT_HELPER_TIMEOUT = 60.0  # 60 second timeout used for apt-helper call
 APT_AUTH_COMMENT = "  # ubuntu-pro-client"
@@ -849,7 +850,7 @@ def update_esm_caches(cfg) -> None:
     apps_available = False
     infra_available = False
 
-    current_status = cfg.read_cache("status-cache")
+    current_status = status_cache_file.read()
     if current_status is None:
         current_status = status(cfg)[0]
 

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -938,6 +938,7 @@ def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
         _perform_disable(ent, cfg, assume_yes=assume_yes, update_status=False)
 
     cfg.delete_cache()
+    state_files.status_cache_file.delete()
     cfg.machine_token_file.delete()
     update_motd_messages(cfg)
     event.info(messages.DETACH_SUCCESS)

--- a/uaclient/cli/cli_util.py
+++ b/uaclient/cli/cli_util.py
@@ -10,9 +10,7 @@ def assert_lock_file(lock_holder=None):
     def wrapper(f):
         @wraps(f)
         def new_f(*args, cfg, **kwargs):
-            with lock.RetryLock(
-                cfg=cfg, lock_holder=lock_holder, sleep_time=1
-            ):
+            with lock.RetryLock(lock_holder=lock_holder, sleep_time=1):
                 retval = f(*args, cfg=cfg, **kwargs)
             return retval
 

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -547,6 +547,7 @@ class TestActionAttach:
             ),
         ),
     )
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(
         "uaclient.entitlements.check_entitlement_apt_directives_are_unique",
@@ -574,6 +575,7 @@ class TestActionAttach:
         _m_attachment_data_file_write,
         _m_check_ent_apt_directives,
         _m_check_lock_info,
+        _m_status_cache_file,
         expected_exception,
         expected_msg,
         expected_outer_msg,

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -7,7 +7,7 @@ import textwrap
 import mock
 import pytest
 
-from uaclient import event_logger, http, messages, util
+from uaclient import event_logger, http, lock, messages, util
 from uaclient.cli import (
     _post_cli_attach,
     action_attach,
@@ -178,49 +178,44 @@ class TestActionAttach:
         }
         assert expected == json.loads(capsys.readouterr()[0])
 
+    @mock.patch("uaclient.lock.check_lock_info")
     @mock.patch("time.sleep")
     @mock.patch("uaclient.system.subp")
     def test_lock_file_exists(
         self,
         m_subp,
         m_sleep,
+        m_check_lock_info,
         capsys,
         FakeConfig,
         event,
     ):
-        """Check when an operation holds a lock file, attach cannot run."""
         cfg = FakeConfig()
-        cfg.write_cache("lock", "123:pro disable")
+        m_check_lock_info.return_value = (123, "pro disable")
+        expected_msg = messages.E_LOCK_HELD_ERROR.format(
+            lock_request="pro attach", lock_holder="pro disable", pid=123
+        )
+        """Check when an operation holds a lock file, attach cannot run."""
         with pytest.raises(LockHeldError) as exc_info:
             action_attach(mock.MagicMock(), cfg=cfg)
-        assert [mock.call(["ps", "123"])] * 12 == m_subp.call_args_list
-        assert (
-            "Unable to perform: pro attach.\n"
-            "Operation in progress: pro disable (pid:123)"
-        ) == exc_info.value.msg
+        assert 12 == m_check_lock_info.call_count
+        assert expected_msg.msg == exc_info.value.msg
 
         with pytest.raises(SystemExit):
             with mock.patch.object(
                 event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
             ):
-                with mock.patch.object(
-                    cfg, "check_lock_info"
-                ) as m_check_lock_info:
-                    m_check_lock_info.return_value = (1, "lock_holder")
-                    main_error_handler(action_attach)(mock.MagicMock(), cfg)
+                main_error_handler(action_attach)(mock.MagicMock(), cfg)
 
-        expected_msg = messages.E_LOCK_HELD_ERROR.format(
-            lock_request="pro attach", lock_holder="lock_holder", pid=1
-        )
         expected = {
             "_schema_version": event_logger.JSON_SCHEMA_VERSION,
             "result": "failure",
             "errors": [
                 {
                     "additional_info": {
-                        "lock_holder": "lock_holder",
+                        "lock_holder": "pro disable",
                         "lock_request": "pro attach",
-                        "pid": 1,
+                        "pid": 123,
                     },
                     "message": expected_msg.msg,
                     "message_code": expected_msg.name,
@@ -254,6 +249,7 @@ class TestActionAttach:
         assert "This machine is now attached to 'test_contract'" in out
         assert "mock_tabular_status" in out
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(
         "uaclient.entitlements.check_entitlement_apt_directives_are_unique",
         return_value=True,
@@ -277,6 +273,7 @@ class TestActionAttach:
         _m_attachment_data_file_write,
         m_update_activity_token,
         _m_check_ent_apt_directives,
+        _m_check_lock_info,
         FakeConfig,
         event,
     ):
@@ -293,7 +290,8 @@ class TestActionAttach:
 
         contract_machine_attach.side_effect = fake_contract_attach
 
-        ret = action_attach(args, cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            ret = action_attach(args, cfg)
 
         assert 0 == ret
         expected_calls = [
@@ -305,6 +303,7 @@ class TestActionAttach:
         assert [mock.call(cfg)] == m_post_cli.call_args_list
 
     @pytest.mark.parametrize("auto_enable", (True, False))
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(
         M_PATH + "contract.UAContractClient.update_activity_token",
     )
@@ -325,6 +324,7 @@ class TestActionAttach:
         _m_should_reboot,
         _m_attachment_data_file_write,
         _m_update_activity_token,
+        _m_check_lock_info,
         auto_enable,
         FakeConfig,
     ):
@@ -333,14 +333,17 @@ class TestActionAttach:
         )
 
         cfg = FakeConfig()
-        action_attach(args, cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            action_attach(args, cfg)
 
         assert [
             mock.call(mock.ANY, token="token", allow_enable=auto_enable)
         ] == m_attach_with_token.call_args_list
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     def test_attach_config_and_token_mutually_exclusive(
         self,
+        _m_check_lock_info,
         FakeConfig,
     ):
         args = mock.MagicMock(
@@ -348,9 +351,12 @@ class TestActionAttach:
         )
         cfg = FakeConfig()
         with pytest.raises(UbuntuProError) as e:
-            action_attach(args, cfg=cfg)
+            with mock.patch.object(lock, "lock_data_file"):
+                action_attach(args, cfg=cfg)
+
         assert e.value.msg == messages.E_ATTACH_TOKEN_ARG_XOR_CONFIG.msg
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(
         M_PATH + "contract.UAContractClient.update_activity_token",
     )
@@ -361,6 +367,7 @@ class TestActionAttach:
         m_attach_with_token,
         _m_post_cli_attach,
         m_update_activity_token,
+        _m_check_lock_info,
         FakeConfig,
     ):
         args = mock.MagicMock(
@@ -368,14 +375,18 @@ class TestActionAttach:
             attach_config=FakeFile(safe_dump({"token": "faketoken"})),
         )
         cfg = FakeConfig()
-        action_attach(args, cfg=cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            action_attach(args, cfg=cfg)
+
         assert [
             mock.call(mock.ANY, token="faketoken", allow_enable=True)
         ] == m_attach_with_token.call_args_list
         assert 1 == m_update_activity_token.call_count
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     def test_attach_config_invalid_config(
         self,
+        _m_check_lock_info,
         FakeConfig,
         capsys,
         event,
@@ -389,7 +400,8 @@ class TestActionAttach:
         )
         cfg = FakeConfig()
         with pytest.raises(UbuntuProError) as e:
-            action_attach(args, cfg=cfg)
+            with mock.patch.object(lock, "lock_data_file"):
+                action_attach(args, cfg=cfg)
         assert "Error while reading fakename:" in e.value.msg
 
         args.attach_config = FakeFile(
@@ -400,7 +412,8 @@ class TestActionAttach:
             with mock.patch.object(
                 event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
             ):
-                main_error_handler(action_attach)(args, cfg)
+                with mock.patch.object(lock, "lock_data_file"):
+                    main_error_handler(action_attach)(args, cfg)
 
         expected_message = messages.E_ATTACH_CONFIG_READ_ERROR.format(
             config_name="fakename",
@@ -438,6 +451,7 @@ class TestActionAttach:
         assert expected == json.loads(capsys.readouterr()[0])
 
     @pytest.mark.parametrize("auto_enable", (True, False))
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(
         M_PATH + "contract.UAContractClient.update_activity_token",
     )
@@ -461,6 +475,7 @@ class TestActionAttach:
         m_attach_with_token,
         m_enable,
         m_update_activity_token,
+        _m_check_lock_info,
         auto_enable,
         FakeConfig,
         event,
@@ -477,7 +492,9 @@ class TestActionAttach:
             ),
             auto_enable=auto_enable,
         )
-        action_attach(args, cfg=cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            action_attach(args, cfg=cfg)
+
         assert [
             mock.call(mock.ANY, token="faketoken", allow_enable=False)
         ] == m_attach_with_token.call_args_list
@@ -498,7 +515,8 @@ class TestActionAttach:
             with mock.patch.object(
                 event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
             ):
-                main_error_handler(action_attach)(args, cfg)
+                with mock.patch.object(lock, "lock_data_file"):
+                    main_error_handler(action_attach)(args, cfg)
 
         expected = {
             "_schema_version": event_logger.JSON_SCHEMA_VERSION,
@@ -529,6 +547,7 @@ class TestActionAttach:
             ),
         ),
     )
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(
         "uaclient.entitlements.check_entitlement_apt_directives_are_unique",
         return_value=True,
@@ -554,6 +573,7 @@ class TestActionAttach:
         m_enable_order,
         _m_attachment_data_file_write,
         _m_check_ent_apt_directives,
+        _m_check_lock_info,
         expected_exception,
         expected_msg,
         expected_outer_msg,
@@ -611,7 +631,8 @@ class TestActionAttach:
                     "_event_logger_mode",
                     event_logger.EventLoggerMode.JSON,
                 ):
-                    main_error_handler(action_attach)(args, cfg)
+                    with mock.patch.object(lock, "lock_data_file"):
+                        main_error_handler(action_attach)(args, cfg)
 
         expected = {
             "_schema_version": event_logger.JSON_SCHEMA_VERSION,
@@ -640,6 +661,7 @@ class TestActionAttach:
         }
         assert expected == json.loads(fake_stdout.getvalue())
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(M_PATH + "_initiate")
     @mock.patch(M_PATH + "_wait")
     @mock.patch(M_PATH + "_revoke")
@@ -648,6 +670,7 @@ class TestActionAttach:
         m_revoke,
         m_wait,
         m_initiate,
+        _m_check_lock_info,
         FakeConfig,
     ):
         m_initiate.return_value = mock.MagicMock(
@@ -657,17 +680,22 @@ class TestActionAttach:
         m_args = mock.MagicMock(token=None, attach_config=None)
 
         with pytest.raises(MagicAttachTokenError):
-            action_attach(args=m_args, cfg=FakeConfig())
+            with mock.patch.object(lock, "lock_data_file"):
+                action_attach(args=m_args, cfg=FakeConfig())
 
         assert 1 == m_initiate.call_count
         assert 1 == m_wait.call_count
         assert 1 == m_revoke.call_count
 
-    def test_magic_attach_fails_if_format_json_param_used(self, FakeConfig):
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
+    def test_magic_attach_fails_if_format_json_param_used(
+        self, _m_check_lock_info, FakeConfig
+    ):
         m_args = mock.MagicMock(token=None, attach_config=None, format="json")
 
         with pytest.raises(MagicAttachInvalidParam) as exc_info:
-            action_attach(args=m_args, cfg=FakeConfig())
+            with mock.patch.object(lock, "lock_data_file"):
+                action_attach(args=m_args, cfg=FakeConfig())
 
         assert (
             "This attach flow does not support --format with value: json"

--- a/uaclient/cli/tests/test_cli_detach.py
+++ b/uaclient/cli/tests/test_cli_detach.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 import mock
 import pytest
 
-from uaclient import event_logger, exceptions, messages
+from uaclient import event_logger, exceptions, lock, messages
 from uaclient.cli import (
     action_detach,
     detach_parser,
@@ -103,12 +103,14 @@ class TestActionDetach:
         }
         assert expected == json.loads(capsys.readouterr()[0])
 
+    @mock.patch("uaclient.lock.check_lock_info")
     @mock.patch("time.sleep")
     @mock.patch("uaclient.system.subp")
     def test_lock_file_exists(
         self,
         m_subp,
         m_sleep,
+        m_check_lock_info,
         m_prompt,
         FakeConfig,
         capsys,
@@ -117,10 +119,12 @@ class TestActionDetach:
         """Check when an operation holds a lock file, detach cannot run."""
         cfg = FakeConfig.for_attached_machine()
         args = mock.MagicMock()
-        cfg.write_cache("lock", "123:pro enable")
+        m_check_lock_info.return_value = (123, "pro enable")
+
         with pytest.raises(exceptions.LockHeldError) as err:
             action_detach(args, cfg=cfg)
-        assert [mock.call(["ps", "123"])] * 12 == m_subp.call_args_list
+
+        assert 12 == m_check_lock_info.call_count
         expected_error_msg = messages.E_LOCK_HELD_ERROR.format(
             lock_request="pro detach", lock_holder="pro enable", pid="123"
         )
@@ -159,6 +163,7 @@ class TestActionDetach:
         "prompt_response,assume_yes,expect_disable",
         [(True, False, True), (False, False, False), (True, True, True)],
     )
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.contract.UAContractClient")
     @mock.patch("uaclient.cli.update_motd_messages")
     @mock.patch("uaclient.cli.entitlements_disable_order")
@@ -169,6 +174,7 @@ class TestActionDetach:
         m_disable_order,
         m_update_apt_and_motd_msgs,
         m_client,
+        _m_check_lock_info,
         m_prompt,
         prompt_response,
         assume_yes,
@@ -195,7 +201,8 @@ class TestActionDetach:
         m_ent_factory.return_value = disabled_cls
 
         args = mock.MagicMock(assume_yes=assume_yes)
-        return_code = action_detach(args, cfg=cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            return_code = action_detach(args, cfg=cfg)
 
         assert [
             mock.call(ignore_dependent_services=True)
@@ -223,7 +230,8 @@ class TestActionDetach:
             with mock.patch.object(
                 event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
             ):
-                main_error_handler(action_detach)(args, cfg)
+                with mock.patch.object(lock, "lock_data_file"):
+                    main_error_handler(action_detach)(args, cfg)
 
         expected = {
             "_schema_version": event_logger.JSON_SCHEMA_VERSION,
@@ -236,6 +244,7 @@ class TestActionDetach:
         }
         assert expected == json.loads(fake_stdout.getvalue())
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
     @mock.patch("uaclient.cli.update_motd_messages")
@@ -244,6 +253,7 @@ class TestActionDetach:
         m_update_apt_and_motd_msgs,
         m_disable_order,
         m_is_attached,
+        _m_check_lock_info,
         _m_prompt,
         tmpdir,
     ):
@@ -255,13 +265,13 @@ class TestActionDetach:
         m_disable_order.return_value = []
 
         m_cfg = mock.MagicMock()
-        m_cfg.check_lock_info.return_value = (-1, "")
-        m_cfg.data_path.return_value = tmpdir.join("lock").strpath
-        action_detach(mock.MagicMock(), m_cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            action_detach(mock.MagicMock(), m_cfg)
 
         assert [mock.call()] == m_cfg.delete_cache.call_args_list
         assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
     @mock.patch("uaclient.cli.update_motd_messages")
@@ -270,6 +280,7 @@ class TestActionDetach:
         m_update_apt_and_motd_msgs,
         m_disable_order,
         m_is_attached,
+        _m_check_lock_info,
         _m_prompt,
         capsys,
         tmpdir,
@@ -282,15 +293,14 @@ class TestActionDetach:
         )
 
         m_cfg = mock.MagicMock()
-        m_cfg.check_lock_info.return_value = (-1, "")
-        m_cfg.data_path.return_value = tmpdir.join("lock").strpath
-        action_detach(mock.MagicMock(), m_cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            action_detach(mock.MagicMock(), m_cfg)
 
         out, _err = capsys.readouterr()
-
         assert messages.DETACH_SUCCESS + "\n" == out
         assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
     @mock.patch("uaclient.cli.update_motd_messages")
@@ -299,6 +309,7 @@ class TestActionDetach:
         m_update_apt_and_motd_msgs,
         m_disable_order,
         m_is_attached,
+        _m_check_lock_info,
         _m_prompt,
         tmpdir,
     ):
@@ -310,11 +321,11 @@ class TestActionDetach:
         )
 
         m_cfg = mock.MagicMock()
-        m_cfg.check_lock_info.return_value = (-1, "")
-        m_cfg.data_path.return_value = tmpdir.join("lock").strpath
-        ret = action_detach(mock.MagicMock(), m_cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            ret = action_detach(mock.MagicMock(), m_cfg)
 
         assert 0 == ret
+        assert [mock.call()] == m_cfg.delete_cache.call_args_list
         assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
     @pytest.mark.parametrize(
@@ -350,6 +361,7 @@ class TestActionDetach:
             ),
         ],
     )
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.update_motd_messages")
     @mock.patch("uaclient.entitlements.entitlement_factory")
@@ -360,6 +372,7 @@ class TestActionDetach:
         m_ent_factory,
         m_update_apt_and_motd_msgs,
         m_is_attached,
+        _m_check_lock_info,
         _m_prompt,
         capsys,
         classes,
@@ -379,11 +392,10 @@ class TestActionDetach:
         )
 
         m_cfg = mock.MagicMock()
-        m_cfg.check_lock_info.return_value = (-1, "")
-        m_cfg.data_path.return_value = tmpdir.join("lock").strpath
         args = mock.MagicMock()
 
-        action_detach(args, m_cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            action_detach(args, m_cfg)
 
         out, _err = capsys.readouterr()
 
@@ -397,7 +409,8 @@ class TestActionDetach:
             with mock.patch.object(
                 event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
             ):
-                main_error_handler(action_detach)(args, cfg)
+                with mock.patch.object(lock, "lock_data_file"):
+                    main_error_handler(action_detach)(args, cfg)
 
         expected = {
             "_schema_version": event_logger.JSON_SCHEMA_VERSION,

--- a/uaclient/cli/tests/test_cli_detach.py
+++ b/uaclient/cli/tests/test_cli_detach.py
@@ -163,6 +163,7 @@ class TestActionDetach:
         "prompt_response,assume_yes,expect_disable",
         [(True, False, True), (False, False, False), (True, True, True)],
     )
+    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.contract.UAContractClient")
     @mock.patch("uaclient.cli.update_motd_messages")
@@ -175,6 +176,7 @@ class TestActionDetach:
         m_update_apt_and_motd_msgs,
         m_client,
         _m_check_lock_info,
+        _m_status_cache_delete,
         m_prompt,
         prompt_response,
         assume_yes,
@@ -244,6 +246,7 @@ class TestActionDetach:
         }
         assert expected == json.loads(fake_stdout.getvalue())
 
+    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
@@ -254,6 +257,7 @@ class TestActionDetach:
         m_disable_order,
         m_is_attached,
         _m_check_lock_info,
+        _m_status_cache_delete,
         _m_prompt,
         tmpdir,
     ):
@@ -271,6 +275,7 @@ class TestActionDetach:
         assert [mock.call()] == m_cfg.delete_cache.call_args_list
         assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
+    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
@@ -281,6 +286,7 @@ class TestActionDetach:
         m_disable_order,
         m_is_attached,
         _m_check_lock_info,
+        _m_status_cache_delete,
         _m_prompt,
         capsys,
         tmpdir,
@@ -300,6 +306,7 @@ class TestActionDetach:
         assert messages.DETACH_SUCCESS + "\n" == out
         assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
+    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
@@ -310,6 +317,7 @@ class TestActionDetach:
         m_disable_order,
         m_is_attached,
         _m_check_lock_info,
+        _m_status_cache_delete,
         _m_prompt,
         tmpdir,
     ):
@@ -361,6 +369,7 @@ class TestActionDetach:
             ),
         ],
     )
+    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.update_motd_messages")
@@ -373,6 +382,7 @@ class TestActionDetach:
         m_update_apt_and_motd_msgs,
         m_is_attached,
         _m_check_lock_info,
+        _m_status_cache_delete,
         _m_prompt,
         capsys,
         classes,

--- a/uaclient/cli/tests/test_cli_disable.py
+++ b/uaclient/cli/tests/test_cli_disable.py
@@ -6,7 +6,7 @@ import textwrap
 import mock
 import pytest
 
-from uaclient import entitlements, event_logger, exceptions, messages
+from uaclient import entitlements, event_logger, exceptions, lock, messages
 from uaclient.cli import action_disable, main, main_error_handler
 from uaclient.entitlements.entitlement_status import (
     CanDisableFailure,
@@ -75,6 +75,7 @@ class TestDisable:
     @pytest.mark.parametrize(
         "disable_return,return_code", ((True, 0), (False, 1))
     )
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(
         "uaclient.cli.contract.UAContractClient.update_activity_token",
     )
@@ -87,6 +88,7 @@ class TestDisable:
         m_valid_services,
         m_entitlement_factory,
         m_update_activity_token,
+        _m_check_lock_info,
         disable_return,
         return_code,
         assume_yes,
@@ -135,7 +137,7 @@ class TestDisable:
         args_mock.assume_yes = assume_yes
         args_mock.purge = False
 
-        with mock.patch.object(cfg, "check_lock_info", return_value=(-1, "")):
+        with mock.patch.object(lock, "lock_data_file"):
             ret = action_disable(args_mock, cfg=cfg)
 
         for m_entitlement_cls in entitlements_cls:
@@ -160,9 +162,7 @@ class TestDisable:
             event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
         ):
             with mock.patch.object(event, "set_event_mode"):
-                with mock.patch.object(
-                    cfg, "check_lock_info", return_value=(-1, "")
-                ):
+                with mock.patch.object(lock, "lock_data_file"):
                     fake_stdout = io.StringIO()
                     with contextlib.redirect_stdout(fake_stdout):
                         ret = action_disable(args_mock, cfg=cfg)
@@ -192,6 +192,7 @@ class TestDisable:
         assert expected == json.loads(fake_stdout.getvalue())
 
     @pytest.mark.parametrize("assume_yes", (True, False))
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.entitlements.entitlement_factory")
     @mock.patch("uaclient.entitlements.valid_services")
     @mock.patch("uaclient.status.status")
@@ -200,6 +201,7 @@ class TestDisable:
         m_status,
         m_valid_services,
         m_entitlement_factory,
+        _m_check_lock_info,
         assume_yes,
         tmpdir,
         event,
@@ -255,9 +257,7 @@ class TestDisable:
         args_mock.purge = False
 
         with pytest.raises(exceptions.UbuntuProError) as err:
-            with mock.patch.object(
-                cfg, "check_lock_info", return_value=(-1, "")
-            ):
+            with mock.patch.object(lock, "lock_data_file"):
                 action_disable(args_mock, cfg=cfg)
 
         assert (
@@ -289,9 +289,7 @@ class TestDisable:
                 event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
             ):
                 with mock.patch.object(event, "set_event_mode"):
-                    with mock.patch.object(
-                        cfg, "check_lock_info", return_value=(-1, "")
-                    ):
+                    with mock.patch.object(lock, "lock_data_file"):
                         fake_stdout = io.StringIO()
                         with contextlib.redirect_stdout(fake_stdout):
                             main_error_handler(action_disable)(
@@ -338,10 +336,12 @@ class TestDisable:
             (False, messages.E_NONROOT_USER),
         ],
     )
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.util.we_are_currently_root")
     def test_invalid_service_error_message(
         self,
         m_we_are_currently_root,
+        _m_check_lock_info,
         root,
         expected_error_template,
         FakeConfig,
@@ -371,8 +371,10 @@ class TestDisable:
             expected_info = None
 
         with pytest.raises(exceptions.UbuntuProError) as err:
-            args.service = ["bogus"]
-            action_disable(args, cfg)
+            with mock.patch.object(lock, "lock_data_file"):
+                args.service = ["bogus"]
+                action_disable(args, cfg)
+
         assert expected_error.msg == err.value.msg
 
         args.assume_yes = True
@@ -384,7 +386,8 @@ class TestDisable:
                 with mock.patch.object(event, "set_event_mode"):
                     fake_stdout = io.StringIO()
                     with contextlib.redirect_stdout(fake_stdout):
-                        main_error_handler(action_disable)(args, cfg)
+                        with mock.patch.object(lock, "lock_data_file"):
+                            main_error_handler(action_disable)(args, cfg)
 
         expected = {
             "_schema_version": event_logger.JSON_SCHEMA_VERSION,
@@ -407,8 +410,10 @@ class TestDisable:
         assert expected == json.loads(fake_stdout.getvalue())
 
     @pytest.mark.parametrize("service", [["bogus"], ["bogus1", "bogus2"]])
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     def test_invalid_service_names(
         self,
+        _m_check_lock_info,
         service,
         FakeConfig,
         event,
@@ -425,8 +430,9 @@ class TestDisable:
             service_msg=all_service_msg,
         )
         with pytest.raises(exceptions.UbuntuProError) as err:
-            args.service = service
-            action_disable(args, cfg)
+            with mock.patch.object(lock, "lock_data_file"):
+                args.service = service
+                action_disable(args, cfg)
 
         assert expected_error.msg == err.value.msg
 
@@ -437,9 +443,10 @@ class TestDisable:
                 event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
             ):
                 with mock.patch.object(event, "set_event_mode"):
-                    fake_stdout = io.StringIO()
-                    with contextlib.redirect_stdout(fake_stdout):
-                        main_error_handler(action_disable)(args, cfg)
+                    with mock.patch.object(lock, "lock_data_file"):
+                        fake_stdout = io.StringIO()
+                        with contextlib.redirect_stdout(fake_stdout):
+                            main_error_handler(action_disable)(args, cfg)
 
         expected = {
             "_schema_version": event_logger.JSON_SCHEMA_VERSION,
@@ -532,12 +539,14 @@ class TestDisable:
             expected["errors"][0]["additional_info"] = expected_info
         assert expected == json.loads(fake_stdout.getvalue())
 
+    @mock.patch("uaclient.lock.check_lock_info")
     @mock.patch("time.sleep")
     @mock.patch("uaclient.system.subp")
     def test_lock_file_exists(
         self,
         m_subp,
         m_sleep,
+        m_check_lock_info,
         FakeConfig,
         event,
     ):
@@ -547,11 +556,11 @@ class TestDisable:
         expected_error = messages.E_LOCK_HELD_ERROR.format(
             lock_request="pro disable", lock_holder="pro enable", pid="123"
         )
-        cfg.write_cache("lock", "123:pro enable")
+        m_check_lock_info.return_value = (123, "pro enable")
         with pytest.raises(exceptions.LockHeldError) as err:
             args.service = ["esm-infra"]
             action_disable(args, cfg)
-        assert [mock.call(["ps", "123"])] * 12 == m_subp.call_args_list
+        assert 12 == m_check_lock_info.call_count
         assert expected_error.msg == err.value.msg
 
         args.assume_yes = True
@@ -621,8 +630,11 @@ class TestDisable:
         }
         assert expected == json.loads(fake_stdout.getvalue())
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
-    def test_purge_assume_yes_incompatible(self, m_is_attached, capsys):
+    def test_purge_assume_yes_incompatible(
+        self, m_is_attached, _m_check_lock_info, capsys
+    ):
         cfg = mock.MagicMock()
         args_mock = mock.MagicMock()
         args_mock.service = "test"
@@ -636,9 +648,7 @@ class TestDisable:
         )
 
         with pytest.raises(SystemExit):
-            with mock.patch.object(
-                cfg, "check_lock_info", return_value=(-1, "")
-            ):
+            with mock.patch.object(lock, "lock_data_file"):
                 main_error_handler(action_disable)(args_mock, cfg)
 
         _out, err = capsys.readouterr()

--- a/uaclient/cli/tests/test_cli_enable.py
+++ b/uaclient/cli/tests/test_cli_enable.py
@@ -445,6 +445,7 @@ class TestActionEnable:
         assert expected == json.loads(fake_stdout.getvalue())
 
     @pytest.mark.parametrize("assume_yes", (True, False))
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(
         "uaclient.cli.contract.UAContractClient.update_activity_token",
@@ -457,6 +458,7 @@ class TestActionEnable:
         _m_get_available_resources,
         _m_update_activity_token,
         _m_check_lock_info,
+        _m_status_cache_file,
         m_refresh,
         _m_public_config,
         assume_yes,
@@ -495,6 +497,7 @@ class TestActionEnable:
             )
         ] == m_entitlement_cls.call_args_list
 
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.status.get_available_resources", return_value={})
     @mock.patch("uaclient.entitlements.entitlement_factory")
@@ -506,6 +509,7 @@ class TestActionEnable:
         _m_get_available_resources,
         _m_check_lock_info,
         _m_refresh,
+        _m_status_cache_file,
         _m_public_config,
         event,
         FakeConfig,
@@ -625,6 +629,7 @@ class TestActionEnable:
         assert expected == json.loads(fake_stdout.getvalue())
 
     @pytest.mark.parametrize("beta_flag", ((False), (True)))
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.status.get_available_resources", return_value={})
     @mock.patch("uaclient.entitlements.entitlement_factory")
@@ -635,6 +640,7 @@ class TestActionEnable:
         m_entitlement_factory,
         _m_get_available_resources,
         _m_check_lock_info,
+        _m_status_cache_file,
         _m_refresh,
         _m_public_config,
         beta_flag,
@@ -782,6 +788,7 @@ class TestActionEnable:
         }
         assert expected == json.loads(fake_stdout.getvalue())
 
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch(
         "uaclient.cli.contract.UAContractClient.update_activity_token",
@@ -792,6 +799,7 @@ class TestActionEnable:
         _m_get_available_resources,
         _m_update_activity_token,
         _m_check_lock_info,
+        _m_status_cache_file,
         _m_refresh,
         _m_public_config,
         event,

--- a/uaclient/cli/tests/test_cli_refresh.py
+++ b/uaclient/cli/tests/test_cli_refresh.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 
-from uaclient import exceptions, messages
+from uaclient import exceptions, lock, messages
 from uaclient.cli import action_refresh, main
 from uaclient.files.notices import Notice
 
@@ -57,8 +57,10 @@ class TestActionRefresh:
         "target, expect_unattached_error",
         [(None, True), ("contract", True), ("config", False)],
     )
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     def test_not_attached_errors(
         self,
+        _m_check_lock_info,
         target,
         expect_unattached_error,
         FakeConfig,
@@ -69,26 +71,31 @@ class TestActionRefresh:
         cfg.user_config.update_messaging_timer = 0
         cfg.user_config.metering_timer = 0
 
-        if expect_unattached_error:
-            with pytest.raises(exceptions.UnattachedError):
+        with mock.patch.object(lock, "lock_data_file"):
+            if expect_unattached_error:
+                with pytest.raises(exceptions.UnattachedError):
+                    action_refresh(mock.MagicMock(target=target), cfg=cfg)
+            else:
                 action_refresh(mock.MagicMock(target=target), cfg=cfg)
-        else:
-            action_refresh(mock.MagicMock(target=target), cfg=cfg)
 
+    @mock.patch("uaclient.lock.check_lock_info")
     @mock.patch("time.sleep")
     @mock.patch("uaclient.system.subp")
-    def test_lock_file_exists(self, m_subp, m_sleep, FakeConfig):
+    def test_lock_file_exists(
+        self, m_subp, m_sleep, m_check_lock_info, FakeConfig
+    ):
         """Check inability to refresh if operation holds lock file."""
         cfg = FakeConfig().for_attached_machine()
-        cfg.write_cache("lock", "123:pro disable")
+        m_check_lock_info.return_value = (123, "pro disable")
         with pytest.raises(exceptions.LockHeldError) as err:
             action_refresh(mock.MagicMock(), cfg=cfg)
-        assert [mock.call(["ps", "123"])] * 12 == m_subp.call_args_list
-        assert (
-            "Unable to perform: pro refresh.\n"
-            "Operation in progress: pro disable (pid:123)"
-        ) == err.value.msg
+        assert 12 == m_check_lock_info.call_count
+        expected_msg = messages.E_LOCK_HELD_ERROR.format(
+            lock_request="pro refresh", lock_holder="pro disable", pid=123
+        )
+        assert expected_msg.msg == err.value.msg
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("logging.exception")
     @mock.patch("uaclient.contract.refresh")
     @mock.patch("uaclient.files.notices.NoticesManager.remove")
@@ -97,6 +104,7 @@ class TestActionRefresh:
         m_remove_notice,
         refresh,
         logging_error,
+        m_check_log_info,
         FakeConfig,
     ):
         """On failure in request_updates_contract emit an error."""
@@ -107,19 +115,22 @@ class TestActionRefresh:
         cfg = FakeConfig.for_attached_machine()
 
         with pytest.raises(exceptions.UbuntuProError) as excinfo:
-            action_refresh(mock.MagicMock(target="contract"), cfg=cfg)
+            with mock.patch.object(lock, "lock_data_file"):
+                action_refresh(mock.MagicMock(target="contract"), cfg=cfg)
 
         assert messages.E_REFRESH_CONTRACT_FAILURE.msg == excinfo.value.msg
         assert [
             mock.call("", messages.NOTICE_REFRESH_CONTRACT_WARNING)
         ] != m_remove_notice.call_args_list
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.contract.refresh")
     @mock.patch("uaclient.files.notices.NoticesManager.remove")
     def test_refresh_contract_happy_path(
         self,
         m_remove_notice,
         refresh,
+        _m_check_lock_info,
         capsys,
         FakeConfig,
     ):
@@ -127,7 +138,8 @@ class TestActionRefresh:
         refresh.return_value = True
 
         cfg = FakeConfig.for_attached_machine()
-        ret = action_refresh(mock.MagicMock(target="contract"), cfg=cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            ret = action_refresh(mock.MagicMock(target="contract"), cfg=cfg)
 
         assert 0 == ret
         assert messages.REFRESH_CONTRACT_SUCCESS in capsys.readouterr()[0]
@@ -137,16 +149,23 @@ class TestActionRefresh:
             mock.call(Notice.OPERATION_IN_PROGRESS),
         ] == m_remove_notice.call_args_list
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.update_motd_messages")
-    def test_refresh_messages_error(self, m_update_motd, FakeConfig):
+    def test_refresh_messages_error(
+        self, m_update_motd, _m_check_lock_info, FakeConfig
+    ):
         """On failure in update_motd_messages emit an error."""
         m_update_motd.side_effect = Exception("test")
 
         with pytest.raises(exceptions.UbuntuProError) as excinfo:
-            action_refresh(mock.MagicMock(target="messages"), cfg=FakeConfig())
+            with mock.patch.object(lock, "lock_data_file"):
+                action_refresh(
+                    mock.MagicMock(target="messages"), cfg=FakeConfig()
+                )
 
         assert messages.E_REFRESH_MESSAGES_FAILURE.msg == excinfo.value.msg
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.apt_news.update_apt_news")
     @mock.patch("uaclient.timer.update_messaging.exists", return_value=True)
     @mock.patch("uaclient.timer.update_messaging.LOG.exception")
@@ -159,21 +178,24 @@ class TestActionRefresh:
         log_exception,
         _m_path,
         _m_update_apt_news,
+        _m_check_lock_info,
         capsys,
         FakeConfig,
     ):
         subp_exc = Exception("test")
         m_subp.side_effect = [subp_exc, ""]
 
-        ret = action_refresh(
-            mock.MagicMock(target="messages"), cfg=FakeConfig()
-        )
+        with mock.patch.object(lock, "lock_data_file"):
+            ret = action_refresh(
+                mock.MagicMock(target="messages"), cfg=FakeConfig()
+            )
 
         assert 0 == ret
         assert 1 == log_exception.call_count
         assert [mock.call(subp_exc)] == log_exception.call_args_list
         assert messages.REFRESH_MESSAGES_SUCCESS in capsys.readouterr()[0]
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.apt_news.update_apt_news")
     @mock.patch("uaclient.cli.refresh_motd")
     @mock.patch("uaclient.cli.update_motd_messages")
@@ -182,12 +204,14 @@ class TestActionRefresh:
         m_update_motd,
         m_refresh_motd,
         m_update_apt_news,
+        _m_check_lock_info,
         capsys,
         FakeConfig,
     ):
         """On success from request_updates_contract root user can refresh."""
         cfg = FakeConfig()
-        ret = action_refresh(mock.MagicMock(target="messages"), cfg=cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            ret = action_refresh(mock.MagicMock(target="messages"), cfg=cfg)
 
         assert 0 == ret
         assert messages.REFRESH_MESSAGES_SUCCESS in capsys.readouterr()[0]
@@ -197,6 +221,7 @@ class TestActionRefresh:
         assert 1 == m_refresh_motd.call_count
         assert 1 == m_update_apt_news.call_count
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("logging.exception")
     @mock.patch(
         "uaclient.config.UAConfig.process_config", side_effect=RuntimeError()
@@ -205,6 +230,7 @@ class TestActionRefresh:
         self,
         _m_process_config,
         _m_logging_error,
+        _m_check_lock_info,
         FakeConfig,
     ):
         """On failure in process_config emit an error."""
@@ -212,26 +238,31 @@ class TestActionRefresh:
         cfg = FakeConfig.for_attached_machine()
 
         with pytest.raises(exceptions.UbuntuProError) as excinfo:
-            action_refresh(mock.MagicMock(target="config"), cfg=cfg)
+            with mock.patch.object(lock, "lock_data_file"):
+                action_refresh(mock.MagicMock(target="config"), cfg=cfg)
 
         assert messages.E_REFRESH_CONFIG_FAILURE.msg == excinfo.value.msg
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.config.UAConfig.process_config")
     def test_refresh_config_happy_path(
         self,
         m_process_config,
+        m_check_lock_info,
         capsys,
         FakeConfig,
     ):
         """On success from process_config root user gets success message."""
 
         cfg = FakeConfig.for_attached_machine()
-        ret = action_refresh(mock.MagicMock(target="config"), cfg=cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            ret = action_refresh(mock.MagicMock(target="config"), cfg=cfg)
 
         assert 0 == ret
         assert messages.REFRESH_CONFIG_SUCCESS in capsys.readouterr()[0]
         assert [mock.call()] == m_process_config.call_args_list
 
+    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.apt_news.update_apt_news")
     @mock.patch("uaclient.cli.refresh_motd")
     @mock.patch("uaclient.cli.update_motd_messages")
@@ -246,13 +277,16 @@ class TestActionRefresh:
         m_update_motd,
         m_refresh_motd,
         m_update_apt_news,
+        _m_check_lock_info,
         capsys,
         FakeConfig,
     ):
         """On success from process_config root user gets success message."""
 
         cfg = FakeConfig.for_attached_machine()
-        ret = action_refresh(mock.MagicMock(target=None), cfg=cfg)
+        with mock.patch.object(lock, "lock_data_file"):
+            ret = action_refresh(mock.MagicMock(target=None), cfg=cfg)
+
         out, err = capsys.readouterr()
 
         assert 0 == ret

--- a/uaclient/cli/tests/test_cli_status.py
+++ b/uaclient/cli/tests/test_cli_status.py
@@ -396,10 +396,12 @@ class TestActionStatus:
             ),
         ),
     )
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     @mock.patch("uaclient.status.format_expires", return_value="formatteddate")
     def test_attached(
         self,
         _m_format_expires,
+        _m_status_cache_file,
         _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
@@ -457,8 +459,10 @@ class TestActionStatus:
             (False),
         ),
     )
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     def test_unattached(
         self,
+        _m_status_cache_file,
         _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
@@ -507,6 +511,7 @@ class TestActionStatus:
         )
         assert expected == capsys.readouterr()[0]
 
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     @mock.patch("uaclient.lock.check_lock_info")
     @mock.patch("uaclient.version.get_version", return_value="test_version")
     @mock.patch("uaclient.system.subp")
@@ -517,6 +522,7 @@ class TestActionStatus:
         _m_subp,
         _m_get_version,
         m_check_lock_info,
+        _m_status_cache_file,
         _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
@@ -569,8 +575,10 @@ class TestActionStatus:
             },
         ),
     )
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     def test_unattached_formats(
         self,
+        _m_status_cache_file,
         _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
@@ -680,8 +688,10 @@ class TestActionStatus:
         ),
     )
     @pytest.mark.parametrize("use_all", (True, False))
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     def test_attached_formats(
         self,
+        _m_status_cache_file,
         _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
@@ -993,10 +1003,12 @@ class TestActionStatus:
         "encoding,expected_dash",
         (("utf-8", "\u2014"), ("UTF-8", "\u2014"), ("ascii", "-")),
     )
+    @mock.patch("uaclient.files.state_files.status_cache_file.write")
     @mock.patch("uaclient.status.format_expires", return_value="formatteddate")
     def test_unicode_dash_replacement_when_unprintable(
         self,
         _m_format_expires,
+        _m_status_cache_file,
         _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,

--- a/uaclient/cli/tests/test_cli_status.py
+++ b/uaclient/cli/tests/test_cli_status.py
@@ -10,7 +10,7 @@ import textwrap
 import mock
 import pytest
 
-from uaclient import exceptions, messages, status, util
+from uaclient import exceptions, lock, messages, status, util
 from uaclient.cli import action_status, get_parser, main, status_parser
 from uaclient.conftest import FakeNotice
 from uaclient.event_logger import EventLoggerMode
@@ -507,6 +507,7 @@ class TestActionStatus:
         )
         assert expected == capsys.readouterr()[0]
 
+    @mock.patch("uaclient.lock.check_lock_info")
     @mock.patch("uaclient.version.get_version", return_value="test_version")
     @mock.patch("uaclient.system.subp")
     @mock.patch(M_PATH + "time.sleep")
@@ -515,6 +516,7 @@ class TestActionStatus:
         m_sleep,
         _m_subp,
         _m_get_version,
+        m_check_lock_info,
         _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
@@ -527,19 +529,20 @@ class TestActionStatus:
         """Check that --wait will will block and poll until lock released."""
         cfg = FakeConfig()
         mock_notice = NoticesManager()
-        lock_file = cfg.data_path("lock")
-        cfg.write_cache("lock", "123:pro auto-attach")
+        m_check_lock_info.return_value = (123, "pro disable")
 
         def fake_sleep(seconds):
             if m_sleep.call_count == 3:
-                os.unlink(lock_file)
+                m_check_lock_info.return_value = (-1, "")
                 mock_notice.remove(Notice.OPERATION_IN_PROGRESS)
 
         m_sleep.side_effect = fake_sleep
 
-        assert 0 == action_status(
-            mock.MagicMock(all=False, simulate_with_token=None), cfg=cfg
-        )
+        with mock.patch.object(lock, "lock_data_file"):
+            assert 0 == action_status(
+                mock.MagicMock(all=False, simulate_with_token=None), cfg=cfg
+            )
+
         assert [mock.call(1)] * 3 == m_sleep.call_args_list
         assert "...\n" + UNATTACHED_STATUS == capsys.readouterr()[0]
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -78,8 +78,6 @@ event = event_logger.get_event_logger()
 
 class UAConfig:
     data_paths = {
-        "instance-id": DataPath("instance-id", True),
-        "machine-access-cis": DataPath("machine-access-cis.json", True),
         "lock": DataPath("lock", False),
         "status-cache": DataPath("status.json", False),
     }  # type: Dict[str, DataPath]

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -77,9 +77,7 @@ event = event_logger.get_event_logger()
 
 
 class UAConfig:
-    data_paths = {
-        "status-cache": DataPath("status.json", False),
-    }  # type: Dict[str, DataPath]
+    data_paths = {}  # type: Dict[str, DataPath]
 
     ua_scoped_proxy_options = ("ua_apt_http_proxy", "ua_apt_https_proxy")
     global_scoped_proxy_options = (

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -266,7 +266,6 @@ def FakeConfig(tmpdir):
 
             config = cls()
             config.machine_token_file._machine_token = machine_token
-            config.write_cache("status-cache", status_cache)
             return config
 
         def override_features(self, features_override):

--- a/uaclient/daemon/poll_for_pro_license.py
+++ b/uaclient/daemon/poll_for_pro_license.py
@@ -15,9 +15,7 @@ LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
 
 def attempt_auto_attach(cfg: UAConfig, cloud: AutoAttachCloudInstance):
     try:
-        with lock.RetryLock(
-            cfg=cfg, lock_holder="pro.daemon.attempt_auto_attach"
-        ):
+        with lock.RetryLock(lock_holder="pro.daemon.attempt_auto_attach"):
             actions.auto_attach(cfg, cloud)
     except Exception as e:
         LOG.error(e)

--- a/uaclient/daemon/retry_auto_attach.py
+++ b/uaclient/daemon/retry_auto_attach.py
@@ -119,7 +119,6 @@ def retry_auto_attach(cfg: UAConfig) -> None:
         )
         try:
             with lock.RetryLock(
-                cfg=cfg,
                 lock_holder="pro.daemon.retry_auto_attach.notice_updates",
             ):
                 notices.add(

--- a/uaclient/daemon/tests/test_poll_for_pro_license.py
+++ b/uaclient/daemon/tests/test_poll_for_pro_license.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 
-from uaclient import exceptions
+from uaclient import exceptions, lock
 from uaclient.clouds.aws import UAAutoAttachAWSInstance
 from uaclient.clouds.gcp import UAAutoAttachGCPInstance
 from uaclient.daemon.poll_for_pro_license import (
@@ -34,10 +34,11 @@ class TestAttemptAutoAttach:
         cfg = FakeConfig()
         cloud = mock.MagicMock()
 
-        attempt_auto_attach(cfg, cloud)
+        with mock.patch.object(lock, "lock_data_file"):
+            attempt_auto_attach(cfg, cloud)
 
         assert [
-            mock.call(cfg=cfg, lock_holder="pro.daemon.attempt_auto_attach")
+            mock.call(lock_holder="pro.daemon.attempt_auto_attach")
         ] == m_spin_lock.call_args_list
         assert [mock.call(cfg, cloud)] == m_auto_attach.call_args_list
         assert [
@@ -67,7 +68,7 @@ class TestAttemptAutoAttach:
         attempt_auto_attach(cfg, cloud)
 
         assert [
-            mock.call(cfg=cfg, lock_holder="pro.daemon.attempt_auto_attach")
+            mock.call(lock_holder="pro.daemon.attempt_auto_attach")
         ] == m_spin_lock.call_args_list
         assert [mock.call(cfg, cloud)] == m_auto_attach.call_args_list
         assert [mock.call(err)] == m_log_error.call_args_list

--- a/uaclient/entitlements/anbox.py
+++ b/uaclient/entitlements/anbox.py
@@ -63,7 +63,7 @@ class AnboxEntitlement(RepoEntitlement):
         machine_token = self.cfg.machine_token["machineToken"]
         client = contract.UAContractClient(self.cfg)
         anbox_images_machine_access = client.get_resource_machine_access(
-            machine_token, "anbox-images", save_file=False
+            machine_token, "anbox-images"
         )
 
         anbox_cloud_data = AnboxCloudData(

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -28,6 +28,7 @@ from uaclient.entitlements.entitlement_status import (
     ContractStatus,
     UserFacingStatus,
 )
+from uaclient.files.state_files import status_cache_file
 from uaclient.types import MessagingOperationsDict, StaticAffordance
 from uaclient.util import is_config_value_true
 
@@ -1205,7 +1206,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
     def _check_application_status_on_cache(self) -> ApplicationStatus:
         """Check on the state of application on the status cache."""
-        status_cache = self.cfg.read_cache("status-cache")
+        status_cache = status_cache_file.read()
 
         if status_cache is None:
             return ApplicationStatus.DISABLED
@@ -1252,7 +1253,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         delta_entitlement = deltas.get("entitlement", {})
         delta_directives = delta_entitlement.get("directives", {})
-        status_cache = self.cfg.read_cache("status-cache")
+        status_cache = status_cache_file.read()
 
         transition_to_unentitled = bool(delta_entitlement == util.DROPPED_KEY)
         if not transition_to_unentitled:

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -21,6 +21,7 @@ from uaclient.entitlements.entitlement_status import (
     CanDisableFailure,
     CanDisableFailureReason,
 )
+from uaclient.files.state_files import status_cache_file
 
 event = event_logger.get_event_logger()
 LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
@@ -398,7 +399,7 @@ class RepoEntitlement(base.UAEntitlement):
         delta_directives = delta_entitlement.get("directives", {})
         delta_apt_url = delta_directives.get("aptURL")
         delta_packages = delta_directives.get("additionalPackages")
-        status_cache = self.cfg.read_cache("status-cache")
+        status_cache = status_cache_file.read()
 
         if delta_directives and status_cache:
             application_status = self._check_application_status_on_cache()

--- a/uaclient/files/data_types.py
+++ b/uaclient/files/data_types.py
@@ -80,3 +80,7 @@ class DataObjectFile(Generic[DOFType]):
 
     def delete(self):
         self.ua_file.delete()
+
+    @property
+    def path(self):
+        return self.ua_file.path

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -12,7 +12,7 @@ from uaclient.data_types import (
     data_list,
 )
 from uaclient.files.data_types import DataObjectFile, DataObjectFileFormat
-from uaclient.files.files import UAFile, UserCacheFile
+from uaclient.files.files import ProJSONFile, UAFile, UserCacheFile
 
 SERVICES_ONCE_ENABLED = "services-once-enabled"
 
@@ -222,4 +222,12 @@ attachment_data_file = DataObjectFile(
     AttachmentData,
     UAFile("attachment.json", private=False),
     DataObjectFileFormat.JSON,
+)
+
+
+status_cache_file = ProJSONFile(
+    pro_file=UAFile(
+        name="status.json",
+        private=False,
+    )
 )

--- a/uaclient/files/tests/test_files.py
+++ b/uaclient/files/tests/test_files.py
@@ -1,4 +1,5 @@
 import os
+import stat
 
 import mock
 
@@ -16,6 +17,17 @@ class TestUAFile:
         res = system.load_file(path)
         assert res == file.read()
         assert res == content
+
+    def test_non_private_file_world_readable(
+        self,
+        tmpdir,
+    ):
+        file = UAFile("test", tmpdir.strpath, False)
+        file.write("dummy file words")
+
+        assert 0o644 == stat.S_IMODE(
+            os.lstat(os.path.join(tmpdir.strpath, "test")).st_mode
+        )
 
 
 class TestMachineTokenFile:

--- a/uaclient/lock.py
+++ b/uaclient/lock.py
@@ -1,24 +1,82 @@
-import functools
 import logging
 import os
 import time
+from typing import Tuple
 
-from uaclient import config, exceptions, util
+from uaclient import exceptions, system, util
+from uaclient.data_types import DataObject, Field, StringDataValue
 from uaclient.files import notices
+from uaclient.files.data_types import DataObjectFile, DataObjectFileFormat
+from uaclient.files.files import UAFile
 from uaclient.files.notices import Notice
 
 LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
 
-# Set a module-level callable here so we don't have to reinstantiate
-# UAConfig in order to determine dynamic data_path exception handling of
-# main_error_handler
-clear_lock_file = None
+
+class LockData(DataObject):
+    fields = [
+        Field("lock_pid", StringDataValue),
+        Field("lock_holder", StringDataValue),
+    ]
+
+    def __init__(self, lock_pid: str, lock_holder: str):
+        self.lock_pid = lock_pid
+        self.lock_holder = lock_holder
+
+
+lock_data_file = DataObjectFile(
+    LockData,
+    UAFile("lock", private=False),
+    DataObjectFileFormat.JSON,
+)
+
+
+def check_lock_info() -> Tuple[int, str]:
+    """Return lock info if lock file is present the lock is active.
+
+    If process claiming the lock is no longer present, remove the lock file
+    and log a warning.
+
+    :return: A tuple (pid, string describing lock holder)
+        If no active lock, pid will be -1.
+    """
+
+    try:
+        lock_data_obj = lock_data_file.read()
+    except exceptions.InvalidFileFormatError:
+        raise exceptions.InvalidLockFile(
+            lock_file_path=os.path.join(lock_data_file.path)
+        )
+
+    no_lock = (-1, "")
+    if not lock_data_obj:
+        return no_lock
+
+    lock_pid = lock_data_obj.lock_pid
+    lock_holder = lock_data_obj.lock_holder
+
+    try:
+        system.subp(["ps", lock_pid])
+        return (int(lock_pid), lock_holder)
+    except exceptions.ProcessExecutionError:
+        if not util.we_are_currently_root():
+            LOG.debug(
+                "Found stale lock file previously held by %s:%s",
+                lock_pid,
+                lock_holder,
+            )
+            return (int(lock_pid), lock_holder)
+        LOG.warning(
+            "Removing stale lock file previously held by %s:%s",
+            lock_pid,
+            lock_holder,
+        )
+        system.ensure_file_absent(lock_data_file.path)
+        return no_lock
 
 
 def clear_lock_file_if_present():
-    global clear_lock_file
-    if clear_lock_file:
-        clear_lock_file()
+    lock_data_file.delete()
 
 
 class RetryLock:
@@ -45,33 +103,29 @@ class RetryLock:
     def __init__(
         self,
         *_args,
-        cfg: config.UAConfig,
         lock_holder: str,
         sleep_time: int = 10,
         max_retries: int = 12
     ):
-        self.cfg = cfg
         self.lock_holder = lock_holder
         self.sleep_time = sleep_time
         self.max_retries = max_retries
 
     def grab_lock(self):
-        global clear_lock_file
-        (lock_pid, cur_lock_holder) = self.cfg.check_lock_info()
+        (lock_pid, cur_lock_holder) = check_lock_info()
         if lock_pid > 0:
             raise exceptions.LockHeldError(
                 lock_request=self.lock_holder,
                 lock_holder=cur_lock_holder,
                 pid=lock_pid,
             )
-        self.cfg.write_cache(
-            "lock", "{}:{}".format(os.getpid(), self.lock_holder)
+        lock_data_file.write(
+            LockData(lock_pid=str(os.getpid()), lock_holder=self.lock_holder)
         )
         notices.add(
             Notice.OPERATION_IN_PROGRESS,
             operation=self.lock_holder,
         )
-        clear_lock_file = functools.partial(self.cfg.delete_cache_key, "lock")
 
     def __enter__(self):
         LOG.debug("spin lock starting for %s", self.lock_holder)
@@ -91,6 +145,5 @@ class RetryLock:
                     time.sleep(self.sleep_time)
 
     def __exit__(self, _exc_type, _exc_value, _traceback):
-        global clear_lock_file
-        self.cfg.delete_cache_key("lock")
-        clear_lock_file = None  # Unset due to successful lock delete
+        lock_data_file.delete()
+        notices.remove(Notice.OPERATION_IN_PROGRESS)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -421,7 +421,7 @@ def status(cfg: UAConfig, show_all: bool = False) -> Dict[str, Any]:
     response.update(_get_config_status(cfg))
 
     if util.we_are_currently_root():
-        cfg.write_cache("status-cache", response)
+        state_files.status_cache_file.write(response)
 
     response = _handle_beta_resources(cfg, show_all, response)
 

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -10,6 +10,7 @@ from uaclient import (
     event_logger,
     exceptions,
     livepatch,
+    lock,
     messages,
     util,
     version,
@@ -372,7 +373,7 @@ def _get_config_status(cfg) -> Dict[str, Any]:
     userStatus = UserFacingConfigStatus
     status_val = userStatus.INACTIVE.value
     status_desc = messages.NO_ACTIVE_OPERATIONS
-    (lock_pid, lock_holder) = cfg.check_lock_info()
+    (lock_pid, lock_holder) = lock.check_lock_info()
     notices_list = notices.list() or []
     if lock_pid > 0:
         status_val = userStatus.ACTIVE.value

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -31,7 +31,6 @@ class TestAttachWithToken:
             "machine_id",
             "entitlements",
             "process_entitlements_delta_side_effect",
-            "instance_id",
             "expected_add_contract_machine_call_args",
             "expected_machine_token_file_write_call_args",
             "expected_get_machine_id_call_args",
@@ -53,7 +52,6 @@ class TestAttachWithToken:
                 None,
                 None,
                 None,
-                None,
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [],
                 [],
@@ -74,7 +72,6 @@ class TestAttachWithToken:
                 "get-machine-id-result",
                 mock.sentinel.entitlements,
                 exceptions.ConnectivityError(cause=Exception(), url="url"),
-                None,
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
@@ -95,7 +92,6 @@ class TestAttachWithToken:
                 "get-machine-id-result",
                 mock.sentinel.entitlements,
                 fakes.FakeUbuntuProError(),
-                None,
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
@@ -116,7 +112,6 @@ class TestAttachWithToken:
                 "get-machine-id-result",
                 mock.sentinel.entitlements,
                 None,
-                None,
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
@@ -137,13 +132,11 @@ class TestAttachWithToken:
                 "get-machine-id-result",
                 mock.sentinel.entitlements,
                 None,
-                "id",
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
                 [
                     mock.call("machine-id", "machine-id"),
-                    mock.call("instance-id", "id"),
                 ],
                 [mock.call(mock.ANY, {}, mock.sentinel.entitlements, True)],
                 [mock.call(mock.ANY)],
@@ -161,13 +154,11 @@ class TestAttachWithToken:
                 "get-machine-id-result",
                 mock.sentinel.entitlements,
                 None,
-                "id",
                 [mock.call(contract_token="token2", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
                 [
                     mock.call("machine-id", "machine-id"),
-                    mock.call("instance-id", "id"),
                 ],
                 [mock.call(mock.ANY, {}, mock.sentinel.entitlements, False)],
                 [mock.call(mock.ANY)],
@@ -185,7 +176,6 @@ class TestAttachWithToken:
         return_value=(True, None),
     )
     @mock.patch(M_PATH + "timer.start")
-    @mock.patch(M_PATH + "identity.get_instance_id", return_value="my-iid")
     @mock.patch(
         M_PATH + "contract.UAContractClient.update_activity_token",
     )
@@ -213,7 +203,6 @@ class TestAttachWithToken:
         m_status,
         m_update_motd_messages,
         m_update_activity_token,
-        m_get_instance_id,
         m_timer_start,
         _m_check_ent_apt_directives,
         token,
@@ -222,7 +211,6 @@ class TestAttachWithToken:
         machine_id,
         entitlements,
         process_entitlements_delta_side_effect,
-        instance_id,
         expected_add_contract_machine_call_args,
         expected_machine_token_file_write_call_args,
         expected_get_machine_id_call_args,
@@ -244,7 +232,6 @@ class TestAttachWithToken:
         m_process_entitlements_delta.side_effect = (
             process_entitlements_delta_side_effect
         )
-        m_get_instance_id.return_value = instance_id
 
         with expected_raises:
             attach_with_token(cfg, token, allow_enable)
@@ -281,10 +268,6 @@ class TestAttachWithToken:
         assert (
             expected_update_activity_token_call_args
             == m_update_activity_token.call_args_list
-        )
-        assert (
-            expected_get_instance_id_call_args
-            == m_get_instance_id.call_args_list
         )
         assert expected_timer_start_call_args == m_timer_start.call_args_list
 
@@ -339,10 +322,8 @@ class TestAutoAttach:
         M_PATH
         + "contract.UAContractClient.get_contract_token_for_cloud_instance"  # noqa
     )
-    @mock.patch(M_PATH + "identity.get_instance_id", return_value="my-iid")
     def test_raise_unexpected_errors(
         self,
-        _m_get_instance_id,
         m_get_contract_token_for_cloud_instances,
         FakeConfig,
     ):

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -1158,6 +1158,9 @@ class TestAptCache:
     @pytest.mark.parametrize("is_esm", (True, False))
     @pytest.mark.parametrize("can_enable_infra", ("yes", "no"))
     @pytest.mark.parametrize("can_enable_apps", ("yes", "no"))
+    @mock.patch(
+        "uaclient.files.state_files.status_cache_file.read", return_value=None
+    )
     @mock.patch("uaclient.entitlements.esm.ESMAppsEntitlement")
     @mock.patch("uaclient.entitlements.esm.ESMInfraEntitlement")
     @mock.patch("uaclient.apt.system.is_current_series_lts")
@@ -1178,6 +1181,7 @@ class TestAptCache:
         m_is_lts,
         m_infra_entitlement,
         m_apps_entitlement,
+        m_status_cache_file_read,
         is_lts,
         cache_call_list,
         apps_status,
@@ -1221,11 +1225,9 @@ class TestAptCache:
         infra_disable_repo_count = 0
         apps_disable_repo_count = 0
         status_count = 0
-        status_cache_args_list = []
 
         if is_lts:
             status_count = 1
-            status_cache_args_list = [mock.call("status-cache")]
             if (
                 apps_status == ApplicationStatus.DISABLED
                 and can_enable_apps == "yes"
@@ -1244,10 +1246,9 @@ class TestAptCache:
                 infra_disable_repo_count = 1
 
         cfg = FakeConfig()
-        with mock.patch.object(cfg, "read_cache", return_value=None):
-            update_esm_caches(cfg)
-            assert cfg.read_cache.call_args_list == status_cache_args_list
+        update_esm_caches(cfg)
 
+        assert status_count == m_status_cache_file_read.call_count
         assert m_esm_cache.call_args_list == cache_call_list
         assert (
             m_infra.setup_local_esm_repo.call_count == infra_setup_repo_count

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -26,8 +26,8 @@ from uaclient.util import depth_first_merge_overlay_dict
 from uaclient.yaml import safe_dump
 
 KNOWN_DATA_PATHS = (
-    ("machine-access-cis", "machine-access-cis.json"),
-    ("instance-id", "instance-id"),
+    ("lock", "lock"),
+    ("status-cache", "status.json"),
 )
 M_PATH = "uaclient.entitlements."
 
@@ -281,7 +281,7 @@ class TestDataPath:
     ):
         """When key is defined in Config.data_paths return data_path value."""
         cfg = FakeConfig({"data_dir": "/my/dir"})
-        private_path = "/my/dir/{}/{}".format(PRIVATE_SUBDIR, path_basename)
+        private_path = "/my/dir/{}".format(path_basename)
         assert private_path == cfg.data_path(key=key)
 
     @pytest.mark.parametrize(
@@ -468,8 +468,7 @@ class TestReadCache:
         self, tmpdir, FakeConfig, key, path_basename
     ):
         cfg = FakeConfig()
-        os.makedirs(tmpdir.join(PRIVATE_SUBDIR).strpath)
-        data_path = tmpdir.join(PRIVATE_SUBDIR, path_basename)
+        data_path = tmpdir.join(path_basename)
         with open(data_path.strpath, "w") as f:
             f.write("content{}".format(key))
 
@@ -480,8 +479,7 @@ class TestReadCache:
         self, tmpdir, FakeConfig, key, path_basename
     ):
         cfg = FakeConfig()
-        os.makedirs(tmpdir.join(PRIVATE_SUBDIR).strpath)
-        data_path = tmpdir.join(PRIVATE_SUBDIR, path_basename)
+        data_path = tmpdir.join(path_basename)
         expected = {key: "content{}".format(key)}
         with open(data_path.strpath, "w") as f:
             f.write(json.dumps(expected))

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -25,7 +25,7 @@ from uaclient.files.notices import NoticesManager
 from uaclient.util import depth_first_merge_overlay_dict
 from uaclient.yaml import safe_dump
 
-KNOWN_DATA_PATHS = (("status-cache", "status.json"),)
+KNOWN_DATA_PATHS = (("machine-id", "machine-id"),)
 M_PATH = "uaclient.entitlements."
 
 
@@ -272,15 +272,6 @@ class TestDataPath:
         cfg = FakeConfig({"data_dir": "/my/dir"})
         assert "/my/dir/{}".format(PRIVATE_SUBDIR) == cfg.data_path()
 
-    @pytest.mark.parametrize("key,path_basename", KNOWN_DATA_PATHS)
-    def test_data_path_returns_file_path_with_defined_data_paths(
-        self, key, path_basename, FakeConfig
-    ):
-        """When key is defined in Config.data_paths return data_path value."""
-        cfg = FakeConfig({"data_dir": "/my/dir"})
-        private_path = "/my/dir/{}".format(path_basename)
-        assert private_path == cfg.data_path(key=key)
-
     @pytest.mark.parametrize(
         "key,path_basename", (("notHere", "notHere"), ("anything", "anything"))
     )
@@ -459,29 +450,6 @@ class TestReadCache:
         cfg = FakeConfig()
         assert None is cfg.read_cache(key)
         assert not tmpdir.join(path_basename).check()
-
-    @pytest.mark.parametrize("key,path_basename", KNOWN_DATA_PATHS)
-    def test_read_cache_returns_content_when_data_path_present(
-        self, tmpdir, FakeConfig, key, path_basename
-    ):
-        cfg = FakeConfig()
-        data_path = tmpdir.join(path_basename)
-        with open(data_path.strpath, "w") as f:
-            f.write("content{}".format(key))
-
-        assert "content{}".format(key) == cfg.read_cache(key)
-
-    @pytest.mark.parametrize("key,path_basename", KNOWN_DATA_PATHS)
-    def test_read_cache_returns_stuctured_content_when_json_data_path_present(
-        self, tmpdir, FakeConfig, key, path_basename
-    ):
-        cfg = FakeConfig()
-        data_path = tmpdir.join(path_basename)
-        expected = {key: "content{}".format(key)}
-        with open(data_path.strpath, "w") as f:
-            f.write(json.dumps(expected))
-
-        assert expected == cfg.read_cache(key)
 
     def test_datetimes_are_unserialised(self, tmpdir, FakeConfig):
         cfg = FakeConfig()

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -25,10 +25,7 @@ from uaclient.files.notices import NoticesManager
 from uaclient.util import depth_first_merge_overlay_dict
 from uaclient.yaml import safe_dump
 
-KNOWN_DATA_PATHS = (
-    ("lock", "lock"),
-    ("status-cache", "status.json"),
-)
+KNOWN_DATA_PATHS = (("status-cache", "status.json"),)
 M_PATH = "uaclient.entitlements."
 
 
@@ -1312,32 +1309,6 @@ class TestGetConfigPath:
     def test_get_default_config_path(self):
         with mock.patch.dict("uaclient.config.os.environ", values={}):
             assert DEFAULT_CONFIG_FILE == get_config_path()
-
-
-class TestCheckLockInfo:
-    @pytest.mark.parametrize("lock_content", ((""), ("corrupted")))
-    @mock.patch("os.path.exists", return_value=True)
-    @mock.patch("uaclient.system.load_file")
-    def test_raise_exception_for_corrupted_lock(
-        self,
-        m_load_file,
-        _m_path_exists,
-        lock_content,
-        FakeConfig,
-    ):
-        cfg = FakeConfig()
-        m_load_file.return_value = lock_content
-
-        expected_msg = messages.E_INVALID_LOCK_FILE.format(
-            lock_file_path=cfg.data_dir + "/lock"
-        )
-
-        with pytest.raises(exceptions.InvalidLockFile) as exc_info:
-            cfg.check_lock_info()
-
-        assert expected_msg.msg == exc_info.value.msg
-        assert m_load_file.call_count == 1
-        assert _m_path_exists.call_count == 1
 
 
 class TestConfigShow:

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -50,8 +50,10 @@ class TestFixProPkgHolds:
             ),
         ],
     )
+    @mock.patch("uaclient.files.state_files.status_cache_file.read")
     def test_fix_pro_pkg_holds(
         self,
+        m_status_cache_file_read,
         m_fips_status,
         m_fips_setup_apt_config,
         m_fips_install_packages,
@@ -66,10 +68,9 @@ class TestFixProPkgHolds:
         m_fips_setup_apt_config.side_effect = fips_setup_apt_config_side_effect
         m_fips_install_packages.side_effect = fips_install_packages_side_effect
         cfg = FakeConfig()
-        fake_status_cache = {
+        m_status_cache_file_read.return_value = {
             "services": [{"name": "fips", "status": fips_status}]
         }
-        cfg.write_cache("status-cache", fake_status_cache)
 
         with expected_raises:
             fix_pro_pkg_holds(cfg)

--- a/uaclient/tests/test_reboot_cmds.py
+++ b/uaclient/tests/test_reboot_cmds.py
@@ -148,7 +148,7 @@ class TestMain:
 
         if expected_calls:
             assert [
-                mock.call(cfg=mock.ANY, lock_holder="pro-reboot-cmds")
+                mock.call(lock_holder="pro-reboot-cmds")
             ] == m_spin_lock.call_args_list
             assert [mock.call(mock.ANY)] == m_fix_pro_pkg_holds.call_args_list
             assert [mock.call(mock.ANY)] == m_refresh_contract.call_args_list


### PR DESCRIPTION
## Why is this needed?
We are active working on making the config module more focused on only handling the actual Pro client configuration. Right now, it still handles some functionality that is not directly tied to the configuration.

This is an initial work that removed some unused data paths from the UAConfig class and also completely remove the lock handling from the config module 

## Test Steps
Guarantee that no test breaks after this change and that our lock mechanism is still working.
For example:

1. Launch a LXD container
2. Run `pro attach`
3. On another window, run `pro refresh`
4. Check that `pro refresh` will only start after `pro attach` has finished

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
