### PR TITLE
tests: apt_messages.feature: run APT Messages tests in VMs as well

### DIFF
--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -641,10 +641,15 @@ Feature: APT Messages
     Examples: ubuntu release
       | release | machine_type  |
       | xenial  | lxd-container |
+      | xenial  | lxd-vm        |
       | bionic  | lxd-container |
+      | bionic  | lxd-vm        |
       | focal   | lxd-container |
+      | focal   | lxd-vm        |
       | jammy   | lxd-container |
+      | jammy   | lxd-vm        |
       | mantic  | lxd-container |
+      | mantic  | lxd-vm        |
 
   Scenario Outline: Cloud and series-specific URLs
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed


### PR DESCRIPTION
Fixes: #3004

## Why is this needed?
Without this change, the apt news service will be using the apparmor profile loaded into the host's kernel only (jammy), instead of the kernel in each ubuntu release.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
