### PR TITLE
Remove config cache

### DIFF
--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -28,6 +28,7 @@ from uaclient.defaults import (
 from uaclient.files.state_files import (
     AttachmentData,
     attachment_data_file,
+    machine_id_file,
     timer_jobs_state_file,
 )
 
@@ -81,7 +82,7 @@ def attach_with_token(
     machine_id = new_machine_token.get("machineTokenInfo", {}).get(
         "machineId", system.get_machine_id(cfg)
     )
-    cfg.write_cache("machine-id", machine_id)
+    machine_id_file.write(machine_id)
 
     try:
         contract.process_entitlements_delta(

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -937,9 +937,8 @@ def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
     for ent in to_disable:
         _perform_disable(ent, cfg, assume_yes=assume_yes, update_status=False)
 
-    cfg.delete_cache()
-    state_files.status_cache_file.delete()
     cfg.machine_token_file.delete()
+    state_files.delete_state_files()
     update_motd_messages(cfg)
     event.info(messages.DETACH_SUCCESS)
     return 0

--- a/uaclient/cli/tests/test_cli.py
+++ b/uaclient/cli/tests/test_cli.py
@@ -359,7 +359,6 @@ class TestMain:
             ),
         ),
     )
-    @mock.patch(M_PATH_UACONFIG + "delete_cache_key")
     @mock.patch("uaclient.cli.event.info")
     @mock.patch("uaclient.cli.LOG.exception")
     @mock.patch("uaclient.cli.setup_logging")
@@ -370,7 +369,6 @@ class TestMain:
         _m_setup_logging,
         m_log_exception,
         m_event_info,
-        m_delete_cache_key,
         event,
         exception,
         expected_error_msg,
@@ -387,7 +385,6 @@ class TestMain:
                     return_value=FakeConfig(),
                 ):
                     main()
-        assert 0 == m_delete_cache_key.call_count
 
         exc = excinfo.value
         assert 1 == exc.code
@@ -405,7 +402,6 @@ class TestMain:
             ),
         ),
     )
-    @mock.patch(M_PATH_UACONFIG + "delete_cache_key")
     @mock.patch("uaclient.cli.LOG.error")
     @mock.patch("uaclient.cli.setup_logging")
     @mock.patch("uaclient.cli.get_parser")
@@ -414,7 +410,6 @@ class TestMain:
         m_get_parser,
         _m_setup_logging,
         m_log_error,
-        m_delete_cache_key,
         exception,
         expected_log,
         FakeConfig,
@@ -429,7 +424,6 @@ class TestMain:
                     return_value=FakeConfig(),
                 ):
                     main()
-        assert 0 == m_delete_cache_key.call_count
 
         exc = excinfo.value
         assert 1 == exc.code

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -257,6 +257,7 @@ class TestActionAttach:
     @mock.patch(
         M_PATH + "contract.UAContractClient.update_activity_token",
     )
+    @mock.patch("uaclient.files.state_files.machine_id_file.write")
     @mock.patch("uaclient.files.state_files.attachment_data_file.write")
     @mock.patch("uaclient.system.should_reboot", return_value=False)
     @mock.patch("uaclient.files.notices.NoticesManager.remove")
@@ -271,6 +272,7 @@ class TestActionAttach:
         _m_remove_notice,
         _m_should_reboot,
         _m_attachment_data_file_write,
+        _m_machine_id_file_write,
         m_update_activity_token,
         _m_check_ent_apt_directives,
         _m_check_lock_info,
@@ -553,6 +555,10 @@ class TestActionAttach:
         "uaclient.entitlements.check_entitlement_apt_directives_are_unique",
         return_value=True,
     )
+    @mock.patch(
+        "uaclient.files.state_files.machine_id_file.read", return_value=None
+    )
+    @mock.patch("uaclient.files.state_files.machine_id_file.write")
     @mock.patch("uaclient.files.state_files.attachment_data_file.write")
     @mock.patch("uaclient.entitlements.entitlements_enable_order")
     @mock.patch("uaclient.contract.process_entitlement_delta")
@@ -573,6 +579,8 @@ class TestActionAttach:
         m_process_entitlement_delta,
         m_enable_order,
         _m_attachment_data_file_write,
+        _m_machine_id_file_write,
+        _m_machine_id_file_read,
         _m_check_ent_apt_directives,
         _m_check_lock_info,
         _m_status_cache_file,

