### PR TITLE
tests: Update tests which call config status

### DIFF
--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -24,6 +24,7 @@ from uaclient.exceptions import (
     NonRootUserError,
     UbuntuProError,
 )
+from uaclient.files.user_config_file import UserConfigData
 from uaclient.testing.fakes import FakeFile, FakeUbuntuProError
 from uaclient.yaml import safe_dump
 
@@ -538,8 +539,14 @@ class TestActionAttach:
     @mock.patch("uaclient.contract.apply_contract_overrides")
     @mock.patch("uaclient.contract.UAContractClient.request_url")
     @mock.patch("uaclient.timer.update_messaging.update_motd_messages")
+    @mock.patch(
+        "uaclient.files.user_config_file.UserConfigFileObject.public_config",
+        new_callable=mock.PropertyMock,
+        return_value=UserConfigData(),
+    )
     def test_attach_when_one_service_fails_to_enable(
         self,
+        m_public_config,
         _m_update_messages,
         m_request_url,
         _m_apply_contract_overrides,

--- a/uaclient/cli/tests/test_cli_enable.py
+++ b/uaclient/cli/tests/test_cli_enable.py
@@ -13,6 +13,7 @@ from uaclient.entitlements.entitlement_status import (
     CanEnableFailure,
     CanEnableFailureReason,
 )
+from uaclient.files.user_config_file import UserConfigData
 
 HELP_OUTPUT = """\
 usage: pro enable <service> [<service>] [flags]
@@ -38,6 +39,11 @@ Flags:
 """
 
 
+@mock.patch(
+    "uaclient.files.user_config_file.UserConfigFileObject.public_config",
+    new_callable=mock.PropertyMock,
+    return_value=UserConfigData(),
+)
 @mock.patch("uaclient.contract.refresh")
 class TestActionEnable:
     @mock.patch("uaclient.cli.setup_logging")
@@ -47,6 +53,7 @@ class TestActionEnable:
         _m_resources,
         _m_setup_logging,
         _refresh,
+        _m_public_config,
         capsys,
         FakeConfig,
     ):
@@ -69,6 +76,7 @@ class TestActionEnable:
         _refresh,
         we_are_currently_root,
         m_setup_logging,
+        _m_public_config,
         capsys,
         event,
         FakeConfig,
@@ -139,6 +147,7 @@ class TestActionEnable:
         m_subp,
         m_sleep,
         _refresh,
+        _m_public_config,
         capsys,
         event,
         FakeConfig,
@@ -205,6 +214,7 @@ class TestActionEnable:
         self,
         m_we_are_currently_root,
         _refresh,
+        _m_public_config,
         root,
         expected_error_template,
         capsys,
@@ -274,6 +284,7 @@ class TestActionEnable:
         self,
         m_we_are_currently_root,
         _refresh,
+        _m_public_config,
         root,
         expected_error_template,
         is_attached,
@@ -370,6 +381,7 @@ class TestActionEnable:
         self,
         m_we_are_currently_root,
         _refresh,
+        _m_public_config,
         root,
         expected_error_template,
         event,
@@ -445,6 +457,7 @@ class TestActionEnable:
         _m_get_available_resources,
         _m_update_activity_token,
         m_refresh,
+        _m_public_config,
         assume_yes,
         FakeConfig,
     ):
@@ -489,6 +502,7 @@ class TestActionEnable:
         m_entitlement_factory,
         _m_get_available_resources,
         _m_refresh,
+        _m_public_config,
         event,
         FakeConfig,
     ):
@@ -614,6 +628,7 @@ class TestActionEnable:
         m_entitlement_factory,
         _m_get_available_resources,
         _m_refresh,
+        _m_public_config,
         beta_flag,
         event,
         FakeConfig,
@@ -766,6 +781,7 @@ class TestActionEnable:
         _m_get_available_resources,
         _m_update_activity_token,
         _m_refresh,
+        _m_public_config,
         event,
         FakeConfig,
     ):
