### PR TITLE
messaging: consistent messages for end of contract UX (SC-1562)

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -144,7 +144,7 @@ jobs:
           sh -c 'printf "%s\n" "$SSH_PRIVATE_KEY" > ~/.ssh/cloudinit_id_rsa'
           sh -c 'printf "%s\n" "$SSH_PUBLIC_KEY" > ~/.ssh/cloudinit_id_rsa.pub'
 
-          sg lxd -c "tox -e behave -- -D machine_types=${{ matrix.platform }} -D releases=${{ matrix.release }} --tags=-slow --tags=-upgrade --tags=-no_gh"
+          sg lxd -c "tox -e behave -- -D machine_types=${{ matrix.platform }} -D releases=${{ matrix.release }} --tags=-slow --tags=-upgrade --tags=-no_gh --tags=-vpn"
       - name: Archive test artifacts
         if: always()
         uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ test-results*
 
 # credentials - don't commit credentials
 tools/ua-test-credentials.yaml
+features/config/protest.yaml
 
 # apt-hook build artifacts
 apt-hook/hook

--- a/debian/po/pt_BR.po
+++ b/debian/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-02 14:07-0400\n"
+"POT-Creation-Date: 2024-04-08 10:20-0400\n"
 "PO-Revision-Date: 2023-09-25 12:29-0400\n"
 "Last-Translator: Lucas Moura <lucas.moura@canonical.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -18,72 +18,72 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: ../../apt-hook/json-hook.cc:159
+#: ../../apt-hook/json-hook.cc:245
 msgid "1 standard LTS security update"
 msgstr "1 atualização de segurança de LTS"
 
-#: ../../apt-hook/json-hook.cc:164
+#: ../../apt-hook/json-hook.cc:250
 #, c-format
 msgid "%lu standard LTS security updates"
 msgstr "%lu atualizações de segurança de LTS"
 
-#: ../../apt-hook/json-hook.cc:171
+#: ../../apt-hook/json-hook.cc:257
 msgid "1 esm-infra security update"
 msgstr "1 atualização de segurança do esm-infra"
 
-#: ../../apt-hook/json-hook.cc:173
+#: ../../apt-hook/json-hook.cc:259
 msgid "1 standard LTS security update and 1 esm-infra security update"
 msgstr ""
 "1 atualização de segurança de LTS e 1 atualização de segurança do esm-infra"
 
-#: ../../apt-hook/json-hook.cc:178
+#: ../../apt-hook/json-hook.cc:264
 #, c-format
 msgid "%lu standard LTS security updates and 1 esm-infra security update"
 msgstr ""
 "%lu atualizações de segurança de LTS e 1 atualização de segurança do esm-"
 "infra"
 
-#: ../../apt-hook/json-hook.cc:188
+#: ../../apt-hook/json-hook.cc:274
 #, c-format
 msgid "%lu esm-infra security updates"
 msgstr "%lu atualizações de segurança do esm-infra"
 
-#: ../../apt-hook/json-hook.cc:196
+#: ../../apt-hook/json-hook.cc:282
 #, c-format
 msgid "1 standard LTS security update and %lu esm-infra security updates"
 msgstr ""
 "1 atualização de segurança de LTS e %lu atualizações de segurança do esm-"
 "infra"
 
-#: ../../apt-hook/json-hook.cc:204
+#: ../../apt-hook/json-hook.cc:290
 #, c-format
 msgid "%lu standard LTS security updates and %lu esm-infra security updates"
 msgstr ""
 "%lu atualizações de segurança de LTS e %lu atualizações de segurança do esm-"
 "infra"
 
-#: ../../apt-hook/json-hook.cc:214
+#: ../../apt-hook/json-hook.cc:300
 msgid "1 esm-apps security update"
 msgstr "1 atualização de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:216
+#: ../../apt-hook/json-hook.cc:302
 msgid "1 standard LTS security update and 1 esm-apps security update"
 msgstr ""
 "1 atualização de segurança de LTS e 1 atualização de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:221
+#: ../../apt-hook/json-hook.cc:307
 #, c-format
 msgid "%lu standard LTS security updates and 1 esm-apps security update"
 msgstr ""
 "%lu atualizações de segurança de LTS e 1 atualização de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:228
+#: ../../apt-hook/json-hook.cc:314
 msgid "1 esm-infra security update and 1 esm-apps security update"
 msgstr ""
 "1 atualização de segurança do esm-infra e 1 atualização de segurança do esm-"
 "apps"
 
-#: ../../apt-hook/json-hook.cc:230
+#: ../../apt-hook/json-hook.cc:316
 msgid ""
 "1 standard LTS security update, 1 esm-infra security update and 1 esm-apps "
 "security update"