--- a/uaclient/cli/tests/test_cli_detach.py
+++ b/uaclient/cli/tests/test_cli_detach.py
@@ -163,7 +163,7 @@ class TestActionDetach:
         "prompt_response,assume_yes,expect_disable",
         [(True, False, True), (False, False, False), (True, True, True)],
     )
-    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
+    @mock.patch("uaclient.files.state_files.delete_state_files")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.contract.UAContractClient")
     @mock.patch("uaclient.cli.update_motd_messages")
@@ -176,7 +176,7 @@ class TestActionDetach:
         m_update_apt_and_motd_msgs,
         m_client,
         _m_check_lock_info,
-        _m_status_cache_delete,
+        _m_delete_state_files,
         m_prompt,
         prompt_response,
         assume_yes,
@@ -246,36 +246,7 @@ class TestActionDetach:
         }
         assert expected == json.loads(fake_stdout.getvalue())
 
-    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
-    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
-    @mock.patch("uaclient.cli.cli_util._is_attached")
-    @mock.patch("uaclient.cli.entitlements_disable_order")
-    @mock.patch("uaclient.cli.update_motd_messages")
-    def test_config_cache_deleted(
-        self,
-        m_update_apt_and_motd_msgs,
-        m_disable_order,
-        m_is_attached,
-        _m_check_lock_info,
-        _m_status_cache_delete,
-        _m_prompt,
-        tmpdir,
-    ):
-        m_is_attached.return_value = mock.MagicMock(
-            is_attached=True,
-            contract_status="active",
-            contract_remaining_days=100,
-        )
-        m_disable_order.return_value = []
-
-        m_cfg = mock.MagicMock()
-        with mock.patch.object(lock, "lock_data_file"):
-            action_detach(mock.MagicMock(), m_cfg)
-
-        assert [mock.call()] == m_cfg.delete_cache.call_args_list
-        assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
-
-    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
+    @mock.patch("uaclient.files.state_files.delete_state_files")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
@@ -286,7 +257,7 @@ class TestActionDetach:
         m_disable_order,
         m_is_attached,
         _m_check_lock_info,
-        _m_status_cache_delete,
+        m_delete_state_files,
         _m_prompt,
         capsys,
         tmpdir,
@@ -305,8 +276,9 @@ class TestActionDetach:
         out, _err = capsys.readouterr()
         assert messages.DETACH_SUCCESS + "\n" == out
         assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
+        assert [mock.call()] == m_delete_state_files.call_args_list
 
-    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
+    @mock.patch("uaclient.files.state_files.delete_state_files")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.entitlements_disable_order")
@@ -317,7 +289,7 @@ class TestActionDetach:
         m_disable_order,
         m_is_attached,
         _m_check_lock_info,
-        _m_status_cache_delete,
+        m_delete_state_files,
         _m_prompt,
         tmpdir,
     ):
@@ -333,7 +305,7 @@ class TestActionDetach:
             ret = action_detach(mock.MagicMock(), m_cfg)
 
         assert 0 == ret
-        assert [mock.call()] == m_cfg.delete_cache.call_args_list
+        assert [mock.call()] == m_delete_state_files.call_args_list
         assert [mock.call(m_cfg)] == m_update_apt_and_motd_msgs.call_args_list
 
     @pytest.mark.parametrize(
@@ -369,7 +341,7 @@ class TestActionDetach:
             ),
         ],
     )
-    @mock.patch("uaclient.files.state_files.status_cache_file.delete")
+    @mock.patch("uaclient.files.state_files.delete_state_files")
     @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
     @mock.patch("uaclient.cli.cli_util._is_attached")
     @mock.patch("uaclient.cli.update_motd_messages")
@@ -382,7 +354,7 @@ class TestActionDetach:
         m_update_apt_and_motd_msgs,
         m_is_attached,
         _m_check_lock_info,
-        _m_status_cache_delete,
+        _m_delete_state_files,
         _m_prompt,
         capsys,
         classes,

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -17,7 +17,7 @@ from uaclient.api.u.pro.status.enabled_services.v1 import _enabled_services
 from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UAConfig
 from uaclient.defaults import ATTACH_FAIL_DATE_FORMAT
