### PR TITLE
chore: bump black to 24.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.3.0  # Also stored in dev-requirements.txt; update both together!
+    rev: 24.3.0  # Also stored in dev-requirements.txt; update both together!
     hooks:
     - id: black
   - repo: https://github.com/pycqa/isort

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # The black, isort, reformat-gherkin and shellcheck-py versions are also in .pre-commit-config.yaml; 
 # make sure to update both together
-black==22.3.0
+black==24.3.0
 isort==5.12.0
 pre-commit
 shellcheck-py==0.9.0.6

--- a/features/steps/airgap.py
+++ b/features/steps/airgap.py
@@ -75,10 +75,10 @@ def set_apt_mirror_file_with_credentials(
         )
 
         apt_mirror_file += "\n" + apt_mirror_cfg + "\n"
-        context.service_mirror_cfg[service.replace("-", "_")][
-            "path"
-        ] = "/var/spool/apt-mirror/mirror/esm.ubuntu.com/{}/".format(
-            service_type
+        context.service_mirror_cfg[service.replace("-", "_")]["path"] = (
+            "/var/spool/apt-mirror/mirror/esm.ubuntu.com/{}/".format(
+                service_type
+            )
         )
 
     apt_mirror_file += "clean http://archive.ubuntu.com/ubuntu"

--- a/uaclient/api/u/pro/security/fix/_common/plan/v1.py
+++ b/uaclient/api/u/pro/security/fix/_common/plan/v1.py
@@ -747,9 +747,9 @@ def _fix_plan_usn(issue_id: str, cfg: UAConfig) -> FixPlanUSNResult:
     )
     additional_data = {
         "associated_cves": [] if not usn.cves_ids else usn.cves_ids,
-        "associated_launchpad_bugs": []
-        if not usn.references
-        else usn.references,
+        "associated_launchpad_bugs": (
+            [] if not usn.references else usn.references
+        ),
     }
 
     target_usn_plan = _generate_fix_plan(
@@ -772,9 +772,9 @@ def _fix_plan_usn(issue_id: str, cfg: UAConfig) -> FixPlanUSNResult:
         )
         additional_data = {
             "associated_cves": [] if not usn.cves_ids else usn.cves_ids,
-            "associated_launchpad_bugs": []
-            if not usn.references
-            else usn.references,
+            "associated_launchpad_bugs": (
+                [] if not usn.references else usn.references
+            ),
         }
 
         related_usns_plan.append(

--- a/uaclient/api/u/pro/security/status/reboot_required/v1.py
+++ b/uaclient/api/u/pro/security/status/reboot_required/v1.py
@@ -149,12 +149,16 @@ def _reboot_required(cfg: UAConfig) -> RebootRequiredResult:
     return RebootRequiredResult(
         reboot_required=reboot_status.value,
         reboot_required_packages=RebootRequiredPkgs(
-            standard_packages=reboot_required_pkgs.standard_packages
-            if reboot_required_pkgs
-            else None,
-            kernel_packages=reboot_required_pkgs.kernel_packages
-            if reboot_required_pkgs
-            else None,
+            standard_packages=(
+                reboot_required_pkgs.standard_packages
+                if reboot_required_pkgs
+                else None
+            ),
+            kernel_packages=(
+                reboot_required_pkgs.kernel_packages
+                if reboot_required_pkgs
+                else None
+            ),
         ),
         livepatch_enabled_and_kernel_patched=livepatch_enabled_and_kernel_patched,  # noqa
         livepatch_enabled=livepatch_enabled,

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -899,7 +899,7 @@ def update_esm_caches(cfg) -> None:
         fetch_progress = EsmAcquireProgress()
         try:
             cache.update(fetch_progress, sources_list, 0)
-        except (SystemError) as e:
+        except SystemError as e:
             LOG.warning("Failed to fetch the ESM Apt Cache: {}".format(str(e)))
 
 

--- a/uaclient/cli/fix.py
+++ b/uaclient/cli/fix.py
@@ -127,9 +127,9 @@ class FixContext:
                     status=status,
                     pkg_index=self.pkg_index,
                     num_pkgs=len(self.affected_pkgs),
-                    pocket_source=get_pocket_description(pocket)
-                    if pocket
-                    else None,
+                    pocket_source=(
+                        get_pocket_description(pocket) if pocket else None
+                    ),
                 )
             )
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -408,9 +408,11 @@ class UAContractClient(serviceclient.UAServiceClient):
                     for service in enabled_services
                     if service.variant_enabled
                 },