@@ -91,7 +91,7 @@ msgstr ""
 "1 atualização de segurança de LTS, 1 atualização de segurança do esm-infra e "
 "1 atualização de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:235
+#: ../../apt-hook/json-hook.cc:321
 #, c-format
 msgid ""
 "%lu standard LTS security updates, 1 esm-infra security update and 1 esm-"
@@ -100,14 +100,14 @@ msgstr ""
 "%lu atualizações de segurança de LTS, 1 atualização de segurança do esm-"
 "infra e 1 atualização de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:245
+#: ../../apt-hook/json-hook.cc:331
 #, c-format
 msgid "%lu esm-infra security updates and 1 esm-apps security update"
 msgstr ""
 "%lu atualizações de segurança do esm-infra e 1 atualização de segurança do "
 "esm-apps"
 
-#: ../../apt-hook/json-hook.cc:253
+#: ../../apt-hook/json-hook.cc:339
 #, c-format
 msgid ""
 "1 standard LTS security update, %lu esm-infra security updates and 1 esm-"
@@ -116,7 +116,7 @@ msgstr ""
 "1 atualização de segurança de LTS, %lu atualizações de segurança do esm-"
 "infra e 1 atualização de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:261
+#: ../../apt-hook/json-hook.cc:347
 #, c-format
 msgid ""
 "%lu standard LTS security updates, %lu esm-infra security updates and 1 esm-"
@@ -125,32 +125,32 @@ msgstr ""
 "%lu atualizações de segurança de LTS, %lu atualizações de segurança do esm-"
 "infra e 1 atualização de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:274
+#: ../../apt-hook/json-hook.cc:360
 #, c-format
 msgid "%lu esm-apps security updates"
 msgstr "%lu atualizações de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:282
+#: ../../apt-hook/json-hook.cc:368
 #, c-format
 msgid "1 standard LTS security update and %lu esm-apps security updates"
 msgstr ""
 "1 atualização de segurança de LTS e %lu atualizações de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:290
+#: ../../apt-hook/json-hook.cc:376
 #, c-format
 msgid "%lu standard LTS security updates and %lu esm-apps security updates"
 msgstr ""
 "%lu atualizações de segurança de LTS and %lu atualizações de segurança do "
 "esm-apps"
 
-#: ../../apt-hook/json-hook.cc:301
+#: ../../apt-hook/json-hook.cc:387
 #, c-format
 msgid "1 esm-infra security update and %lu esm-apps security updates"
 msgstr ""
 "1 atualização de segurança do esm-infra e %lu atualizações de segurança do "
 "esm-apps"
 
-#: ../../apt-hook/json-hook.cc:309
+#: ../../apt-hook/json-hook.cc:395
 #, c-format
 msgid ""
 "1 standard LTS security update, 1 esm-infra security update and %lu esm-apps "
@@ -159,7 +159,7 @@ msgstr ""
 "1 atualização de segurança de LTS, 1 atualização de segurança do esm-infra e "
 "%lu atualizações de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:317
+#: ../../apt-hook/json-hook.cc:403
 #, c-format
 msgid ""
 "%lu standard LTS security updates, 1 esm-infra security update and %lu esm-"
@@ -168,14 +168,14 @@ msgstr ""
 "%lu atualizações de segurança de LTS, 1 atualização de segurança de esm-"
 "infra e%lu atualizações de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:328
+#: ../../apt-hook/json-hook.cc:414
 #, c-format
 msgid "%lu esm-infra security updates and %lu esm-apps security updates"
 msgstr ""
 "%lu atualizações de segurança do esm-infra e %lu atualizações de segurança "
 "do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:337
+#: ../../apt-hook/json-hook.cc:423
 #, c-format
 msgid ""
 "1 standard LTS security update, %lu esm-infra security updates and %lu esm-"
@@ -184,7 +184,7 @@ msgstr ""
 "1 atualização de segurança de LTS, %lu atualizações de segurança do esm-"
 "infra e%lu atualizações de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:346
+#: ../../apt-hook/json-hook.cc:432
 #, c-format
 msgid ""
 "%lu standard LTS security updates, %lu esm-infra security updates and %lu "
@@ -193,47 +193,47 @@ msgstr ""
 "%lu atualizações de segurança de LTS, %lu atualizações de segurança do esm-"
 "infra e %lu atualizações de segurança do esm-apps"
 