-from uaclient.files.state_files import attachment_data_file
+from uaclient.files.state_files import attachment_data_file, machine_id_file
 from uaclient.http import serviceclient
 from uaclient.log import get_user_or_root_log_file_path
 
@@ -658,7 +658,7 @@ def refresh(cfg):
     machine_id = resp.get("machineTokenInfo", {}).get(
         "machineId", system.get_machine_id(cfg)
     )
-    cfg.write_cache("machine-id", machine_id)
+    machine_id_file.write(machine_id)
 
     process_entitlements_delta(
         cfg,

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -165,7 +165,6 @@ class UAContractClient(serviceclient.UAServiceClient):
         machine_token: str,
         resource: str,
         machine_id: Optional[str] = None,
-        save_file: bool = True,
     ) -> Dict[str, Any]:
         """Requests machine access context for a given resource
 
@@ -174,7 +173,6 @@ class UAContractClient(serviceclient.UAServiceClient):
         @param resource: Entitlement name.
         @param machine_id: Optional unique system machine id. When absent,
             contents of /etc/machine-id will be used.
-        @save_file: If the machine access should be saved on the user machine
 
         @return: Dict of the JSON response containing entitlement accessInfo.
         """
@@ -194,10 +192,6 @@ class UAContractClient(serviceclient.UAServiceClient):
             )
         if response.headers.get("expires"):
             response.json_dict["expires"] = response.headers["expires"]
-        if save_file:
-            self.cfg.write_cache(
-                "machine-access-{}".format(resource), response.json_dict
-            )
         return response.json_dict
 
     def update_activity_token(self):

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -157,7 +157,6 @@ class UAContractClient(serviceclient.UAServiceClient):
                 body=response.body,
             )
 
-        self.cfg.write_cache("contract-token", response.json_dict)
         return response.json_dict
 
     def get_resource_machine_access(

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -1298,10 +1298,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                             service=self.name
                         )
                     )
-            # Clean up former entitled machine-access-<name> response cache
-            # file because uaclient doesn't access machine-access-* routes or
-            # responses on unentitled services.
-            self.cfg.delete_cache_key("machine-access-{}".format(self.name))
             return True
 
         resourceToken = orig_access.get("resourceToken")

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -634,14 +634,6 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
 
     def _perform_enable(self, silent: bool = False) -> bool:
         if super()._perform_enable(silent=silent):
-            services_once_enabled = (
-                self.cfg.read_cache("services-once-enabled") or {}
-            )
-            services_once_enabled.update({self.name: True})
-            self.cfg.write_cache(
-                key="services-once-enabled", content=services_once_enabled
-            )
-
             services_once_enabled_file.write(
                 ServicesOnceEnabledData(fips_updates=True)
             )

--- a/uaclient/files/files.py
+++ b/uaclient/files/files.py
@@ -80,7 +80,12 @@ class ProJSONFile:
         content = self.pro_file.read()
 
         if content:
-            return json.loads(content, cls=util.DatetimeAwareJSONDecoder)
+            try:
+                return json.loads(content, cls=util.DatetimeAwareJSONDecoder)
+            except json.JSONDecodeError as e:
+                raise exceptions.InvalidJson(
+                    source=self.pro_file.path, out="\n" + str(e)
+                )
 
         return None
 

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -231,3 +231,9 @@ status_cache_file = ProJSONFile(
         private=False,
     )
 )
+
+machine_id_file = UAFile(
+    "machine-id",
+    defaults.DEFAULT_PRIVATE_DATA_DIR,
+    private=True,
+)

--- a/uaclient/files/state_files.py
+++ b/uaclient/files/state_files.py
@@ -237,3 +237,12 @@ machine_id_file = UAFile(
     defaults.DEFAULT_PRIVATE_DATA_DIR,
     private=True,
 )
+
+
+def delete_state_files():
+    machine_id_file.delete()
+    status_cache_file.delete()
+    attachment_data_file.delete()
+    anbox_cloud_credentials_file.delete()
+    reboot_cmd_marker_file.delete()
+    status_cache_file.delete()

--- a/uaclient/lock.py
+++ b/uaclient/lock.py
@@ -44,9 +44,7 @@ def check_lock_info() -> Tuple[int, str]:
     try:
         lock_data_obj = lock_data_file.read()
     except exceptions.InvalidFileFormatError:
