### PR TITLE
Better messaging for enable/disable noop fails

### DIFF
--- a/debian/po/pt_BR.po
+++ b/debian/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-25 12:01-0400\n"
+"POT-Creation-Date: 2024-04-02 07:25-0300\n"
 "PO-Revision-Date: 2023-09-25 12:29-0400\n"
 "Last-Translator: Lucas Moura <lucas.moura@canonical.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -2345,7 +2345,7 @@ msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1324
-#: ../../uaclient/messages/__init__.py:1763
+#: ../../uaclient/messages/__init__.py:1765
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
@@ -2493,9 +2493,8 @@ msgid "Livepatch support requires a system reboot across LTS upgrade."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1425
-#, fuzzy
 msgid "Installing Livepatch"
-msgstr "Instalando {packages}"
+msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1426
 msgid "Setting up Livepatch"
@@ -2726,130 +2725,130 @@ msgstr ""
 #: ../../uaclient/messages/__init__.py:1680
 #, python-brace-format
 msgid ""
-"{title} is not currently enabled\n"
+"{title} is not currently enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1687
+#: ../../uaclient/messages/__init__.py:1688
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1694
+#: ../../uaclient/messages/__init__.py:1695
 #, python-brace-format
 msgid ""
-"{title} is already enabled.\n"
+"{title} is already enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1701
+#: ../../uaclient/messages/__init__.py:1703
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1707
+#: ../../uaclient/messages/__init__.py:1709
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1713
+#: ../../uaclient/messages/__init__.py:1715
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1721
+#: ../../uaclient/messages/__init__.py:1723
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1729
+#: ../../uaclient/messages/__init__.py:1731
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1736
+#: ../../uaclient/messages/__init__.py:1738
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1744
+#: ../../uaclient/messages/__init__.py:1746
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1751
+#: ../../uaclient/messages/__init__.py:1753
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1757
+#: ../../uaclient/messages/__init__.py:1759
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1767
+#: ../../uaclient/messages/__init__.py:1769
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1770
+#: ../../uaclient/messages/__init__.py:1772
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1774
+#: ../../uaclient/messages/__init__.py:1776
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1779
+#: ../../uaclient/messages/__init__.py:1781
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1787
+#: ../../uaclient/messages/__init__.py:1789
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1796
+#: ../../uaclient/messages/__init__.py:1798
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1804
+#: ../../uaclient/messages/__init__.py:1806
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1808
+#: ../../uaclient/messages/__init__.py:1810
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1813
+#: ../../uaclient/messages/__init__.py:1815
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1821
+#: ../../uaclient/messages/__init__.py:1823
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2859,7 +2858,7 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1830
+#: ../../uaclient/messages/__init__.py:1832
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2868,79 +2867,79 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1840
+#: ../../uaclient/messages/__init__.py:1842
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1846
+#: ../../uaclient/messages/__init__.py:1848
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1855
+#: ../../uaclient/messages/__init__.py:1857
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1862
+#: ../../uaclient/messages/__init__.py:1864
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1869
+#: ../../uaclient/messages/__init__.py:1871
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1874
+#: ../../uaclient/messages/__init__.py:1876
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1878
+#: ../../uaclient/messages/__init__.py:1880
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1883
+#: ../../uaclient/messages/__init__.py:1885
 msgid "ROS packages assume ESM updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1888
+#: ../../uaclient/messages/__init__.py:1890
 msgid "ROS bug-fix updates assume ROS security fix updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1894
+#: ../../uaclient/messages/__init__.py:1896
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1898
+#: ../../uaclient/messages/__init__.py:1900
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1902
+#: ../../uaclient/messages/__init__.py:1904
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1906
+#: ../../uaclient/messages/__init__.py:1908
 msgid "unattended-upgrades package is not installed"
 msgstr "O pacote unattended-upgrades não está instalado"
 
