### PR TITLE
Fix broken landscape link

### DIFF
--- a/docs/howtoguides/enable_landscape.rst
+++ b/docs/howtoguides/enable_landscape.rst
@@ -74,4 +74,4 @@ management.
 
 .. include:: ../links.txt
 
-.. _parameters supported by: https://manpages.ubuntu.com/landscape-config
+.. _parameters supported by: https://manpages.ubuntu.com/manpages/en/man1/landscape-config.1.html

--- a/docs/howtoguides/enable_landscape.rst
+++ b/docs/howtoguides/enable_landscape.rst
@@ -74,4 +74,4 @@ management.
 
 .. include:: ../links.txt
 
-.. _parameters supported by: https://manpages.ubuntu.com/manpages/en/man1/landscape-config.1.html
+.. _parameters supported by: https://manpages.ubuntu.com/manpages/noble/en/man1/landscape-config.1.html


### PR DESCRIPTION
The link is not actually "broken", but it does fail link checks due to the string of redirects. I have updated it to a more direct link to the manpage in question.
