### PR TITLE
apt: better ux on lock held

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -217,7 +217,7 @@ def run_apt_command(
             override_env_vars=override_env_vars,
         )
     except exceptions.ProcessExecutionError as e:
-        if "Could not get lock /var/lib/dpkg/lock" in str(e.stderr):
+        if "Could not get lock" in str(e.stderr):
             raise exceptions.APTProcessConflictError()
         else:
             """

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -106,7 +106,7 @@ class APTInvalidRepoError(UbuntuProError):
     _formatted_msg = messages.E_APT_UPDATE_INVALID_URL_CONFIG
 
 
-class APTUpdateProcessConflictError(UbuntuProError):
+class APTUpdateProcessConflictError(APTProcessConflictError):
     _msg = messages.E_APT_UPDATE_PROCESS_CONFLICT
 
 
@@ -118,7 +118,7 @@ class APTUpdateFailed(UbuntuProError):
     _formatted_msg = messages.E_APT_UPDATE_FAILED
 
 
-class APTInstallProcessConflictError(UbuntuProError):
+class APTInstallProcessConflictError(APTProcessConflictError):
     _msg = messages.E_APT_INSTALL_PROCESS_CONFLICT
 
 


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it will improve the experience users have with apt locks being held.

This is blocked on the Progress Reporting implementation, because it would duplicate logic to identify CLI calls unnecessarily.

## Test Steps
n/a

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:
 
## Does this PR require extra reviews?
- [ ] Yes
- [x] No
