### PR TITLE
Add detach API endpoint

### DIFF
--- a/features/api.feature
+++ b/features/api.feature
@@ -23,6 +23,7 @@ Feature: Client behaviour for the API endpoints
     When I run `python3 -c "from uaclient.api.u.security.package_manifest.v1 import package_manifest"` as non-root
     When I run `python3 -c "from uaclient.api.u.unattended_upgrades.status.v1 import status"` as non-root
     When I run `python3 -c "from uaclient.api.u.apt_news.current_news.v1 import current_news"` as non-root
+    When I run `python3 -c "from uaclient.api.u.pro.detach.v1 import detach"` as non-root
 
     Examples: ubuntu release
       | release | machine_type  |

--- a/features/api_detach.feature
+++ b/features/api_detach.feature
@@ -1,0 +1,112 @@
+Feature: Detach API endpoint
+
+  @uses.config.contract_token
+  Scenario Outline: Detach API endpoint on an attached machine
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I verify that running `pro api u.pro.detach.v1` `as non-root` exits `1`
+    Then stdout is a json matching the `api_response` schema
+    And API full output matches regexp:
+      """
+      {
+        "_schema_version": "v1",
+        "data": {
+          "meta": {
+            "environment_vars": []
+          }
+        },
+        "errors": [
+          {
+            "code": "nonroot-user",
+            "meta": {},
+            "title": "This command must be run as root (try using sudo)."
+          }
+        ],
+        "result": "failure",
+        "version": ".*",
+        "warnings": []
+      }
+      """
+    When I run `pro api u.pro.detach.v1` with sudo
+    Then stdout is a json matching the `api_response` schema
+    And API full output matches regexp:
+      """
+      {
+        "_schema_version": "v1",
+        "data": {
+          "attributes": {
+            "disabled": [],
+            "reboot_required": false
+          },
+          "meta": {
+            "environment_vars": []
+          },
+          "type": "Detach"
+        },
+        "errors": [],
+        "result": "success",
+        "version": ".*",
+        "warnings": []
+      }
+      """
+    When I attach `contract_token` with sudo
+    And I run `pro api u.pro.detach.v1` with sudo
+    Then stdout is a json matching the `api_response` schema
+    And the json API response data matches the `detach` schema
+    And API full output matches regexp:
+      """
+      {
+        "_schema_version": "v1",
+        "data": {
+          "attributes": {
+            "disabled": [
+              "esm-apps",
+              "esm-infra"
+            ],
+            "reboot_required": false
+          },
+          "meta": {
+            "environment_vars": []
+          },
+          "type": "Detach"
+        },
+        "errors": [],
+        "result": "success",
+        "version": ".*",
+        "warnings": []
+      }
+      """
+    When I attach `contract_token` with sudo
+    And I run `touch /var/run/reboot-required` with sudo
+    And I run `pro api u.pro.detach.v1` with sudo
+    Then stdout is a json matching the `api_response` schema
+    And the json API response data matches the `detach` schema
+    And API full output matches regexp:
+      """
+      {
+        "_schema_version": "v1",
+        "data": {
+          "attributes": {
+            "disabled": [
+              "esm-apps",
+              "esm-infra"
+            ],
+            "reboot_required": true
+          },
+          "meta": {
+            "environment_vars": []
+          },
+          "type": "Detach"
+        },
+        "errors": [],
+        "result": "success",
+        "version": ".*",
+        "warnings": []
+      }
+      """
+
+    Examples: ubuntu release
+      | release | machine_type  |
+      | xenial  | lxd-container |
+      | bionic  | lxd-container |
+      | focal   | lxd-container |
+      | jammy   | lxd-container |

--- a/features/schemas/detach.json
+++ b/features/schemas/detach.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "required": [ "disabled", "reboot_required"],
+    "properties": {
+        "disabled": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "reboot_required": {
+          "type": "boolean"
+        }
+    }
+}