-#: ../../uaclient/messages/__init__.py:1912
+#: ../../uaclient/messages/__init__.py:1914
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1921
+#: ../../uaclient/messages/__init__.py:1923
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1928
+#: ../../uaclient/messages/__init__.py:1930
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2950,28 +2949,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1942
+#: ../../uaclient/messages/__init__.py:1944
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1948
+#: ../../uaclient/messages/__init__.py:1950
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1978
+#: ../../uaclient/messages/__init__.py:1980
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1983
+#: ../../uaclient/messages/__init__.py:1985
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1989
+#: ../../uaclient/messages/__init__.py:1991
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2979,107 +2978,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1999
+#: ../../uaclient/messages/__init__.py:2001
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2006
+#: ../../uaclient/messages/__init__.py:2008
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2011
+#: ../../uaclient/messages/__init__.py:2013
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2015
+#: ../../uaclient/messages/__init__.py:2017
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2019
+#: ../../uaclient/messages/__init__.py:2021
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2024
+#: ../../uaclient/messages/__init__.py:2026
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2029
+#: ../../uaclient/messages/__init__.py:2031
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2034
+#: ../../uaclient/messages/__init__.py:2036
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2040
+#: ../../uaclient/messages/__init__.py:2042
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2046
+#: ../../uaclient/messages/__init__.py:2048
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2050
+#: ../../uaclient/messages/__init__.py:2052
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2056
+#: ../../uaclient/messages/__init__.py:2058
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2064
+#: ../../uaclient/messages/__init__.py:2066
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2070
+#: ../../uaclient/messages/__init__.py:2072
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2079
+#: ../../uaclient/messages/__init__.py:2081
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2086
+#: ../../uaclient/messages/__init__.py:2088
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2093
+#: ../../uaclient/messages/__init__.py:2095
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2098
+#: ../../uaclient/messages/__init__.py:2100
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2104
+#: ../../uaclient/messages/__init__.py:2106
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3087,7 +3086,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2114
+#: ../../uaclient/messages/__init__.py:2116
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3095,7 +3094,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2124
+#: ../../uaclient/messages/__init__.py:2126
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3103,99 +3102,100 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2134
+#: ../../uaclient/messages/__init__.py:2136
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2141
+#: ../../uaclient/messages/__init__.py:2143
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2147
+#: ../../uaclient/messages/__init__.py:2149
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2153
+#: ../../uaclient/messages/__init__.py:2155
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2158
+#: ../../uaclient/messages/__init__.py:2160
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2164
+#: ../../uaclient/messages/__init__.py:2166
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2172
+#: ../../uaclient/messages/__init__.py:2174
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2181
+#: ../../uaclient/messages/__init__.py:2183
 #, python-brace-format
 msgid ""
-"To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
-"Personal and community subscriptions are available at no charge\n"
+"Cannot {{operation}} services when unattached - nothing to do.\n"
+"To use '{{valid_service}}' you need an Ubuntu Pro subscription.\n"
+"Personal and community subscriptions are available at no charge.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2197
+#: ../../uaclient/messages/__init__.py:2200
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2202
+#: ../../uaclient/messages/__init__.py:2205
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2208
+#: ../../uaclient/messages/__init__.py:2211
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2216
+#: ../../uaclient/messages/__init__.py:2219
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2224
+#: ../../uaclient/messages/__init__.py:2227
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2231
+#: ../../uaclient/messages/__init__.py:2234
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2238
+#: ../../uaclient/messages/__init__.py:2241
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2247
+#: ../../uaclient/messages/__init__.py:2250
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2253
+#: ../../uaclient/messages/__init__.py:2256
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2261
+#: ../../uaclient/messages/__init__.py:2264
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2270
+#: ../../uaclient/messages/__init__.py:2273
 #, python-brace-format
 msgid ""
 "Failed to identify this image as a valid Ubuntu Pro image.\n"
@@ -3203,14 +3203,14 @@ msgid ""
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2280
+#: ../../uaclient/messages/__init__.py:2283
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2287
+#: ../../uaclient/messages/__init__.py:2290
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -3218,16 +3218,16 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2297
+#: ../../uaclient/messages/__init__.py:2300
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2304
+#: ../../uaclient/messages/__init__.py:2307
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2312
+#: ../../uaclient/messages/__init__.py:2315
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
@@ -3236,7 +3236,7 @@ msgstr ""
 "Suporte para auto-attach não está disponível para esta imagem\n"
 "Veja {url}"
 
-#: ../../uaclient/messages/__init__.py:2321
+#: ../../uaclient/messages/__init__.py:2324
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
@@ -3245,18 +3245,18 @@ msgstr ""
 "Suporte para auto-attach não está disponível para {{cloud_type}}\n"
 "Veja: {url}"
 
-#: ../../uaclient/messages/__init__.py:2329
+#: ../../uaclient/messages/__init__.py:2332
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2335
+#: ../../uaclient/messages/__init__.py:2338
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2343
+#: ../../uaclient/messages/__init__.py:2346
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -3267,7 +3267,7 @@ msgstr ""
 "o campo VERSION não tem a informação de versão: {version}\n"
 "e o campo VERSION_CODENAME não está presente"
 
-#: ../../uaclient/messages/__init__.py:2353
+#: ../../uaclient/messages/__init__.py:2356
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -3281,12 +3281,12 @@ msgstr ""
 "\n"
 "$ sudo rm {lock_file_path}"
 
-#: ../../uaclient/messages/__init__.py:2362
+#: ../../uaclient/messages/__init__.py:2365
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr "{source} retornou um json inválido: {out}"
 
-#: ../../uaclient/messages/__init__.py:2368
+#: ../../uaclient/messages/__init__.py:2371
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
@@ -3295,7 +3295,7 @@ msgstr ""
 "Valor inválido para {path_to_value} em /etc/ubuntu-advantage/uaclient.conf."
 "Esperava {expected_value}, mas {value} foi encontrado."
 
-#: ../../uaclient/messages/__init__.py:2377
+#: ../../uaclient/messages/__init__.py:2380
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
@@ -3303,17 +3303,17 @@ msgstr ""
 "Não foi possível associar {key} a {value}: <value> precisa ser um inteiro "
 "positivo."
 
