### PR TITLE
api: add extra fields to is_attached endpoint

### DIFF
--- a/features/api.feature
+++ b/features/api.feature
@@ -120,7 +120,7 @@ Feature: Client behaviour for the API endpoints
         "type": "Version"
       }
       """
-    When I run `ua api u.pro.attach.auto.should_auto_attach.v1` with sudo
+    When I run `pro api u.pro.attach.auto.should_auto_attach.v1` with sudo
     Then API data field output matches regexp:
       """
       {
@@ -133,7 +133,7 @@ Feature: Client behaviour for the API endpoints
         "type": "ShouldAutoAttach"
       }
       """
-    When I run `ua api u.pro.status.is_attached.v1` with sudo
+    When I run `pro api u.pro.status.is_attached.v1` with sudo
     Then API data field output matches regexp:
       """
       {
@@ -149,7 +149,7 @@ Feature: Client behaviour for the API endpoints
         "type": "IsAttached"
       }
       """
-    When I run `ua api u.pro.status.enabled_services.v1` with sudo
+    When I run `pro api u.pro.status.enabled_services.v1` with sudo
     Then API data field output matches regexp:
       """
       {
@@ -174,110 +174,110 @@ Feature: Client behaviour for the API endpoints
   @uses.config.contract_token
   Scenario Outline: u.pro.status.is_attached.v1
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-    When I run `ua api u.pro.status.is_attached.v1` with sudo
+    When I run `pro api u.pro.status.is_attached.v1` with sudo
     Then API data field output matches regexp:
-    """
-    {
-      "attributes": {
-        "contract_remaining_days": 0,
-        "contract_status": null,
-        "is_attached": false,
-        "is_attached_and_contract_valid": false
-      },
-      "meta": {
-        "environment_vars": []
-      },
-      "type": "IsAttached"
-    }
-    """
+      """
+      {
+        "attributes": {
+          "contract_remaining_days": 0,
+          "contract_status": null,
+          "is_attached": false,
+          "is_attached_and_contract_valid": false
+        },
+        "meta": {
+          "environment_vars": []
+        },
+        "type": "IsAttached"
+      }
+      """
     When I attach `contract_token` with sudo
-    And I run `ua api u.pro.status.is_attached.v1` with sudo
+    And I run `pro api u.pro.status.is_attached.v1` with sudo
     Then API data field output matches regexp:
-    """
-    {
-      "attributes": {
-        "contract_remaining_days": \d+,
-        "contract_status": "active",
-        "is_attached": true,
-        "is_attached_and_contract_valid": true
-      },
-      "meta": {
-        "environment_vars": []
-      },
-      "type": "IsAttached"
-    }
-    """
+      """
+      {
+        "attributes": {
+          "contract_remaining_days": \d+,
+          "contract_status": "active",
+          "is_attached": true,
+          "is_attached_and_contract_valid": true
+        },
+        "meta": {
+          "environment_vars": []
+        },
+        "type": "IsAttached"
+      }
+      """
     When I set the machine token overlay to the following yaml
-    """
-    machineTokenInfo:
-      contractInfo:
-        effectiveTo: $behave_var{today +2}
-    """
+      """
+      machineTokenInfo:
+        contractInfo:
+          effectiveTo: $behave_var{today +2}
+      """
     And I run `ua api u.pro.status.is_attached.v1` with sudo
     Then API data field output matches regexp:
-    """
-    {
-      "attributes": {
-        "contract_remaining_days": 2,
-        "contract_status": "active-soon-to-expire",
-        "is_attached": true,
-        "is_attached_and_contract_valid": true
-      },
-      "meta": {
-        "environment_vars": []
-      },
-      "type": "IsAttached"
-    }
-    """
+      """
+      {
+        "attributes": {
+          "contract_remaining_days": 2,
+          "contract_status": "active-soon-to-expire",
+          "is_attached": true,
+          "is_attached_and_contract_valid": true
+        },
+        "meta": {
+          "environment_vars": []
+        },
+        "type": "IsAttached"
+      }
+      """
     When I set the machine token overlay to the following yaml
-    """
-    machineTokenInfo:
-      contractInfo:
-        effectiveTo: $behave_var{today -2}
-    """
-    And I run `ua api u.pro.status.is_attached.v1` with sudo
+      """
+      machineTokenInfo:
+        contractInfo:
+          effectiveTo: $behave_var{today -2}
+      """
+    And I run `pro api u.pro.status.is_attached.v1` with sudo
     Then API data field output matches regexp:
-    """
-    {
-      "attributes": {
-        "contract_remaining_days": -2,
-        "contract_status": "grace-period",
-        "is_attached": true,
-        "is_attached_and_contract_valid": true
-      },
-      "meta": {
-        "environment_vars": []
-      },
-      "type": "IsAttached"
-    }
-    """
+      """
+      {
+        "attributes": {
+          "contract_remaining_days": -2,
+          "contract_status": "grace-period",
+          "is_attached": true,
+          "is_attached_and_contract_valid": true
+        },
+        "meta": {
+          "environment_vars": []
+        },
+        "type": "IsAttached"
+      }
+      """
     When I set the machine token overlay to the following yaml
-    """
-    machineTokenInfo:
-      contractInfo:
-        effectiveTo: $behave_var{today -50}
-    """
-    And I run `ua api u.pro.status.is_attached.v1` with sudo
+      """
+      machineTokenInfo:
+        contractInfo:
+          effectiveTo: $behave_var{today -50}
+      """
+    And I run `pro api u.pro.status.is_attached.v1` with sudo
     Then API data field output matches regexp:
-    """
-    {
-      "attributes": {
-        "contract_remaining_days": -50,
-        "contract_status": "expired",
-        "is_attached": true,
-        "is_attached_and_contract_valid": false
-      },
-      "meta": {
-        "environment_vars": []
-      },
-      "type": "IsAttached"
-    }
-    """
+      """
+      {
+        "attributes": {
+          "contract_remaining_days": -50,
+          "contract_status": "expired",
+          "is_attached": true,
+          "is_attached_and_contract_valid": false
+        },
+        "meta": {
+          "environment_vars": []
+        },
+        "type": "IsAttached"
+      }
+      """
 
     Examples: ubuntu release
-    | release | machine_type  |
-    | xenial  | lxd-container |
-    | bionic  | lxd-container |
-    | focal   | lxd-container |
-    | jammy   | lxd-container |
-    | mantic  | lxd-container |
+      | release | machine_type  |
+      | xenial  | lxd-container |
+      | bionic  | lxd-container |
+      | focal   | lxd-container |
+      | jammy   | lxd-container |
+      | mantic  | lxd-container |

--- a/features/api.feature
+++ b/features/api.feature
@@ -138,7 +138,10 @@ Feature: Client behaviour for the API endpoints
       """
       {
         "attributes": {
-          "is_attached": false
+          "contract_remaining_days": 0,
+          "contract_status": null,
+          "is_attached": false,
+          "is_attached_and_contract_valid": false
         },
         "meta": {
           "environment_vars": []
@@ -167,3 +170,114 @@ Feature: Client behaviour for the API endpoints
       | focal   | lxd-container |
       | jammy   | lxd-container |
       | mantic  | lxd-container |
+
+  @uses.config.contract_token
+  Scenario Outline: u.pro.status.is_attached.v1
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I run `ua api u.pro.status.is_attached.v1` with sudo
+    Then API data field output matches regexp:
+    """
+    {
+      "attributes": {
+        "contract_remaining_days": 0,
+        "contract_status": null,
+        "is_attached": false,
+        "is_attached_and_contract_valid": false
+      },
+      "meta": {
+        "environment_vars": []
+      },
+      "type": "IsAttached"
+    }
+    """
+    When I attach `contract_token` with sudo
+    And I run `ua api u.pro.status.is_attached.v1` with sudo
+    Then API data field output matches regexp:
+    """
+    {
+      "attributes": {
+        "contract_remaining_days": \d+,
+        "contract_status": "active",
+        "is_attached": true,
+        "is_attached_and_contract_valid": true
+      },
+      "meta": {
+        "environment_vars": []
+      },
+      "type": "IsAttached"
+    }
+    """
+    When I set the machine token overlay to the following yaml
+    """
+    machineTokenInfo:
+      contractInfo:
+        effectiveTo: $behave_var{today +2}
+    """
+    And I run `ua api u.pro.status.is_attached.v1` with sudo
+    Then API data field output matches regexp:
+    """
+    {
+      "attributes": {
+        "contract_remaining_days": 2,
+        "contract_status": "active-soon-to-expire",
+        "is_attached": true,
+        "is_attached_and_contract_valid": true
+      },
+      "meta": {
+        "environment_vars": []
+      },
+      "type": "IsAttached"
+    }
+    """
+    When I set the machine token overlay to the following yaml
+    """
+    machineTokenInfo:
+      contractInfo:
+        effectiveTo: $behave_var{today -2}
+    """
+    And I run `ua api u.pro.status.is_attached.v1` with sudo
+    Then API data field output matches regexp:
+    """
+    {
+      "attributes": {
+        "contract_remaining_days": -2,
+        "contract_status": "grace-period",
+        "is_attached": true,
+        "is_attached_and_contract_valid": true
+      },
+      "meta": {
+        "environment_vars": []
+      },
+      "type": "IsAttached"
+    }
+    """
+    When I set the machine token overlay to the following yaml
+    """
+    machineTokenInfo:
+      contractInfo:
+        effectiveTo: $behave_var{today -50}
+    """
+    And I run `ua api u.pro.status.is_attached.v1` with sudo
+    Then API data field output matches regexp:
+    """
+    {
+      "attributes": {
+        "contract_remaining_days": -50,
+        "contract_status": "expired",
+        "is_attached": true,
+        "is_attached_and_contract_valid": false
+      },
+      "meta": {
+        "environment_vars": []
+      },
+      "type": "IsAttached"
+    }
+    """
+
+    Examples: ubuntu release
+    | release | machine_type  |
+    | xenial  | lxd-container |
+    | bionic  | lxd-container |
+    | focal   | lxd-container |
+    | jammy   | lxd-container |
+    | mantic  | lxd-container |

--- a/uaclient/api/tests/test_api_u_pro_status_is_attached_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_status_is_attached_v1.py
@@ -1,0 +1,38 @@
+import datetime
+
+import pytest
+
+from uaclient.api.u.pro.status.is_attached.v1 import (
+    ContractExpiryStatus,
+    _is_attached,
+)
+
+
+class TestGetContractExpiryStatus:
+    @pytest.mark.parametrize(
+        "contract_remaining_days,expected_status",
+        (
+            (21, ContractExpiryStatus.ACTIVE),
+            (20, ContractExpiryStatus.ACTIVE_EXPIRED_SOON),
+            (-1, ContractExpiryStatus.EXPIRED_GRACE_PERIOD),
+            (-20, ContractExpiryStatus.EXPIRED),
+        ),
+    )
+    def test_contract_expiry_status_based_on_remaining_days(
+        self, contract_remaining_days, expected_status, FakeConfig
+    ):
+        """Return a tuple of ContractExpiryStatus and remaining_days"""
+        now = datetime.datetime.utcnow()
+        expire_date = now + datetime.timedelta(days=contract_remaining_days)
+        cfg = FakeConfig.for_attached_machine()
+        m_token = cfg.machine_token
+        m_token["machineTokenInfo"]["contractInfo"][
+            "effectiveTo"
+        ] = expire_date
+
+        is_attached_info = _is_attached(cfg)
+        assert is_attached_info.is_attached
+        assert expected_status.value == is_attached_info.contract_status
+        assert (
+            contract_remaining_days == is_attached_info.contract_remaining_days
+        )

--- a/uaclient/api/u/pro/security/fix/_common/plan/v1.py
+++ b/uaclient/api/u/pro/security/fix/_common/plan/v1.py
@@ -22,9 +22,11 @@ from uaclient.api.u.pro.security.fix._common import (
     query_installed_source_pkg_versions,
 )
 from uaclient.api.u.pro.status.enabled_services.v1 import _enabled_services
-from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
+from uaclient.api.u.pro.status.is_attached.v1 import (
+    ContractExpiryStatus,
+    _is_attached,
+)
 from uaclient.config import UAConfig
-from uaclient.contract import ContractExpiryStatus, get_contract_expiry_status
 from uaclient.data_types import (
     DataObject,
     Field,
@@ -985,8 +987,8 @@ def _generate_fix_plan(
                     },
                 )
             else:
-                contract_expiry_status, _ = get_contract_expiry_status(cfg)
-                if contract_expiry_status != ContractExpiryStatus.ACTIVE:
+                contract_expiry_status = _is_attached(cfg).contract_status
+                if contract_expiry_status != ContractExpiryStatus.ACTIVE.value:
                     fix_plan.register_step(
                         operation=FixStepType.ATTACH,
                         data={

--- a/uaclient/api/u/pro/status/is_attached/v1.py
+++ b/uaclient/api/u/pro/status/is_attached/v1.py
@@ -1,16 +1,76 @@
+import enum
+from typing import Optional, Tuple
+
 from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
 from uaclient.config import UAConfig
-from uaclient.data_types import BoolDataValue, DataObject, Field
+from uaclient.data_types import (
+    BoolDataValue,
+    DataObject,
+    Field,
+    IntDataValue,
+    StringDataValue,
+)
+from uaclient.defaults import (
+    CONTRACT_EXPIRY_GRACE_PERIOD_DAYS,
+    CONTRACT_EXPIRY_PENDING_DAYS,
+)
 
 
 class IsAttachedResult(DataObject, AdditionalInfo):
     fields = [
         Field("is_attached", BoolDataValue),
+        Field("contract_status", StringDataValue, False),
+        Field("contract_remaining_days", IntDataValue),
+        Field("is_attached_and_contract_valid", BoolDataValue),
     ]
 
-    def __init__(self, *, is_attached: bool):
+    def __init__(
+        self,
+        *,
+        is_attached: bool,
+        contract_status: Optional[str],
+        contract_remaining_days: int,
+        is_attached_and_contract_valid: bool
+    ):
         self.is_attached = is_attached
+        self.contract_status = contract_status
+        self.contract_remaining_days = contract_remaining_days
+        self.is_attached_and_contract_valid = is_attached_and_contract_valid
+
+
+@enum.unique
+class ContractExpiryStatus(enum.Enum):
+    NONE = None
+    ACTIVE = "active"
+    ACTIVE_EXPIRED_SOON = "active-soon-to-expire"
+    EXPIRED_GRACE_PERIOD = "grace-period"
+    EXPIRED = "expired"
+
+
+def _get_contract_expiry_status(
+    cfg: UAConfig,
+    is_machine_attached: bool,
+) -> Tuple[ContractExpiryStatus, int]:
+    """Return a tuple [ContractExpiryStatus, num_days]"""
+    if not is_machine_attached:
+        return ContractExpiryStatus.NONE, 0
+
+    grace_period = CONTRACT_EXPIRY_GRACE_PERIOD_DAYS
+    pending_expiry = CONTRACT_EXPIRY_PENDING_DAYS
+    remaining_days = cfg.machine_token_file.contract_remaining_days
+
+    # if unknown assume the worst
+    if remaining_days is None:
+        return ContractExpiryStatus.EXPIRED, -grace_period
+
+    if 0 <= remaining_days <= pending_expiry:
+        return ContractExpiryStatus.ACTIVE_EXPIRED_SOON, remaining_days
+    elif -grace_period <= remaining_days < 0:
+        return ContractExpiryStatus.EXPIRED_GRACE_PERIOD, remaining_days
+    elif remaining_days < -grace_period:
+        return ContractExpiryStatus.EXPIRED, remaining_days
+    return ContractExpiryStatus.ACTIVE, remaining_days
 
 
 def is_attached() -> IsAttachedResult:
@@ -18,7 +78,23 @@ def is_attached() -> IsAttachedResult:
 
 
 def _is_attached(cfg: UAConfig) -> IsAttachedResult:
-    return IsAttachedResult(is_attached=bool(cfg.machine_token))
+    is_machine_attached = bool(cfg.machine_token)
+    contract_status, remaining_days = _get_contract_expiry_status(
+        cfg, is_machine_attached
+    )
+    is_attached_and_contract_valid = True
+    if (
+        not is_machine_attached
+        or contract_status == ContractExpiryStatus.EXPIRED
+    ):
+        is_attached_and_contract_valid = False
+
+    return IsAttachedResult(
+        is_attached=is_machine_attached,
+        contract_status=contract_status.value,
+        contract_remaining_days=remaining_days,
+        is_attached_and_contract_valid=is_attached_and_contract_valid,
+    )
 
 
 endpoint = APIEndpoint(

--- a/uaclient/cli/fix.py
+++ b/uaclient/cli/fix.py
@@ -53,7 +53,10 @@ from uaclient.api.u.pro.security.fix.cve.plan.v1 import CVEFixPlanOptions
 from uaclient.api.u.pro.security.fix.cve.plan.v1 import _plan as cve_plan
 from uaclient.api.u.pro.security.fix.usn.plan.v1 import USNFixPlanOptions
 from uaclient.api.u.pro.security.fix.usn.plan.v1 import _plan as usn_plan
-from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
+from uaclient.api.u.pro.status.is_attached.v1 import (
+    ContractExpiryStatus,
+    _is_attached,
+)
 from uaclient.cli.constants import NAME, USAGE_TMPL
 from uaclient.clouds.identity import (
     CLOUD_TYPE_TO_TITLE,
@@ -61,7 +64,6 @@ from uaclient.clouds.identity import (
     get_cloud_type,
 )
 from uaclient.config import UAConfig
-from uaclient.contract import ContractExpiryStatus, get_contract_expiry_status
 from uaclient.defaults import PRINT_WRAP_WIDTH
 from uaclient.entitlements import entitlement_factory
 from uaclient.entitlements.entitlement_status import (
@@ -450,8 +452,11 @@ def _check_subscription_is_expired(cfg: UAConfig, dry_run: bool) -> bool:
 
     :returns: True if subscription is expired and not renewed.
     """
-    contract_expiry_status = get_contract_expiry_status(cfg)
-    if contract_expiry_status[0] == ContractExpiryStatus.EXPIRED:
+    contract_expiry_status = _is_attached(cfg).contract_status
+    if (
+        contract_expiry_status
+        and contract_expiry_status == ContractExpiryStatus.EXPIRED.value
+    ):
         if dry_run:
             print(messages.SECURITY_DRY_RUN_UA_EXPIRED_SUBSCRIPTION)
             return False

--- a/uaclient/cli/tests/test_cli_detach.py
+++ b/uaclient/cli/tests/test_cli_detach.py
@@ -236,22 +236,23 @@ class TestActionDetach:
         }
         assert expected == json.loads(fake_stdout.getvalue())
 