--- a/uaclient/api/api.py
+++ b/uaclient/api/api.py
@@ -16,6 +16,7 @@ VALID_ENDPOINTS = [
     "u.pro.attach.magic.initiate.v1",
     "u.pro.attach.magic.revoke.v1",
     "u.pro.attach.magic.wait.v1",
+    "u.pro.detach.v1",
     "u.pro.packages.summary.v1",
     "u.pro.packages.updates.v1",
     "u.pro.security.fix.cve.execute.v1",

--- a/uaclient/api/tests/test_api_u_pro_detach_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_detach_v1.py
@@ -1,0 +1,145 @@
+import mock
+import pytest
+
+from uaclient import entitlements, exceptions, messages
+from uaclient.api.data_types import ErrorWarningObject
+from uaclient.api.u.pro.detach.v1 import DetachResult, _detach
+from uaclient.entitlements.entitlement_status import (
+    CanDisableFailure,
+    CanDisableFailureReason,
+)
+
+M_PATH = "uaclient.api.u.pro.detach.v1."
+
+
+@mock.patch("uaclient.lock.RetryLock.__enter__")
+class TestDetachV1:
+    @mock.patch(M_PATH + "_is_attached")
+    def test_detach_when_unattached(self, m_is_attached, _m_lock_enter):
+        m_is_attached.return_value = mock.MagicMock(is_attached=False)
+        assert DetachResult(disabled=[], reboot_required=False) == _detach(
+            mock.MagicMock()
+        )
+
+    @mock.patch("uaclient.util.we_are_currently_root")
+    def test_detach_when_non_root(
+        self, m_we_are_currently_root, _m_lock_enter
+    ):
+        m_we_are_currently_root.return_value = False
+        with pytest.raises(exceptions.NonRootUserError):
+            _detach(mock.MagicMock())
+
+    @mock.patch("uaclient.timer.stop")
+    @mock.patch("uaclient.daemon.start")
+    @mock.patch("uaclient.files.state_files.delete_state_files")
+    @mock.patch(M_PATH + "_reboot_required")
+    @mock.patch(M_PATH + "_is_attached")
+    @mock.patch(M_PATH + "update_motd_messages")
+    def test_detach(
+        self,
+        m_update_motd_messages,
+        m_is_attached,
+        m_reboot_required,
+        m_delete_state_files,
+        m_daemon_start,
+        m_timer_stop,
+        _m_lock_enter,
+        mock_entitlement,
+    ):
+        m_is_attached.return_value = mock.MagicMock(is_attached=True)
+        m_reboot_required.return_value = mock.MagicMock(reboot_required="yes")
+
+        m_ent1_cls, _ = mock_entitlement(
+            name="ent1",
+            disable=(True, None),
+            can_disable=(True, None),
+        )
+
+        m_ent2_cls, _ = mock_entitlement(
+            name="ent2",
+            disable=(True, None),
+            can_disable=(True, None),
+        )
+
+        m_ent3_cls, _ = mock_entitlement(
+            name="ent3",
+            can_disable=(False, None),
+        )
+
+        m_ent4_cls, _ = mock_entitlement(
+            name="ent4",
+            can_disable=(True, None),
+            disable=(
+                False,
+                CanDisableFailure(
+                    reason=CanDisableFailureReason.NOT_APPLICABLE,
+                    message=messages.CANNOT_DISABLE_NOT_APPLICABLE.format(
+                        title="ent4"
+                    ),
+                ),
+            ),
+        )
+
+        m_ent5_cls, _ = mock_entitlement(
+            name="ent5",
+            can_disable=(True, None),
+            disable=(
+                False,
+                None,
+            ),
+        )
+
+        def ent_factory_side_effect(cfg, name):
+            if name == "ent1":
+                return m_ent1_cls
+            elif name == "ent2":
+                return m_ent2_cls
+            elif name == "ent3":
+                return m_ent3_cls
+            elif name == "ent4":
+                return m_ent4_cls
+            else:
+                return m_ent5_cls
+
+        with mock.patch.object(
+            entitlements,
+            "entitlements_disable_order",
+            return_value=["ent2", "ent3", "ent5", "ent1", "ent4"],
+        ):
+            with mock.patch.object(
+                entitlements, "entitlement_factory"
+            ) as m_factory:
+                m_factory.side_effect = ent_factory_side_effect
+                m_cfg = mock.MagicMock()
+                m_machine_token = mock.MagicMock()
+                m_cfg.machine_token_file = m_machine_token
+
+                actual_result = _detach(m_cfg)
+
+        expected_warn_msg = messages.CANNOT_DISABLE_NOT_APPLICABLE.format(
+            title="ent4"
+        )
+        expected_result = DetachResult(
+            disabled=["ent1", "ent2"],
+            reboot_required=True,
+        )
+        expected_result.warnings = (
+            [
+                ErrorWarningObject(
+                    title=messages.DISABLE_FAILED_TMPL.format(title="ent5"),
+                    code="",
+                    meta={"service": "ent_5"},
+                ),
+                ErrorWarningObject(
+                    title=expected_warn_msg.msg,
+                    code=expected_warn_msg.name,
+                    meta={"service": "ent_4"},
+                ),
+            ],
+        )
+
+        assert expected_result == actual_result
+        assert 1 == m_daemon_start.call_count
+        assert 1 == m_timer_stop.call_count
+        assert 1 == m_delete_state_files.call_count
+        assert 1 == m_machine_token.delete.call_count

--- a/uaclient/api/u/pro/detach/v1.py
+++ b/uaclient/api/u/pro/detach/v1.py
@@ -1,0 +1,122 @@
+from typing import List
+
+from uaclient import (
+    daemon,
+    entitlements,
+    exceptions,
+    lock,
+    messages,
+    timer,
+    util,
+)
+from uaclient.api.api import APIEndpoint
+from uaclient.api.data_types import AdditionalInfo, ErrorWarningObject
+from uaclient.api.u.pro.security.status.reboot_required.v1 import (
+    _reboot_required,
+)
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
+from uaclient.config import UAConfig
+from uaclient.data_types import (
+    BoolDataValue,
+    DataObject,
+    Field,
+    StringDataValue,
+    data_list,
+)
+from uaclient.files import state_files
+from uaclient.timer.update_messaging import update_motd_messages
+
+
+class DetachResult(DataObject, AdditionalInfo):
+    fields = [
+        Field("disabled", data_list(StringDataValue)),
+        Field("reboot_required", BoolDataValue),
+    ]
+
+    def __init__(self, disabled: List[str], reboot_required: bool):
+        self.disabled = disabled
+        self.reboot_required = reboot_required
+
+
+def detach() -> DetachResult:
+    return _detach(UAConfig())
+
+
+def _detach(cfg: UAConfig) -> DetachResult:
+    if not util.we_are_currently_root():
+        raise exceptions.NonRootUserError
+
+    try:
+        with lock.RetryLock(
+            lock_holder="pro.api.u.pro.detach.v1",
+        ):
+            ret = _detach_in_lock(cfg)
+    except Exception as e:
+        lock.clear_lock_file_if_present()
+        raise e
+    return ret
+
+
+def _detach_in_lock(cfg: UAConfig) -> DetachResult:
+    if not _is_attached(cfg).is_attached:
+        return DetachResult(
+            disabled=[],
+            reboot_required=False,
+        )
+
+    disabled = []
+    warnings = []  # type: List[ErrorWarningObject]
+    for ent_name in entitlements.entitlements_disable_order(cfg):
+        try:
+            ent_cls = entitlements.entitlement_factory(cfg=cfg, name=ent_name)
+        except exceptions.EntitlementNotFoundError:
+            continue
+
+        ent = ent_cls(cfg=cfg, assume_yes=True)
+        # For detach, we should not consider that a service
+        # cannot be disabled because of dependent services,
+        # since we are going to disable all of them anyway
+        can_disable, _ = ent.can_disable(ignore_dependent_services=True)
+        if can_disable:
+            ret, reason = ent.disable(silent=True)
+            if not ret:
+                if reason and reason.message:
+                    msg = reason.message.msg
+                    code = reason.message.name
+                else:
+                    msg = messages.DISABLE_FAILED_TMPL.format(title=ent_name)
+                    code = ""
+
+                warnings.append(
+                    ErrorWarningObject(
+                        title=msg,
+                        code=code,
+                        meta={"service": ent_name},
+                    )
+                )
+            else:
+                disabled.append(ent_name)
+
+    state_files.delete_state_files()
+    cfg.machine_token_file.delete()
+    update_motd_messages(cfg)
+    daemon.start()
+    timer.stop()
+
+    reboot_required_result = _reboot_required(cfg)
+
+    result = DetachResult(
+        disabled=sorted(disabled),
+        reboot_required=reboot_required_result.reboot_required == "yes",
+    )
+    result.warnings = warnings
+
+    return result
+
+
+endpoint = APIEndpoint(
+    version="v1",
+    name="Detach",
+    fn=_detach,
+    options_cls=None,
+)

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -13,6 +13,7 @@ import pytest
 try:
     from uaclient import event_logger
     from uaclient.config import UAConfig
+    from uaclient.entitlements.entitlement_status import ApplicationStatus
     from uaclient.files.notices import NoticeFileDetails
     from uaclient.files.user_config_file import UserConfigData
 except ImportError:
@@ -308,3 +309,28 @@ def mock_notices_dir(tmpdir_factory):
             temp_dir.strpath,
         ):
             yield