-#: ../../apt-hook/json-hook.cc:403
+#: ../../apt-hook/json-hook.cc:489
 #, c-format
 msgid "Learn more about Ubuntu Pro for 16.04 on Azure at %s"
 msgstr "Saiba mais sobre o Ubuntu Pro para a versão 16.04 no Azure em %s"
 
-#: ../../apt-hook/json-hook.cc:412
+#: ../../apt-hook/json-hook.cc:498
 #, c-format
 msgid "Learn more about Ubuntu Pro for 16.04 at %s"
 msgstr "Saiba mais sobre o Ubuntu Pro para a versão 16.04 em %s"
 
-#: ../../apt-hook/json-hook.cc:423
+#: ../../apt-hook/json-hook.cc:509
 #, c-format
 msgid "Learn more about Ubuntu Pro for 18.04 on Azure at %s"
 msgstr "Saiba mais sobre o Ubuntu Pro para a versão 18.04 no Azure em %s"
 
-#: ../../apt-hook/json-hook.cc:432
+#: ../../apt-hook/json-hook.cc:518
 #, c-format
 msgid "Learn more about Ubuntu Pro for 18.04 at %s"
 msgstr "Saiba mais sobre o Ubuntu Pro para a versão 18.04 em %s"
 
-#: ../../apt-hook/json-hook.cc:443
+#: ../../apt-hook/json-hook.cc:529
 #, c-format
 msgid "Learn more about Ubuntu Pro on Azure at %s"
 msgstr "Saiba mais sobre o Ubuntu Pro no Azure em %s"
 
-#: ../../apt-hook/json-hook.cc:452
+#: ../../apt-hook/json-hook.cc:538
 #, c-format
 msgid "Learn more about Ubuntu Pro on AWS at %s"
 msgstr "Saiba mais sobre o Ubuntu Pro na AWS em %s"
 
-#: ../../apt-hook/json-hook.cc:461
+#: ../../apt-hook/json-hook.cc:547
 #, c-format
 msgid "Learn more about Ubuntu Pro on GCP at %s"
 msgstr "Saiba mais sobre o Ubuntu Pro no GCP em %s"
 
-#: ../../apt-hook/json-hook.cc:472
+#: ../../apt-hook/json-hook.cc:558
 #, c-format
 msgid "Learn more about Ubuntu Pro at %s"
 msgstr "Saiba mais sobre o Ubuntu Pro em %s"
 
-#: ../../apt-hook/json-hook.cc:485
+#: ../../apt-hook/json-hook.cc:584
 #, c-format
 msgid "Get another security update through Ubuntu Pro with 'esm-apps' enabled:"
 msgid_plural ""
@@ -245,7 +245,7 @@ msgstr[1] ""
 "Obtenha mais atualizações de segurança através do Ubuntu Pro com 'esm-apps' "
 "habilitado:"
 
-#: ../../apt-hook/json-hook.cc:494
+#: ../../apt-hook/json-hook.cc:593
 #, c-format
 msgid ""
 "The following security update requires Ubuntu Pro with 'esm-infra' enabled:"
@@ -257,6 +257,18 @@ msgstr[0] ""
 msgstr[1] ""
 "As seguintes atualizações de segurança requerem o Ubuntu Pro com 'esm-infra' "
 "habilitado:"
+
+#: ../../apt-hook/json-hook.cc:609
+#, c-format
+msgid ""
+"The following packages will fail to download because your Ubuntu Pro "
+"subscription has expired"
+msgstr ""
+
+#: ../../apt-hook/json-hook.cc:618
+#, c-format
+msgid "Renew your subscription or `sudo pro detach` to remove these errors"
+msgstr ""
 
 #. Description
 #: ../ubuntu-advantage-tools.templates:3
@@ -479,11 +491,11 @@ msgid "The following package(s) will be reinstalled from the archive:"
 msgstr "O(s) pacote(s) à seguir serão reinstalados:"
 
 #: ../../uaclient/messages/__init__.py:163
-#, python-brace-format
+#, fuzzy, python-brace-format
 msgid ""
 "*Your Ubuntu Pro subscription has EXPIRED*\n"
-"{{pkg_num}} additional security update require Ubuntu Pro with '{{service}}' "
-"enabled.\n"
+"{{pkg_num}} additional security update requires Ubuntu Pro with "
+"'{{service}}' enabled.\n"
 "Renew your subscription at {url}"
 msgid_plural ""
 "*Your Ubuntu Pro subscription has EXPIRED*\n"

--- a/debian/po/ubuntu-pro.pot
+++ b/debian/po/ubuntu-pro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-02 14:07-0400\n"
+"POT-Creation-Date: 2024-04-08 10:20-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,186 +18,186 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../../apt-hook/json-hook.cc:159
+#: ../../apt-hook/json-hook.cc:245
 msgid "1 standard LTS security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:164