-#: ../../uaclient/messages/__init__.py:2384
+#: ../../uaclient/messages/__init__.py:2387
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr "url inválida no arquivo de configuração. {key}: {value}"
 
-#: ../../uaclient/messages/__init__.py:2389
+#: ../../uaclient/messages/__init__.py:2392
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr "Não foi possível encontrar o arquivo yaml: {filepath}"
 
-#: ../../uaclient/messages/__init__.py:2395
+#: ../../uaclient/messages/__init__.py:2398
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
@@ -3324,27 +3324,27 @@ msgstr ""
 "pro de apt ao mesmo tempo não é suportado.\n"
 "Cancelando o processo de configuração.\n"
 
-#: ../../uaclient/messages/__init__.py:2405
+#: ../../uaclient/messages/__init__.py:2408
 msgid "Can't load the distro-info database."
 msgstr "Não foi possível carregar o banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2410
+#: ../../uaclient/messages/__init__.py:2413
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 "Não foi possível encontrar a série {series} na banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2418
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr "Erro: não é possível usar {option1} junto com {option2}"
 
-#: ../../uaclient/messages/__init__.py:2419
+#: ../../uaclient/messages/__init__.py:2422
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr "Ajuda não disponível para '{name}'"
 
-#: ../../uaclient/messages/__init__.py:2425
+#: ../../uaclient/messages/__init__.py:2428
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
@@ -3353,39 +3353,39 @@ msgstr ""
 "Erro: problema de segurnça \"{issue}\" não foi reconhecido.\n"
 "Use: \"pro fix CVE-yyyy-nnnn\" ou \"pro fix USN-nnnn\""
 
-#: ../../uaclient/messages/__init__.py:2431
+#: ../../uaclient/messages/__init__.py:2434
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr "{arg} precisa ser um de: {choices}"
 
-#: ../../uaclient/messages/__init__.py:2436
+#: ../../uaclient/messages/__init__.py:2439
 #, python-brace-format
 msgid "Empty value provided for {arg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2441
+#: ../../uaclient/messages/__init__.py:2444
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr "Esperava {expected} mas encontrou: {actual}"
 
-#: ../../uaclient/messages/__init__.py:2445
+#: ../../uaclient/messages/__init__.py:2448
 msgid "Unable to process uaclient.conf"
 msgstr "Falha ao processar uaclient.conf"
 
-#: ../../uaclient/messages/__init__.py:2450
+#: ../../uaclient/messages/__init__.py:2453
 msgid "Unable to refresh your subscription"
 msgstr "Falha ao atualizar sua assinatura"
 
-#: ../../uaclient/messages/__init__.py:2455
+#: ../../uaclient/messages/__init__.py:2458
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 "Falha ao atualizar as mensagens de APT e MOTD relacioandas ao Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:2461
+#: ../../uaclient/messages/__init__.py:2464
 msgid "json formatted response requires --assume-yes flag."
 msgstr "resposta formatada em json necessita do paramêtro --assume-yes"
 
-#: ../../uaclient/messages/__init__.py:2469
+#: ../../uaclient/messages/__init__.py:2472
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
@@ -3395,54 +3395,54 @@ msgstr ""
 "Ao invés disso, inclua o token no arquivo de attach-config.\n"
 "    "
 
-#: ../../uaclient/messages/__init__.py:2478
+#: ../../uaclient/messages/__init__.py:2481
 msgid "Cannot provide both --args and --data at the same time"
 msgstr "Não é possível usar --args e --data ao mesmo tempo"
 
-#: ../../uaclient/messages/__init__.py:2483
+#: ../../uaclient/messages/__init__.py:2486
 msgid "Operation cancelled by user"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2489
+#: ../../uaclient/messages/__init__.py:2492
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr "Falha ao executar: {lock_request}.\n"
 
-#: ../../uaclient/messages/__init__.py:2498
+#: ../../uaclient/messages/__init__.py:2501
 msgid "This command must be run as root (try using sudo)."
 msgstr "Esse comando precisa ser executado como root (tente usando sudo)."
 
-#: ../../uaclient/messages/__init__.py:2503
+#: ../../uaclient/messages/__init__.py:2506
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr "Metadados para {issue} não são válidos. Erro: {error_msg}."
 
-#: ../../uaclient/messages/__init__.py:2510
+#: ../../uaclient/messages/__init__.py:2513
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr "Erro: {issue_id} não encontrada."
 
-#: ../../uaclient/messages/__init__.py:2514
+#: ../../uaclient/messages/__init__.py:2517
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr "chave GPG '{keyfile}' não foi encontrada"
 
-#: ../../uaclient/messages/__init__.py:2519
+#: ../../uaclient/messages/__init__.py:2522
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr "'{endpoint}' não é um endpoint válido"
 
-#: ../../uaclient/messages/__init__.py:2524
+#: ../../uaclient/messages/__init__.py:2527
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr "'{arg}' está faltando para endpoint {endpoint}"
 
-#: ../../uaclient/messages/__init__.py:2529
+#: ../../uaclient/messages/__init__.py:2532
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr "{endpoint} não aceita paramêtros"
 