+    @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
-    @mock.patch("uaclient.contract.UAContractClient")
     @mock.patch("uaclient.cli.update_motd_messages")
     def test_config_cache_deleted(
         self,
         m_update_apt_and_motd_msgs,
-        m_client,
         m_disable_order,
+        m_is_attached,
         _m_prompt,
-        FakeConfig,
         tmpdir,
     ):
+        m_is_attached.return_value = mock.MagicMock(
+            is_attached=True,
+            contract_status="active",
+            contract_remaining_days=100,
+        )
         m_disable_order.return_value = []
-
-        fake_client = FakeContractClient(FakeConfig.for_attached_machine())
-        m_client.return_value = fake_client
 
         m_cfg = mock.MagicMock()
         m_cfg.check_lock_info.return_value = (-1, "")
@@ -261,23 +262,24 @@ class TestActionDetach:
         assert [mock.call()] == m_cfg.delete_cache.call_args_list
         assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
+    @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
-    @mock.patch("uaclient.contract.UAContractClient")
     @mock.patch("uaclient.cli.update_motd_messages")
     def test_correct_message_emitted(
         self,
         m_update_apt_and_motd_msgs,
-        m_client,
         m_disable_order,
+        m_is_attached,
         _m_prompt,
         capsys,
-        FakeConfig,
         tmpdir,
     ):
         m_disable_order.return_value = []
