### PR TITLE
d/postinst: ensure migrations happen in correct package postinst

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -474,6 +474,10 @@ case "$1" in
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "29~"; then
           rename_gpg_keys
       fi
+
+      if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "31~"; then
+          /usr/lib/ubuntu-advantage/postinst-migrations.sh $PREVIOUS_PKG_VER
+      fi
       ;;
 esac
 

--- a/debian/ubuntu-pro-client.postinst
+++ b/debian/ubuntu-pro-client.postinst
@@ -41,55 +41,19 @@ mark_reboot_cmds_as_needed() {
     fi
 }
 
-#
-# Migration functions
-#
-create_public_user_config_file() {
-    # When we perform the write operation through
-    # UserConfigFile we already write the public
-    # version of the user-config file with all the
-    # sensitive data removed.
-    # We also move the user-config.json file to the private 
-    # directory
-    source_file="/var/lib/ubuntu-advantage/user-config.json"
-    destination_dir="/var/lib/ubuntu-advantage/private"
-    # Check if the source file exists
-    if [ -f "$source_file" ]; then
-        mkdir -p "$destination_dir"
-        # Move the user-config.json file to the private directory
-        mv "$source_file" "$destination_dir/user-config.json"
-
-        /usr/bin/python3 -c "
-from uaclient.files import UserConfigFileObject
-try:
-    user_config_file = UserConfigFileObject()
-    content = user_config_file.read()
-    user_config_file.write(content)
-except Exception as e:
-    print('Error while creating public user-config file: {}'.format(e))
-"
-    fi
-}
-
 case "$1" in
     configure)
       PREVIOUS_PKG_VER=$2
 
       #
-      # Migrations from previous ubuntu-pro-client package versions
-      #
-      # These should always be version-gated using PREVIOUS_PKG_VER and execute in order from oldest to newest.
-      # For example:
-      #   if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "33~"; then
-      #       # do the migrations to version 33
-      #   fi
-      #   if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "34~"; then
-      #       # do the migrations to version 34
-      #   fi
+      # Migrations from previous ubuntu-pro-client package versions.
+      # These all exist in postinst-migrations.sh.
+      # See the explanation in that file.
+      # Do not add additional version migrations directly in this file.
       #
 
-      if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "32~"; then
-          create_public_user_config_file
+      if dpkg --compare-versions "$PREVIOUS_PKG_VER" gt "30"; then
+          /usr/lib/ubuntu-advantage/postinst-migrations.sh $PREVIOUS_PKG_VER
       fi
 
       #

--- a/lib/postinst-migrations.sh
+++ b/lib/postinst-migrations.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+#
+# Migrations from previous ubuntu-pro-client/ubuntu-advantage-tools versions
+#
+# These exist in this script separate from the *.postinst scripts because they
+# may need to be called from either ubuntu-pro-client.postinst or from
+# ubuntu-advantage-tools.postinst, depending on the situation.
+#
+# Because ubuntu-advantage-tools Depends on ubuntu-pro-client,
+# ubuntu-pro-client.postinst will always be executed before
+# ubuntu-advantage-tools.postinst.
+#
+# If the system already has ubuntu-pro-client and is upgrading to a new version
+# of ubuntu-pro-client, that means all migrations present in
+# ubuntu-advantage-tools.postinst must have already run at the time the system
+# upgraded to the renamed ubuntu-pro-client. That means the migrations in this
+# file can and should execute as part of ubuntu-pro-client.postinst.
+#
+# If upgrading from before the rename to the current version (from before
+# version 31), then not necessarily all migrations inside of
+# ubuntu-advantage-tools.postinst will have already run. Because the migrations
+# present in this file may depend on those previous migrations, then this file
+# must execute at the end of ubuntu-advantage-tools.postinst.
+#
+# In practice, this file is executed conditionally in either
+# ubuntu-pro-client.postinst or ubuntu-advantage-tools.postinst using version
+# checks. If we're upgrading from a version earlier than 31, then this executes
+# in ubuntu-advantage-tools.postinst. If we're upgrading from version 31 or
+# later, then this executes in ubuntu-pro-client.postinst.
+#
+#
+#
+# Migrations should always be version-gated using PREVIOUS_PKG_VER and execute
+# in order from oldest to newest.
+#
+# For example:
+#   if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "33~"; then
+#       # do the migrations to version 33
+#   fi
+#   if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "34~"; then
+#       # do the migrations to version 34
+#   fi
+#
+
+PREVIOUS_PKG_VER=$1
+
+if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "32~"; then
+    # When we perform the write operation through
+    # UserConfigFile we write the public
+    # version of the user-config file with all the
+    # sensitive data removed.
+    # We also move the user-config.json file to the private
+    # directory
+    source_file="/var/lib/ubuntu-advantage/user-config.json"
+    destination_dir="/var/lib/ubuntu-advantage/private"
+    # Check if the source file exists
+    if [ -f "$source_file" ]; then
+        mkdir -p "$destination_dir"
+        # Move the user-config.json file to the private directory
+        mv "$source_file" "$destination_dir/user-config.json"
+
+        /usr/bin/python3 -c "
+from uaclient.files import UserConfigFileObject
+try:
+    user_config_file = UserConfigFileObject()
+    content = user_config_file.read()
+    user_config_file.write(content)
+except Exception as e:
+    print('Error while creating public user-config file: {}'.format(e))
+"
+    fi
+fi


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
I wrote a book in the file itself, please read that.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

Test upgrade from older versions.
I added extra `echo executing from u-p-c` and `echo executing from u-a-t` lines to debug which postinst was executing the script.
Upgrading from current lxd daily images works well for testing a few scenarios
```
./test-in-lxd.sh xenial
./test-in-lxd.sh bionic
./test-in-lxd.sh focal
./test-in-lxd.sh jammy
./test-in-lxd.sh mantic
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