-#: ../../uaclient/messages/__init__.py:2534
+#: ../../uaclient/messages/__init__.py:2537
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
@@ -3451,32 +3451,32 @@ msgstr ""
 "Error ao analisar paramêtro data para API json:\n"
 "{data}"
 
-#: ../../uaclient/messages/__init__.py:2539
+#: ../../uaclient/messages/__init__.py:2542
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr "'{arg}' não está formatado como 'chave=valor'"
 
-#: ../../uaclient/messages/__init__.py:2544
+#: ../../uaclient/messages/__init__.py:2547
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr "Não foi possível determinar a versão: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2549
+#: ../../uaclient/messages/__init__.py:2552
 msgid "features.disable_auto_attach set in config"
 msgstr "features.disable_auto_attach definida na configuração"
 
-#: ../../uaclient/messages/__init__.py:2554
+#: ../../uaclient/messages/__init__.py:2557
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 "Não foi possível determinar o status do unattended-upgrades: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2560
+#: ../../uaclient/messages/__init__.py:2563
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr "Esperava valor com tipo {expected_type}, mas recebeu tipo {got_type}"
 
-#: ../../uaclient/messages/__init__.py:2566
+#: ../../uaclient/messages/__init__.py:2569
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
@@ -3485,7 +3485,7 @@ msgstr ""
 "Valor com tipo incorreto na posição {index}:\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2572
+#: ../../uaclient/messages/__init__.py:2575
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
@@ -3494,19 +3494,19 @@ msgstr ""
 "Valor com tipo incorreto para o campo \"{key}\":\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2579
+#: ../../uaclient/messages/__init__.py:2582
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""
 "Valor fornecido não está presente nos valores permitidos de {enum_class}: "
 "{values}"
 
-#: ../../uaclient/messages/__init__.py:2590
+#: ../../uaclient/messages/__init__.py:2593
 #, python-brace-format
 msgid "Error updating ESM services cache: {error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2596
+#: ../../uaclient/messages/__init__.py:2599
 #, python-brace-format
 msgid ""
 "There is a problem with the resource directives provided by {url}\n"
@@ -3516,7 +3516,7 @@ msgid ""
 "These directives need to be unique for every entitlement."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2605
+#: ../../uaclient/messages/__init__.py:2608
 msgid "landscape-config command failed"
 msgstr ""
 

--- a/debian/po/ubuntu-pro.pot
+++ b/debian/po/ubuntu-pro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-25 12:01-0400\n"
+"POT-Creation-Date: 2024-04-02 07:25-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2014,7 +2014,7 @@ msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1324
-#: ../../uaclient/messages/__init__.py:1763
+#: ../../uaclient/messages/__init__.py:1765
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
@@ -2391,130 +2391,130 @@ msgstr ""
 #: ../../uaclient/messages/__init__.py:1680
 #, python-brace-format
 msgid ""
-"{title} is not currently enabled\n"
+"{title} is not currently enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1687
+#: ../../uaclient/messages/__init__.py:1688
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1694
+#: ../../uaclient/messages/__init__.py:1695
 #, python-brace-format
 msgid ""
-"{title} is already enabled.\n"
+"{title} is already enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1701
+#: ../../uaclient/messages/__init__.py:1703
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1707
+#: ../../uaclient/messages/__init__.py:1709
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1713
+#: ../../uaclient/messages/__init__.py:1715
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1721
+#: ../../uaclient/messages/__init__.py:1723
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1729
+#: ../../uaclient/messages/__init__.py:1731
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1736
+#: ../../uaclient/messages/__init__.py:1738
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1744
+#: ../../uaclient/messages/__init__.py:1746
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1751
+#: ../../uaclient/messages/__init__.py:1753
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1757
+#: ../../uaclient/messages/__init__.py:1759
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1767
+#: ../../uaclient/messages/__init__.py:1769
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1770
+#: ../../uaclient/messages/__init__.py:1772
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1774
+#: ../../uaclient/messages/__init__.py:1776
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1779
+#: ../../uaclient/messages/__init__.py:1781
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1787
+#: ../../uaclient/messages/__init__.py:1789
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1796
+#: ../../uaclient/messages/__init__.py:1798
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1804
+#: ../../uaclient/messages/__init__.py:1806
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1808
+#: ../../uaclient/messages/__init__.py:1810
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1813
+#: ../../uaclient/messages/__init__.py:1815
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1821
+#: ../../uaclient/messages/__init__.py:1823
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2524,7 +2524,7 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1830
+#: ../../uaclient/messages/__init__.py:1832
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2533,79 +2533,79 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1840
+#: ../../uaclient/messages/__init__.py:1842
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1846
+#: ../../uaclient/messages/__init__.py:1848
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1855
+#: ../../uaclient/messages/__init__.py:1857
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1862
+#: ../../uaclient/messages/__init__.py:1864
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1869
+#: ../../uaclient/messages/__init__.py:1871
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1874
+#: ../../uaclient/messages/__init__.py:1876
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1878
+#: ../../uaclient/messages/__init__.py:1880
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1883
+#: ../../uaclient/messages/__init__.py:1885
 msgid "ROS packages assume ESM updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1888
