### PR TITLE
refactor: use enable api in cli subcommand

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -1027,7 +1027,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       corrupted
       """
     Then I verify that running `pro enable esm-infra --assume-yes` `with sudo` exits `1`
-    And stderr matches regexp:
+    And stdout matches regexp:
       """
       There is a corrupted lock file in the system. To continue, please remove it
       from the system by running:

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -83,7 +83,6 @@ def _enable_default_services(
             ent_ret, reason = enable_entitlement_by_name(
                 cfg=cfg,
                 name=enable_by_default_service.name,
-                assume_yes=True,
                 allow_beta=True,
                 variant=enable_by_default_service.variant,
                 silent=silent,
@@ -219,7 +218,6 @@ def enable_entitlement_by_name(
     cfg: config.UAConfig,
     name: str,
     *,
-    assume_yes: bool = False,
     allow_beta: bool = False,
     access_only: bool = False,
     variant: str = "",
@@ -236,7 +234,6 @@ def enable_entitlement_by_name(
         cfg=cfg,
         name=name,
         variant=variant,
-        assume_yes=assume_yes,
         allow_beta=allow_beta,
         access_only=access_only,
         extra_args=extra_args,

--- a/uaclient/api/tests/test_api_u_pro_attach_auto_full_auto_attach_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_attach_auto_full_auto_attach_v1.py
@@ -35,11 +35,7 @@ class TestEnableServicesByName:
                 ["esm-infra"],
                 True,
                 [(True, None)],
-                [
-                    mock.call(
-                        mock.ANY, "esm-infra", assume_yes=True, allow_beta=True
-                    )
-                ],
+                [mock.call(mock.ANY, "esm-infra", allow_beta=True)],
                 [],
             ),
             # success multi service, no allow beta
@@ -48,19 +44,15 @@ class TestEnableServicesByName:
                 False,
                 [(True, None), (True, None), (True, None)],
                 [
-                    mock.call(
-                        mock.ANY, "esm-apps", assume_yes=True, allow_beta=False
-                    ),
+                    mock.call(mock.ANY, "esm-apps", allow_beta=False),
                     mock.call(
                         mock.ANY,
                         "esm-infra",
-                        assume_yes=True,
                         allow_beta=False,
                     ),
                     mock.call(
                         mock.ANY,
                         "livepatch",
-                        assume_yes=True,
                         allow_beta=False,
                     ),
                 ],
@@ -78,19 +70,15 @@ class TestEnableServicesByName:
                     fakes.FakeUbuntuProError(),
                 ],
                 [
-                    mock.call(
-                        mock.ANY, "esm-apps", assume_yes=True, allow_beta=False
-                    ),
+                    mock.call(mock.ANY, "esm-apps", allow_beta=False),
                     mock.call(
                         mock.ANY,
                         "esm-infra",
-                        assume_yes=True,
                         allow_beta=False,
                     ),
                     mock.call(
                         mock.ANY,
                         "livepatch",
-                        assume_yes=True,
                         allow_beta=False,
                     ),
                 ],
@@ -120,19 +108,15 @@ class TestEnableServicesByName:
                     ),
                 ],
                 [
-                    mock.call(
-                        mock.ANY, "esm-apps", assume_yes=True, allow_beta=False
-                    ),
+                    mock.call(mock.ANY, "esm-apps", allow_beta=False),
                     mock.call(
                         mock.ANY,
                         "esm-infra",
-                        assume_yes=True,
                         allow_beta=False,
                     ),
                     mock.call(
                         mock.ANY,
                         "livepatch",
-                        assume_yes=True,
                         allow_beta=False,
                     ),
                 ],
@@ -190,7 +174,7 @@ class TestFullAutoAttachV1:
     ):
         cfg = FakeConfig()
 
-        def enable_ent_side_effect(cfg, name, assume_yes, allow_beta):
+        def enable_ent_side_effect(cfg, name, allow_beta):
             if name != "wrong":
                 return (True, None)
 

--- a/uaclient/api/tests/test_api_u_pro_detach_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_detach_v1.py
@@ -90,7 +90,7 @@ class TestDetachV1:
             ),
         )
 
-        def ent_factory_side_effect(cfg, name, assume_yes):
+        def ent_factory_side_effect(cfg, name):
             if name == "ent1":
                 return m_ent1_obj
             elif name == "ent2":

--- a/uaclient/api/tests/test_api_u_pro_services_disable_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_services_disable_v1.py
@@ -150,7 +150,6 @@ class TestDisable:
                 mock.call(
                     cfg=cfg,
                     name=options.service,
-                    assume_yes=True,
                     purge=options.purge,
                 )
             ]

--- a/uaclient/api/tests/test_api_u_pro_services_enable_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_services_enable_v1.py
@@ -226,7 +226,6 @@ class TestEnable:
                     cfg=cfg,
                     name=options.service,
                     variant=options.variant or "",
-                    assume_yes=True,
                     allow_beta=True,
                     access_only=options.access_only,
                 )

