### PR TITLE
deps: pick the proper python-apt based on the Python version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,4 +10,12 @@ pytest-cov
 # python3-apt
 # We know it is in the distro, but for testing in venvs we need to install it
 # And well, there is no pypi package
-git+https://salsa.debian.org/apt-team/python-apt@main
+# We are using git-ubuntu to get the proper version by python version.
+# We try to support the latest LTS, the latest released version,
+# and the devel version.
+# fixme: This may cause weird behavior in the future, or even break, if
+# two releases have the same python_version.
+git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/jammy-updates ; python_version == '3.10'
+git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/mantic ; python_version == '3.11'
+# need to keep an aye to bump this when python-apt is in noble-updates
+git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/noble ; python_version == '3.12'


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it enables us to run our unit test suite again.
`python-apt` had an update which breaks installing from source on older releases (and even Jammy is too old for that) so now we are looking at the python version, and cloning it from a git-ubuntu branch which "matches" what you have.

This implies that developers + GH CI are always running one of the supported development environments (latest LTS, latest released, or devel) and that they did NOT change their Python version on that system.

The damage is very low if you decide to change whatever though, so this is very acceptable.

## Test Steps
- `make clean`, then run unit tests on a Jammy machine (py 3.10). All should work. Then check the venv, and see python3-apt is installed from `f043e6` (jammy-updates).
- `make clean`, then run unit tests on a Mantic/Noble machine (py 3.11). All should work. Then check the venv, and see python3-apt is installed from `f058cb` (mantic).
- When Noble migrates to 3.12 this will pick it from (noble) and all should work fine too.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: 

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