+#: ../../uaclient/messages/__init__.py:1890
 msgid "ROS bug-fix updates assume ROS security fix updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1894
+#: ../../uaclient/messages/__init__.py:1896
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1898
+#: ../../uaclient/messages/__init__.py:1900
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1902
+#: ../../uaclient/messages/__init__.py:1904
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1906
+#: ../../uaclient/messages/__init__.py:1908
 msgid "unattended-upgrades package is not installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1912
+#: ../../uaclient/messages/__init__.py:1914
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1921
+#: ../../uaclient/messages/__init__.py:1923
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1928
+#: ../../uaclient/messages/__init__.py:1930
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2615,28 +2615,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1942
+#: ../../uaclient/messages/__init__.py:1944
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1948
+#: ../../uaclient/messages/__init__.py:1950
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1978
+#: ../../uaclient/messages/__init__.py:1980
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1983
+#: ../../uaclient/messages/__init__.py:1985
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1989
+#: ../../uaclient/messages/__init__.py:1991
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2644,107 +2644,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1999
+#: ../../uaclient/messages/__init__.py:2001
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2006
+#: ../../uaclient/messages/__init__.py:2008
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2011
+#: ../../uaclient/messages/__init__.py:2013
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2015
+#: ../../uaclient/messages/__init__.py:2017
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2019
+#: ../../uaclient/messages/__init__.py:2021
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2024
+#: ../../uaclient/messages/__init__.py:2026
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2029
+#: ../../uaclient/messages/__init__.py:2031
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2034
+#: ../../uaclient/messages/__init__.py:2036
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2040
+#: ../../uaclient/messages/__init__.py:2042
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2046
+#: ../../uaclient/messages/__init__.py:2048
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2050
+#: ../../uaclient/messages/__init__.py:2052
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2056
+#: ../../uaclient/messages/__init__.py:2058
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2064
+#: ../../uaclient/messages/__init__.py:2066
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2070
+#: ../../uaclient/messages/__init__.py:2072
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2079
+#: ../../uaclient/messages/__init__.py:2081
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2086
+#: ../../uaclient/messages/__init__.py:2088
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2093
+#: ../../uaclient/messages/__init__.py:2095
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2098
+#: ../../uaclient/messages/__init__.py:2100
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2104
+#: ../../uaclient/messages/__init__.py:2106
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2752,7 +2752,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2114
+#: ../../uaclient/messages/__init__.py:2116
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2760,7 +2760,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2124
+#: ../../uaclient/messages/__init__.py:2126
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2768,99 +2768,100 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2134
+#: ../../uaclient/messages/__init__.py:2136
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2141
+#: ../../uaclient/messages/__init__.py:2143
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2147
+#: ../../uaclient/messages/__init__.py:2149
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2153
+#: ../../uaclient/messages/__init__.py:2155
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2158
+#: ../../uaclient/messages/__init__.py:2160
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2164
+#: ../../uaclient/messages/__init__.py:2166
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2172
+#: ../../uaclient/messages/__init__.py:2174
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2181
+#: ../../uaclient/messages/__init__.py:2183
 #, python-brace-format
 msgid ""
-"To use '{{valid_service}}' you need an Ubuntu Pro subscription\n"
-"Personal and community subscriptions are available at no charge\n"
+"Cannot {{operation}} services when unattached - nothing to do.\n"
+"To use '{{valid_service}}' you need an Ubuntu Pro subscription.\n"
+"Personal and community subscriptions are available at no charge.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2197
+#: ../../uaclient/messages/__init__.py:2200
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2202
+#: ../../uaclient/messages/__init__.py:2205
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2208
+#: ../../uaclient/messages/__init__.py:2211
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2216
+#: ../../uaclient/messages/__init__.py:2219
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2224
+#: ../../uaclient/messages/__init__.py:2227
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2231
+#: ../../uaclient/messages/__init__.py:2234
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2238
+#: ../../uaclient/messages/__init__.py:2241
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2247
+#: ../../uaclient/messages/__init__.py:2250
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2253
+#: ../../uaclient/messages/__init__.py:2256
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2261
+#: ../../uaclient/messages/__init__.py:2264
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2270
+#: ../../uaclient/messages/__init__.py:2273
 #, python-brace-format
 msgid ""
 "Failed to identify this image as a valid Ubuntu Pro image.\n"
@@ -2868,14 +2869,14 @@ msgid ""
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2280
+#: ../../uaclient/messages/__init__.py:2283
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2287
+#: ../../uaclient/messages/__init__.py:2290
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -2883,41 +2884,41 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2297
+#: ../../uaclient/messages/__init__.py:2300
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2304
+#: ../../uaclient/messages/__init__.py:2307
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2312
+#: ../../uaclient/messages/__init__.py:2315
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2321
+#: ../../uaclient/messages/__init__.py:2324
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2329
+#: ../../uaclient/messages/__init__.py:2332
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2335
+#: ../../uaclient/messages/__init__.py:2338
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2343
+#: ../../uaclient/messages/__init__.py:2346
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -2925,7 +2926,7 @@ msgid ""
 "and the VERSION_CODENAME information is not present"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2353