-                "lastAttachment": attachment_data.attached_at.isoformat()
-                if attachment_data
-                else None,
+                "lastAttachment": (
+                    attachment_data.attached_at.isoformat()
+                    if attachment_data
+                    else None
+                ),
             }
         else:
             activity_info = {}
@@ -738,9 +740,9 @@ def _select_overrides(
 
     series_overrides = entitlement.pop("series", {}).pop(series_name, {})
     if series_overrides:
-        overrides[
-            OVERRIDE_SELECTOR_WEIGHTS["series_overrides"]
-        ] = series_overrides
+        overrides[OVERRIDE_SELECTOR_WEIGHTS["series_overrides"]] = (
+            series_overrides
+        )
 
     general_overrides = copy.deepcopy(entitlement.get("overrides", []))
     for override in general_overrides:

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -1,4 +1,5 @@
 """Tests related to uaclient.entitlement.base module."""
+
 import copy
 import logging
 from functools import partial

--- a/uaclient/entitlements/tests/test_entitlements.py
+++ b/uaclient/entitlements/tests/test_entitlements.py
@@ -1,4 +1,5 @@
 """Tests related to uaclient.entitlement.__init__ module."""
+
 import mock
 import pytest
 

--- a/uaclient/files/tests/test_notices.py
+++ b/uaclient/files/tests/test_notices.py
@@ -152,8 +152,8 @@ class TestNotices:
     def test_list(self, m_load_file, m_get_notice_file_names):
         notice = NoticesManager()
 
-        m_get_notice_file_names.side_effect = (
-            lambda directory: []
+        m_get_notice_file_names.side_effect = lambda directory: (
+            []
             if directory == defaults.NOTICES_TEMPORARY_DIRECTORY
             else ["fakeNotice1"]
         )

--- a/uaclient/http/tests/test_serviceclient.py
+++ b/uaclient/http/tests/test_serviceclient.py
@@ -130,10 +130,14 @@ class Test_GetFakeResponses:
                 code=response["code"],
                 headers=response.get("headers", {}),
                 body=json.dumps(response["response"], sort_keys=True),
-                json_dict=response["response"]
-                if isinstance(response["response"], dict)
-                else {},
-                json_list=response["response"]
-                if isinstance(response["response"], list)
-                else [],
+                json_dict=(
+                    response["response"]
+                    if isinstance(response["response"], dict)
+                    else {}
+                ),
+                json_list=(
+                    response["response"]
+                    if isinstance(response["response"], list)
+                    else []
+                ),
             ) == client._get_fake_responses(url)

--- a/uaclient/livepatch.py
+++ b/uaclient/livepatch.py
@@ -201,9 +201,9 @@ class UALivepatchClient(serviceclient.UAServiceClient):
             "flavour": flavor,
             "architecture": arch,
             "codename": codename,
-            "build-date": build_date.isoformat()
-            if build_date is not None
-            else "unknown",
+            "build-date": (
+                build_date.isoformat() if build_date is not None else "unknown"
+            ),
         }
         headers = self.headers()
         try:

--- a/uaclient/security_status.py
+++ b/uaclient/security_status.py
@@ -57,9 +57,9 @@ def get_origin_information_to_service_map():
     }
 
 