-
-        fake_client = FakeContractClient(FakeConfig.for_attached_machine())
-        m_client.return_value = fake_client
+        m_is_attached.return_value = mock.MagicMock(
+            is_attached=True,
+            contract_status="active",
+            contract_remaining_days=100,
+        )
 
         m_cfg = mock.MagicMock()
         m_cfg.check_lock_info.return_value = (-1, "")
@@ -289,22 +291,23 @@ class TestActionDetach:
         assert messages.DETACH_SUCCESS + "\n" == out
         assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
+    @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
-    @mock.patch("uaclient.contract.UAContractClient")
     @mock.patch("uaclient.cli.update_motd_messages")
     def test_returns_zero(
         self,
         m_update_apt_and_motd_msgs,
-        m_client,
         m_disable_order,
+        m_is_attached,
         _m_prompt,
-        FakeConfig,
         tmpdir,
     ):
         m_disable_order.return_value = []
-
-        fake_client = FakeContractClient(FakeConfig.for_attached_machine())
-        m_client.return_value = fake_client
+        m_is_attached.return_value = mock.MagicMock(
+            is_attached=True,
+            contract_status="active",
+            contract_remaining_days=100,
+        )
 
         m_cfg = mock.MagicMock()
         m_cfg.check_lock_info.return_value = (-1, "")