+
+
+@pytest.fixture
+def mock_entitlement():
+    def factory_func(
+        *,
+        name="test",
+        title="test",
+        application_status=(ApplicationStatus.DISABLED, ""),
+        can_disable=(False, None),
+        disable=(False, None),
+        enable=(False, None)
+    ):
+        m_ent_cls = mock.MagicMock()
+        type(m_ent_cls).name = mock.PropertyMock(return_value=name)
+        m_ent_obj = m_ent_cls.return_value
+        type(m_ent_obj).title = mock.PropertyMock(return_value=title)
+        m_ent_obj.application_status.return_value = application_status
+        m_ent_obj.disable.return_value = disable
+        m_ent_obj.enable.return_value = enable
+        m_ent_obj.can_disable.return_value = can_disable
+
+        return (m_ent_cls, m_ent_obj)
+
+    return factory_func

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -1,10 +1,8 @@
 from typing import Any, Dict, List, Optional
 
-import mock
 import pytest
 
 from uaclient import config, event_logger
-from uaclient.entitlements.entitlement_status import ApplicationStatus
 
 
 def machine_token(
@@ -161,26 +159,3 @@ def event():
     event.reset()
 
     return event
-
-
-@pytest.fixture
-def mock_entitlement():
-    def factory_func(
-        *,
-        name="test",
-        title="test",
-        application_status=(ApplicationStatus.DISABLED, ""),
-        disable=(False, None),
-        enable=(False, None)
-    ):
-        m_ent_cls = mock.MagicMock()
-        type(m_ent_cls).name = mock.PropertyMock(return_value=name)
-        m_ent_obj = m_ent_cls.return_value
-        type(m_ent_obj).title = mock.PropertyMock(return_value=title)
-        m_ent_obj.application_status.return_value = application_status
-        m_ent_obj.disable.return_value = disable
-        m_ent_obj.enable.return_value = enable
-
-        return (m_ent_cls, m_ent_obj)
-
-    return factory_func


### PR DESCRIPTION
## Why is this needed?
We are adding an endpoint for the detach functionality.

Notice that we still need to refactor it in the future to make the CLI logic use that endpoint.

## Test Steps
Run the new integration tests

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [x] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