+#: ../../uaclient/messages/__init__.py:2356
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -2934,208 +2935,208 @@ msgid ""
 "$ sudo rm {lock_file_path}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2362
+#: ../../uaclient/messages/__init__.py:2365
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2368
+#: ../../uaclient/messages/__init__.py:2371
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
 "Expected {expected_value}, found {value}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2377
+#: ../../uaclient/messages/__init__.py:2380
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2384
+#: ../../uaclient/messages/__init__.py:2387
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2389
+#: ../../uaclient/messages/__init__.py:2392
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2395
+#: ../../uaclient/messages/__init__.py:2398
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
 "Cancelling config process operation.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2405
+#: ../../uaclient/messages/__init__.py:2408
 msgid "Can't load the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2410
+#: ../../uaclient/messages/__init__.py:2413
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2418
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2419
+#: ../../uaclient/messages/__init__.py:2422
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2425
+#: ../../uaclient/messages/__init__.py:2428
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
 "Usage: \"pro fix CVE-yyyy-nnnn\" or \"pro fix USN-nnnn\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2431
+#: ../../uaclient/messages/__init__.py:2434
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2436
+#: ../../uaclient/messages/__init__.py:2439
 #, python-brace-format
 msgid "Empty value provided for {arg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2441
+#: ../../uaclient/messages/__init__.py:2444
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2445
+#: ../../uaclient/messages/__init__.py:2448
 msgid "Unable to process uaclient.conf"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2450
+#: ../../uaclient/messages/__init__.py:2453
 msgid "Unable to refresh your subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2455
+#: ../../uaclient/messages/__init__.py:2458
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2461
+#: ../../uaclient/messages/__init__.py:2464
 msgid "json formatted response requires --assume-yes flag."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2469
+#: ../../uaclient/messages/__init__.py:2472
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
 "    "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2478
+#: ../../uaclient/messages/__init__.py:2481
 msgid "Cannot provide both --args and --data at the same time"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2483
+#: ../../uaclient/messages/__init__.py:2486
 msgid "Operation cancelled by user"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2489
+#: ../../uaclient/messages/__init__.py:2492
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2498
+#: ../../uaclient/messages/__init__.py:2501
 msgid "This command must be run as root (try using sudo)."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2503
+#: ../../uaclient/messages/__init__.py:2506
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2510
+#: ../../uaclient/messages/__init__.py:2513
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2514
+#: ../../uaclient/messages/__init__.py:2517
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2519
+#: ../../uaclient/messages/__init__.py:2522
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2524
+#: ../../uaclient/messages/__init__.py:2527
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2529
+#: ../../uaclient/messages/__init__.py:2532
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2534
+#: ../../uaclient/messages/__init__.py:2537
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
 "{data}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2539
+#: ../../uaclient/messages/__init__.py:2542
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2544
+#: ../../uaclient/messages/__init__.py:2547
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2549
+#: ../../uaclient/messages/__init__.py:2552
 msgid "features.disable_auto_attach set in config"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2554
+#: ../../uaclient/messages/__init__.py:2557
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2560
+#: ../../uaclient/messages/__init__.py:2563
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2566
+#: ../../uaclient/messages/__init__.py:2569
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2572
+#: ../../uaclient/messages/__init__.py:2575
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2579
+#: ../../uaclient/messages/__init__.py:2582
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2590
+#: ../../uaclient/messages/__init__.py:2593
 #, python-brace-format
 msgid "Error updating ESM services cache: {error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2596
+#: ../../uaclient/messages/__init__.py:2599
 #, python-brace-format
 msgid ""
 "There is a problem with the resource directives provided by {url}\n"
@@ -3145,6 +3146,6 @@ msgid ""
 "These directives need to be unique for every entitlement."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2605
+#: ../../uaclient/messages/__init__.py:2608
 msgid "landscape-config command failed"
 msgstr ""

--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -62,7 +62,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
     When I verify that running `pro disable livepatch` `with sudo` exits `1`
     Then I will see the following on stdout:
       """
-      Livepatch is not currently enabled
+      Livepatch is not currently enabled - nothing to do.
       See: sudo pro status
       """
     When I verify that running `pro disable foobar` `with sudo` exits `1`
@@ -79,7 +79,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
     When I verify that running `pro disable livepatch foobar` `with sudo` exits `1`
     Then I will see the following on stdout:
       """
-      Livepatch is not currently enabled
+      Livepatch is not currently enabled - nothing to do.
       See: sudo pro status
       """
     And stderr matches regexp:
