### PR TITLE
Add watchfiles module

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
 sphinx:
   builder: dirhtml
   configuration: docs/conf.py
-  fail_on_warning: false
+  fail_on_warning: true
 
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
 sphinx:
   builder: dirhtml
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,8 +19,8 @@ sphinx:
 
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
+#formats:
+#   - pdf
 
 # Optionally declare the Python requirements required to build your docs
 python:

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -10,3 +10,4 @@ sphinx-notfound-page
 sphinxcontrib-mermaid
 sphinxcontrib-jquery
 sphinxext-opengraph
+watchfiles

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinxcontrib.jquery",
     "sphinxext.opengraph",
+    "watchfiles",
 ]
 autosectionlabel_prefix_document = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,6 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinxcontrib.jquery",
     "sphinxext.opengraph",
-    "watchfiles",
 ]
 autosectionlabel_prefix_document = True
 


### PR DESCRIPTION
The RTD build was breaking for two reasons:
- Changed dependency
- PDF file generation broken

The autobuild function removed the previous dependency and added the watchfiles dependency instead. I have added this dependency to make sure that `make run` will still work.

Also removed PDF generation option from the .readthedocs.yaml file since this was breaking the RTD build. We can add this back in the future, but it will require some work on the auto-generated LaTeX file (there is another TA investigating this).