-def get_installed_packages_by_origin() -> DefaultDict[
-    "str", List[apt_pkg.Package]
-]:
+def get_installed_packages_by_origin() -> (
+    DefaultDict["str", List[apt_pkg.Package]]
+):
     result = defaultdict(list)
 
     with PreserveAptCfg(get_apt_pkg_cache) as cache:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -135,9 +135,11 @@ DEFAULT_STATUS = {
 def _get_blocked_by_services(ent):
     return [
         {
-            "name": service.entitlement.name
-            if not service.entitlement.is_variant
-            else service.entitlement.variant_name,
+            "name": (
+                service.entitlement.name
+                if not service.entitlement.is_variant
+                else service.entitlement.variant_name
+            ),
             "reason_code": service.named_msg.name,
             "reason": service.named_msg.msg,
         }
@@ -444,9 +446,13 @@ def _get_entitlement_information(
         if entitlement.get("type") == entitlement_name:
             return {
                 "entitled": "yes" if entitlement.get("entitled") else "no",
-                "auto_enabled": "yes"
-                if entitlement.get("obligations", {}).get("enableByDefault")
-                else "no",
+                "auto_enabled": (
+                    "yes"
+                    if entitlement.get("obligations", {}).get(
+                        "enableByDefault"
+                    )
+                    else "no"
+                ),
                 "affordances": entitlement.get("affordances", {}),
             }
     return {"entitled": "no", "auto_enabled": "no", "affordances": {}}
@@ -547,9 +553,9 @@ def simulate_status(
                 "description": ent.description,
                 "entitled": entitlement_information["entitled"],
                 "auto_enabled": entitlement_information["auto_enabled"],
-                "available": "yes"
-                if ent.name not in inapplicable_resources
-                else "no",
+                "available": (
+                    "yes" if ent.name not in inapplicable_resources else "no"
+                ),
             }
         )
     response["services"].sort(key=lambda x: x.get("name", ""))

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -500,13 +500,15 @@ class TestStatus:
         expected_services = [
             {
                 "description": cls.description,
-                "entitled": uf_entitled
-                if cls.name in resource_names
-                else default_entitled,
+                "entitled": (
+                    uf_entitled
+                    if cls.name in resource_names
+                    else default_entitled
+                ),
                 "name": cls.name,
-                "status": uf_status
-                if cls.name in resource_names
-                else default_status,
+                "status": (
+                    uf_status if cls.name in resource_names else default_status
+                ),
                 "status_details": mock.ANY,
                 "description_override": None,
                 "available": mock.ANY,

--- a/uaclient/tests/test_ua_timer.py
+++ b/uaclient/tests/test_ua_timer.py
@@ -210,10 +210,8 @@ class TestMeteringTimedJob:
     ):
         m_run_interval_seconds.return_value = config_value
         m_cfg = mock.MagicMock()
-        type(
-            m_cfg.machine_token_file
-        ).activity_ping_interval = mock.PropertyMock(
-            return_value=activity_ping_interval_value
+        type(m_cfg.machine_token_file).activity_ping_interval = (
+            mock.PropertyMock(return_value=activity_ping_interval_value)
         )
 
         metering_job = MeteringTimedJob(

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -1,4 +1,5 @@
 """Tests related to uaclient.util module."""
+
 import datetime
 import json
 

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -1,6 +1,7 @@
 """
 Client version related functions
 """
+
 import os.path
 from math import inf
 from typing import Optional


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it mitigates CVE-2024-21503 on our codebase.

I know the formatting changes are annoying, but our friend `Dependabot` annoyed us first [with this lovely PR](https://github.com/canonical/ubuntu-pro-client/pull/3007) which was only bumping the deps.

This resolves [a security alert](https://github.com/canonical/ubuntu-pro-client/security/dependabot/2) we have around.

## Test Steps
Pretty much `tox` and see how the new `black` formatting is poggers or noggers depending on developer opinion, which `black` itself mostly ignores.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