+#: ../../apt-hook/json-hook.cc:250
 #, c-format
 msgid "%lu standard LTS security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:171
+#: ../../apt-hook/json-hook.cc:257
 msgid "1 esm-infra security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:173
+#: ../../apt-hook/json-hook.cc:259
 msgid "1 standard LTS security update and 1 esm-infra security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:178
+#: ../../apt-hook/json-hook.cc:264
 #, c-format
 msgid "%lu standard LTS security updates and 1 esm-infra security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:188
+#: ../../apt-hook/json-hook.cc:274
 #, c-format
 msgid "%lu esm-infra security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:196
+#: ../../apt-hook/json-hook.cc:282
 #, c-format
 msgid "1 standard LTS security update and %lu esm-infra security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:204
+#: ../../apt-hook/json-hook.cc:290
 #, c-format
 msgid "%lu standard LTS security updates and %lu esm-infra security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:214
+#: ../../apt-hook/json-hook.cc:300
 msgid "1 esm-apps security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:216
+#: ../../apt-hook/json-hook.cc:302
 msgid "1 standard LTS security update and 1 esm-apps security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:221
+#: ../../apt-hook/json-hook.cc:307
 #, c-format
 msgid "%lu standard LTS security updates and 1 esm-apps security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:228
+#: ../../apt-hook/json-hook.cc:314
 msgid "1 esm-infra security update and 1 esm-apps security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:230
+#: ../../apt-hook/json-hook.cc:316
 msgid ""
 "1 standard LTS security update, 1 esm-infra security update and 1 esm-apps "
 "security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:235
+#: ../../apt-hook/json-hook.cc:321
 #, c-format
 msgid ""
 "%lu standard LTS security updates, 1 esm-infra security update and 1 esm-"
 "apps security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:245
+#: ../../apt-hook/json-hook.cc:331
 #, c-format
 msgid "%lu esm-infra security updates and 1 esm-apps security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:253
+#: ../../apt-hook/json-hook.cc:339
 #, c-format
 msgid ""
 "1 standard LTS security update, %lu esm-infra security updates and 1 esm-"
 "apps security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:261
+#: ../../apt-hook/json-hook.cc:347
 #, c-format
 msgid ""
 "%lu standard LTS security updates, %lu esm-infra security updates and 1 esm-"
 "apps security update"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:274
+#: ../../apt-hook/json-hook.cc:360
 #, c-format
 msgid "%lu esm-apps security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:282
+#: ../../apt-hook/json-hook.cc:368
 #, c-format
 msgid "1 standard LTS security update and %lu esm-apps security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:290
+#: ../../apt-hook/json-hook.cc:376
 #, c-format
 msgid "%lu standard LTS security updates and %lu esm-apps security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:301
+#: ../../apt-hook/json-hook.cc:387
 #, c-format
 msgid "1 esm-infra security update and %lu esm-apps security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:309
+#: ../../apt-hook/json-hook.cc:395
 #, c-format
 msgid ""
 "1 standard LTS security update, 1 esm-infra security update and %lu esm-apps "
 "security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:317
+#: ../../apt-hook/json-hook.cc:403
 #, c-format
 msgid ""
 "%lu standard LTS security updates, 1 esm-infra security update and %lu esm-"
 "apps security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:328
+#: ../../apt-hook/json-hook.cc:414
 #, c-format
 msgid "%lu esm-infra security updates and %lu esm-apps security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:337
+#: ../../apt-hook/json-hook.cc:423
 #, c-format
 msgid ""
 "1 standard LTS security update, %lu esm-infra security updates and %lu esm-"
 "apps security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:346
+#: ../../apt-hook/json-hook.cc:432
 #, c-format
 msgid ""
 "%lu standard LTS security updates, %lu esm-infra security updates and %lu "
 "esm-apps security updates"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:403
+#: ../../apt-hook/json-hook.cc:489
 #, c-format
 msgid "Learn more about Ubuntu Pro for 16.04 on Azure at %s"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:412
+#: ../../apt-hook/json-hook.cc:498
 #, c-format
 msgid "Learn more about Ubuntu Pro for 16.04 at %s"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:423
+#: ../../apt-hook/json-hook.cc:509
 #, c-format
 msgid "Learn more about Ubuntu Pro for 18.04 on Azure at %s"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:432
+#: ../../apt-hook/json-hook.cc:518
 #, c-format
 msgid "Learn more about Ubuntu Pro for 18.04 at %s"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:443
