### PR TITLE
livepatch: fix delta check for enableByDefault

### DIFF
--- a/features/api_fix_execute.feature
+++ b/features/api_fix_execute.feature
@@ -407,6 +407,13 @@ Feature: Fix execute API endpoints
                         "version": ".*"
                       }
                     ]
+                  },
+                  {
+                    "description": "klibc vulnerabilities",
+                    "errors": null,
+                    "status": "fixed",
+                    "title": "USN-6736-1",
+                    "upgraded_packages": []
                   }
                 ],
                 "target_usn": {
@@ -464,6 +471,13 @@ Feature: Fix execute API endpoints
                     "errors": null,
                     "status": "fixed",
                     "title": "USN-5570-2",
+                    "upgraded_packages": []
+                  },
+                  {
+                    "description": "klibc vulnerabilities",
+                    "errors": null,
+                    "status": "fixed",
+                    "title": "USN-6736-1",
                     "upgraded_packages": []
                   }
                 ],

--- a/features/api_fix_plan.feature
+++ b/features/api_fix_plan.feature
@@ -435,6 +435,38 @@ Feature: Fix plan API endpoints
                     ],
                     "title": "USN-5570-2",
                     "warnings": []
+                  },
+                  {
+                    "additional_data": {
+                      "associated_cves": [
+                        "CVE-2018-25032",
+                        "CVE-2016-9840",
+                        "CVE-2022-37434",
+                        "CVE-2016-9841"
+                      ],
+                      "associated_launchpad_bugs": []
+                    },
+                    "affected_packages": [
+                      "klibc"
+                    ],
+                    "description": "klibc vulnerabilities",
+                    "error": null,
+                    "expected_status": "fixed",
+                    "plan": [
+                      {
+                        "data": {
+                          "pocket": "standard-updates",
+                          "source_packages": [
+                            "klibc"
+                          ],
+                          "status": "cve-already-fixed"
+                        },
+                        "operation": "no-op",
+                        "order": 1
+                      }
+                    ],
+                    "title": "USN-6736-1",
+                    "warnings": []
                   }
                 ],
                 "target_usn_plan": {
@@ -576,6 +608,38 @@ Feature: Fix plan API endpoints
                       }
                     ],
                     "title": "USN-5570-2",
+                    "warnings": []
+                  },
+                  {
+                    "additional_data": {
+                      "associated_cves": [
+                        "CVE-2018-25032",
+                        "CVE-2016-9840",
+                        "CVE-2022-37434",
+                        "CVE-2016-9841"
+                      ],
+                      "associated_launchpad_bugs": []
+                    },
+                    "affected_packages": [
+                      "klibc"
+                    ],
+                    "description": "klibc vulnerabilities",
+                    "error": null,
+                    "expected_status": "fixed",
+                    "plan": [
+                      {
+                        "data": {
+                          "pocket": "standard-updates",
+                          "source_packages": [
+                            "klibc"
+                          ],
+                          "status": "cve-already-fixed"
+                        },
+                        "operation": "no-op",
+                        "order": 1
+                      }
+                    ],
+                    "title": "USN-6736-1",
                     "warnings": []
                   }
                 ],

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -111,6 +111,7 @@ Feature: Ua fix command behaviour
       Found related USNs:
       - USN-5570-1
       - USN-5570-2
+      - USN-6736-1
 
       Fixing related USNs:
       - USN-5570-1
@@ -126,10 +127,19 @@ Feature: Ua fix command behaviour
 
       .*✔.* USN-5570-2 is resolved.
 
+      - USN-6736-1
+      1 affected source package is installed: klibc
+      \(1/1\) klibc:
+      A fix is available in Ubuntu standard updates.
+      The update is already installed.
+
+      .*✔.* USN-6736-1 is resolved.
+
       Summary:
       .*✔.* USN-5573-1 \[requested\] is resolved.
       .*✔.* USN-5570-1 \[related\] does not affect your system.
       .*✔.* USN-5570-2 \[related\] is resolved.
+      .*✔.* USN-6736-1 \[related\] is resolved.
       """
     When I run `pro fix USN-5573-1` with sudo
     Then stdout matches regexp:
@@ -149,6 +159,7 @@ Feature: Ua fix command behaviour
       Found related USNs:
       - USN-5570-1
       - USN-5570-2
+      - USN-6736-1
 
       Fixing related USNs:
       - USN-5570-1
@@ -164,10 +175,19 @@ Feature: Ua fix command behaviour
 
       .*✔.* USN-5570-2 is resolved.
 
+      - USN-6736-1
+      1 affected source package is installed: klibc
+      \(1/1\) klibc:
+      A fix is available in Ubuntu standard updates.
+      The update is already installed.
+
+      .*✔.* USN-6736-1 is resolved.
+
       Summary:
       .*✔.* USN-5573-1 \[requested\] is resolved.
       .*✔.* USN-5570-1 \[related\] does not affect your system.
       .*✔.* USN-5570-2 \[related\] is resolved.
+      .*✔.* USN-6736-1 \[related\] is resolved.
       """
     When I run `pro fix USN-5573-1 --no-related` with sudo
     Then stdout matches regexp:
@@ -398,8 +418,6 @@ Feature: Ua fix command behaviour
       Choose: \[S\]ubscribe at https://ubuntu.com/pro/subscribe \[A\]ttach existing token \[C\]ancel
       > Enter your token \(from https://ubuntu.com/pro/dashboard\) to attach this system:
       > .*\{ pro attach .*\}.*
-      Ubuntu Pro: ESM Apps enabled
-      Ubuntu Pro: ESM Infra enabled
       """
     And stdout matches regexp:
       """

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -327,7 +327,7 @@ class LivepatchEntitlement(UAEntitlement):
 
         delta_entitlement = deltas.get("entitlement", {})
         process_enable_default = delta_entitlement.get("obligations", {}).get(
-            "enabledByDefault", False
+            "enableByDefault", False
         )
 
         if process_enable_default:

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -289,6 +289,21 @@ class TestLivepatchProcessContractDeltas:
             setup_calls = []
         assert setup_calls == m_setup_livepatch_config.call_args_list
 
+    @mock.patch(M_PATH + "LivepatchEntitlement.enable")
+    @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
+    def test_livepatch_disable_and_delta_with_enable_by_default(
+        self,
+        m_application_status,
+        m_enable,
+        entitlement,
+    ):
+        deltas = {"entitlement": {"obligations": {"enableByDefault": True}}}
+        m_enable.return_value = (True, None)
+        application_status = ApplicationStatus.DISABLED
+        m_application_status.return_value = (application_status, "")
+        entitlement.process_contract_deltas({}, deltas, False)
+        assert [mock.call(mock.ANY)] == m_enable.call_args_list
+
 
 @mock.patch(M_PATH + "snap.is_snapd_installed_as_a_snap")
 @mock.patch(M_PATH + "snap.is_snapd_installed")


### PR DESCRIPTION
### Why is this needed?
On the `process_contract_deltas` function, there is a check to see if the entitlement delta has an enableByDefault directive. However, there was a typo on when fetching that value from the delta dict. We are now fixing this typo and adding an unittest for it


## Test Steps
check the new unittest for this change

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