@@ -134,7 +134,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
     And stdout is a json matching the `ua_operation` schema
     And I will see the following on stdout:
       """
-      {"_schema_version": "0.1", "errors": [{"message": "Livepatch is not currently enabled\nSee: sudo pro status", "message_code": "service-already-disabled", "service": "livepatch", "type": "service"}], "failed_services": ["livepatch"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+      {"_schema_version": "0.1", "errors": [{"message": "Livepatch is not currently enabled - nothing to do.\nSee: sudo pro status", "message_code": "service-already-disabled", "service": "livepatch", "type": "service"}], "failed_services": ["livepatch"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
       """
     And I verify that running `pro disable esm-infra esm-apps --format json --assume-yes` `with sudo` exits `0`
     And stdout is a json matching the `ua_operation` schema

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -157,7 +157,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     And stdout is a json matching the `ua_operation` schema
     Then I will see the following on stdout:
       """
-      {"_schema_version": "0.1", "errors": [{"message": "Ubuntu Pro: ESM Infra is already enabled.\nSee: sudo pro status", "message_code": "service-already-enabled", "service": "esm-infra", "type": "service"}], "failed_services": ["esm-infra"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+      {"_schema_version": "0.1", "errors": [{"message": "Ubuntu Pro: ESM Infra is already enabled - nothing to do.\nSee: sudo pro status", "message_code": "service-already-enabled", "service": "esm-infra", "type": "service"}], "failed_services": ["esm-infra"], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
       """
     When I run `pro disable esm-infra` with sudo
     And I run `pro enable esm-infra --format json --assume-yes` with sudo
@@ -214,7 +214,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     And I will see the following on stdout:
       """
       One moment, checking your subscription first
-      Ubuntu Pro: ESM Infra is already enabled.
+      Ubuntu Pro: ESM Infra is already enabled - nothing to do.
       See: sudo pro status
       Could not enable Ubuntu Pro: ESM Infra.
       """
@@ -344,7 +344,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     Then stdout matches regexp
       """
       One moment, checking your subscription first
-      CIS Audit is already enabled.
+      CIS Audit is already enabled - nothing to do.
       See: sudo pro status
       """
     When I run `cis-audit level1_server` with sudo
@@ -425,7 +425,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       From Ubuntu 20.04 onward 'pro enable cis' has been
       replaced by 'pro enable usg'. See more information at:
       https://ubuntu.com/security/certifications/docs/usg
-      CIS Audit is already enabled.
+      CIS Audit is already enabled - nothing to do.
       See: sudo pro status
       """
     When I run `cis-audit level1_server` with sudo
@@ -998,7 +998,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     Then stdout matches regexp
       """
       One moment, checking your subscription first
-      Ubuntu Pro: ESM Apps is already enabled.
+      Ubuntu Pro: ESM Apps is already enabled - nothing to do.
       See: sudo pro status
       """
 

--- a/features/landscape.feature
+++ b/features/landscape.feature
@@ -41,7 +41,7 @@ Feature: Enable landscape on Ubuntu
     When I verify that running `sudo pro disable landscape` `with sudo` exits `1`
     Then I will see the following on stdout:
       """
-      Landscape is not currently enabled
+      Landscape is not currently enabled - nothing to do.
       See: sudo pro status
       """
     # Fail to enable with assume-yes

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -84,7 +84,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     Then stdout matches regexp
       """
       One moment, checking your subscription first
-      Real-time kernel is already enabled.
+      Real-time kernel is already enabled - nothing to do.
       See: sudo pro status
       """
     When I reboot the machine
@@ -183,7 +183,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     When I verify that running `pro enable realtime-kernel` `with sudo` exits `1`
     Then stdout contains substring:
       """
-      Real-time kernel is already enabled.
+      Real-time kernel is already enabled - nothing to do.
       """
     When I run `pro disable realtime-kernel --assume-yes` with sudo
     When I run `apt-cache policy ubuntu-intel-iot-realtime` as non-root

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -118,15 +118,16 @@ Feature: Command behaviour when unattached
     When I verify that running `pro <command> esm-infra` `with sudo` exits `1`
     Then I will see the following on stderr:
       """
-      To use 'esm-infra' you need an Ubuntu Pro subscription
-      Personal and community subscriptions are available at no charge
+      Cannot <command> services when unattached - nothing to do.
+      To use 'esm-infra' you need an Ubuntu Pro subscription.
+      Personal and community subscriptions are available at no charge.
       See https://ubuntu.com/pro
       """
     When I verify that running `pro <command> esm-infra --format json --assume-yes` `with sudo` exits `1`
     Then stdout is a json matching the `ua_operation` schema
     And I will see the following on stdout:
       """