@@ -841,6 +857,7 @@ class TestActionEnable:
     def test_invalid_service_names(
         self,
         _m_refresh,
+        _m_public_config,
         service,
         beta,
         event,
@@ -922,6 +939,7 @@ class TestActionEnable:
         _m_get_available_resources,
         m_update_activity_token,
         _m_refresh,
+        _m_public_config,
         allow_beta,
         event,
         FakeConfig,
@@ -993,7 +1011,7 @@ class TestActionEnable:
         assert expected_ret == ret
 
     def test_format_json_fails_when_assume_yes_flag_not_used(
-        self, _m_get_available_resources, event
+        self, _m_get_available_resources, _m_public_config, event
     ):
         cfg = mock.MagicMock()
         args_mock = mock.MagicMock()
@@ -1028,7 +1046,7 @@ class TestActionEnable:
         assert expected == json.loads(fake_stdout.getvalue())
 
     def test_access_only_cannot_be_used_together_with_variant(
-        self, _m_get_available_resources, FakeConfig
+        self, _m_get_available_resources, _m_public_config, FakeConfig
     ):
         cfg = FakeConfig.for_attached_machine()
         args_mock = mock.MagicMock()

--- a/uaclient/cli/tests/test_cli_status.py
+++ b/uaclient/cli/tests/test_cli_status.py
@@ -15,6 +15,7 @@ from uaclient.cli import action_status, get_parser, main, status_parser
 from uaclient.conftest import FakeNotice
 from uaclient.event_logger import EventLoggerMode
 from uaclient.files.notices import Notice, NoticesManager
+from uaclient.files.user_config_file import UserConfigData
 from uaclient.yaml import safe_load
 
 M_PATH = "uaclient.cli."
@@ -341,11 +342,17 @@ Flags:
     "uaclient.status.get_contract_information",
     return_value=RESPONSE_CONTRACT_INFO,
 )
