### PR TITLE
repo: fix how repo_policy_check_tmpl is defined

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -34,7 +34,6 @@ class RepoEntitlement(base.UAEntitlement):
     repo_file_tmpl = "/etc/apt/sources.list.d/ubuntu-{name}.{extension}"
     repo_pref_file_tmpl = "/etc/apt/preferences.d/ubuntu-{name}"
     repo_url_tmpl = "{}/ubuntu"
-    repo_policy_check_tmpl = repo_url_tmpl + " {}"
 
     # The repo Origin value defined in apt metadata
     origin = None  # type: Optional[str]
@@ -61,6 +60,10 @@ class RepoEntitlement(base.UAEntitlement):
         if series in apt.SERIES_NOT_USING_DEB822:
             extension = "list"
         return self.repo_file_tmpl.format(name=self.name, extension=extension)
+
+    @property
+    def repo_policy_check_tmpl(self) -> str:
+        return self.repo_url_tmpl + " {}"
 
     @property
     def packages(self) -> List[str]:


### PR DESCRIPTION
## Why is this needed?
On Anbox, we need to update that variable, since the service uses a different pattern. We are now turning this variable into a property to guarantee that this variable is overridden for the Anbox service

## Test Steps
Run the Anbox container test

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