+#: ../../apt-hook/json-hook.cc:529
 #, c-format
 msgid "Learn more about Ubuntu Pro on Azure at %s"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:452
+#: ../../apt-hook/json-hook.cc:538
 #, c-format
 msgid "Learn more about Ubuntu Pro on AWS at %s"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:461
+#: ../../apt-hook/json-hook.cc:547
 #, c-format
 msgid "Learn more about Ubuntu Pro on GCP at %s"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:472
+#: ../../apt-hook/json-hook.cc:558
 #, c-format
 msgid "Learn more about Ubuntu Pro at %s"
 msgstr ""
 
-#: ../../apt-hook/json-hook.cc:485
+#: ../../apt-hook/json-hook.cc:584
 #, c-format
 msgid "Get another security update through Ubuntu Pro with 'esm-apps' enabled:"
 msgid_plural ""
@@ -205,7 +205,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../apt-hook/json-hook.cc:494
+#: ../../apt-hook/json-hook.cc:593
 #, c-format
 msgid ""
 "The following security update requires Ubuntu Pro with 'esm-infra' enabled:"
@@ -213,6 +213,18 @@ msgid_plural ""
 "The following security updates require Ubuntu Pro with 'esm-infra' enabled:"
 msgstr[0] ""
 msgstr[1] ""
+
+#: ../../apt-hook/json-hook.cc:609
+#, c-format
+msgid ""
+"The following packages will fail to download because your Ubuntu Pro "
+"subscription has expired"
+msgstr ""
+
+#: ../../apt-hook/json-hook.cc:618
+#, c-format
+msgid "Renew your subscription or `sudo pro detach` to remove these errors"
+msgstr ""
 
 #. Description
 #: ../ubuntu-advantage-tools.templates:3
@@ -420,8 +432,8 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "*Your Ubuntu Pro subscription has EXPIRED*\n"
-"{{pkg_num}} additional security update require Ubuntu Pro with '{{service}}' "
-"enabled.\n"
+"{{pkg_num}} additional security update requires Ubuntu Pro with "
+"'{{service}}' enabled.\n"
 "Renew your subscription at {url}"
 msgid_plural ""
 "*Your Ubuntu Pro subscription has EXPIRED*\n"

--- a/features/config/protest.example.yaml
+++ b/features/config/protest.example.yaml
@@ -1,6 +1,10 @@
 contract_token: <token for testing>
 contract_token_staging: <staging token for testing>
 contract_token_staging_expired: <expired staging token for testing>
+contract_token_staging_expired_sometimes: <staging token to be modified during tests>
+
+contract_staging_service_account_username: pro-client-ci
+contract_staging_service_account_password: <staging service account password>
 
 landscape_registration_key: <landscape registration key>
 landscape_api_access_key: <landscape access key>

--- a/features/config/protest.example.yaml
+++ b/features/config/protest.example.yaml
@@ -1,0 +1,11 @@
+contract_token: <token for testing>
+contract_token_staging: <staging token for testing>
+contract_token_staging_expired: <expired staging token for testing>
+
+landscape_registration_key: <landscape registration key>
+landscape_api_access_key: <landscape access key>
+landscape_api_secret_key: <landscape secret key>
+
+wsl_pubkey_path: <wsl pubkey path>
+wsl_privkey_path: <wsl privkey path>
+wsl_ip_address: <wsl instance ip address>