@@ -347,7 +350,7 @@ class TestActionDetach:
             ),
         ],
     )
-    @mock.patch("uaclient.contract.UAContractClient")
+    @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.update_motd_messages")
     @mock.patch("uaclient.entitlements.entitlement_factory")
     @mock.patch("uaclient.cli.entitlements_disable_order")
@@ -356,22 +359,24 @@ class TestActionDetach:
         m_disable_order,
         m_ent_factory,
         m_update_apt_and_motd_msgs,
-        m_client,
+        m_is_attached,
         _m_prompt,
         capsys,
         classes,
         disable_order,
         expected_message,
         disabled_services,
-        FakeConfig,
         tmpdir,
+        FakeConfig,
         event,
     ):
         m_ent_factory.side_effect = classes
         m_disable_order.return_value = disable_order
-
-        fake_client = FakeContractClient(FakeConfig.for_attached_machine())
-        m_client.return_value = fake_client
+        m_is_attached.return_value = mock.MagicMock(
+            is_attached=True,
+            contract_status="active",
+            contract_remaining_days=100,
+        )
 
         m_cfg = mock.MagicMock()
         m_cfg.check_lock_info.return_value = (-1, "")

--- a/uaclient/cli/tests/test_cli_disable.py
+++ b/uaclient/cli/tests/test_cli_disable.py
@@ -621,12 +621,19 @@ class TestDisable:
         }
         assert expected == json.loads(fake_stdout.getvalue())
 