-      {"_schema_version": "0.1", "errors": [{"additional_info": {"valid_service": "esm-infra"}, "message": "To use 'esm-infra' you need an Ubuntu Pro subscription\nPersonal and community subscriptions are available at no charge\nSee https://ubuntu.com/pro", "message_code": "valid-service-failure-unattached", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+      {"_schema_version": "0.1", "errors": [{"additional_info": {"operation": "<command>", "valid_service": "esm-infra"}, "message": "Cannot <command> services when unattached - nothing to do.\nTo use 'esm-infra' you need an Ubuntu Pro subscription.\nPersonal and community subscriptions are available at no charge.\nSee https://ubuntu.com/pro", "message_code": "valid-service-failure-unattached", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
       """
     When I verify that running `pro <command> unknown` `as non-root` exits `1`
     Then I will see the following on stderr:
@@ -154,15 +155,16 @@ Feature: Command behaviour when unattached
       """
       Cannot <command> unknown service 'unknown'.
 
-      To use 'esm-infra' you need an Ubuntu Pro subscription
-      Personal and community subscriptions are available at no charge
+      Cannot <command> services when unattached - nothing to do.
+      To use 'esm-infra' you need an Ubuntu Pro subscription.
+      Personal and community subscriptions are available at no charge.
       See https://ubuntu.com/pro
       """
     When I verify that running `pro <command> esm-infra unknown --format json --assume-yes` `with sudo` exits `1`
     Then stdout is a json matching the `ua_operation` schema
     And I will see the following on stdout:
       """
-      {"_schema_version": "0.1", "errors": [{"additional_info": {"invalid_service": "unknown", "operation": "<command>", "service_msg": "", "valid_service": "esm-infra"}, "message": "Cannot <command> unknown service 'unknown'.\n\nTo use 'esm-infra' you need an Ubuntu Pro subscription\nPersonal and community subscriptions are available at no charge\nSee https://ubuntu.com/pro", "message_code": "mixed-services-failure-unattached", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
+      {"_schema_version": "0.1", "errors": [{"additional_info": {"invalid_service": "unknown", "operation": "<command>", "service_msg": "", "valid_service": "esm-infra"}, "message": "Cannot <command> unknown service 'unknown'.\n\nCannot <command> services when unattached - nothing to do.\nTo use 'esm-infra' you need an Ubuntu Pro subscription.\nPersonal and community subscriptions are available at no charge.\nSee https://ubuntu.com/pro", "message_code": "mixed-services-failure-unattached", "service": null, "type": "system"}], "failed_services": [], "needs_reboot": false, "processed_services": [], "result": "failure", "warnings": []}
       """
 
     Examples: ubuntu release

--- a/uaclient/cli/cli_util.py
+++ b/uaclient/cli/cli_util.py
@@ -105,7 +105,7 @@ def _raise_enable_disable_unattached_error(command, service_names, cfg):
         )
     elif entitlements_found:
         raise exceptions.UnattachedValidServicesError(
-            valid_service=", ".join(entitlements_found)
+            valid_service=", ".join(entitlements_found), operation=command
         )
     else:
         raise exceptions.UnattachedInvalidServicesError(

--- a/uaclient/cli/tests/test_cli_disable.py
+++ b/uaclient/cli/tests/test_cli_disable.py
@@ -495,9 +495,12 @@ class TestDisable:
         args.command = "disable"
         if root:
             expected_error = expected_error_template.format(
-                valid_service="esm-infra"
+                valid_service="esm-infra", operation="disable"
             )
-            expected_info = {"valid_service": "esm-infra"}
+            expected_info = {
+                "valid_service": "esm-infra",
+                "operation": "disable",
+            }
         else:
             expected_error = expected_error_template
             expected_info = None

--- a/uaclient/cli/tests/test_cli_enable.py
+++ b/uaclient/cli/tests/test_cli_enable.py
@@ -237,10 +237,11 @@ class TestActionEnable:
 
         if root:
             expected_error = expected_error_template.format(
-                valid_service="esm-infra"
+                valid_service="esm-infra", operation="enable"
             )
             expected_info = {
                 "valid_service": "esm-infra",
+                "operation": "enable",
             }
         else:
             expected_error = expected_error_template

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1692,7 +1692,8 @@ ALREADY_ENABLED = FormattedNamedMessage(
     "service-already-enabled",
     t.gettext(
         """\
-{title} is already enabled.\nSee: sudo pro status"""
+{title} is already enabled - nothing to do.
+See: sudo pro status"""
     ),
 )
 UNENTITLED = FormattedNamedMessage(

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1678,7 +1678,8 @@ ALREADY_DISABLED = FormattedNamedMessage(
     "service-already-disabled",
     t.gettext(
         """\
-{title} is not currently enabled\nSee: sudo pro status"""
+{title} is not currently enabled - nothing to do.
+See: sudo pro status"""
     ),
 )
 CANNOT_DISABLE_NOT_APPLICABLE = FormattedNamedMessage(

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -2181,8 +2181,9 @@ E_VALID_SERVICE_FAILURE_UNATTACHED = FormattedNamedMessage(
     "valid-service-failure-unattached",
     t.gettext(
         """\
-To use '{{valid_service}}' you need an Ubuntu Pro subscription
-Personal and community subscriptions are available at no charge
+Cannot {{operation}} services when unattached - nothing to do.
+To use '{{valid_service}}' you need an Ubuntu Pro subscription.
+Personal and community subscriptions are available at no charge.
 See {url}"""
     ).format(url=urls.PRO_HOME_PAGE),
 )


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it

Fixes: #2487

Those are message adjustments to indicate enable/disable are noops, both in attached and unattached scenarios.

## Test Steps
Check the changed messages, run CI

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