--- a/features/contract_expired.feature
+++ b/features/contract_expired.feature
@@ -1,0 +1,63 @@
+Feature: End of contract messages
+
+  @vpn @uses.config.contract_token
+  Scenario Outline: Display expired messages in all relevant places
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I apt upgrade
+    When I apt install `hello update-motd`
+    When I set the test contract expiration date to `$behave_var{today +1}`
+    When I attach `contract_token_staging_expired_sometimes` with sudo and options `--no-auto-enable`
+    # HACK NOTICE: This part relies on implementation details of pro-client
+    # we hack apt-helper to let pro enable go through to simulate being expired with services enabled
+    # we can't just enable before expiring the contract because esm-auth is cached
+    When I create the file `/usr/bin/apt-helper-always-true` with the following
+      """
+      #!/usr/bin/bash
+      true
+      """
+    When I run `chmod +x /usr/bin/apt-helper-always-true` with sudo
+    When I run `mv /usr/lib/apt/apt-helper /usr/lib/apt/apt-helper.backup` with sudo
+    When I run `ln -s /usr/bin/apt-helper-always-true /usr/lib/apt/apt-helper` with sudo
+    When I run `pro enable esm-apps` with sudo
+    When I set the test contract expiration date to `$behave_var{today -20}`
+    When I run `pro refresh` with sudo
+    When I run `pro status` with sudo
+    Then stdout contains substring:
+      """
+      *Your Ubuntu Pro subscription has EXPIRED*
+      Renew your subscription at https://ubuntu.com/pro/dashboard
+      """
+    When I verify that running `apt upgrade -y` `with sudo` exits `100`
+    Then stdout contains substring:
+      """
+      #
+      # *Your Ubuntu Pro subscription has EXPIRED*
+      # Renew your subscription at https://ubuntu.com/pro/dashboard
+      #
+      The following packages will fail to download because your Ubuntu Pro subscription has expired
+        hello
+      Renew your subscription or `sudo pro detach` to remove these errors
+      """
+    And stderr matches regexp:
+      """
+      E: Failed to fetch https://esm\.staging\.ubuntu\.com/apps/ubuntu/pool/main/h/hello/hello_(.*)\.deb  401  Unauthorized \[IP: (.*) 443\]
+      """
+    When I run `update-motd` with sudo
+    Then stdout contains substring:
+      """
+      *Your Ubuntu Pro subscription has EXPIRED*
+      1 additional security update requires Ubuntu Pro with 'esm-apps' enabled.
+      Renew your subscription at https://ubuntu.com/pro/dashboard
+      """
+    When I run `pro disable esm-apps` with sudo
+    When I verify that running `pro enable esm-apps` `with sudo` exits `1`
+    Then I will see the following on stdout:
+      """
+      One moment, checking your subscription first
+      *Your Ubuntu Pro subscription has EXPIRED*
+      Renew your subscription at https://ubuntu.com/pro/dashboard
+      """
+
+    Examples: ubuntu release
+      | release | machine_type  |
+      | jammy   | lxd-container |

--- a/features/environment.py
+++ b/features/environment.py
@@ -83,6 +83,9 @@ class UAClientBehaveConfig:
         "contract_token",
         "contract_token_staging",
         "contract_token_staging_expired",
+        "contract_token_staging_expired_sometimes",
+        "contract_staging_service_account_username",
+        "contract_staging_service_account_password",
         "landscape_registration_key",
         "landscape_api_access_key",
         "landscape_api_secret_key",
@@ -105,6 +108,8 @@ class UAClientBehaveConfig:
         "contract_token",
         "contract_token_staging",
         "contract_token_staging_expired",
+        "contract_token_staging_expired_sometimes",
+        "contract_staging_service_account_password",
         "landscape_registration_key",
         "landscape_api_access_key",
         "landscape_api_secret_key",
@@ -130,6 +135,9 @@ class UAClientBehaveConfig:
         contract_token: Optional[str] = None,
         contract_token_staging: Optional[str] = None,
         contract_token_staging_expired: Optional[str] = None,
+        contract_token_staging_expired_sometimes: Optional[str] = None,
+        contract_staging_service_account_username: Optional[str] = None,
+        contract_staging_service_account_password: Optional[str] = None,
         landscape_registration_key: Optional[str] = None,
         landscape_api_access_key: Optional[str] = None,
         landscape_api_secret_key: Optional[str] = None,
@@ -153,6 +161,15 @@ class UAClientBehaveConfig:
         self.contract_token = contract_token
         self.contract_token_staging = contract_token_staging
         self.contract_token_staging_expired = contract_token_staging_expired
+        self.contract_token_staging_expired_sometimes = (
+            contract_token_staging_expired_sometimes
+        )
+        self.contract_staging_service_account_username = (
+            contract_staging_service_account_username
+        )
+        self.contract_staging_service_account_password = (
+            contract_staging_service_account_password
+        )
         self.landscape_registration_key = landscape_registration_key
         self.landscape_api_access_key = landscape_api_access_key
         self.landscape_api_secret_key = landscape_api_secret_key

--- a/features/environment.py
+++ b/features/environment.py
@@ -9,6 +9,7 @@ import tarfile
 from typing import Dict, List, Optional, Tuple, Union  # noqa: F401
 
 import pycloudlib  # type: ignore  # noqa: F401
+import yaml
 from behave.model import Feature, Scenario
 from behave.model_core import Status
 from behave.runner import Context