-    def test_purge_assume_yes_incompatible(self, capsys):
+    @mock.patch("uaclient.cli.cli_util._is_attached")
+    def test_purge_assume_yes_incompatible(self, m_is_attached, capsys):
         cfg = mock.MagicMock()
         args_mock = mock.MagicMock()
         args_mock.service = "test"
         args_mock.assume_yes = True
         args_mock.purge = True
+
+        m_is_attached.return_value = mock.MagicMock(
+            is_attached=True,
+            contract_status="active",
+            contract_remaining_days=100,
+        )
 
         with pytest.raises(SystemExit):
             with mock.patch.object(

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -717,7 +717,12 @@ class TestUAContractClient:
                 True,
                 "lxc",
                 "8001",
-                IsAttachedResult(is_attached=False),
+                IsAttachedResult(
+                    is_attached=False,
+                    contract_status="none",
+                    contract_remaining_days=0,
+                    is_attached_and_contract_valid=False,
+                ),
                 None,
                 None,
                 None,
@@ -755,7 +760,12 @@ class TestUAContractClient:
                 True,
                 "lxc",
                 "8001",
-                IsAttachedResult(is_attached=True),
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="active",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=True,
+                ),
                 mock.MagicMock(
                     enabled_services=[
                         helpers.mock_with_name_attr(
@@ -810,7 +820,12 @@ class TestUAContractClient:
                 True,
                 "lxc",
                 "8001",
-                IsAttachedResult(is_attached=True),
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="active",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=True,
+                ),
                 mock.MagicMock(
                     enabled_services=[
                         helpers.mock_with_name_attr(

--- a/uaclient/timer/update_messaging.py
+++ b/uaclient/timer/update_messaging.py
@@ -14,7 +14,10 @@ from uaclient import contract, defaults, messages, system, util
 from uaclient.api.u.pro.packages.updates.v1 import (
     _updates as api_u_pro_packages_updates_v1,
 )
-from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
+from uaclient.api.u.pro.status.is_attached.v1 import (
+    ContractExpiryStatus,
+    _is_attached,
+)
 from uaclient.config import UAConfig
 from uaclient.entitlements import ESMAppsEntitlement, ESMInfraEntitlement
 from uaclient.entitlements.entitlement_status import ApplicationStatus
@@ -58,7 +61,8 @@ def update_motd_messages(cfg: UAConfig) -> bool:
 
     :param cfg: UAConfig instance for this environment.
     """
-    if not _is_attached(cfg).is_attached:
+    is_attached_info = _is_attached(cfg)
+    if not is_attached_info.is_attached:
         return False
 
     LOG.debug("Updating Ubuntu Pro messages for MOTD.")
@@ -66,23 +70,25 @@ def update_motd_messages(cfg: UAConfig) -> bool:
         cfg.data_dir, "messages", MOTD_CONTRACT_STATUS_FILE_NAME
     )
 
-    expiry_status, remaining_days = contract.get_contract_expiry_status(cfg)
-    if expiry_status in (
-        contract.ContractExpiryStatus.ACTIVE_EXPIRED_SOON,
-        contract.ContractExpiryStatus.EXPIRED_GRACE_PERIOD,
-        contract.ContractExpiryStatus.EXPIRED,
-    ):
-        update_contract_expiry(cfg)
-        expiry_status, remaining_days = contract.get_contract_expiry_status(
-            cfg
-        )
+    expiry_status = is_attached_info.contract_status
+    remaining_days = is_attached_info.contract_remaining_days
 
     if expiry_status in (
-        contract.ContractExpiryStatus.ACTIVE,
-        contract.ContractExpiryStatus.NONE,
+        ContractExpiryStatus.ACTIVE_EXPIRED_SOON.value,
+        ContractExpiryStatus.EXPIRED_GRACE_PERIOD.value,
+        ContractExpiryStatus.EXPIRED.value,
+    ):
+        update_contract_expiry(cfg)
+        is_attached_info = _is_attached(cfg)
+        expiry_status = is_attached_info.contract_status
+        remaining_days = is_attached_info.contract_remaining_days
+
+    if expiry_status in (
+        ContractExpiryStatus.ACTIVE.value,
+        ContractExpiryStatus.NONE.value,
     ):
         system.ensure_file_absent(motd_contract_status_msg_path)
-    elif expiry_status == contract.ContractExpiryStatus.ACTIVE_EXPIRED_SOON:
+    elif expiry_status == ContractExpiryStatus.ACTIVE_EXPIRED_SOON.value:
         system.write_file(
             motd_contract_status_msg_path,
             messages.CONTRACT_EXPIRES_SOON.pluralize(remaining_days).format(
@@ -90,7 +96,7 @@ def update_motd_messages(cfg: UAConfig) -> bool:
             )
             + "\n\n",
         )
-    elif expiry_status == contract.ContractExpiryStatus.EXPIRED_GRACE_PERIOD:
+    elif expiry_status == ContractExpiryStatus.EXPIRED_GRACE_PERIOD.value:
         grace_period_remaining = (
             defaults.CONTRACT_EXPIRY_GRACE_PERIOD_DAYS + remaining_days
         )
@@ -109,7 +115,7 @@ def update_motd_messages(cfg: UAConfig) -> bool:
             )
             + "\n\n",
         )
-    elif expiry_status == contract.ContractExpiryStatus.EXPIRED:
+    elif expiry_status == ContractExpiryStatus.EXPIRED.value:
         service = "n/a"
         pkg_num = 0
 


### PR DESCRIPTION
## Why is this needed?
Adding contract related information to the is_attached endpoint. This will allow user to not only verify if the machine is attached, but also verify if they have a contract that is valid on that machine

## Test Steps
Run the new integration tests

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
