### PR TITLE
fix: wait for cloud-init.service to fully activate

### DIFF
--- a/uaclient/tests/test_lib_daemon.py
+++ b/uaclient/tests/test_lib_daemon.py
@@ -17,24 +17,41 @@ class TestWaitForCloudConfig:
         (
             # not activating
             (
-                ["active"],
+                ["active"] * 2,
+                [],
+            ),
+            # inactive (all cloud-init)
+            (
+                ["inactive"] * 2,
                 [],
             ),
             (
-                ["inactive"],
+                [None] * 2,
                 [],
             ),
+            # cloud-config activating, then finishes
+            # cloud-init is active
             (
-                [None],
-                [],
-            ),
-            # activating, then finishes
-            (
-                (["activating"] * 11) + ["active"],
+                (["activating", "active"] * 11) + ["active"] * 2,
                 [mock.call(WAIT_FOR_CLOUD_CONFIG_SLEEP_TIME)] * 11,
             ),
             (
-                (["activating"] * 11) + ["failed"],
+                (["activating", "active"] * 11) + ["failed"] + ["active"],
+                [mock.call(WAIT_FOR_CLOUD_CONFIG_SLEEP_TIME)] * 11,
+            ),
+            # inactive cloud-config, active cloud-init
+            (
+                (["inactive", "active"] * 6)
+                + (["activating", "active"] * 5)
+                + ["active"] * 2,
+                [mock.call(WAIT_FOR_CLOUD_CONFIG_SLEEP_TIME)] * 11,
+            ),
+            # inactive cloud-config, activating cloud-init
+            (
+                (["inactive", "activating"] * 2)
+                + (["inactive", "active"] * 4)
+                + (["activating", "active"] * 5)
+                + ["active"] * 2,
                 [mock.call(WAIT_FOR_CLOUD_CONFIG_SLEEP_TIME)] * 11,
             ),
             # still activating after polling maximum times


### PR DESCRIPTION
Once the systemd constraint on After cloud-config.service was removed, there are situations where cloud-config.service runs so long after pro that the python code that waits for cloud-config.service to finish activating is being bypassed as if cloud-init isn't on the system.  This change forces pro to wait for cloud-config to finish if cloud-init is running at all.

Fixes #3000

## Please Squash this PR with this commit message

```
fix: wait for cloud-init.service to fully activate

Once the systemd constraint on After cloud-config.service was
removed, there are situations where cloud-config.service runs so
long after pro that the python code that waits for
cloud-config.service to finish activating is being bypassed as if
cloud-init isn't on the system.  This change forces pro to wait
for cloud-config to finish if cloud-init is running at all.

Fixes: #3000 
LP: #2059952
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