-        raise exceptions.InvalidLockFile(
-            lock_file_path=os.path.join(lock_data_file.path)
-        )
+        raise exceptions.InvalidLockFile(lock_file_path=lock_data_file.path)
 
     no_lock = (-1, "")
     if not lock_data_obj:

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -274,6 +274,7 @@ def get_machine_id(cfg) -> str:
     We first check for the machine-id in machine-token.json before
     looking at the system file.
     """
+    from uaclient.files.state_files import machine_id_file
 
     if cfg.machine_token:
         cfg_machine_id = cfg.machine_token.get("machineTokenInfo", {}).get(
@@ -282,15 +283,19 @@ def get_machine_id(cfg) -> str:
         if cfg_machine_id:
             return cfg_machine_id
 
-    fallback_machine_id_file = cfg.data_path("machine-id")
+    fallback_machine_id = machine_id_file.read()
 
-    for path in [ETC_MACHINE_ID, DBUS_MACHINE_ID, fallback_machine_id_file]:
+    for path in [ETC_MACHINE_ID, DBUS_MACHINE_ID]:
         if os.path.exists(path):
             content = load_file(path).rstrip("\n")
             if content:
                 return content
+
+    if fallback_machine_id:
+        return fallback_machine_id
+
     machine_id = str(uuid.uuid4())
-    cfg.write_cache("machine-id", machine_id)
+    machine_id_file.write(machine_id)
     return machine_id
 
 

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -34,7 +34,7 @@ class TestAttachWithToken:
             "expected_add_contract_machine_call_args",
             "expected_machine_token_file_write_call_args",
             "expected_get_machine_id_call_args",
-            "expected_config_write_cache_call_args",
+            "expected_machine_id_file_call_count",
             "expected_process_entitlements_delta_call_args",
             "expected_attachment_data_file_write_call_args",
             "expected_status_call_args",
@@ -55,7 +55,7 @@ class TestAttachWithToken:
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [],
                 [],
-                [],
+                0,
                 [],
                 [],
                 [],
@@ -75,7 +75,7 @@ class TestAttachWithToken:
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
-                [mock.call("machine-id", "machine-id")],
+                1,
                 [mock.call(mock.ANY, {}, mock.sentinel.entitlements, True)],
                 [mock.call(mock.ANY)],
                 [mock.call(cfg=mock.ANY)],
@@ -95,7 +95,7 @@ class TestAttachWithToken:
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
-                [mock.call("machine-id", "machine-id")],
+                1,
                 [mock.call(mock.ANY, {}, mock.sentinel.entitlements, True)],
                 [mock.call(mock.ANY)],
                 [mock.call(cfg=mock.ANY)],
@@ -115,7 +115,7 @@ class TestAttachWithToken:
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
-                [mock.call("machine-id", "machine-id")],
+                1,
                 [mock.call(mock.ANY, {}, mock.sentinel.entitlements, True)],
                 [mock.call(mock.ANY)],
                 [],
@@ -135,9 +135,7 @@ class TestAttachWithToken:
                 [mock.call(contract_token="token", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
-                [
-                    mock.call("machine-id", "machine-id"),
-                ],
+                1,
                 [mock.call(mock.ANY, {}, mock.sentinel.entitlements, True)],
                 [mock.call(mock.ANY)],
                 [],
@@ -157,9 +155,7 @@ class TestAttachWithToken:
                 [mock.call(contract_token="token2", attachment_dt=mock.ANY)],
                 [mock.call({"machineTokenInfo": {"machineId": "machine-id"}})],
                 [mock.call(mock.ANY)],
-                [
-                    mock.call("machine-id", "machine-id"),
-                ],
+                1,
                 [mock.call(mock.ANY, {}, mock.sentinel.entitlements, False)],
                 [mock.call(mock.ANY)],
                 [],
@@ -181,6 +177,7 @@ class TestAttachWithToken:
     )
     @mock.patch("uaclient.timer.update_messaging.update_motd_messages")
     @mock.patch(M_PATH + "ua_status.status")
+    @mock.patch("uaclient.files.state_files.machine_id_file.write")
     @mock.patch("uaclient.files.state_files.attachment_data_file.write")
     @mock.patch(M_PATH + "contract.process_entitlements_delta")
     @mock.patch(
@@ -200,6 +197,7 @@ class TestAttachWithToken:
         m_entitlements,
         m_process_entitlements_delta,
         m_attachment_data_file_write,
+        m_machine_id_file_write,
         m_status,
         m_update_motd_messages,
         m_update_activity_token,
@@ -214,7 +212,7 @@ class TestAttachWithToken:
         expected_add_contract_machine_call_args,
         expected_machine_token_file_write_call_args,
         expected_get_machine_id_call_args,
-        expected_config_write_cache_call_args,
+        expected_machine_id_file_call_count,
         expected_process_entitlements_delta_call_args,
         expected_attachment_data_file_write_call_args,
         expected_status_call_args,
@@ -249,8 +247,8 @@ class TestAttachWithToken:
             == m_get_machine_id.call_args_list
         )
         assert (
-            expected_config_write_cache_call_args
-            == m_config_write_cache.call_args_list
+            expected_machine_id_file_call_count
+            == m_machine_token_file_write.call_count
         )
         assert (
             expected_process_entitlements_delta_call_args

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -184,7 +184,6 @@ class TestAttachWithToken:
         "uaclient.files.MachineTokenFile.entitlements",
         new_callable=mock.PropertyMock,
     )
-    @mock.patch(M_PATH + "config.UAConfig.write_cache")
     @mock.patch(M_PATH + "system.get_machine_id")
     @mock.patch("uaclient.files.MachineTokenFile.write")
     @mock.patch(M_PATH + "contract.UAContractClient.add_contract_machine")
@@ -193,7 +192,6 @@ class TestAttachWithToken:
         m_add_contract_machine,
         m_machine_token_file_write,
         m_get_machine_id,
-        m_config_write_cache,
         m_entitlements,
         m_process_entitlements_delta,
         m_attachment_data_file_write,

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -249,7 +249,6 @@ class TestUAContractClient:
         assert {"test": "response"} == client.get_resource_machine_access(
             **kwargs
         )
-        assert {"test": "response"} == cfg.read_cache("machine-access-cis")
         params = {
             "headers": {
                 "user-agent": "UA-Client/{}".format(get_version()),

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -1249,13 +1249,9 @@ class TestRefresh:
     @pytest.mark.parametrize(
         [
             "update_contract_machine_result",
-            "expected_write_cache_call_args",
         ],
         [
-            (
-                {"response": "val"},
-                [mock.call("machine-id", mock.sentinel.system_machine_id)],
-            ),
+            ({"response": "val"},),
             (
                 {
                     "response": "val",
@@ -1263,12 +1259,11 @@ class TestRefresh:
                         "machineId": mock.sentinel.response_machine_id
                     },
                 },
-                [mock.call("machine-id", mock.sentinel.response_machine_id)],
             ),
         ],
     )
     @mock.patch(M_PATH + "process_entitlements_delta")
-    @mock.patch(M_PATH + "UAConfig.write_cache")
+    @mock.patch("uaclient.files.state_files.machine_id_file.write")
     @mock.patch(M_PATH + "system.get_machine_id")
     @mock.patch("uaclient.files.MachineTokenFile.write")
     @mock.patch(M_PATH + "UAContractClient.update_contract_machine")
@@ -1286,10 +1281,9 @@ class TestRefresh:
         m_update_contract_machine,
         m_machine_token_file_write,
         m_get_machine_id,
-        m_write_cache,
+        m_machine_id_file_write,
         m_process_entitlements_deltas,
         update_contract_machine_result,
-        expected_write_cache_call_args,
         FakeConfig,
     ):
         m_entitlements.side_effect = [
@@ -1311,7 +1305,7 @@ class TestRefresh:
         assert [
             mock.call(update_contract_machine_result)
         ] == m_machine_token_file_write.call_args_list
-        assert expected_write_cache_call_args == m_write_cache.call_args_list
+        assert 1 == m_machine_id_file_write.call_count
         assert [
             mock.call(
                 mock.ANY,


### PR DESCRIPTION
## Why is this needed?
The is no need for the config module to hold a cache anymore, as this cache is not tied to any particular user config.
We are creating dedicated files for each state that the config module handles and placing them on more appropriate modules.

PS: This PR is based on #2949. We need to merge it first

## Test Steps
Guarantee that the cache files are still being created. This can be verified by running the `attach` command and verifying that all necessary files are still created

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