--- a/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
@@ -44,7 +44,7 @@ def _enable_services_by_name(
     for name in order_entitlements_for_enabling(cfg, services):
         try:
             ent_ret, reason = actions.enable_entitlement_by_name(
-                cfg, name, assume_yes=True, allow_beta=allow_beta
+                cfg, name, allow_beta=allow_beta
             )
         except exceptions.UbuntuProError as e:
             failed_services.append(

--- a/uaclient/api/u/pro/detach/v1.py
+++ b/uaclient/api/u/pro/detach/v1.py
@@ -69,9 +69,7 @@ def _detach_in_lock(cfg: UAConfig) -> DetachResult:
     warnings = []  # type: List[ErrorWarningObject]
     for ent_name in entitlements.entitlements_disable_order(cfg):
         try:
-            ent = entitlements.entitlement_factory(
-                cfg=cfg, name=ent_name, assume_yes=True
-            )
+            ent = entitlements.entitlement_factory(cfg=cfg, name=ent_name)
         except exceptions.EntitlementNotFoundError:
             continue
 

--- a/uaclient/api/u/pro/services/disable/v1.py
+++ b/uaclient/api/u/pro/services/disable/v1.py
@@ -65,7 +65,6 @@ def _disable(
     entitlement = entitlements.entitlement_factory(
         cfg=cfg,
         name=options.service,
-        assume_yes=True,
         purge=options.purge,
     )
 

--- a/uaclient/api/u/pro/services/enable/v1.py
+++ b/uaclient/api/u/pro/services/enable/v1.py
@@ -100,7 +100,6 @@ def _enable(
         cfg=cfg,
         name=options.service,
         variant=options.variant or "",
-        assume_yes=True,
         allow_beta=True,
         access_only=options.access_only,
     )

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -529,7 +529,9 @@ def _print_help_for_subcommand(
         )
 
 
-def _perform_disable(entitlement, cfg, *, json_output, update_status=True):
+def _perform_disable(
+    entitlement, cfg, *, json_output, assume_yes, update_status=True
+):
     """Perform the disable action on a named entitlement.
 
     :param entitlement_name: the name of the entitlement to enable
@@ -547,7 +549,9 @@ def _perform_disable(entitlement, cfg, *, json_output, update_status=True):
     if json_output:
         progress = api.ProgressWrapper()
     else:
-        progress = api.ProgressWrapper(cli_util.CLIEnableDisableProgress())
+        progress = api.ProgressWrapper(
+            cli_util.CLIEnableDisableProgress(assume_yes=assume_yes)
+        )
 
     ret, reason = entitlement.disable(progress)
 
@@ -819,7 +823,6 @@ def _detach(cfg: config.UAConfig, assume_yes: bool, json_output: bool) -> int:
             ent = entitlements.entitlement_factory(
                 cfg=cfg,
                 name=ent_name,
-                assume_yes=assume_yes,
             )
         except exceptions.EntitlementNotFoundError:
             continue
@@ -839,7 +842,11 @@ def _detach(cfg: config.UAConfig, assume_yes: bool, json_output: bool) -> int:
         return 1
     for ent in to_disable:
         _perform_disable(
-            ent, cfg, json_output=json_output, update_status=False
+            ent,
+            cfg,
+            json_output=json_output,
+            assume_yes=assume_yes,
+            update_status=False,
         )
 
     machine_token_file = machine_token.get_machine_token_file(cfg)
@@ -959,7 +966,7 @@ def action_attach(args, *, cfg, **kwargs):
             )
             for name in found:
                 ent_ret, reason = actions.enable_entitlement_by_name(
-                    cfg, name, assume_yes=True, allow_beta=True
+                    cfg, name, allow_beta=True
                 )
                 if not ent_ret:
                     ret = 1

--- a/uaclient/cli/cli_util.py
+++ b/uaclient/cli/cli_util.py
@@ -25,7 +25,7 @@ class CLIEnableDisableProgress(api.AbstractProgress):
         if event == "info":
             print(payload)
         elif event == "message_operation":
-            if not util.handle_message_operations(payload, print):
+            if not util.handle_message_operations(payload):
                 raise exceptions.PromptDeniedError()
 
 

--- a/uaclient/cli/cli_util.py
+++ b/uaclient/cli/cli_util.py
@@ -7,8 +7,9 @@ from uaclient.files import machine_token
 
 
 class CLIEnableDisableProgress(api.AbstractProgress):
-    def __init__(self):
-        self.is_interactive = True
+    def __init__(self, *, assume_yes: bool):
+        self.is_interactive = not assume_yes
+        self.assume_yes = assume_yes
 
     def progress(
         self,
@@ -25,7 +26,7 @@ class CLIEnableDisableProgress(api.AbstractProgress):
         if event == "info":
             print(payload)
         elif event == "message_operation":
-            if not util.handle_message_operations(payload):
+            if not util.handle_message_operations(payload, self.assume_yes):
                 raise exceptions.PromptDeniedError()
 
 

--- a/uaclient/cli/disable.py
+++ b/uaclient/cli/disable.py
@@ -77,6 +77,7 @@ def action_disable(args, *, cfg, **kwargs):
     }
 
     json_output = args.format == "json"
+    assume_yes = args.assume_yes
     # HACK NOTICE: interactive_only_print here will be a no-op "null_print"
     # function defined above if args.format == "json". We use this function
     # throughout enable for things that should get printed in the normal
@@ -85,7 +86,7 @@ def action_disable(args, *, cfg, **kwargs):
         json_output
     )
 
-    if args.purge and args.assume_yes:
+    if args.purge and assume_yes:
         raise exceptions.InvalidOptionCombination(
             option1="--purge", option2="--assume-yes"
         )
@@ -105,7 +106,6 @@ def action_disable(args, *, cfg, **kwargs):
         ent = entitlements.entitlement_factory(
             cfg=cfg,
             name=ent_name,
-            assume_yes=args.assume_yes,
             purge=args.purge,
         )
 
@@ -113,7 +113,7 @@ def action_disable(args, *, cfg, **kwargs):
         if variant is not None:
             ent = variant
 
-        if not args.assume_yes:
+        if not assume_yes:
             # this never happens for json output because we assert earlier that
             # assume_yes must be True for json output
             try:
@@ -137,7 +137,9 @@ def action_disable(args, *, cfg, **kwargs):
         if json_output:
             progress = api.ProgressWrapper()
         else:
-            progress = api.ProgressWrapper(cli_util.CLIEnableDisableProgress())
+            progress = api.ProgressWrapper(
+                cli_util.CLIEnableDisableProgress(assume_yes=assume_yes)
+            )
         progress.total_steps = ent.calculate_total_disable_steps()
         try:
             disable_ret, reason = ent.disable(progress)

--- a/uaclient/cli/enable.py
+++ b/uaclient/cli/enable.py
@@ -146,6 +146,7 @@ def action_enable(args, *, cfg, **kwargs) -> int:
 
     variant = getattr(args, "variant", "")
     access_only = args.access_only
+    assume_yes = args.assume_yes
 
     if variant and access_only:
         raise exceptions.InvalidOptionCombination(
@@ -205,7 +206,6 @@ def action_enable(args, *, cfg, **kwargs) -> int:
             cfg=cfg,
             name=ent_name,
             variant=variant,
-            assume_yes=args.assume_yes,
             allow_beta=args.beta,
             access_only=access_only,
             extra_args=kwargs.get("extra_args"),
@@ -213,7 +213,7 @@ def action_enable(args, *, cfg, **kwargs) -> int:
         real_name = ent.name
         ent_title = ent.title
 
-        if not args.assume_yes:
+        if not assume_yes:
             # this never happens for json output because we assert earlier that
             # assume_yes must be True for json output
             try:
@@ -239,7 +239,7 @@ def action_enable(args, *, cfg, **kwargs) -> int:
                 progress = api.ProgressWrapper()
             else:
                 progress = api.ProgressWrapper(
-                    cli_util.CLIEnableDisableProgress()
+                    cli_util.CLIEnableDisableProgress(assume_yes=assume_yes)
                 )
 
             progress.total_steps = ent.calculate_total_enable_steps()

--- a/uaclient/cli/fix.py
+++ b/uaclient/cli/fix.py
@@ -505,9 +505,7 @@ def _prompt_for_enable(cfg: UAConfig, service: str) -> bool:
 
     if choice == "e":
         print(colorize_commands([["pro", "enable", service]]))
-        ret, reason = enable_entitlement_by_name(
-            cfg=cfg, name=service, assume_yes=True
-        )
+        ret, reason = enable_entitlement_by_name(cfg=cfg, name=service)
 
         if (
             not ret

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -505,7 +505,7 @@ class TestActionAttach:
         ] == m_attach_with_token.call_args_list
         if auto_enable:
             assert [
-                mock.call(cfg, "cis", assume_yes=True, allow_beta=True)
+                mock.call(cfg, "cis", allow_beta=True)
             ] == m_enable.call_args_list
         else:
             assert [] == m_enable.call_args_list

--- a/uaclient/cli/tests/test_cli_enable.py
+++ b/uaclient/cli/tests/test_cli_enable.py
@@ -1,23 +1,29 @@
-import contextlib
-import io
-import json
-import textwrap
+from argparse import Namespace
 
 import mock
 import pytest
 
-from uaclient import entitlements, event_logger, exceptions, lock, messages
+from uaclient import exceptions, messages
 from uaclient.api.u.pro.services.dependencies.v1 import (
+    DependenciesResult,
     ServiceWithDependencies,
     ServiceWithReason,
 )
-from uaclient.cli import main, main_error_handler
-from uaclient.cli.enable import action_enable, prompt_for_dependency_handling
-from uaclient.entitlements.entitlement_status import (
-    CanEnableFailure,
-    CanEnableFailureReason,
+from uaclient.api.u.pro.services.enable.v1 import EnableOptions, EnableResult
+from uaclient.api.u.pro.status.enabled_services.v1 import (
+    EnabledService,
+    EnabledServicesResult,
 )
-from uaclient.files.user_config_file import UserConfigData
+from uaclient.api.u.pro.status.is_attached.v1 import IsAttachedResult
+from uaclient.cli import main
+from uaclient.cli.enable import (
+    _enable_landscape,
+    _enable_one_service,
+    _EnableOneServiceResult,
+    _print_json_output,
+    action_enable,
+    prompt_for_dependency_handling,
+)
 from uaclient.testing.helpers import does_not_raise
 
 HELP_OUTPUT = """\
@@ -44,13 +50,6 @@ Flags:
 """
 
 
-@mock.patch(
-    "uaclient.files.user_config_file.UserConfigFileObject.public_config",
-    new_callable=mock.PropertyMock,
-    return_value=UserConfigData(),
-)
-@mock.patch("uaclient.contract.UAContractClient.update_activity_token")
-@mock.patch("uaclient.contract.refresh")
 class TestActionEnable:
     @mock.patch("uaclient.log.setup_cli_logging")
     @mock.patch("uaclient.cli.contract.get_available_resources")
@@ -58,9 +57,6 @@ class TestActionEnable:
         self,
         _m_resources,
         _m_setup_logging,
-        _refresh,
-        _m_update_activity_token,
-        _m_public_config,
         capsys,
         FakeConfig,
     ):
@@ -74,1046 +70,822 @@ class TestActionEnable:
         out, _err = capsys.readouterr()
         assert HELP_OUTPUT == out
 
-    @mock.patch("uaclient.log.setup_cli_logging")
-    @mock.patch("uaclient.util.we_are_currently_root", return_value=False)
-    @mock.patch("uaclient.cli.contract.get_available_resources")
-    def test_non_root_users_are_rejected(
-        self,
-        _m_resources,
-        _refresh,
-        we_are_currently_root,
-        m_setup_logging,
-        _m_update_activity_token,
-        _m_public_config,
-        capsys,
-        event,
-        FakeConfig,
-        fake_machine_token_file,
-        tmpdir,
-    ):
-        """Check that a UID != 0 will receive a message and exit non-zero"""
-        fake_machine_token_file.attached = True
-        args = mock.MagicMock()
-
-        with pytest.raises(exceptions.NonRootUserError):
-            action_enable(args, cfg=None)
-
-        default_get_user_log_file = tmpdir.join("default.log").strpath
-        defaults_ret = {
-            "log_level": "debug",
-            "log_file": default_get_user_log_file,
-        }
-
-        with pytest.raises(SystemExit):
-            with mock.patch(
-                "sys.argv",
-                [
-                    "/usr/bin/ua",
-                    "enable",
-                    "foobar",
-                    "--assume-yes",
-                    "--format",
-                    "json",
-                ],
-            ):
-                with mock.patch(
-                    "uaclient.config.UAConfig",
-                    return_value=FakeConfig(),
-                ):
-                    with mock.patch(
-                        "uaclient.log.get_user_log_file",
-                        return_value=tmpdir.join("user.log").strpath,
-                    ):
-                        with mock.patch.dict(
-                            "uaclient.cli.defaults.CONFIG_DEFAULTS",
-                            defaults_ret,
-                        ):
-                            main()
-
-        expected_message = messages.E_NONROOT_USER
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
-                {
-                    "message": expected_message.msg,
-                    "message_code": expected_message.name,
-                    "service": None,
-                    "type": "system",
-                }
-            ],
-            "failed_services": [],
-            "needs_reboot": False,
-            "processed_services": [],
-            "warnings": [],
-        }
-        assert expected == json.loads(capsys.readouterr()[0])
-
-    @mock.patch("uaclient.lock.check_lock_info")
-    @mock.patch("time.sleep")
-    @mock.patch("uaclient.system.subp")
-    def test_lock_file_exists(
-        self,
-        m_subp,
-        m_sleep,
-        m_check_lock_info,
-        _refresh,
-        _m_update_activity_token,
-        _m_public_config,
-        capsys,
-        event,
-        FakeConfig,
-        fake_machine_token_file,
-    ):
-        """Check inability to enable if operation holds lock file."""
-        cfg = FakeConfig()
-        fake_machine_token_file.attached = True
-        m_check_lock_info.return_value = (123, "pro disable")
-        args = mock.MagicMock()
-
-        with pytest.raises(exceptions.LockHeldError) as err:
-            action_enable(args, cfg=cfg)
-        assert 12 == m_check_lock_info.call_count
-
-        expected_msg = messages.E_LOCK_HELD_ERROR.format(
-            lock_request="pro enable", lock_holder="pro disable", pid="123"
-        )
-        assert expected_msg.msg == err.value.msg
-
-        with pytest.raises(SystemExit):
-            with mock.patch.object(
-                event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
-            ):
-                main_error_handler(action_enable)(args, cfg)
-
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
-                {
-                    "additional_info": {
-                        "lock_holder": "pro disable",
-                        "lock_request": "pro enable",
-                        "pid": 123,
-                    },
-                    "message": expected_msg.msg,
-                    "message_code": expected_msg.name,
-                    "service": None,
-                    "type": "system",
-                }
-            ],
-            "failed_services": [],
-            "needs_reboot": False,
-            "processed_services": [],
-            "warnings": [],
-        }
-        assert expected == json.loads(capsys.readouterr()[0])
-
     @pytest.mark.parametrize(
-        "root,expected_error_template",
         [
-            (True, messages.E_VALID_SERVICE_FAILURE_UNATTACHED),
-            (False, messages.E_NONROOT_USER),
+            "is_attached",
+            "args",
+            "kwargs",
+            "refresh_side_effect",
+            "valid_entitlement_names",
+            "enabled_services",
+            "dependencies",
+            "entitlements_for_enabling",
+            "enable_one_service_side_effect",
+            "expected_enable_one_service_calls",
+            "expected_print_json_output_calls",
+            "expected_raises",
         ],
-    )
-    @mock.patch("uaclient.util.we_are_currently_root")
-    def test_unattached_error_message(
-        self,
-        m_we_are_currently_root,
-        _refresh,
-        _m_update_activity_token,
-        _m_public_config,
-        root,
-        expected_error_template,
-        capsys,
-        event,
-        FakeConfig,
-    ):
-        """Check that root user gets unattached message."""
-
-        m_we_are_currently_root.return_value = root
-
-        cfg = FakeConfig()
-        args = mock.MagicMock()
-        args.command = "enable"
-        args.service = ["esm-infra"]
-
-        if root:
-            expected_error = expected_error_template.format(
-                valid_service="esm-infra", operation="enable"
-            )
-            expected_info = {
-                "valid_service": "esm-infra",
-                "operation": "enable",
-            }
-        else:
-            expected_error = expected_error_template
-            expected_info = None
-
-        with pytest.raises(exceptions.UbuntuProError) as err:
-            action_enable(args, cfg)
-        assert expected_error.msg == err.value.msg
-
-        with pytest.raises(SystemExit):
-            with mock.patch.object(
-                event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
-            ):
-                main_error_handler(action_enable)(args, cfg)
-
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
-                {
-                    "message": expected_error.msg,
-                    "message_code": expected_error.name,
-                    "service": None,
-                    "type": "system",
-                }
-            ],
-            "failed_services": [],
-            "needs_reboot": False,
-            "processed_services": [],
-            "warnings": [],
-        }
-        if expected_info is not None:
-            expected["errors"][0]["additional_info"] = expected_info
-        assert expected == json.loads(capsys.readouterr()[0])
-
-    @pytest.mark.parametrize("is_attached", (True, False))
-    @pytest.mark.parametrize(
-        "root,expected_error_template",
-        [
-            (True, messages.E_INVALID_SERVICE_OP_FAILURE),
-            (False, messages.E_NONROOT_USER),
-        ],
-    )
-    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
-    @mock.patch("uaclient.util.we_are_currently_root")
-    def test_invalid_service_error_message(
-        self,
-        m_we_are_currently_root,
-        _m_check_lock_info,
-        _refresh,
-        _m_update_activity_token,
-        _m_public_config,
-        root,
-        expected_error_template,
-        is_attached,
-        event,
-        FakeConfig,
-        fake_machine_token_file,
-    ):
-        """Check invalid service name results in custom error message."""
-
-        m_we_are_currently_root.return_value = root
-        fake_machine_token_file.attached = is_attached
-        cfg = FakeConfig()
-        if is_attached:
-            service_msg = "\n".join(
-                textwrap.wrap(
-                    (
-                        "Try "
-                        + ", ".join(
-                            entitlements.valid_services(
-                                cfg=cfg, allow_beta=True
-                            )
-                        )
-                        + "."
-                    ),
-                    width=80,
-                    break_long_words=False,
-                    break_on_hyphens=False,
-                )
-            )
-        else:
-            service_msg = ""
-
-        args = mock.MagicMock()
-        args.service = ["bogus"]
-        args.command = "enable"
-        args.access_only = False
-
-        fake_stdout = io.StringIO()
-        if root and is_attached:
-            expected_err = does_not_raise()
-        else:
-            expected_err = pytest.raises(exceptions.UbuntuProError)
-        with expected_err as err:
-            with mock.patch.object(lock, "lock_data_file"):
-                with contextlib.redirect_stdout(fake_stdout):
-                    action_enable(args, cfg=cfg)
-
-        if root:
-            expected_error = expected_error_template.format(
-                operation="enable",
-                invalid_service="bogus",
-                service_msg=service_msg,
-            )
-            expected_info = {
-                "invalid_service": "bogus",
-                "operation": "enable",
-                "service_msg": service_msg,
-            }
-        else:
-            expected_error = expected_error_template
-            expected_info = None
-
-        if root and is_attached:
-            assert expected_error.msg in fake_stdout.getvalue()
-        else:
-            assert expected_error.msg == err.value.msg
-
-        args.assume_yes = True
-        args.format = "json"
-        if root and is_attached:
-            expected_err = does_not_raise()
-        else:
-            expected_err = pytest.raises(SystemExit)
-        with expected_err:
-            with mock.patch.object(
-                event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
-            ):
-                with mock.patch.object(lock, "lock_data_file"):
-                    fake_stdout = io.StringIO()
-                    with contextlib.redirect_stdout(fake_stdout):
-                        main_error_handler(action_enable)(args, cfg)
-
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
-                {
-                    "message": expected_error.msg,
-                    "message_code": expected_error.name,
-                    "service": None,
-                    "type": "system",
-                }
-            ],
-            "failed_services": ["bogus"] if root and is_attached else [],
-            "needs_reboot": False,
-            "processed_services": [],
-            "warnings": [],
-        }
-        if expected_info is not None:
-            expected["errors"][0]["additional_info"] = expected_info
-        assert expected == json.loads(fake_stdout.getvalue())
-
-    @pytest.mark.parametrize(
-        "root,expected_error_template",
-        [
-            (True, messages.E_MIXED_SERVICES_FAILURE_UNATTACHED),
-            (False, messages.E_NONROOT_USER),
-        ],
-    )
-    @mock.patch("uaclient.util.we_are_currently_root")
-    def test_unattached_invalid_and_valid_service_error_message(
-        self,
-        m_we_are_currently_root,
-        _refresh,
-        _m_update_activity_token,
-        _m_public_config,
-        root,
-        expected_error_template,
-        event,
-        FakeConfig,
-    ):
-        """Check invalid service name results in custom error message."""
-
-        m_we_are_currently_root.return_value = root
-        cfg = FakeConfig()
-
-        args = mock.MagicMock()
-        args.service = ["bogus", "fips"]
-        args.command = "enable"
-        with pytest.raises(exceptions.UbuntuProError) as err:
-            action_enable(args, cfg)
-
-        if root:
-            expected_error = expected_error_template.format(
-                operation="enable",
-                valid_service="fips",
-                invalid_service="bogus",
-                service_msg="",
-            )
-            expected_info = {
-                "invalid_service": "bogus",
-                "operation": "enable",
-                "service_msg": "",
-                "valid_service": "fips",
-            }
-        else:
-            expected_error = expected_error_template
-            expected_info = None
-
-        assert expected_error.msg == err.value.msg
-
-        with pytest.raises(SystemExit):
-            with mock.patch.object(
-                event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
-            ):
-                fake_stdout = io.StringIO()
-                with contextlib.redirect_stdout(fake_stdout):
-                    main_error_handler(action_enable)(args, cfg)
-
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
-                {
-                    "message": expected_error.msg,
-                    "message_code": expected_error.name,
-                    "service": None,
-                    "type": "system",
-                }
-            ],
-            "failed_services": [],
-            "needs_reboot": False,
-            "processed_services": [],
-            "warnings": [],
-        }
-        if expected_info is not None:
-            expected["errors"][0]["additional_info"] = expected_info
-        assert expected == json.loads(fake_stdout.getvalue())
-
-    @mock.patch("uaclient.cli.enable._enabled_services")
-    @mock.patch("uaclient.cli.enable._dependencies")
-    @mock.patch("uaclient.files.state_files.status_cache_file.write")
-    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
-    @mock.patch("uaclient.status.get_available_resources", return_value={})
-    @mock.patch("uaclient.entitlements.entitlement_factory")
-    @mock.patch("uaclient.entitlements.valid_services")
-    def test_entitlements_not_found_disabled_and_enabled(
-        self,
-        m_valid_services,
-        m_entitlement_factory,
-        _m_get_available_resources,
-        _m_check_lock_info,
-        _m_refresh,
-        _m_status_cache_file,
-        m_enabled_services,
-        m_dependencies,
-        _m_update_activity_token,
-        _m_public_config,
-        event,
-        FakeConfig,
-        fake_machine_token_file,
-    ):
-        m_enabled_services.return_value = mock.MagicMock(enabled_services=[])
-        m_dependencies.return_value = mock.MagicMock(all_dependencies=[])
-
-        expected_error_tmpl = messages.E_INVALID_SERVICE_OP_FAILURE
-
-        m_ent1_obj = mock.MagicMock()
-        m_ent1_obj.enable.return_value = (False, None)
-        m_ent1_obj._check_for_reboot.return_value = False
-
-        m_ent2_obj = mock.MagicMock(title="Ent2")
-        m_ent2_obj.name = "ent2"
-        m_ent2_is_beta = mock.PropertyMock(return_value=True)
-        type(m_ent2_obj).is_beta = m_ent2_is_beta
-        type(m_ent2_obj).required_services = mock.PropertyMock(return_value=[])
-        m_ent2_obj.enable.return_value = (
-            False,
-            CanEnableFailure(CanEnableFailureReason.IS_BETA),
-        )
-
-        m_ent3_obj = mock.MagicMock(title="Ent3")
-        m_ent3_obj.name = "ent3"
-        m_ent3_is_beta = mock.PropertyMock(return_value=False)
-        type(m_ent3_obj).is_beta = m_ent3_is_beta
-        type(m_ent3_obj).required_services = mock.PropertyMock(return_value=[])
-        m_ent3_obj.enable.return_value = (True, None)
-        m_ent3_obj._check_for_reboot.return_value = False
-
-        def factory_side_effect(cfg, name, **kwargs):
-            if name == "ent2":
-                return m_ent2_obj
-            if name == "ent3":
-                return m_ent3_obj
-            return None
-
-        m_entitlement_factory.side_effect = factory_side_effect
-        m_valid_services.return_value = ["ent2", "ent3"]
-
-        fake_machine_token_file.attached = True
-        cfg = FakeConfig()
-        assume_yes = False
-        args_mock = mock.Mock()
-        args_mock.service = ["ent1", "ent2", "ent3"]
-        args_mock.access_only = False
-        args_mock.assume_yes = assume_yes
-        args_mock.beta = False
-        args_mock.variant = ""
-
-        expected_msg = (
-            "One moment, checking your subscription first\n"
-            "Could not enable Ent2.\n"
-            "Ent3 enabled\n"
-        )
-
-        with mock.patch.object(lock, "lock_data_file"):
-            fake_stdout = io.StringIO()
-            with contextlib.redirect_stdout(fake_stdout):
-                with mock.patch.object(
-                    entitlements,
-                    "ENTITLEMENT_CLASSES",
-                    [m_ent2_obj, m_ent3_obj],
-                ):
-                    action_enable(args_mock, cfg=cfg)
-
-        service_msg = (
-            "Try "
-            + ", ".join(entitlements.valid_services(allow_beta=False))
-            + "."
-        )
-        expected_error = expected_error_tmpl.format(
-            operation="enable",
-            invalid_service="ent1, ent2",
-            service_msg=service_msg,
-        )
-        assert (
-            expected_msg + expected_error.msg + "\n" == fake_stdout.getvalue()
-        )
-
-        expected_enable_call = mock.call(mock.ANY)
-        for m_ent in [m_ent2_obj, m_ent3_obj]:
-            assert [expected_enable_call] == m_ent.enable.call_args_list
-
-        assert 0 == m_ent1_obj.call_count
-
-        event.reset()
-        args_mock.assume_yes = True
-        args_mock.format = "json"
-        with mock.patch.object(lock, "lock_data_file"):
-            fake_stdout = io.StringIO()
-            with contextlib.redirect_stdout(fake_stdout):
-                with mock.patch.object(
-                    entitlements,
-                    "ENTITLEMENT_CLASSES",
-                    [m_ent2_obj, m_ent3_obj],
-                ):
-                    main_error_handler(action_enable)(args_mock, cfg)
-
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
-                {
-                    "additional_info": {
-                        "invalid_service": "ent1, ent2",
-                        "operation": "enable",
-                        "service_msg": service_msg,
-                    },
-                    "message": expected_error.msg,
-                    "message_code": expected_error.name,
-                    "service": None,
-                    "type": "system",
-                }
-            ],
-            "failed_services": ["ent1", "ent2"],
-            "needs_reboot": False,
-            "processed_services": ["ent3"],
-            "warnings": [],
-        }
-        assert expected == json.loads(fake_stdout.getvalue())
-
-    @pytest.mark.parametrize("beta_flag", ((False), (True)))
-    @mock.patch("uaclient.cli.enable._enabled_services")
-    @mock.patch("uaclient.cli.enable._dependencies")
-    @mock.patch("uaclient.files.state_files.status_cache_file.write")
-    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
-    @mock.patch("uaclient.status.get_available_resources", return_value={})
-    @mock.patch("uaclient.entitlements.entitlement_factory")
-    @mock.patch("uaclient.entitlements.valid_services")
-    def test_entitlements_not_found_and_beta(
-        self,
-        m_valid_services,
-        m_entitlement_factory,
-        _m_get_available_resources,
-        _m_check_lock_info,
-        _m_status_cache_file,
-        m_enabled_services,
-        m_dependencies,
-        _m_refresh,
-        _m_update_activity_token,
-        _m_public_config,
-        beta_flag,
-        event,
-        FakeConfig,
-        fake_machine_token_file,
-    ):
-        m_enabled_services.return_value = mock.MagicMock(enabled_services=[])
-        m_dependencies.return_value = mock.MagicMock(all_dependencies=[])
-
-        expected_error_tmpl = messages.E_INVALID_SERVICE_OP_FAILURE
-
-        m_ent1_cls = mock.MagicMock()
-        m_ent1_cls.name = "ent1"
-        m_ent1_obj = m_ent1_cls.return_value
-        m_ent1_obj.enable.return_value = (False, None)
-        m_ent1_obj._check_for_reboot.return_value = False
-        type(m_ent1_obj).title = mock.PropertyMock(return_value="Ent1")
-        type(m_ent1_obj).required_services = mock.PropertyMock(return_value=[])
-
-        m_ent2_cls = mock.MagicMock()
-        m_ent2_cls.name = "ent2"
-        m_ent2_obj = m_ent2_cls.return_value
-        m_ent2_obj.name = "ent2"
-        m_ent2_obj.messaging = {}
-        m_ent2_obj._check_for_reboot.return_value = False
-        m_ent2_is_beta = mock.PropertyMock(return_value=True)
-        type(m_ent2_obj)._is_beta = m_ent2_is_beta
-        type(m_ent2_obj).title = mock.PropertyMock(return_value="Ent2")
-        type(m_ent2_obj).required_services = mock.PropertyMock(return_value=[])
-
-        failure_reason = CanEnableFailure(CanEnableFailureReason.IS_BETA)
-        if beta_flag:
-            m_ent2_obj.enable.return_value = (True, None)
-        else:
-            m_ent2_obj.enable.return_value = (False, failure_reason)
-
-        m_ent3_cls = mock.MagicMock()
-        m_ent3_cls.name = "ent3"
-        m_ent3_obj = m_ent3_cls.return_value
-        m_ent3_obj.name = "ent3"
-        m_ent3_obj.messaging = {}
-        m_ent3_is_beta = mock.PropertyMock(return_value=False)
-        m_ent3_obj._check_for_reboot.return_value = False
-        type(m_ent3_obj)._is_beta = m_ent3_is_beta
-        type(m_ent3_obj).title = mock.PropertyMock(return_value="Ent3")
-        type(m_ent3_obj).required_services = mock.PropertyMock(return_value=[])
-        m_ent3_obj.enable.return_value = (True, None)
-        m_ent3_obj._check_for_reboot.return_value = False
-
-        fake_machine_token_file.attached = True
-        cfg = FakeConfig()
-        assume_yes = False
-        args_mock = mock.Mock()
-        args_mock.service = ["ent1", "ent2", "ent3"]
-        args_mock.access_only = False
-        args_mock.assume_yes = assume_yes
-        args_mock.beta = beta_flag
-        args_mock.variant = ""
-
-        def factory_side_effect(cfg, name, **kwargs):
-            if name == "ent2":
-                return m_ent2_obj
-            if name == "ent3":
-                return m_ent3_obj
-            return None
-
-        m_entitlement_factory.side_effect = factory_side_effect
-
-        def valid_services_side_effect(cfg, allow_beta, all_names=False):
-            if allow_beta:
-                return ["ent2", "ent3"]
-            return ["ent2"]
-
-        m_valid_services.side_effect = valid_services_side_effect
-
-        if beta_flag:
-            expected_msg = (
-                "One moment, checking your subscription first\n"
-                "Ent2 enabled\n"
-                "Ent3 enabled\n"
-            )
-        else:
-            expected_msg = (
-                "One moment, checking your subscription first\n"
-                "Could not enable Ent2.\n"
-                "Ent3 enabled\n"
-            )
-        not_found_name = "ent1"
-        mock_obj_list = [m_ent3_obj]
-
-        service_names = entitlements.valid_services(cfg, allow_beta=beta_flag)
-        ent_str = "Try " + ", ".join(service_names) + "."
-        if not beta_flag:
-            not_found_name += ", ent2"
-        else:
-            mock_obj_list.append(m_ent3_obj)
-        service_msg = "\n".join(
-            textwrap.wrap(
-                ent_str,
-                width=80,
-                break_long_words=False,
-                break_on_hyphens=False,
-            )
-        )
-
-        with mock.patch.object(lock, "lock_data_file"):
-            with mock.patch.object(
-                entitlements, "ENTITLEMENT_CLASSES", [m_ent2_cls, m_ent3_cls]
-            ):
-                fake_stdout = io.StringIO()
-                with contextlib.redirect_stdout(fake_stdout):
-                    action_enable(args_mock, cfg=cfg)
-
-        expected_error = expected_error_tmpl.format(
-            operation="enable",
-            invalid_service=not_found_name,
-            service_msg=service_msg,
-        )
-        assert (
-            expected_msg + expected_error.msg + "\n" == fake_stdout.getvalue()
-        )
-
-        expected_enable_call = mock.call(mock.ANY)
-        for m_ent in mock_obj_list:
-            assert [expected_enable_call] == m_ent.enable.call_args_list
-
-        assert 0 == m_ent1_obj.call_count
-
-        event.reset()
-        args_mock.assume_yes = True
-        args_mock.format = "json"
-        with mock.patch.object(lock, "lock_data_file"):
-            fake_stdout = io.StringIO()
-            with contextlib.redirect_stdout(fake_stdout):
-                with mock.patch.object(
-                    entitlements,
-                    "ENTITLEMENT_CLASSES",
-                    [m_ent2_obj, m_ent3_obj],
-                ):
-                    main_error_handler(action_enable)(args_mock, cfg=cfg)
-
-        expected_failed_services = ["ent1", "ent2"]
-        if beta_flag:
-            expected_failed_services = ["ent1"]
-
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
-                {
-                    "additional_info": {
-                        "invalid_service": ", ".join(
-                            sorted(expected_failed_services)
-                        ),
-                        "operation": "enable",
-                        "service_msg": service_msg,
-                    },
-                    "message": expected_error.msg,
-                    "message_code": expected_error.name,
-                    "service": None,
-                    "type": "system",
-                }
-            ],
-            "failed_services": expected_failed_services,
-            "needs_reboot": False,
-            "processed_services": ["ent2", "ent3"] if beta_flag else ["ent3"],
-            "warnings": [],
-        }
-        assert expected == json.loads(fake_stdout.getvalue())
-
-    @mock.patch("uaclient.cli.enable._enabled_services")
-    @mock.patch("uaclient.cli.enable._dependencies")
-    @mock.patch("uaclient.files.state_files.status_cache_file.write")
-    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
-    @mock.patch("uaclient.status.get_available_resources", return_value={})
-    def test_print_message_when_can_enable_fails(
-        self,
-        _m_get_available_resources,
-        _m_check_lock_info,
-        _m_status_cache_file,
-        m_enabled_services,
-        m_dependencies,
-        _m_refresh,
-        _m_update_activity_token,
-        _m_public_config,
-        event,
-        FakeConfig,
-        fake_machine_token_file,
-    ):
-        m_enabled_services.return_value = mock.MagicMock(enabled_services=[])
-        m_dependencies.return_value = mock.MagicMock(all_dependencies=[])
-        m_entitlement_obj = mock.Mock(title="Title")
-        type(m_entitlement_obj).required_services = mock.PropertyMock(
-            return_value=[]
-        )
-        type(m_entitlement_obj).is_beta = mock.PropertyMock(return_value=False)
-        m_entitlement_obj.enable.return_value = (
-            False,
-            CanEnableFailure(
-                CanEnableFailureReason.ALREADY_ENABLED,
-                message=messages.NamedMessage("test-code", "msg"),
+        (
+            # assume-yes required for json output
+            (
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=True,
+                ),
+                Namespace(
+                    format="json",
+                    variant="",
+                    access_only=False,
+                    assume_yes=False,
+                ),
+                {},
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [],
+                [],
+                pytest.raises(exceptions.CLIJSONFormatRequireAssumeYes),
             ),
-        )
-
-        cfg = FakeConfig()
-        fake_machine_token_file.attached = True
-        args_mock = mock.Mock()
-        args_mock.service = ["ent1"]
-        args_mock.assume_yes = False
-        args_mock.beta = False
-        args_mock.access_only = False
-
-        with mock.patch(
-            "uaclient.entitlements.entitlement_factory",
-            return_value=m_entitlement_obj,
-        ), mock.patch(
-            "uaclient.entitlements.valid_services", return_value=["ent1"]
-        ):
-            with mock.patch.object(lock, "lock_data_file"):
-                fake_stdout = io.StringIO()
-                with contextlib.redirect_stdout(fake_stdout):
-                    action_enable(args_mock, cfg=cfg)
-
-            assert (
-                "One moment, checking your subscription first\nmsg\n"
-                "Could not enable Title.\n"
-            ) == fake_stdout.getvalue()
-
-        args_mock.assume_yes = True
-        args_mock.format = "json"
-
-        with mock.patch(
-            "uaclient.entitlements.entitlement_factory",
-            return_value=m_entitlement_obj,
-        ), mock.patch(
-            "uaclient.entitlements.valid_services", return_value=["ent1"]
-        ):
-            with mock.patch.object(lock, "lock_data_file"):
-                fake_stdout = io.StringIO()
-                with contextlib.redirect_stdout(fake_stdout):
-                    ret = action_enable(args_mock, cfg=cfg)
-
-        expected_ret = 1
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
-                {
-                    "message": "msg",
-                    "message_code": "test-code",
-                    "service": "ent1",
-                    "type": "service",
-                }
-            ],
-            "failed_services": ["ent1"],
-            "needs_reboot": False,
-            "processed_services": [],
-            "warnings": [],
-        }
-        assert expected == json.loads(fake_stdout.getvalue())
-        assert expected_ret == ret
-
-    @pytest.mark.parametrize(
-        "service, beta",
-        ((["bogus"], False), (["bogus"], True), (["bogus1", "bogus2"], False)),
+            # variant + access-only not allowed
+            (
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=True,
+                ),
+                Namespace(
+                    format="cli",
+                    variant="variant",
+                    access_only=True,
+                    assume_yes=False,
+                ),
+                {},
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [],
+                [],
+                pytest.raises(exceptions.InvalidOptionCombination),
+            ),
+            # contract not valid
+            (
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=False,
+                ),
+                Namespace(
+                    format="cli",
+                    variant="",
+                    access_only=False,
+                    assume_yes=False,
+                ),
+                {},
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [],
+                [
+                    mock.call(
+                        False,
+                        {"_schema_version": "0.1", "needs_reboot": False},
+                        [],
+                        [],
+                        [
+                            {
+                                "type": "system",
+                                "message": messages.E_CONTRACT_EXPIRED.msg,
+                                "message_code": messages.E_CONTRACT_EXPIRED.name,  # noqa: E501
+                            }
+                        ],
+                        [],
+                        success=False,
+                    )
+                ],
+                does_not_raise(),
+            ),
+            # contract not valid, json output
+            (
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=False,
+                ),
+                Namespace(
+                    format="json",
+                    variant="",
+                    access_only=False,
+                    assume_yes=True,
+                ),
+                {},
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [],
+                [
+                    mock.call(
+                        True,
+                        {"_schema_version": "0.1", "needs_reboot": False},
+                        [],
+                        [],
+                        [
+                            {
+                                "type": "system",
+                                "message": messages.E_CONTRACT_EXPIRED.msg,
+                                "message_code": messages.E_CONTRACT_EXPIRED.name,  # noqa: E501
+                            }
+                        ],
+                        [],
+                        success=False,
+                    )
+                ],
+                does_not_raise(),
+            ),
+            # contract not valid, json output, contract refresh warning
+            (
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=False,
+                ),
+                Namespace(
+                    format="json",
+                    variant="",
+                    access_only=False,
+                    assume_yes=True,
+                ),
+                {},
+                exceptions.ConnectivityError(cause=Exception(), url=""),
+                None,
+                None,
+                None,
+                None,
+                None,
+                [],
+                [
+                    mock.call(
+                        True,
+                        {"_schema_version": "0.1", "needs_reboot": False},
+                        [],
+                        [],
+                        [
+                            {
+                                "type": "system",
+                                "message": messages.E_CONTRACT_EXPIRED.msg,
+                                "message_code": messages.E_CONTRACT_EXPIRED.name,  # noqa: E501
+                            }
+                        ],
+                        [
+                            {
+                                "type": "system",
+                                "message": messages.E_REFRESH_CONTRACT_FAILURE.msg,  # noqa: E501
+                                "message_code": messages.E_REFRESH_CONTRACT_FAILURE.name,  # noqa: E501
+                            }
+                        ],
+                        success=False,
+                    )
+                ],
+                does_not_raise(),
+            ),
+            # success multiple services, one needs reboot
+            (
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=True,
+                ),
+                Namespace(
+                    service=["one", "two", "three"],
+                    format="json",
+                    variant="",
+                    access_only=False,
+                    assume_yes=True,
+                    beta=False,
+                ),
+                {},
+                None,
+                (["one", "two", "three"], []),
+                EnabledServicesResult(enabled_services=[]),
+                DependenciesResult(services=mock.sentinel.dependencies),
+                ["three", "two", "one"],
+                [
+                    _EnableOneServiceResult(
+                        success=True, needs_reboot=False, error=None
+                    ),
+                    _EnableOneServiceResult(
+                        success=True, needs_reboot=True, error=None
+                    ),
+                    _EnableOneServiceResult(
+                        success=True, needs_reboot=False, error=None
+                    ),
+                ],
+                [
+                    mock.call(
+                        mock.ANY,
+                        "three",
+                        "",
+                        False,
+                        False,
+                        True,
+                        True,
+                        None,
+                        [],
+                        mock.sentinel.dependencies,
+                    ),
+                    mock.call(
+                        mock.ANY,
+                        "two",
+                        "",
+                        False,
+                        False,
+                        True,
+                        True,
+                        None,
+                        [],
+                        mock.sentinel.dependencies,
+                    ),
+                    mock.call(
+                        mock.ANY,
+                        "one",
+                        "",
+                        False,
+                        False,
+                        True,
+                        True,
+                        None,
+                        [],
+                        mock.sentinel.dependencies,
+                    ),
+                ],
+                [
+                    mock.call(
+                        True,
+                        {"_schema_version": "0.1", "needs_reboot": True},
+                        ["three", "two", "one"],
+                        [],
+                        [],
+                        [],
+                        success=True,
+                    )
+                ],
+                does_not_raise(),
+            ),
+            # some services not found
+            (
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=True,
+                ),
+                Namespace(
+                    service=["one", "two", "three"],
+                    format="json",
+                    variant="",
+                    access_only=False,
+                    assume_yes=True,
+                    beta=False,
+                ),
+                {},
+                None,
+                (["two"], ["one", "three"]),
+                EnabledServicesResult(enabled_services=[]),
+                DependenciesResult(services=mock.sentinel.dependencies),
+                ["two"],
+                [
+                    _EnableOneServiceResult(
+                        success=True, needs_reboot=False, error=None
+                    ),
+                ],
+                [
+                    mock.call(
+                        mock.ANY,
+                        "two",
+                        "",
+                        False,
+                        False,
+                        True,
+                        True,
+                        None,
+                        [],
+                        mock.sentinel.dependencies,
+                    ),
+                ],
+                [
+                    mock.call(
+                        True,
+                        {"_schema_version": "0.1", "needs_reboot": False},
+                        ["two"],
+                        ["one", "three"],
+                        [
+                            {
+                                "type": "system",
+                                "service": None,
+                                "message": mock.ANY,
+                                "message_code": "invalid-service-or-failure",
+                                "additional_info": {
+                                    "operation": "enable",
+                                    "invalid_service": "one, three",
+                                    "service_msg": mock.ANY,
+                                },
+                            }
+                        ],
+                        [],
+                        success=False,
+                    )
+                ],
+                does_not_raise(),
+            ),
+            # one success, one fail, one not found
+            (
+                IsAttachedResult(
+                    is_attached=True,
+                    contract_status="",
+                    contract_remaining_days=100,
+                    is_attached_and_contract_valid=True,
+                ),
+                Namespace(
+                    service=["one", "two", "three"],
+                    format="json",
+                    variant="",
+                    access_only=False,
+                    assume_yes=True,
+                    beta=False,
+                ),
+                {},
+                None,
+                (["one", "two"], ["three"]),
+                EnabledServicesResult(enabled_services=[]),
+                DependenciesResult(services=mock.sentinel.dependencies),
+                ["two", "one"],
+                [
+                    _EnableOneServiceResult(
+                        success=False,
+                        needs_reboot=False,
+                        error={"test": "error"},
+                    ),
+                    _EnableOneServiceResult(
+                        success=True, needs_reboot=False, error=None
+                    ),
+                ],
+                [
+                    mock.call(
+                        mock.ANY,
+                        "two",
+                        "",
+                        False,
+                        False,
+                        True,
+                        True,
+                        None,
+                        [],
+                        mock.sentinel.dependencies,
+                    ),
+                    mock.call(
+                        mock.ANY,
+                        "one",
+                        "",
+                        False,
+                        False,
+                        True,
+                        True,
+                        None,
+                        [],
+                        mock.sentinel.dependencies,
+                    ),
+                ],
+                [
+                    mock.call(
+                        True,
+                        {"_schema_version": "0.1", "needs_reboot": False},
+                        ["one"],
+                        ["two", "three"],
+                        [
+                            {"test": "error"},
+                            {
+                                "type": "system",
+                                "service": None,
+                                "message": mock.ANY,
+                                "message_code": "invalid-service-or-failure",
+                                "additional_info": {
+                                    "operation": "enable",
+                                    "invalid_service": "three",
+                                    "service_msg": mock.ANY,
+                                },
+                            },
+                        ],
+                        [],
+                        success=False,
+                    )
+                ],
+                does_not_raise(),
+            ),
+        ),
     )
-    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
-    def test_invalid_service_names(
+    @mock.patch("uaclient.contract.UAContractClient.update_activity_token")
+    @mock.patch("uaclient.cli.enable._enable_one_service")
+    @mock.patch("uaclient.entitlements.order_entitlements_for_enabling")
+    @mock.patch("uaclient.cli.enable._dependencies")
+    @mock.patch("uaclient.cli.enable._enabled_services")
+    @mock.patch("uaclient.entitlements.get_valid_entitlement_names")
+    @mock.patch("uaclient.cli.enable._print_json_output")
+    @mock.patch("uaclient.contract.refresh")
+    @mock.patch("uaclient.cli.cli_util.create_interactive_only_print_function")
+    @mock.patch("uaclient.util.we_are_currently_root", return_value=True)
+    @mock.patch("uaclient.cli.enable._is_attached")
+    def test_action_enable(
         self,
-        _m_check_lock_info,
-        _m_refresh,
-        _m_update_activity_token,
-        _m_public_config,
-        service,
-        beta,
-        event,
+        m_is_attached,
+        m_we_are_currently_root,
+        m_create_interactive_only_print_function,
+        m_refresh,
+        m_print_json_output,
+        m_get_valid_entitlement_names,
+        m_enabled_services,
+        m_dependencies,
+        m_order_entitlements_for_enabling,
+        m_enable_one_service,
+        m_update_activity_token,
+        is_attached,
+        args,
+        kwargs,
+        refresh_side_effect,
+        valid_entitlement_names,
+        enabled_services,
+        dependencies,
+        entitlements_for_enabling,
+        enable_one_service_side_effect,
+        expected_enable_one_service_calls,
+        expected_print_json_output_calls,
+        expected_raises,
         FakeConfig,
         fake_machine_token_file,
     ):
-        expected_error_tmpl = messages.E_INVALID_SERVICE_OP_FAILURE
-        expected_msg = "One moment, checking your subscription first\n"
-
-        fake_machine_token_file.attached = True
-        cfg = FakeConfig()
-        args_mock = mock.MagicMock()
-        args_mock.service = service
-        args_mock.beta = beta
-        args_mock.access_only = False
-
-        with mock.patch.object(lock, "lock_data_file"):
-            fake_stdout = io.StringIO()
-            with contextlib.redirect_stdout(fake_stdout):
-                action_enable(args_mock, cfg=cfg)
-
-        service_names = entitlements.valid_services(cfg=cfg, allow_beta=beta)
-        ent_str = "Try " + ", ".join(service_names) + "."
-        service_msg = "\n".join(
-            textwrap.wrap(
-                ent_str,
-                width=80,
-                break_long_words=False,
-                break_on_hyphens=False,
-            )
+        m_is_attached.return_value = is_attached
+        m_refresh.side_effect = refresh_side_effect
+        m_get_valid_entitlement_names.return_value = valid_entitlement_names
+        m_enabled_services.return_value = enabled_services
+        m_dependencies.return_value = dependencies
+        m_order_entitlements_for_enabling.return_value = (
+            entitlements_for_enabling
         )
-        expected_error = expected_error_tmpl.format(
-            operation="enable",
-            invalid_service=", ".join(sorted(service)),
-            service_msg=service_msg,
+        m_enable_one_service.side_effect = enable_one_service_side_effect
+        fake_machine_token_file.attached = True
+
+        with expected_raises:
+            action_enable(args, cfg=FakeConfig(), **kwargs)
+
+        assert (
+            expected_enable_one_service_calls
+            == m_enable_one_service.call_args_list
         )
         assert (
-            expected_msg + expected_error.msg + "\n" == fake_stdout.getvalue()
+            expected_print_json_output_calls
+            == m_print_json_output.call_args_list
         )
 
-        args_mock.assume_yes = True
-        args_mock.format = "json"
-
-        with mock.patch.object(lock, "lock_data_file"):
-            fake_stdout = io.StringIO()
-            with contextlib.redirect_stdout(fake_stdout):
-                main_error_handler(action_enable)(args_mock, cfg)
-
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
+    @pytest.mark.parametrize(
+        [
+            "kwargs",
+            "prompt_for_dependency_handling_side_effect",
+            "enable_landscape_result",
+            "enable_result",
+            "expected_prompt_for_dependency_handling_calls",
+            "expected_enable_landscape_calls",
+            "expected_enable_calls",
+            "expected_status_calls",
+            "expected_result",
+        ],
+        (
+            # already enabled
+            (
                 {
-                    "additional_info": {
-                        "invalid_service": ", ".join(sorted(service)),
-                        "operation": "enable",
-                        "service_msg": service_msg,
+                    "ent_name": "one",
+                    "variant": "",
+                    "allow_beta": False,
+                    "access_only": False,
+                    "assume_yes": False,
+                    "json_output": False,
+                    "extra_args": None,
+                    "enabled_services": [EnabledService(name="one")],
+                    "all_dependencies": [],
+                },
+                None,
+                None,
+                None,
+                [],
+                [],
+                [],
+                [],
+                _EnableOneServiceResult(
+                    success=False,
+                    needs_reboot=False,
+                    error={
+                        "type": "service",
+                        "service": "one",
+                        "message": messages.ALREADY_ENABLED.format(
+                            title=mock.sentinel.ent_title
+                        ).msg,
+                        "message_code": "service-already-enabled",
                     },
-                    "message": expected_error.msg,
-                    "message_code": expected_error.name,
-                    "service": None,
-                    "type": "system",
-                }
-            ],
-            "failed_services": service,
-            "needs_reboot": False,
-            "processed_services": [],
-            "warnings": [],
-        }
-        assert expected == json.loads(fake_stdout.getvalue())
-
-    @pytest.mark.parametrize("allow_beta", ((True), (False)))
-    @mock.patch("uaclient.cli.enable._enabled_services")
-    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
-    @mock.patch("uaclient.status.get_available_resources", return_value={})
-    @mock.patch("uaclient.status.status")
-    def test_entitlement_instantiated_and_enabled(
-        self,
-        m_status,
-        _m_get_available_resources,
-        _m_check_lock_info,
-        m_enabled_services,
-        _m_refresh,
-        m_update_activity_token,
-        _m_public_config,
-        allow_beta,
-        event,
-        fake_machine_token_file,
-    ):
-        m_enabled_services.return_value = mock.MagicMock(enabled_services=[])
-        m_entitlement_obj = mock.MagicMock()
-        m_entitlement_obj.enable.return_value = (True, None)
-        m_entitlement_obj._check_for_reboot.return_value = False
-
-        fake_machine_token_file.attached = True
-
-        args_mock = mock.MagicMock()
-        args_mock.access_only = False
-        args_mock.assume_yes = True
-        args_mock.beta = allow_beta
-        args_mock.service = ["test"]
-        args_mock.variant = ""
-        args_mock.format = "json"
-
-        with mock.patch(
-            "uaclient.entitlements.entitlement_factory",
-            return_value=m_entitlement_obj,
-        ), mock.patch(
-            "uaclient.entitlements.valid_services",
-            return_value=["test"],
-        ):
-            with mock.patch.object(lock, "lock_data_file"):
-                ret = action_enable(args_mock, cfg=None)
-
-        expected_enable_call = mock.call(mock.ANY)
-        expected_ret = 0
-        assert [
-            expected_enable_call
-        ] == m_entitlement_obj.enable.call_args_list
-        assert expected_ret == ret
-        assert 1 == m_status.call_count
-        assert 1 == m_update_activity_token.call_count
-
-        with mock.patch(
-            "uaclient.entitlements.entitlement_factory",
-            return_value=m_entitlement_obj,
-        ), mock.patch(
-            "uaclient.entitlements.valid_services",
-            return_value=["test"],
-        ), mock.patch.object(
-            event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
-        ):
-            with mock.patch.object(lock, "lock_data_file"):
-                fake_stdout = io.StringIO()
-                with contextlib.redirect_stdout(fake_stdout):
-                    ret = action_enable(args_mock, cfg=None)
-
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "success",
-            "errors": [],
-            "failed_services": [],
-            "needs_reboot": False,
-            "processed_services": ["test"],
-            "warnings": [],
-        }
-        assert expected == json.loads(fake_stdout.getvalue())
-        assert expected_ret == ret
-
-    def test_format_json_fails_when_assume_yes_flag_not_used(
-        self,
-        _m_get_available_resources,
-        _m_update_activity_token,
-        _m_public_config,
-        event,
-    ):
-        args_mock = mock.MagicMock()
-        args_mock.format = "json"
-        args_mock.assume_yes = False
-
-        with pytest.raises(SystemExit):
-            with mock.patch.object(
-                event, "_event_logger_mode", event_logger.EventLoggerMode.JSON
-            ):
-                fake_stdout = io.StringIO()
-                with contextlib.redirect_stdout(fake_stdout):
-                    main_error_handler(action_enable)(args_mock, None)
-
-        expected_message = messages.E_JSON_FORMAT_REQUIRE_ASSUME_YES
-        expected = {
-            "_schema_version": event_logger.JSON_SCHEMA_VERSION,
-            "result": "failure",
-            "errors": [
+                ),
+            ),
+            # prompt denied fails
+            (
                 {
-                    "message": expected_message.msg,
-                    "message_code": expected_message.name,
-                    "service": None,
-                    "type": "system",
-                }
-            ],
-            "failed_services": [],
-            "needs_reboot": False,
-            "processed_services": [],
-            "warnings": [],
-        }
-        assert expected == json.loads(fake_stdout.getvalue())
-
-    @mock.patch("uaclient.lock.check_lock_info", return_value=(-1, ""))
-    def test_access_only_cannot_be_used_together_with_variant(
+                    "ent_name": "one",
+                    "variant": "",
+                    "allow_beta": False,
+                    "access_only": False,
+                    "assume_yes": False,
+                    "json_output": False,
+                    "extra_args": None,
+                    "enabled_services": [],
+                    "all_dependencies": [],
+                },
+                [exceptions.PromptDeniedError()],
+                None,
+                None,
+                [
+                    mock.call(
+                        mock.ANY,
+                        "one",
+                        [],
+                        [],
+                        called_name="one",
+                        service_title=mock.sentinel.ent_title,
+                    )
+                ],
+                [],
+                [],
+                [],
+                _EnableOneServiceResult(
+                    success=False, needs_reboot=False, error=None
+                ),
+            ),
+            # landscape
+            (
+                {
+                    "ent_name": "landscape",
+                    "variant": "",
+                    "allow_beta": mock.sentinel.allow_beta,
+                    "access_only": mock.sentinel.access_only,
+                    "assume_yes": mock.sentinel.assume_yes,
+                    "json_output": False,
+                    "extra_args": mock.sentinel.extra_args,
+                    "enabled_services": [],
+                    "all_dependencies": [],
+                },
+                None,
+                EnableResult(
+                    enabled=["landscape"],
+                    disabled=[],
+                    reboot_required=mock.sentinel.reboot,
+                    messages=[],
+                ),
+                None,
+                [],
+                [
+                    mock.call(
+                        mock.ANY,
+                        mock.sentinel.allow_beta,
+                        mock.sentinel.access_only,
+                        extra_args=mock.sentinel.extra_args,
+                        progress_object=mock.sentinel.cli_progress,
+                    )
+                ],
+                [],
+                [mock.call(cfg=mock.ANY)],
+                _EnableOneServiceResult(
+                    success=True, needs_reboot=mock.sentinel.reboot, error=None
+                ),
+            ),
+            # non-landscape
+            (
+                {
+                    "ent_name": "one",
+                    "variant": mock.sentinel.variant,
+                    "allow_beta": mock.sentinel.allow_beta,
+                    "access_only": mock.sentinel.access_only,
+                    "assume_yes": mock.sentinel.assume_yes,
+                    "json_output": False,
+                    "extra_args": mock.sentinel.extra_args,
+                    "enabled_services": [],
+                    "all_dependencies": [],
+                },
+                None,
+                None,
+                EnableResult(
+                    enabled=["one"],
+                    disabled=[],
+                    reboot_required=mock.sentinel.reboot,
+                    messages=[],
+                ),
+                [],
+                [],
+                [
+                    mock.call(
+                        EnableOptions(
+                            service="one",
+                            variant=mock.sentinel.variant,
+                            access_only=mock.sentinel.access_only,
+                        ),
+                        mock.ANY,
+                        progress_object=mock.sentinel.cli_progress,
+                    )
+                ],
+                [mock.call(cfg=mock.ANY)],
+                _EnableOneServiceResult(
+                    success=True, needs_reboot=mock.sentinel.reboot, error=None
+                ),
+            ),
+            # json output
+            (
+                {
+                    "ent_name": "one",
+                    "variant": mock.sentinel.variant,
+                    "allow_beta": mock.sentinel.allow_beta,
+                    "access_only": mock.sentinel.access_only,
+                    "assume_yes": mock.sentinel.assume_yes,
+                    "json_output": True,
+                    "extra_args": mock.sentinel.extra_args,
+                    "enabled_services": [],
+                    "all_dependencies": [],
+                },
+                None,
+                None,
+                EnableResult(
+                    enabled=["one"],
+                    disabled=[],
+                    reboot_required=mock.sentinel.reboot,
+                    messages=[],
+                ),
+                [],
+                [],
+                [
+                    mock.call(
+                        EnableOptions(
+                            service="one",
+                            variant=mock.sentinel.variant,
+                            access_only=mock.sentinel.access_only,
+                        ),
+                        mock.ANY,
+                        progress_object=None,
+                    )
+                ],
+                [mock.call(cfg=mock.ANY)],
+                _EnableOneServiceResult(
+                    success=True, needs_reboot=mock.sentinel.reboot, error=None
+                ),
+            ),
+        ),
+    )
+    @mock.patch("uaclient.cli.status.status")
+    @mock.patch("uaclient.cli.enable._enable")
+    @mock.patch("uaclient.cli.enable._enable_landscape")
+    @mock.patch("uaclient.cli.enable.cli_util.CLIEnableDisableProgress")
+    @mock.patch("uaclient.cli.enable.prompt_for_dependency_handling")
+    @mock.patch("uaclient.cli.enable.entitlements.entitlement_factory")
+    @mock.patch("uaclient.cli.cli_util.create_interactive_only_print_function")
+    def test_enable_one_service(
         self,
-        _m_check_lock_info,
-        _m_get_available_resources,
-        _m_update_activity_token,
-        _m_public_config,
-        fake_machine_token_file,
+        m_create_interactive_only_print_function,
+        m_entitlement_factory,
+        m_prompt_for_dependency_handling,
+        m_progress_class,
+        m_enable_landscape,
+        m_enable,
+        m_status,
+        kwargs,
+        prompt_for_dependency_handling_side_effect,
+        enable_landscape_result,
+        enable_result,
+        expected_prompt_for_dependency_handling_calls,
+        expected_enable_landscape_calls,
+        expected_enable_calls,
+        expected_status_calls,
+        expected_result,
+        FakeConfig,
     ):
-        fake_machine_token_file.attached = True
-        args_mock = mock.MagicMock()
-        args_mock.access_only = True
-        args_mock.variant = "variant"
+        mock_ent = mock.MagicMock()
+        m_entitlement_factory.return_value = mock_ent
+        mock_ent.name = kwargs.get("ent_name")
+        mock_ent.title = mock.sentinel.ent_title
+        m_prompt_for_dependency_handling.side_effect = (
+            prompt_for_dependency_handling_side_effect
+        )
+        m_progress_class.return_value = mock.sentinel.cli_progress
+        m_enable_landscape.return_value = enable_landscape_result
+        m_enable.return_value = enable_result
 
-        with pytest.raises(exceptions.InvalidOptionCombination):
-            with mock.patch.object(lock, "lock_data_file"):
-                action_enable(args_mock, None)
+        assert expected_result == _enable_one_service(FakeConfig(), **kwargs)
+
+        assert (
+            expected_prompt_for_dependency_handling_calls
+            == m_prompt_for_dependency_handling.call_args_list
+        )
+        assert (
+            expected_enable_landscape_calls
+            == m_enable_landscape.call_args_list
+        )
+        assert expected_enable_calls == m_enable.call_args_list
+        assert expected_status_calls == m_status.call_args_list
+
+    @pytest.mark.parametrize(
+        [
+            "enable_side_effect",
+            "expected_raises",
+            "expected_result",
+        ],
+        (
+            (
+                exceptions.LandscapeConfigFailed(),
+                pytest.raises(exceptions.LandscapeConfigFailed),
+                None,
+            ),
+            (
+                [(False, None)],
+                pytest.raises(exceptions.EntitlementNotEnabledError),
+                None,
+            ),
+            (
+                [(True, None)],
+                does_not_raise(),
+                EnableResult(
+                    enabled=["landscape"],
+                    disabled=[],
+                    reboot_required=False,
+                    messages=[],
+                ),
+            ),
+        ),
+    )
+    @mock.patch("uaclient.cli.enable.lock.RetryLock")
+    @mock.patch("uaclient.cli.enable.entitlements.LandscapeEntitlement")
+    def test_enable_landscape(
+        self,
+        m_landscape_entitlement,
+        m_lock,
+        enable_side_effect,
+        expected_raises,
+        expected_result,
+        FakeConfig,
+    ):
+        m_enable = m_landscape_entitlement.return_value.enable
+        m_enable.side_effect = enable_side_effect
+        with expected_raises:
+            assert expected_result == _enable_landscape(
+                FakeConfig,
+                mock.sentinel.allow_beta,
+                mock.sentinel.access_only,
+                mock.sentinel.extra_args,
+                None,
+            )
+        assert [
+            mock.call(
+                mock.ANY,
+                allow_beta=mock.sentinel.allow_beta,
+                called_name="landscape",
+                access_only=mock.sentinel.access_only,
+                extra_args=mock.sentinel.extra_args,
+            )
+        ] == m_landscape_entitlement.call_args_list
+
+    @pytest.mark.parametrize(
+        [
+            "json_output",
+            "expected_print_calls",
+        ],
+        (
+            (True, [mock.call(mock.ANY)]),
+            (False, []),
+        ),
+    )
+    @mock.patch("builtins.print")
+    def test_print_json_output(
+        self, m_print, json_output, expected_print_calls
+    ):
+        _print_json_output(json_output, {}, [], [], [], [], True)
+        assert expected_print_calls == m_print.call_args_list
 
 
 class TestPromptForDependencyHandling:

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -626,7 +626,6 @@ def process_entitlement_delta(
                 cfg=cfg,
                 name=name,
                 variant=variant,
-                assume_yes=allow_enable,
             )
         except exceptions.EntitlementNotFoundError as exc:
             LOG.debug(

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -41,7 +41,6 @@ def entitlement_factory(
     cfg: UAConfig,
     name: str,
     variant: str = "",
-    assume_yes: bool = False,
     allow_beta: bool = False,
     purge: bool = False,
     access_only: bool = False,
@@ -54,7 +53,6 @@ def entitlement_factory(
     :param cfg: UAConfig instance
     :param name: The name of the entitlement to return
     :param  variant: The variant name to be used
-    :param assume_yes: Assume a yes answer to any prompts requested.
     :param allow_beta: If True, allow beta services to be used
     :param purge: If purge operation is enabled
     :param access_only: If entitlement should be set with access only
@@ -68,7 +66,6 @@ def entitlement_factory(
     for entitlement in ENTITLEMENT_CLASSES:
         ent = entitlement(
             cfg=cfg,
-            assume_yes=assume_yes,
             allow_beta=allow_beta,
             access_only=access_only,
             called_name=name,
@@ -81,7 +78,6 @@ def entitlement_factory(
             elif variant in ent.variants:
                 return ent.variants[variant](
                     cfg=cfg,
-                    assume_yes=assume_yes,
                     allow_beta=allow_beta,
                     called_name=name,
                     purge=purge,

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -155,10 +155,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
         return FIPS_CONDITIONAL_PACKAGES.get(series, [])
 
-    def prompt_if_kernel_downgrade(
-        self,
-        assume_yes: bool = False,
-    ) -> bool:
+    def prompt_if_kernel_downgrade(self, *, assume_yes: bool) -> bool:
         """Check if installing a FIPS kernel will downgrade the kernel
         and prompt for confirmation if it will.
         """
@@ -194,8 +191,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                     )
                 )
                 return util.prompt_for_confirmation(
-                    msg=messages.PROMPT_YES_NO,
-                    assume_yes=self.assume_yes,
+                    msg=messages.PROMPT_YES_NO, assume_yes=assume_yes
                 )
         else:
             LOG.warning(
@@ -530,7 +526,6 @@ class FIPSEntitlement(FIPSCommonEntitlement):
                         "msg": messages.PROMPT_FIPS_PRE_DISABLE.format(
                             title=self.title
                         ),
-                        "assume_yes": self.assume_yes,
                     },
                 )
             ]
@@ -539,15 +534,13 @@ class FIPSEntitlement(FIPSCommonEntitlement):
             "pre_enable": [
                 (
                     util.prompt_for_confirmation,
-                    {"msg": pre_enable_prompt, "assume_yes": self.assume_yes},
+                    {"msg": pre_enable_prompt},
                 )
             ],
             "pre_install": [
                 (
                     self.prompt_if_kernel_downgrade,
-                    {
-                        "assume_yes": self.assume_yes,
-                    },
+                    {},
                 )
             ],
             "post_enable": post_enable,
@@ -614,7 +607,6 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
                         "msg": messages.PROMPT_FIPS_PRE_DISABLE.format(
                             title=self.title
                         ),
-                        "assume_yes": self.assume_yes,
                     },
                 )
             ]
@@ -623,15 +615,13 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
             "pre_enable": [
                 (
                     util.prompt_for_confirmation,
-                    {"msg": pre_enable_prompt, "assume_yes": self.assume_yes},
+                    {"msg": pre_enable_prompt},
                 )
             ],
             "pre_install": [
                 (
                     self.prompt_if_kernel_downgrade,
-                    {
-                        "assume_yes": self.assume_yes,
-                    },
+                    {},
                 )
             ],
             "post_enable": post_enable,

--- a/uaclient/entitlements/landscape.py
+++ b/uaclient/entitlements/landscape.py
@@ -24,7 +24,7 @@ class LandscapeEntitlement(UAEntitlement):
 
     def _perform_enable(self, progress: api.ProgressWrapper) -> bool:
         cmd = ["landscape-config"] + self.extra_args
-        if self.assume_yes and "--silent" not in cmd:
+        if not progress.is_interactive() and "--silent" not in cmd:
             cmd += ["--silent"]
 
         LOG.debug("Executing: %r", cmd)
@@ -34,10 +34,10 @@ class LandscapeEntitlement(UAEntitlement):
             )
         )
         try:
-            system.subp(cmd, pipe_stdouterr=self.assume_yes)
+            system.subp(cmd, pipe_stdouterr=not progress.is_interactive())
         except exceptions.ProcessExecutionError as e:
             LOG.exception(e)
-            if self.assume_yes:
+            if not progress.is_interactive():
                 progress.emit("info", e.stderr.strip())
                 raise exceptions.LandscapeConfigFailed(
                     stdout=e.stdout.strip(), stderr=e.stderr.strip()

--- a/uaclient/entitlements/realtime.py
+++ b/uaclient/entitlements/realtime.py
@@ -83,7 +83,6 @@ class RealtimeKernelEntitlement(repo.RepoEntitlement):
                     util.prompt_for_confirmation,
                     {
                         "msg": messages.REALTIME_PROMPT,
-                        "assume_yes": self.assume_yes,
                         "default": True,
                     },
                 )
@@ -96,7 +95,6 @@ class RealtimeKernelEntitlement(repo.RepoEntitlement):
                     util.prompt_for_confirmation,
                     {
                         "msg": messages.REALTIME_PRE_DISABLE_PROMPT,
-                        "assume_yes": self.assume_yes,
                     },
                 )
             ]

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -105,7 +105,6 @@ def entitlement_factory(tmpdir, FakeConfig, fake_machine_token_file):
         called_name: str = "",
         access_only: bool = False,
         purge: bool = False,
-        assume_yes: Optional[bool] = None,
         suites: List[str] = None,
         additional_packages: List[str] = None,
         cfg: Optional[config.UAConfig] = None,
@@ -141,8 +140,6 @@ def entitlement_factory(tmpdir, FakeConfig, fake_machine_token_file):
             "access_only": access_only,
             "purge": purge,
         }
-        if assume_yes is not None:
-            args["assume_yes"] = assume_yes
 
         if extra_args:
             args = {**args, **extra_args}

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -34,7 +34,6 @@ class ConcreteTestEntitlement(base.UAEntitlement):
         applicability_status=None,
         application_status=(ApplicationStatus.DISABLED, ""),
         allow_beta=False,
-        assume_yes=False,
         supports_access_only=False,
         access_only=False,
         supports_purge=False,
@@ -49,7 +48,6 @@ class ConcreteTestEntitlement(base.UAEntitlement):
         super().__init__(
             cfg,
             allow_beta=allow_beta,
-            assume_yes=assume_yes,
             access_only=access_only,
             purge=purge,
         )
@@ -368,7 +366,7 @@ class TestEntitlementCanEnable:
 
 class TestEntitlementEnable:
     @pytest.mark.parametrize(
-        "block_disable_on_enable,assume_yes",
+        "block_disable_on_enable",
         [(False, False), (False, True), (True, False), (True, True)],
     )
     @mock.patch("uaclient.util.is_config_value_true")
@@ -376,7 +374,6 @@ class TestEntitlementEnable:
         self,
         m_is_config_value_true,
         block_disable_on_enable,
-        assume_yes,
         base_entitlement_factory,
         mock_entitlement,
     ):
@@ -417,9 +414,8 @@ class TestEntitlementEnable:
         assert m_is_config_value_true.call_count == 1
         assert m_incompatible_obj.disable.call_count == expected_disable_call
 
-    @pytest.mark.parametrize("assume_yes", ((False), (True)))
     def test_enable_when_required_service_found(
-        self, assume_yes, base_entitlement_factory, mock_entitlement
+        self, base_entitlement_factory, mock_entitlement
     ):
         m_required_service_cls, m_required_service_obj = mock_entitlement(
             application_status=(ApplicationStatus.DISABLED, ""),
@@ -602,7 +598,6 @@ class TestEntitlementEnable:
             incompatible_service_cls, messages.NamedMessage("code", "msg")
         )
         entitlement = base_entitlement_factory(
-            assume_yes=True,
             extra_args={
                 "blocking_incompatible_services": [
                     incompatible_services_definition

--- a/uaclient/entitlements/tests/test_landscape.py
+++ b/uaclient/entitlements/tests/test_landscape.py
@@ -90,10 +90,10 @@ class TestLandscapeEntitlement:
         FakeConfig,
     ):
         m_subp.side_effect = subp_sideeffect
-        landscape = LandscapeEntitlement(
-            FakeConfig(), assume_yes=assume_yes, extra_args=extra_args
-        )
-        assert expected_result == landscape._perform_enable(mock.MagicMock())
+        landscape = LandscapeEntitlement(FakeConfig(), extra_args=extra_args)
+        mock_progress = mock.MagicMock()
+        mock_progress.is_interactive.return_value = not assume_yes
+        assert expected_result == landscape._perform_enable(mock_progress)
         assert expected_subp_calls == m_subp.call_args_list
 
     @pytest.mark.parametrize(

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -1309,34 +1309,3 @@ class TestApplicationStatus:
             expected_explanation = "Repo Test Class is not configured"
         assert expected_status == application_status
         assert expected_explanation == explanation.msg
-
-
-def success_call():
-    print("success")
-    return True
-
-
-def fail_call(a=None):
-    print("fail %s" % a)
-    return False
-
-
-class TestHandleMessageOperations:
-    @pytest.mark.parametrize(
-        "msg_ops, retval, output",
-        (
-            ([], True, ""),
-            (["msg1", "msg2"], True, "msg1\nmsg2\n"),
-            (
-                [(success_call, {}), "msg1", (fail_call, {"a": 1}), "msg2"],
-                False,
-                "success\nmsg1\nfail 1\n",
-            ),
-        ),
-    )
-    def test_handle_message_operations_for_strings_and_callables(
-        self, msg_ops, retval, output, capsys
-    ):
-        assert retval is util.handle_message_operations(msg_ops)
-        out, _err = capsys.readouterr()
-        assert output == out

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -1337,6 +1337,6 @@ class TestHandleMessageOperations:
     def test_handle_message_operations_for_strings_and_callables(
         self, msg_ops, retval, output, capsys
     ):
-        assert retval is util.handle_message_operations(msg_ops, print)
+        assert retval is util.handle_message_operations(msg_ops)
         out, _err = capsys.readouterr()
         assert output == out

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -635,3 +635,38 @@ class TestSetFilenameExtension:
             util.set_filename_extension(input_string, extension)
             == output_string
         )
+
+
+def success_call(**kwargs):
+    if kwargs.get("assume_yes"):
+        print("success")
+        return True
+    return False
+
+
+def fail_call(a=None, **kwargs):
+    print("fail %s" % a)
+    return False
+
+
+class TestHandleMessageOperations:
+    @pytest.mark.parametrize(
+        "msg_ops, retval, output",
+        (
+            ([], True, ""),
+            (["msg1", "msg2"], True, "msg1\nmsg2\n"),
+            (
+                [(success_call, {}), "msg1", (fail_call, {"a": 1}), "msg2"],
+                False,
+                "success\nmsg1\nfail 1\n",
+            ),
+        ),
+    )
+    def test_handle_message_operations_for_strings_and_callables(
+        self, msg_ops, retval, output, capsys
+    ):
+        assert retval is util.handle_message_operations(
+            msg_ops, assume_yes=True
+        )
+        out, _err = capsys.readouterr()
+        assert output == out

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -265,10 +265,7 @@ def redact_sensitive_logs(
     return redacted_log
 
 
-def handle_message_operations(
-    msg_ops: Optional[MessagingOperations],
-    print_fn: Callable[[str], None],
-) -> bool:
+def handle_message_operations(msg_ops: Optional[MessagingOperations]) -> bool:
     """Emit messages to the console for user interaction
 
     :param msg_op: A list of strings or tuples. Any string items are printed.
@@ -283,7 +280,7 @@ def handle_message_operations(
 
     for msg_op in msg_ops:
         if isinstance(msg_op, str):
-            print_fn(msg_op)
+            print(msg_op)
         else:  # Then we are a callable and dict of args
             functor, args = msg_op
             if not functor(**args):

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -265,7 +265,9 @@ def redact_sensitive_logs(
     return redacted_log
 
 
-def handle_message_operations(msg_ops: Optional[MessagingOperations]) -> bool:
+def handle_message_operations(
+    msg_ops: Optional[MessagingOperations], assume_yes: bool
+) -> bool:
     """Emit messages to the console for user interaction
 
     :param msg_op: A list of strings or tuples. Any string items are printed.
@@ -283,6 +285,7 @@ def handle_message_operations(msg_ops: Optional[MessagingOperations]) -> bool:
             print(msg_op)
         else:  # Then we are a callable and dict of args
             functor, args = msg_op
+            args["assume_yes"] = assume_yes
             if not functor(**args):
                 return False
     return True


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This refactors the enable cli code to use the api for enabling services.
Some adjustments had to be made: 
- the api doesn't support landscape so we need a special case for that
- assume_yes was being set to True by the api, so I extracted that out of the enable logic to be only a cli concern

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
All enable tests should work exactly the same as before.
<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
