### PR TITLE
Add coverage for behave tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[paths]
+source = 
+	uaclient/
+	/usr/lib/python3/dist-packages/uaclient/

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 from behave import given, when
 from pycloudlib.instance import BaseInstance  # type: ignore
 
-from features.steps.packages import when_i_apt_update
+from features.steps.packages import when_i_apt_install, when_i_apt_update
 from features.steps.shell import when_i_run_command
 from features.steps.ubuntu_advantage_tools import when_i_install_uat
 from features.util import (
@@ -109,6 +109,23 @@ def given_a_machine(
 
     # make sure the machine has up-to-date apt data
     when_i_apt_update(context, machine_name=machine_name)
+
+    # add coverage
+    when_i_apt_install(context, "python3-coverage", machine_name=machine_name)
+
+    # Create the .coveragerc file in the lxd container
+    if hasattr(context, "machines") and SUT in context.machines:
+        context.machines[SUT].instance.execute(
+            [
+                "bash",
+                "-c",
+                "echo -e '[run]\nrelative_files = True\n\n[paths]\nsource = \
+                    \n\tuaclient/ \
+                    \n\tusr/lib/python3/dist-packages/uaclient/' > \
+                    /usr/lib/python3/dist-packages/uaclient/.coveragerc",
+            ],
+            use_sudo=True,
+        )
 
     if cleanup:
 

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -111,20 +111,9 @@ def given_a_machine(
     when_i_apt_update(context, machine_name=machine_name)
 
     # add coverage
-    when_i_apt_install(context, "python3-coverage", machine_name=machine_name)
-
-    # Create the .coveragerc file in the lxd container
-    if hasattr(context, "machines") and SUT in context.machines:
-        context.machines[SUT].instance.execute(
-            [
-                "bash",
-                "-c",
-                "echo -e '[run]\nrelative_files = True\n\n[paths]\nsource = \
-                    \n\tuaclient/ \
-                    \n\tusr/lib/python3/dist-packages/uaclient/' > \
-                    /usr/lib/python3/dist-packages/uaclient/.coveragerc",
-            ],
-            use_sudo=True,
+    if context.pro_config.collect_coverage:
+        when_i_apt_install(
+            context, "python3-coverage", machine_name=machine_name
         )
 
     if cleanup:

--- a/features/steps/shell.py
+++ b/features/steps/shell.py
@@ -64,7 +64,18 @@ def when_i_run_command(
 ):
     command = process_template_vars(context, command)
     prefix = get_command_prefix_for_user_spec(user_spec)
-    full_cmd = prefix + shlex.split(command)
+    if "pro" in command.split():
+        command = command.replace(
+            "pro",
+            "python3 -m coverage run \
+                --rcfile=/usr/lib/python3/dist-packages/uaclient/.coveragerc \
+                --source=/usr/lib/python3/dist-packages/uaclient /usr/bin/pro",
+            1,
+        )
+
+    split_command = shlex.split(command)
+    print(split_command)
+    full_cmd = prefix + split_command
 
     if stdin is not None:
         stdin = stdin.replace("\\n", "\n")

--- a/features/steps/shell.py
+++ b/features/steps/shell.py
@@ -64,18 +64,17 @@ def when_i_run_command(
 ):
     command = process_template_vars(context, command)
     prefix = get_command_prefix_for_user_spec(user_spec)
-    if "pro" in command.split():
-        command = command.replace(
-            "pro",
-            "python3 -m coverage run \
-                --rcfile=/usr/lib/python3/dist-packages/uaclient/.coveragerc \
-                --source=/usr/lib/python3/dist-packages/uaclient /usr/bin/pro",
-            1,
-        )
 
-    split_command = shlex.split(command)
-    print(split_command)
-    full_cmd = prefix + split_command
+    if context.pro_config.collect_coverage:
+        coverage_command = (
+            "python3 -m coverage run "
+            "--source=/usr/lib/python3/dist-packages/uaclient /usr/bin/pro"
+        )
+        split_command = command.split()
+        if split_command[0] == "pro":
+            command = " ".join([coverage_command] + split_command[1:])
+
+    full_cmd = prefix + shlex.split(command)
 
     if stdin is not None:
         stdin = stdin.replace("\\n", "\n")


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
We did not have code coverage for the behave integration tests. This captures code coverage for the feature files when the tests are run.

### Obtaining coverage
Obtaining coverage is optional. To enable it,  set the following environment variable:
`export UACLIENT_BEHAVE_COLLECT_COVERAGE=True`

The `.coverage` files are saved in the `artifacts/coverage/` directory for each run.
To obtain converage, run the following in the `ubuntu-pro-client` directory:

`python3-coverage combine --rcfile=.coveragerc /artifacts/coverage/*` 
`python3-coverage report`

This PR is for issue: #2903.

Note: 
Coverage reports only being generated for `jammy` and `mantic` currently. `xenial, bionic, focal` are excluded from the integration test coverage due to difference in python and python-coverage versions. Most current method of reporting code coverage does not support older versions.
Breaking change in python-coverage version 5.0.0. [Read more about the change](https://coverage.readthedocs.io/en/latest/whatsnew5x.html)
<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
