### PR TITLE
apt-news.service: ignore apparmor errors when starting

### DIFF
--- a/systemd/apt-news.service
+++ b/systemd/apt-news.service
@@ -14,7 +14,7 @@ Description=Update APT News
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/apt_news.py
-AppArmorProfile=ubuntu_pro_apt_news
+AppArmorProfile=-ubuntu_pro_apt_news
 CapabilityBoundingSet=~CAP_SYS_ADMIN
 CapabilityBoundingSet=~CAP_NET_ADMIN
 CapabilityBoundingSet=~CAP_NET_BIND_SERVICE


### PR DESCRIPTION
## Why is this needed?

It's possible to have a system where apparmor is enabled, but no profile is loaded. This happens when the user removed the apparmor debian package. In that situation, the ubuntu_pro_apt_news profile will not be loaded into the kernel at startup, and systemd will fail to apply it to the service when starting.

Systemd already ignores the apparmor setting when apparmor is disabled, but in this situation it is still enabled. The fix is to configure the service to also ignore errors when apparmor is enabled.

The drawback is that the service might run unconfined now if there are problems applying the selected apparmor profile on startup.

Fixes: #3002
LP: #2057937

## Test Steps
To reproduce the problem, launch an ubuntu lxd container, or a VM, and:

* install ubuntu-advantage-tools 31 or later. It's in updates right now, so just make sure the system is updated:
```
sudo apt update && sudo apt install ubuntu-advantage-tools -y
```
* verify it's version 31 or higher:
```
$ dpkg -l ubuntu-advantage-tools | grep ubuntu-advantage-tools
ii ubuntu-advantage-tools 31.2~22.04 all transitional dummy package for ubuntu-pro-client
```
* remove (not purge) apparmor:
```
sudo apt remove apparmor -y
```
* reboot
```
sudo reboot
```
* start apt-news.service, and verify it fails:
```
$ sudo systemctl start apt-news.service
Job for apt-news.service failed because the control process exited with error code.
See "systemctl status apt-news.service" and "journalctl -xeu apt-news.service" for details.
```
* The log will show it's because it couldn't confine the service with the ubuntu_pro_apt_news profile:
```
$ systemctl status apt-news.service
× apt-news.service - Update APT News
     Loaded: loaded (/lib/systemd/system/apt-news.service; static)
     Active: failed (Result: exit-code) since Mon 2024-03-18 20:35:41 UTC; 35s ago
    Process: 263 ExecStart=/usr/bin/python3 /usr/lib/ubuntu-advantage/apt_news.py (code=exited, status=231/APPARMOR)
   Main PID: 263 (code=exited, status=231/APPARMOR)
        CPU: 7ms

Mar 18 20:35:41 j systemd[1]: Starting Update APT News...
Mar 18 20:35:41 j systemd[263]: apt-news.service: Failed to prepare AppArmor profile change to ubuntu_pro_apt_news: No such file or directory
Mar 18 20:35:41 j systemd[263]: apt-news.service: Failed at step APPARMOR spawning /usr/bin/python3: No such file or directory
Mar 18 20:35:41 j systemd[1]: apt-news.service: Main process exited, code=exited, status=231/APPARMOR
Mar 18 20:35:41 j systemd[1]: apt-news.service: Failed with result 'exit-code'.
Mar 18 20:35:41 j systemd[1]: Failed to start Update APT News.
```
With the fixed package, the service will not fail to start.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