@@ -65,6 +66,7 @@ class UAClientBehaveConfig:
     """
 
     prefix = "UACLIENT_BEHAVE_"
+    file_config_path = "./features/config/protest.yaml"
 
     # These variables are used in .from_environ() to convert the string
     # environment variable input to the appropriate Python types for use within
@@ -243,11 +245,24 @@ class UAClientBehaveConfig:
 
     @classmethod
     def from_environ(cls, config) -> "UAClientBehaveConfig":
-        """Gather config options from os.environ and return a config object"""
+        """Gather config options from:
+
+        1. features/config/protest.yaml
+        2. os.environ with prefix UACLIENT_BEHAVE_
+        3. -D command line options
+
+        each of which can override the previous.
+        """
         # First, gather all known options
         kwargs = (
             {}
         )  # type: Dict[str, Union[str, bool, List, InstallationSource]]
+
+        try:
+            with open(cls.file_config_path) as file_config:
+                kwargs = yaml.safe_load(file_config)
+        except FileNotFoundError:
+            print("No config file found at {}".format(cls.file_config_path))
 
         for key, value in os.environ.items():
             if not key.startswith(cls.prefix):

--- a/features/steps/attach.py
+++ b/features/steps/attach.py
@@ -31,6 +31,7 @@ def when_i_attach_staging_token(
     if (
         token_type == "contract_token_staging"
         or token_type == "contract_token_staging_expired"
+        or token_type == "contract_token_staging_expired_sometimes"
     ):
         change_contract_endpoint_to_staging(context, user_spec)
     cmd = "pro attach {} {}".format(token, options).strip()

--- a/features/steps/contract.py
+++ b/features/steps/contract.py
@@ -1,5 +1,7 @@
 import json
+import logging
 
+import requests
 import yaml
 from behave import then, when
 from hamcrest import assert_that, equal_to, not_
@@ -134,3 +136,29 @@ def when_i_set_the_machine_token_overlay(context):
         "{ machine_token_overlay: "
         "/var/lib/ubuntu-advantage/machine-token-overlay.json}",
     )
+
+
+@when("I set the test contract expiration date to `{date_str}`")
+def when_i_set_the_test_contract_expiration_date_to(context, date_str):
+    date_str = process_template_vars(context, date_str)
+    resp = requests.put(
+        "https://contracts.staging.canonical.com/v1/contract-items",
+        auth=(
+            context.pro_config.contract_staging_service_account_username,
+            context.pro_config.contract_staging_service_account_password,
+        ),
+        json=[
+            {
+                # Do not delete any of these fields. They are all required.
+                "contractID": "cAOEJ9Vymiwr47-HZ3FnYR_YDCPILpaTfdloKpojyNPE",
+                "id": 39398,
+                "effectiveFrom": "2024-01-01T00:00:00Z",
+                "effectiveTo": date_str,
+                "metric": "units",
+                "reason": "contract_created",
+                "value": 1000,
+            }
+        ],
+    )
+    logging.debug(resp.json())
+    assert resp.status_code == 200

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -3,6 +3,7 @@ behave
 jsonschema
 PyHamcrest
 pycloudlib==1!5.6.0
+requests
 toml==0.10
 
 ipdb

--- a/types-requirements.txt
+++ b/types-requirements.txt
@@ -3,3 +3,4 @@ types-PyYAML
 types-toml
 types-pycurl
 types-paramiko
+types-requests

--- a/uaclient/apt_news.py
+++ b/uaclient/apt_news.py
@@ -23,7 +23,7 @@ from uaclient.data_types import (
     StringDataValue,
     data_list,
 )
-from uaclient.files import state_files
+from uaclient.files import notices, state_files
 
 LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
 
@@ -227,6 +227,12 @@ def local_apt_news(cfg: UAConfig) -> Optional[str]:
     expiry_status = is_attached_info.contract_status
     remaining_days = is_attached_info.contract_remaining_days
 
+    if expiry_status == ContractExpiryStatus.EXPIRED.value:
+        notices.add(notices.Notice.CONTRACT_EXPIRED)
+        return messages.CONTRACT_EXPIRED
+
+    notices.remove(notices.Notice.CONTRACT_EXPIRED)
+
     if expiry_status == ContractExpiryStatus.ACTIVE_EXPIRED_SOON.value:
         return messages.CONTRACT_EXPIRES_SOON.pluralize(remaining_days).format(
             remaining_days=remaining_days
@@ -246,9 +252,6 @@ def local_apt_news(cfg: UAConfig) -> Optional[str]:
         ).format(
             expired_date=exp_dt_str, remaining_days=grace_period_remaining
         )
-
-    if expiry_status == ContractExpiryStatus.EXPIRED.value:
-        return messages.CONTRACT_EXPIRED
 
     return None
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -248,6 +248,10 @@ UrlError = ConnectivityError
 ###############################################################################
 
 
+class ContractExpiredError(UbuntuProError):
+    _msg = messages.E_CONTRACT_EXPIRED
+
+
 class InvalidServiceOpError(UbuntuProError):
     _formatted_msg = messages.E_INVALID_SERVICE_OP_FAILURE
 

--- a/uaclient/files/notices.py
+++ b/uaclient/files/notices.py
@@ -14,6 +14,12 @@ NoticeFileDetails = namedtuple(
 
 
 class Notice(NoticeFileDetails, Enum):
+    CONTRACT_EXPIRED = NoticeFileDetails(
+        label="contract_expired",
+        order_id="5",
+        is_permanent=True,
+        message=messages.CONTRACT_EXPIRED,
+    )
     REBOOT_REQUIRED = NoticeFileDetails(
         label="reboot_required",
         order_id="10",

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -162,7 +162,7 @@ CONTRACT_EXPIRED_WITH_PKGS = P(
     lambda n: t.ngettext(
         """\
 *Your Ubuntu Pro subscription has EXPIRED*
