### PR TITLE
daemon: remove unnecessary None check for state

### DIFF
--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -24,13 +24,9 @@ def _wait_for_cloud_config():
         LOG.debug("cloud-init.service state: %r", ci_state)
         # if cloud-config.service is not yet activating but cloud-init is
         # running, wait for cloud-config to start
-        if state is not None and (
-            state == "activating"
-            or (
-                state == "inactive"
-                and ci_state is not None
-                and (ci_state == "activating" or ci_state == "active")
-            )
+        if state == "activating" or (
+            state == "inactive"
+            and (ci_state == "activating" or ci_state == "active")
         ):
             if i < WAIT_FOR_CLOUD_CONFIG_POLL_TIMES:
                 LOG.debug(


### PR DESCRIPTION
## Why is this needed?
We had a check to see if the cloud-config.service is not None, which is redundant given the logic we have in place

## Test Steps
Nothing should change here

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
