### PR TITLE
Pro attach docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,15 +1,31 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_checkout:
+      - python3 build_requirements.py
+
+# Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: dirhtml
   configuration: docs/conf.py
   fail_on_warning: true
 
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.10"
 
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+# Optionally declare the Python requirements required to build your docs
 python:
   install:
   - requirements: docs-requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,9 +10,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  jobs:
-    post_checkout:
-      - python3 build_requirements.py
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,28 +1,115 @@
-/** Fix the font weight (300 for normal, 400 for slightly bold) **/
+/**
+    Ubuntu variable font definitions.
+    Based on https://github.com/canonical/vanilla-framework/blob/main/scss/_base_fontfaces.scss
 
-/** We are creating both of these styles only to have the
- *  headers of the compatibility matrix to be vertically
- *  aligned. The impact for other tables is that headers
- *  will be forcedly aligned to the bottom line, but that
- *  does not change the visualization of the other tables
- **/
-.v {
-  writing-mode: vertical-lr;
-  transform: rotate(180deg);
-  white-space: nowrap;
+    When font files are updated in Vanilla, the links to font files will need to be updated here as well.
+*/
+
+/* default font set */
+@font-face {
+  font-family: 'Ubuntu variable';
+  font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
+  font-style: normal;
+  font-weight: 100 800; /*  min and max value for the weight axis */
+  src: url('https://assets.ubuntu.com/v1/f1ea362b-Ubuntu%5Bwdth,wght%5D-latin-v0.896a.woff2') format('woff2-variations');
 }
 
-table.docutils th.text-center {
-  vertical-align: bottom;
+@font-face {
+  font-family: 'Ubuntu variable';
+  font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
+  font-style: italic;
+  font-weight: 100 800; /*  min and max value for the weight axis */
+  src: url('https://assets.ubuntu.com/v1/90b59210-Ubuntu-Italic%5Bwdth,wght%5D-latin-v0.896a.woff2') format('woff2-variations');
 }
 
-
-div.page, h1, h2, h3, h4, h5, h6, .sidebar-tree .current-page>.reference, button, input, optgroup, select, textarea, th.head {
-    font-weight: 300
+@font-face {
+  font-family: 'Ubuntu Mono variable';
+  font-style: normal;
+  font-weight: 100 800; /*  min and max value for the weight axis */
+  src: url('https://assets.ubuntu.com/v1/d5fc1819-UbuntuMono%5Bwght%5D-latin-v0.869.woff2') format('woff2-variations');
 }
 
-.toc-tree li.scroll-current>.reference, dl.glossary dt, dl.simple dt, dl:not([class]) dt {
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Ubuntu variable';
+  font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
+  font-style: normal;
+  font-weight: 100 800; /*  min and max value for the weight axis */
+  src: url('https://assets.ubuntu.com/v1/77cd6650-Ubuntu%5Bwdth,wght%5D-cyrillic-extended-v0.896a.woff2') format('woff2-variations');
+  unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
+}
+
+/* cyrillic */
+@font-face {
+  font-family: 'Ubuntu variable';
+  font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
+  font-style: normal;
+  font-weight: 100 800; /*  min and max value for the weight axis */
+  src: url('https://assets.ubuntu.com/v1/2702fce5-Ubuntu%5Bwdth,wght%5D-cyrillic-v0.896a.woff2') format('woff2-variations');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+
+/* greek-ext */
+@font-face {
+  font-family: 'Ubuntu variable';
+  font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
+  font-style: normal;
+  font-weight: 100 800; /*  min and max value for the weight axis */
+  src: url('https://assets.ubuntu.com/v1/5c108b7d-Ubuntu%5Bwdth,wght%5D-greek-extended-v0.896a.woff2') format('woff2-variations');
+  unicode-range: U+1F00-1FFF;
+}
+
+/* greek */
+@font-face {
+  font-family: 'Ubuntu variable';
+  font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
+  font-style: normal;
+  font-weight: 100 800; /*  min and max value for the weight axis */
+  src: url('https://assets.ubuntu.com/v1/0a14c405-Ubuntu%5Bwdth,wght%5D-greek-v0.896a.woff2') format('woff2-variations');
+  unicode-range: U+0370-03FF;
+}
+
+/* latin-ext */
+@font-face {
+  font-family: 'Ubuntu variable';
+  font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
+  font-style: normal;
+  font-weight: 100 800; /*  min and max value for the weight axis */
+  src: url('https://assets.ubuntu.com/v1/19f68eeb-Ubuntu%5Bwdth,wght%5D-latin-extended-v0.896a.woff2') format('woff2-variations');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/** Define font-weights as per Vanilla
+    Based on: https://github.com/canonical/vanilla-framework/blob/main/scss/_base_typography-definitions.scss
+
+    regular text: 400,
+    bold: 550,
+    thin: 300,
+
+    h1: bold,
+    h2: 180;
+    h3: bold,
+    h4: 275,
+    h5: bold,
+    h6: regular
+*/
+
+/* default regular text */
+html {
     font-weight: 400;
+}
+
+/* heading specific definitions */
+h1, h3, h5 { font-weight: 550; }
+h2 { font-weight: 180; }
+h4 { font-weight: 275; }
+
+/* bold */
+.toc-tree li.scroll-current>.reference,
+dl.glossary dt,
+dl.simple dt,
+dl:not([class]) dt {
+    font-weight: 550;
 }
 
 /** Table styling **/
@@ -30,6 +117,11 @@ div.page, h1, h2, h3, h4, h5, h6, .sidebar-tree .current-page>.reference, button
 th.head {
     text-transform: uppercase;
     font-size: var(--font-size--small);
+    text-align: initial;
+}
+
+table.align-center th.head {
+    text-align: center
 }
 
 table.docutils {
@@ -204,3 +296,48 @@ details summary {
     color: var(--color-version-popup);
     font-weight: bolder;
 }
+
+/* Code-block copybutton invisible by default
+   (overriding Furo config to achieve default copybutton setting). */
+.highlight button.copybtn {
+   opacity: 0;
+}
+
+/* Mimicking the 'Give feedback' button for UX consistency */
+.sidebar-search-container input[type=submit] {
+    color: #FFFFFF;
+    border: 2px solid #D6410D;
+    padding: var(--sidebar-search-input-spacing-vertical) var(--sidebar-search-input-spacing-horizontal);
+    background: #D6410D;
+    font-weight: bold;
+    font-size: var(--font-size--small);
+    cursor: pointer;
+}
+
+.sidebar-search-container input[type=submit]:hover {
+    text-decoration: underline;
+}
+
+/* Make inline code the same size as code blocks */
+p code.literal {
+    border: 0;
+    font-size: var(--code-font-size);
+}
+
+/** Custom for the Pro Client docs
+ *  We are creating both of these styles only to have the
+ *  headers of the compatibility matrix to be vertically
+ *  aligned. The impact for other tables is that headers
+ *  will be forcedly aligned to the bottom line, but that
+ *  does not change the visualization of the other tables
+ **/
+.v {
+  writing-mode: vertical-lr;
+  transform: rotate(180deg);
+  white-space: nowrap;
+}
+
+table.docutils th.text-center {
+  vertical-align: bottom;
+}
+

--- a/docs/_static/css/furo_colors.css
+++ b/docs/_static/css/furo_colors.css
@@ -1,8 +1,9 @@
 body {
     --color-code-background: #f8f8f8;
     --color-code-foreground: black;
-    --font-stack: Ubuntu, -apple-system, Segoe UI, Roboto, Oxygen, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-    --font-stack--monospace: Ubuntu Mono, Consolas, Monaco, Courier, monospace;
+    --code-font-size: 1rem;
+    --font-stack: Ubuntu variable, Ubuntu, -apple-system, Segoe UI, Roboto, Oxygen, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+    --font-stack--monospace: Ubuntu Mono variable, Ubuntu Mono, Consolas, Monaco, Courier, monospace;
     --color-foreground-primary: #111;
     --color-foreground-secondary: var(--color-foreground-primary);
     --color-foreground-muted: #333;

--- a/docs/explanations.rst
+++ b/docs/explanations.rst
@@ -1,3 +1,5 @@
+.. _explanation:
+
 Ubuntu Pro Client explanation
 *****************************
 
@@ -64,6 +66,7 @@ Other Pro features explained
 ..  toctree::
     :maxdepth: 1
 
+    explanations/which_services.rst
     explanations/about_esm.md
     explanations/what_are_the_timer_jobs.md
     explanations/using_pro_offline.rst

--- a/docs/explanations/which_services.rst
+++ b/docs/explanations/which_services.rst
@@ -1,0 +1,188 @@
+.. _which-services:
+
+Which services are for me?
+**************************
+
+Ubuntu Pro is a broad subscription designed to meet many different needs. You
+are unlikely to want to use all of these tools and services at the same time,
+so you are free to select the precise stream of updates and versions you want
+to apply on any given machine covered by your Pro subscription.
+
+To help you navigate the services offered through Ubuntu Pro, click on the tab
+that best describes your needs for our suggestions on which services might be
+of interest to you. For example, Pro includes a set of package versions that
+are compliant with FIPS regulations. You will only want these versions on
+machines that *need* to meet FIPS requirements, so you can choose to enable
+that stream specifically on those machines.
+
+.. tab-set::
+
+    .. tab-item:: Commercial
+
+       * **Expanded Security Maintenance (ESM)**
+
+         If you're using any Ubuntu LTS -- Desktop or Server -- in a commercial
+         setting and you rely on 'Universe' packages, or if you're on an older
+         LTS and don't want to upgrade yet, you can get additional security
+         support through `Expanded Security Maintenance (ESM) <esm_>`_. We recommend
+         it for everyone using Pro, and it's enabled by default. It includes
+         two services:
+
+         * ``esm-infra`` provides security updates for packages in the Ubuntu
+           'main' repository (packages from Ubuntu) for five additional years
+           beyond the standard five years of security maintenance of 'main'
+           packages.
+
+         * ``esm-apps`` covers packages in the 'universe' repository (which
+           are from Debian and the community) for ten years after the LTS
+           release. 
+
+         * Whether you need one or both of these depends on your subscription.
+           If you're not sure which services best support the needs of your
+           organisation, contact us for `a security assessment`_.
+
+       * **Livepatch**
+
+         Ubuntu `Livepatch`_ reduces costly unplanned maintenance by patching
+         vulnerabilities while the system runs. It removes the need to
+         immediately reboot after a kernel upgrade so that you can schedule
+         downtime when it's convenient. This tooling is available through
+         ``livepatch`` and is one of the services we enable by default.
+
+         * Find out more about what Livepatch can do for your organisation in
+           the `Livepatch documentation`_, or learn
+           :ref:`how to enable it<manage-livepatch>` with ``pro``.
+
+       * **Landscape**
+
+         `Landscape`_ is the leading management and administration tool for
+         Ubuntu. It can manage up to 40,000 Ubuntu machines with a single
+         interface, and can automate security patching, as well as hardening
+         and compliance. Landscape can be `self-hosted`_ or you can use Canonical's
+         `Landscape SaaS`_ offering.
+
+         * Find out more about
+           :ref:`registering a machine with Landscape<manage-landscape>`
+           using ``pro``.
+
+       Want more information?
+
+    .. tab-item:: Security certification
+
+       Ubuntu provides security `compliance, certifications, and hardening <certifications_>`_:
+
+       * **FIPS 140-2**
+
+         * `FIPS 140-2 Certified Modules <fips_>`_ are available through ``fips``.
+
+         * Compliant but non-certified patches are available through
+           ``fips-updates``.
+
+         * Find out more :ref:`about managing FIPS<manage-fips>`.
+
+       * **Ubuntu Security Guide (USG)**
+
+         * In the 20.04 LTS we introduced the `Ubuntu Security Guide <usg_>`_, which
+           provides security tooling through ``usg``. It bundles together
+           multiple key components, such as CIS benchmarking and DISA-STIG.
+
+         * Before USG, Center for Internet Security `(CIS) Benchmark <cis_>`_ tooling
+           was available as a separate service through ``cis``. This can be
+           used up to (and including) 20.04 LTS, but on all later LTS releases
+           this functionality is provided through ``usg``.
+
+         * Find out :ref:`how to manage USG (and CIS)<manage-cis>`
+           with the Pro Client.
+
+       * **Common Criteria**
+
+         * `Common Criteria EAL2 (CC EAL) <CC_>`_ certification tooling is available
+           through ``cc-eal``. The Ubuntu 18.04 LTS and 16.04 LTS have both
+           been certified.
+
+         * Find out :ref:`how to enable CC EAL<manage-cc>` on your LTS.
+
+       Want more information?
+
+    .. tab-item:: Personal user
+
+       * **Expanded Security Maintenance (ESM)**
+
+         If you're using Pro on an LTS machine (Desktop or Server) you can get
+         additional security support through
+         `Expanded Security Maintenance (ESM) <esm_>`_. We recommend it for everyone
+         using Pro, and it's enabled by default. It includes two services:
+
+         * ``esm-infra`` provides security updates for packages in the Ubuntu
+           'main' repository (packages from Ubuntu) for five additional years
+           beyond the standard five years of security maintenance of 'main'
+           packages.
+
+         * ``esm-apps`` covers packages in the 'universe' repository (which
+           are from Debian and the community) for ten years after the LTS
+           release. 
+
+         * Read more
+           :ref:`about ESM-Apps and ESM-Infra<expl-ESM>`.
+
+       * **Livepatch**
+
+         Ubuntu `Livepatch`_ removes the need to immediately reboot your
+         machine after a patch is applied to the kernel, so you can perform
+         device reboots when it's convenient for you. Although it's
+         lightweight, it may not be suitable on a very small system with
+         limited memory. Check our `list of supported kernels`_ if you're
+         unsure.
+
+         * Find out
+           :ref:`how to enable Livepatch<manage-livepatch>`.
+
+       Want more information?
+
+    .. tab-item:: Specialty services
+
+       * **ROS ESM**
+
+         Our Robot Operating System Expanded Security Maintenance (`ROS ESM`_)
+         service provides security maintenance for ROS LTS releases, starting
+         with ROS Kinetic on Ubuntu 16.04 -- including packages from the Ubuntu
+         'universe' repository.
+
+         * ``ros`` provides security updates to the 600+ packages for ROS 1
+           Kinetic and Melodic, and ROS 2 Foxy -- in addition to the security
+           coverage already provided by ESM. 
+
+         * ``ros-updates`` also gives you access to non-security updates.
+
+         * Want to know how to enable ROS ESM? Check out
+           `this introductory guide`_ by the ROS team to get started.
+
+       * **Real-time kernel**
+
+         The Ubuntu 22.04 LTS brought the new, enterprise-grade
+         `real-time kernel <realtime_>`_, which reduces kernel latencies and ensures
+         predictable performance for time-sensitive task execution. It was
+         designed to deliver stable, ultra-low latency and security for
+         critical telco infrastructure, but has applications across a wide
+         variety of industries.
+
+         * Find out `more information about real-time Ubuntu`_ and what it can
+           do for your organisation. 
+
+         * Or see our guide on
+           :ref:`how to enable the real-time kernel<manage-realtime>`. 
+
+       Want more information?
+       
+.. LINKS
+
+.. include:: ../links.txt
+
+.. _a security assessment: https://ubuntu.com/contact-us/form?product=pro
+.. _this introductory guide: https://discourse.ubuntu.com/t/ros-esm-user-introduction/26206
+.. _Livepatch documentation: https://ubuntu.com/security/livepatch/docs
+.. _list of supported kernels: https://ubuntu.com/security/livepatch/docs/livepatch/reference/kernels
+.. _self-hosted: https://ubuntu.com/landscape/pricing
+.. _Landscape SaaS: https://ubuntu.com/landscape/pricing
+.. _more information about real-time Ubuntu: https://ubuntu.com/kernel/real-time/contact-us
+

--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -19,8 +19,8 @@ How to use ``pro`` commands
 .. toctree::
    :maxdepth: 1
 
-   Get an Ubuntu Pro token and attach to a subscription <howtoguides/get_token_and_attach>
-   Attach with a configuration file <howtoguides/how_to_attach_with_config_file>
+   Attach a machine to a subscription <howtoguides/get_token_and_attach>
+   Attach via a configuration file <howtoguides/how_to_attach_with_config_file>
 
 ``pro collect-logs``
 --------------------

--- a/docs/howtoguides/enable_in_dockerfile.rst
+++ b/docs/howtoguides/enable_in_dockerfile.rst
@@ -17,13 +17,13 @@ check the version you are running with the following command:
 
 .. code-block:: bash
 
-    $ pro version
+    pro version
 
 If you're on a version lower than 27.7, you can update it by running: 
 
 .. code-block:: bash
 
-    $ sudo apt update && sudo apt upgrade -y
+    sudo apt update && sudo apt install ubuntu-advantage-tools
 
 Create an Ubuntu Pro Attach Config file
 =======================================

--- a/docs/howtoguides/get_token_and_attach.rst
+++ b/docs/howtoguides/get_token_and_attach.rst
@@ -1,53 +1,58 @@
 .. _get_token_and_attach:
 
-How to get an Ubuntu Pro token and attach to a subscription
-***********************************************************
+How to attach a machine to your Ubuntu Pro subscription
+*******************************************************
 
-Get an Ubuntu Pro token
-=======================
-
-Retrieve your Ubuntu Pro token from the `Ubuntu Pro portal <Pro_>`_. Log in
-with your "Single Sign On" credentials, the same credentials you use for
-https://login.ubuntu.com.
-
-After you have logged in you can go to the
-`Ubuntu Pro Dashboard <Pro_dashboard_>`_ associated with your user account. It
-will show you all subscriptions currently available to you and for each
-associated token.
-
-Note that even without buying anything you can always obtain a free personal
-token that way, which provides you with access to several of the Ubuntu Pro
-services.
-
-Attach to a subscription
-========================
-
-Once you have obtained your token, run the following command to attach your
-machine to a subscription:
+To attach your machine to a subscription, run the following command in your
+terminal:
 
 .. code-block:: bash
 
-    $ sudo pro attach YOUR_TOKEN
+    $ sudo pro attach
 
-You should see output like this, which indicates that you have successfully
-associated this machine with your account:
+You should see output like this, giving you a link and a code:
 
-.. code-block:: text
+.. code-block:: bash
 
+    ubuntu@test:~$ sudo pro attach
+    Initiating attach operation...
+
+    Please sign in to your Ubuntu Pro account at this link:
+    https://ubuntu.com/pro/attach
+    And provide the following code: H31JIV
+
+Open the link without closing your terminal window. 
+
+In the field that asks you to enter your code, copy and paste the code shown
+in the terminal. Then, choose which subscription you want to attach to. 
+By default, the Free Personal Token will be selected.
+
+If you have a paid subscription and want to attach to a different token, you
+may want to log in first so that your additional tokens will appear. 
+
+Once you have pasted your code and chosen the subscription you want to attach
+your machine to, click on the "Submit" button.
+
+The attach process will then continue in the terminal window, and you should
+eventually be presented with the following message:
+
+.. code-block:: bash 
+
+    Attaching the machine...
+    Enabling default service esm-apps
+    Updating Ubuntu Pro: ESM Apps package lists
+    Ubuntu Pro: ESM Apps enabled
     Enabling default service esm-infra
-    Updating package lists
-    ESM Infra enabled
-    This machine is now attached to 'Ubuntu Pro'
+    Updating Ubuntu Pro: ESM Infra package lists
+    Ubuntu Pro: ESM Infra enabled
+    Enabling default service livepatch
+    Installing snapd snap
+    Installing canonical-livepatch snap
+    Canonical Livepatch enabled
+    This machine is now attached to 'Ubuntu Pro - free personal subscription'
 
-    SERVICE       ENTITLED  STATUS    DESCRIPTION
-    esm-apps      yes       enabled   Expanded Security Maintenance for Applications
-    esm-infra     yes       enabled   Expanded Security Maintenance for Infrastructure
-    livepatch     yes       enabled   Canonical Livepatch service
-
-    NOTICES
-    Operation in progress: pro attach
-
-    Enable services with: pro enable <service>
+When the machine has successfully been attached, you will also see a summary of
+which services are enabled and information about your subscription.
 
 Once the Ubuntu Pro Client is attached to your Ubuntu Pro account, you can use
 it to activate various services, including: access to ESM packages, Livepatch,
@@ -78,7 +83,12 @@ the ``--no-auto-enable`` flag to ``attach`` in the following way:
 
 .. code-block:: bash
 
-    $ sudo pro attach YOUR_TOKEN --no-auto-enable
+    $ sudo pro attach --no-auto-enable
+
+.. note::
+   
+   If you want to control which services are enabled during attach, you can
+   :ref:`attach with a configuration file <attach-with-config>` instead.
 
 .. LINKS
 

--- a/docs/howtoguides/how_to_attach_with_config_file.rst
+++ b/docs/howtoguides/how_to_attach_with_config_file.rst
@@ -50,3 +50,7 @@ And can be passed via the CLI with the following command:
 .. code-block:: bash
 
     sudo pro attach --attach-config /path/to/file.yaml
+    
+.. LINKS
+
+.. include:: ../links.txt

--- a/docs/howtoguides/how_to_attach_with_config_file.rst
+++ b/docs/howtoguides/how_to_attach_with_config_file.rst
@@ -1,3 +1,5 @@
+.. _attach-with-config:
+
 How to attach with a configuration file
 ***************************************
 
@@ -11,6 +13,27 @@ the secret token in a file.
 
 Optionally, the attached config file can be used to override the services that
 are automatically enabled as a part of the attach process.
+
+
+Get an Ubuntu Pro token
+=======================
+
+Retrieve your Ubuntu Pro token from the `Ubuntu Pro portal <Pro_>`_. Log in
+with your "Single Sign On" credentials, the same credentials you use for
+https://login.ubuntu.com.
+
+After you have logged in you can go to the
+`Ubuntu Pro Dashboard <Pro_dashboard_>`_ associated with your user account. It
+will show you all subscriptions currently available to you and for each
+associated token.
+
+Note that even without buying anything you can always obtain a free personal
+token that way, which provides you with access to several of the Ubuntu Pro
+services.
+
+
+The attach config file
+======================
 
 An attach config file looks like this:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,10 @@
 Ubuntu Pro Client
 #################
 
-`Ubuntu Pro <Pro_>`_ is a suite of additional services provided by Canonical on top of
-Ubuntu. Whether you’re an enterprise customer deploying systems at scale or
+Whether you’re an enterprise customer deploying systems at scale or
 want security patching for your personal Ubuntu LTS at home, the Ubuntu Pro
-Client (``pro``) is the command-line tool that will help you manage the
-services you need. If you're not sure which services you need,
+Client (``pro``) is the command-line tool that will help you manage your 
+`Ubuntu Pro <Pro_>`_ services. If you're not sure which services you need,
 :ref:`check out our overview <which-services>`.
 
 The Ubuntu Pro Client comes pre-installed on every Ubuntu system. You can run

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,219 +5,41 @@ Ubuntu Pro Client
 Ubuntu. Whether you’re an enterprise customer deploying systems at scale or
 want security patching for your personal Ubuntu LTS at home, the Ubuntu Pro
 Client (``pro``) is the command-line tool that will help you manage the
-services you need.
+services you need. If you're not sure which services you need,
+:ref:`check out our overview <which-services>`.
 
 The Ubuntu Pro Client comes pre-installed on every Ubuntu system. You can run
 ``pro help`` in your terminal window to see a list of the ``pro``
 services and commands available, or get started
 :ref:`with our hands-on tutorial<tutorial-commands>` to try it out in
-a virtual environment.
+a virtual environment. 
 
-Which services are for me?
-==========================
-
-Ubuntu Pro is a broad subscription designed to meet many different needs. You
-are unlikely to want to use all of these tools and services at the same time,
-so you are free to select the precise stream of updates and versions you want
-to apply on any given machine covered by your Pro subscription.
-
-To help you navigate the services offered through Ubuntu Pro, click on the tab
-that best describes your needs for our suggestions on which services might be
-of interest to you. For example, Pro includes a set of package versions that
-are compliant with FIPS regulations. You will only want these versions on
-machines that *need* to meet FIPS requirements, so you can choose to enable
-that stream specifically on those machines.
-
-.. tab-set::
-
-    .. tab-item:: Commercial
-
-       * **Expanded Security Maintenance (ESM)**
-
-         If you're using any Ubuntu LTS -- Desktop or Server -- in a commercial
-         setting and you rely on 'Universe' packages, or if you're on an older
-         LTS and don't want to upgrade yet, you can get additional security
-         support through `Expanded Security Maintenance (ESM) <esm_>`_. We recommend
-         it for everyone using Pro, and it's enabled by default. It includes
-         two services:
-
-         * ``esm-infra`` provides security updates for packages in the Ubuntu
-           'main' repository (packages from Ubuntu) for five additional years
-           beyond the standard five years of security maintenance of 'main'
-           packages.
-
-         * ``esm-apps`` covers packages in the 'universe' repository (which
-           are from Debian and the community) for ten years after the LTS
-           release. 
-
-         * Whether you need one or both of these depends on your subscription.
-           If you're not sure which services best support the needs of your
-           organisation, contact us for `a security assessment`_.
-
-       * **Livepatch**
-
-         Ubuntu `Livepatch`_ reduces costly unplanned maintenance by patching
-         vulnerabilities while the system runs. It removes the need to
-         immediately reboot after a kernel upgrade so that you can schedule
-         downtime when it's convenient. This tooling is available through
-         ``livepatch`` and is one of the services we enable by default.
-
-         * Find out more about what Livepatch can do for your organisation in
-           the `Livepatch documentation`_, or learn
-           :ref:`how to enable it<manage-livepatch>` with ``pro``.
-
-       * **Landscape**
-
-         `Landscape`_ is the leading management and administration tool for
-         Ubuntu. It can manage up to 40,000 Ubuntu machines with a single
-         interface, and can automate security patching, as well as hardening
-         and compliance. Landscape can be `self-hosted`_ or you can use Canonical's
-         `Landscape SaaS`_ offering.
-
-         * Find out more about
-           :ref:`registering a machine with Landscape<manage-landscape>`
-           using ``pro``.
-
-       Want more information?
-
-    .. tab-item:: Security certification
-
-       Ubuntu provides security `compliance, certifications, and hardening <certifications_>`_:
-
-       * **FIPS 140-2**
-
-         * `FIPS 140-2 Certified Modules <fips_>`_ are available through ``fips``.
-
-         * Compliant but non-certified patches are available through
-           ``fips-updates``.
-
-         * Find out more :ref:`about managing FIPS<manage-fips>`.
-
-       * **Ubuntu Security Guide (USG)**
-
-         * In the 20.04 LTS we introduced the `Ubuntu Security Guide <usg_>`_, which
-           provides security tooling through ``usg``. It bundles together
-           multiple key components, such as CIS benchmarking and DISA-STIG.
-
-         * Before USG, Center for Internet Security `(CIS) Benchmark <cis_>`_ tooling
-           was available as a separate service through ``cis``. This can be
-           used up to (and including) 20.04 LTS, but on all later LTS releases
-           this functionality is provided through ``usg``.
-
-         * Find out :ref:`how to manage USG (and CIS)<manage-cis>`
-           with the Pro Client.
-
-       * **Common Criteria**
-
-         * `Common Criteria EAL2 (CC EAL) <CC_>`_ certification tooling is available
-           through ``cc-eal``. The Ubuntu 18.04 LTS and 16.04 LTS have both
-           been certified.
-
-         * Find out :ref:`how to enable CC EAL<manage-cc>` on your LTS.
-
-       Want more information?
-
-    .. tab-item:: Personal user
-
-       * **Expanded Security Maintenance (ESM)**
-
-         If you're using Pro on an LTS machine (Desktop or Server) you can get
-         additional security support through
-         `Expanded Security Maintenance (ESM) <esm_>`_. We recommend it for everyone
-         using Pro, and it's enabled by default. It includes two services:
-
-         * ``esm-infra`` provides security updates for packages in the Ubuntu
-           'main' repository (packages from Ubuntu) for five additional years
-           beyond the standard five years of security maintenance of 'main'
-           packages.
-
-         * ``esm-apps`` covers packages in the 'universe' repository (which
-           are from Debian and the community) for ten years after the LTS
-           release. 
-
-         * Read more
-           :ref:`about ESM-Apps and ESM-Infra<expl-ESM>`.
-
-       * **Livepatch**
-
-         Ubuntu `Livepatch`_ removes the need to immediately reboot your
-         machine after a patch is applied to the kernel, so you can perform
-         device reboots when it's convenient for you. Although it's
-         lightweight, it may not be suitable on a very small system with
-         limited memory. Check our `list of supported kernels`_ if you're
-         unsure.
-
-         * Find out
-           :ref:`how to enable Livepatch<manage-livepatch>`.
-
-       Want more information?
-
-    .. tab-item:: Specialty services
-
-       * **ROS ESM**
-
-         Our Robot Operating System Expanded Security Maintenance (`ROS ESM`_)
-         service provides security maintenance for ROS LTS releases, starting
-         with ROS Kinetic on Ubuntu 16.04 -- including packages from the Ubuntu
-         'universe' repository.
-
-         * ``ros`` provides security updates to the 600+ packages for ROS 1
-           Kinetic and Melodic, and ROS 2 Foxy -- in addition to the security
-           coverage already provided by ESM. 
-
-         * ``ros-updates`` also gives you access to non-security updates.
-
-         * Want to know how to enable ROS ESM? Check out
-           `this introductory guide`_ by the ROS team to get started.
-
-       * **Real-time kernel**
-
-         The Ubuntu 22.04 LTS brought the new, enterprise-grade
-         `real-time kernel <realtime_>`_, which reduces kernel latencies and ensures
-         predictable performance for time-sensitive task execution. It was
-         designed to deliver stable, ultra-low latency and security for
-         critical telco infrastructure, but has applications across a wide
-         variety of industries.
-
-         * Find out `more information about real-time Ubuntu`_ and what it can
-           do for your organisation. 
-
-         * Or see our guide on
-           :ref:`how to enable the real-time kernel<manage-realtime>`. 
-
-       Want more information?
+---------
 
 Explore our documentation
 =========================
 
 .. grid:: 1 1 2 2
    :gutter: 3
+   :margin: 0
 
-   .. grid-item-card:: **Tutorials**
-       :link: tutorials
-       :link-type: doc
+   .. grid-item-card:: :ref:`Tutorials <tutorial>`
 
-       Get started - a hands-on introduction to Ubuntu Pro Client for new users
+       Get started with our hands-on introduction to Ubuntu Pro Client for new users
 
-   .. grid-item-card:: **How-to guides**
-       :link: howtoguides
-       :link-type: doc
+   .. grid-item-card:: :ref:`How-to guides <how-to>`
 
        Step-by-step guides covering key operations and common tasks
 
-   .. grid-item-card:: **Explanation**
-       :link: explanations
-       :link-type: doc
+   .. grid-item-card:: :ref:`Explanation <explanation>`
 
        Discussion and clarification of key topics
 
-   .. grid-item-card:: **Reference**
-       :link: references
-       :link-type: doc
+   .. grid-item-card:: :ref:`Reference <reference>`
 
        Technical information - specifications, APIs, architecture
 
------
+---------
 
 Getting help
 ============
@@ -282,11 +104,4 @@ constructive feedback.
 
 .. include:: links.txt
 
-.. _a security assessment: https://ubuntu.com/contact-us/form?product=pro
-.. _this introductory guide: https://discourse.ubuntu.com/t/ros-esm-user-introduction/26206
-.. _Livepatch documentation: https://ubuntu.com/security/livepatch/docs
-.. _list of supported kernels: https://ubuntu.com/security/livepatch/docs/livepatch/reference/kernels
-.. _self-hosted: https://ubuntu.com/landscape/pricing
-.. _Landscape SaaS: https://ubuntu.com/landscape/pricing
-.. _more information about real-time Ubuntu: https://ubuntu.com/kernel/real-time/contact-us
 .. _contribute: https://github.com/canonical/ubuntu-pro-client/blob/docs/CONTRIBUTING.md

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -1,3 +1,5 @@
+.. _reference:
+
 Ubuntu Pro Client reference
 ***************************
 

--- a/docs/tutorials/basic_commands.rst
+++ b/docs/tutorials/basic_commands.rst
@@ -82,20 +82,33 @@ We have seen which service offerings are available to us, but to access them we
 first need to attach an Ubuntu Pro subscription. We can do this by running the
 ``attach`` command.
 
-Before you run this command, you will need to get your Ubuntu Pro token. Any
-user with an Ubuntu One account is entitled to a free personal token to use
-with Ubuntu Pro.
+.. code-block:: bash
 
-You can retrieve your Ubuntu Pro token from the `Ubuntu Pro portal <Pro_>`_.
-Log in with your "single sign on" (SSO) credentials -- the same credentials you
-use for https://login.ubuntu.com. Copy your Ubuntu Pro token, then go to the VM
-and run:
+    $ sudo pro attach
+    
+You should see output like this, giving you a link and a code:
 
 .. code-block:: bash
 
-    $ sudo pro attach YOUR_TOKEN
+    ubuntu@test:~$ sudo pro attach
+    Initiating attach operation...
 
-You should then see output similar to this:
+    Please sign in to your Ubuntu Pro account at this link:
+    https://ubuntu.com/pro/attach
+    And provide the following code: H31JIV
+
+Open the link without closing your terminal window. 
+
+In the field that asks you to enter your code, copy and paste the code shown
+in the terminal. Then, choose which subscription you want to attach to. 
+By default, the Free Personal Token will be selected, which is fine for the
+purposes of this tutorial.
+
+Once you have pasted your code and chosen the subscription you want to attach
+your machine to, click on the "Submit" button.
+
+The attach process will then continue in the terminal window, and you should
+eventually be presented with the following message:
 
 .. code-block:: text
 


### PR DESCRIPTION
## Why is this needed?
It came to my attention that pro attach <token> is no longer the desired or recommended way for users to attach to their subscription except in specific circumstances. 

I have restructured and revamped several pages where this was the instruction we gave, and have also taken the opportunity to bring our docs visually in line with the new Pro Handbook

This includes moving the "Which services are for me?" off the front page and into its own document. 

Fixes: #2706 

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [X] No