-{{pkg_num}} additional security update require Ubuntu Pro with '{{service}}' enabled.
+{{pkg_num}} additional security update requires Ubuntu Pro with '{{service}}' enabled.
 Renew your subscription at {url}""",  # noqa: E501
         """\
 *Your Ubuntu Pro subscription has EXPIRED*
@@ -2642,4 +2642,9 @@ E_NON_INTERACTIVE_KERNEL_PURGE_DISALLOWED = NamedMessage(
 E_NOT_SUPPORTED = NamedMessage(
     "not-supported",
     t.gettext("The operation is not supported"),
+)
+
+E_CONTRACT_EXPIRED = NamedMessage(
+    "contract-expired",
+    CONTRACT_EXPIRED,
 )

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -210,6 +210,8 @@ def _attached_status(cfg: UAConfig) -> Dict[str, Any]:
     """Return configuration of attached status as a dictionary."""
     notices.remove(Notice.AUTO_ATTACH_RETRY_FULL_NOTICE)
     notices.remove(Notice.AUTO_ATTACH_RETRY_TOTAL_FAILURE)
+    if _is_attached(cfg).is_attached_and_contract_valid:
+        notices.remove(Notice.CONTRACT_EXPIRED)
 
     response = copy.deepcopy(DEFAULT_STATUS)
     machineTokenInfo = cfg.machine_token["machineTokenInfo"]

--- a/uaclient/timer/update_messaging.py
+++ b/uaclient/timer/update_messaging.py
@@ -21,6 +21,7 @@ from uaclient.api.u.pro.status.is_attached.v1 import (
 from uaclient.config import UAConfig
 from uaclient.entitlements import ESMAppsEntitlement, ESMInfraEntitlement
 from uaclient.entitlements.entitlement_status import ApplicationStatus
+from uaclient.files import notices
 
 MOTD_CONTRACT_STATUS_FILE_NAME = "motd-contract-status"
 UPDATE_NOTIFIER_MOTD_SCRIPT = (
@@ -87,8 +88,10 @@ def update_motd_messages(cfg: UAConfig) -> bool:
         ContractExpiryStatus.ACTIVE.value,
         ContractExpiryStatus.NONE.value,
     ):
+        notices.remove(notices.Notice.CONTRACT_EXPIRED)
         system.ensure_file_absent(motd_contract_status_msg_path)
     elif expiry_status == ContractExpiryStatus.ACTIVE_EXPIRED_SOON.value:
+        notices.remove(notices.Notice.CONTRACT_EXPIRED)
         system.write_file(
             motd_contract_status_msg_path,
             messages.CONTRACT_EXPIRES_SOON.pluralize(remaining_days).format(
@@ -97,6 +100,7 @@ def update_motd_messages(cfg: UAConfig) -> bool:
             + "\n\n",
         )
     elif expiry_status == ContractExpiryStatus.EXPIRED_GRACE_PERIOD.value:
+        notices.remove(notices.Notice.CONTRACT_EXPIRED)
         grace_period_remaining = (
             defaults.CONTRACT_EXPIRY_GRACE_PERIOD_DAYS + remaining_days
         )
@@ -116,6 +120,8 @@ def update_motd_messages(cfg: UAConfig) -> bool:
             + "\n\n",
         )
     elif expiry_status == ContractExpiryStatus.EXPIRED.value:
+        notices.add(notices.Notice.CONTRACT_EXPIRED)
+
         service = "n/a"
         pkg_num = 0
 


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This improves the end-of-contract ux by doing the following:
- adds explanation to apt upgrade message that certain packages will fail to download and why and what to do
- changes generic "authentication failed" to clear error message on `pro enable`
- adds notice to status output (this is just for now until the bigger status rework happens)


## Test Steps
Run the new test, it requires being on the vpn

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