+@mock.patch(
+    "uaclient.files.user_config_file.UserConfigFileObject.public_config",
+    new_callable=mock.PropertyMock,
+    return_value=UserConfigData(),
+)
 class TestActionStatus:
     @mock.patch(M_PATH + "setup_logging")
     def test_status_help(
         self,
         _m_setup_logging,
+        _m_public_config,
         _m_get_contract_information,
         _m_get_available_resources,
         _m_should_reboot,
@@ -393,6 +400,7 @@ class TestActionStatus:
     def test_attached(
         self,
         _m_format_expires,
+        _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,
@@ -451,6 +459,7 @@ class TestActionStatus:
     )
     def test_unattached(
         self,
+        _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,
@@ -478,6 +487,7 @@ class TestActionStatus:
     )
     def test_simulated(
         self,
+        _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,
@@ -505,6 +515,7 @@ class TestActionStatus:
         m_sleep,
         _m_subp,
         _m_get_version,
+        _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,
@@ -557,6 +568,7 @@ class TestActionStatus:
     )
     def test_unattached_formats(
         self,
+        _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,
@@ -667,6 +679,7 @@ class TestActionStatus:
     @pytest.mark.parametrize("use_all", (True, False))
     def test_attached_formats(
         self,
+        _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,
@@ -800,6 +813,7 @@ class TestActionStatus:
     @pytest.mark.parametrize("use_all", (True, False))
     def test_simulated_formats(
         self,
+        _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,
@@ -951,6 +965,7 @@ class TestActionStatus:
 
     def test_error_on_connectivity_errors(
         self,
+        _m_public_config,
         _m_get_contract_information,
         m_get_avail_resources,
         _m_should_reboot,
@@ -979,6 +994,7 @@ class TestActionStatus:
     def test_unicode_dash_replacement_when_unprintable(
         self,
         _m_format_expires,
+        _m_public_config,
         _m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,
@@ -1040,6 +1056,7 @@ class TestActionStatus:
     )
     def test_errors_are_raised_appropriately(
         self,
+        _m_public_config,
         m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,
@@ -1101,6 +1118,7 @@ class TestActionStatus:
     )
     def test_errors_for_token_dates(
         self,
+        _m_public_config,
         m_get_contract_information,
         _m_get_avail_resources,
         _m_should_reboot,

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -24,6 +24,7 @@ from uaclient.entitlements.fips import FIPSEntitlement
 from uaclient.entitlements.ros import ROSEntitlement
 from uaclient.entitlements.tests.test_base import ConcreteTestEntitlement
 from uaclient.files.notices import Notice, NoticesManager
+from uaclient.files.user_config_file import UserConfigData
 from uaclient.status import (
     DEFAULT_STATUS,
     TxtColor,
@@ -566,8 +567,13 @@ class TestStatus:
 
     @mock.patch("uaclient.util.we_are_currently_root")
     @mock.patch("uaclient.status.get_available_resources")
+    @mock.patch(
+        "uaclient.files.user_config_file.UserConfigFileObject.public_config",
+        new_callable=mock.PropertyMock,
+    )
     def test_nonroot_unattached_is_same_as_unattached_root(
         self,
+        m_public_config,
         m_get_available_resources,
         m_we_are_currently_root,
         _m_should_reboot,
@@ -575,6 +581,7 @@ class TestStatus:
         m_on_supported_kernel,
         FakeConfig,
     ):
+        m_public_config.return_value = UserConfigData()
         m_get_available_resources.return_value = [
             {"name": "esm-infra", "available": True}
         ]
@@ -590,8 +597,13 @@ class TestStatus:
 
     @mock.patch("uaclient.util.we_are_currently_root")
     @mock.patch("uaclient.status.get_available_resources")
+    @mock.patch(
+        "uaclient.files.user_config_file.UserConfigFileObject.public_config",
+        new_callable=mock.PropertyMock,
+    )
     def test_root_and_non_root_are_same_attached(
         self,
+        m_public_config,
         m_get_available_resources,
         m_we_are_currently_root,
         _m_should_reboot,
@@ -599,6 +611,7 @@ class TestStatus:
         m_on_supported_kernel,
         FakeConfig,
     ):
+        m_public_config.return_value = UserConfigData()
         m_we_are_currently_root.return_value = True
         root_cfg = FakeConfig.for_attached_machine()
         root_status = status.status(cfg=root_cfg)
@@ -608,14 +621,20 @@ class TestStatus:
         assert normal_status == root_status
 
     @mock.patch("uaclient.status.get_available_resources", return_value=[])
+    @mock.patch(
+        "uaclient.files.user_config_file.UserConfigFileObject.public_config",
+        new_callable=mock.PropertyMock,
+    )
     def test_cache_file_is_written_world_readable(
         self,
+        m_public_config,
         _m_get_available_resources,
         _m_should_reboot,
         m_remove_notice,
         m_on_supported_kernel,
         FakeConfig,
     ):
+        m_public_config.return_value = UserConfigData()
         cfg = FakeConfig()
         status.status(cfg=cfg)
 
@@ -873,8 +892,13 @@ class TestStatus:
     @pytest.mark.usefixtures("all_resources_available")
     @mock.patch("uaclient.util.we_are_currently_root")
     @mock.patch("uaclient.status.get_available_resources")
+    @mock.patch(
+        "uaclient.files.user_config_file.UserConfigFileObject.public_config",
+        new_callable=mock.PropertyMock,
+    )
     def test_expires_handled_appropriately(
         self,
+        m_public_config,
         _m_get_available_resources,
         m_we_are_currently_root,
         _m_should_reboot,
@@ -883,6 +907,7 @@ class TestStatus:
         all_resources_available,
         FakeConfig,
     ):
+        m_public_config.return_value = UserConfigData()
         m_we_are_currently_root.return_value = True
         token = {
             "availableResources": all_resources_available,
@@ -927,16 +952,22 @@ class TestStatus:
         "uaclient.files.state_files.reboot_cmd_marker_file",
         new_callable=mock.PropertyMock,
     )
+    @mock.patch(
+        "uaclient.files.user_config_file.UserConfigFileObject.public_config",
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch("uaclient.status.get_available_resources", return_value={})
     def test_nonroot_user_does_not_use_cache(
         self,
         _m_get_available_resources,
+        m_public_config,
         m_reboot_cmd_marker_file,
         _m_should_reboot,
         m_remove_notice,
         m_on_supported_kernel,
         FakeConfig,
     ):
+        m_public_config.return_value = UserConfigData()
         m_reboot_cmd_marker_file.is_present = True
         cached_status = {"pass": True}
         cfg = FakeConfig()


### PR DESCRIPTION
Fixes: #2996

## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because  a bug was introduced earlier which allowed the unit tests to read a system file, which should not be happening.
<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
