### PR TITLE
Add attach messages back

### DIFF
--- a/debian/po/pt_BR.po
+++ b/debian/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-08 10:20-0400\n"
+"POT-Creation-Date: 2024-04-25 15:27-0300\n"
 "PO-Revision-Date: 2023-09-25 12:29-0400\n"
 "Last-Translator: Lucas Moura <lucas.moura@canonical.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -726,20 +726,25 @@ msgstr "Um momento, checando a sua assinatura"
 
 #: ../../uaclient/messages/__init__.py:319
 #, python-brace-format
+msgid "Enabling {title}"
+msgstr "Habilitando {title}"
+
+#: ../../uaclient/messages/__init__.py:320
+#, python-brace-format
 msgid "{title} enabled"
 msgstr "{title} habilitado"
 
-#: ../../uaclient/messages/__init__.py:320
+#: ../../uaclient/messages/__init__.py:321
 #, python-brace-format
 msgid "{title} access enabled"
 msgstr "acesso habilitado para {title}"
 
-#: ../../uaclient/messages/__init__.py:321
+#: ../../uaclient/messages/__init__.py:322
 #, python-brace-format
 msgid "Could not enable {title}."
 msgstr "Não foi possível habilitar {title}"
 
-#: ../../uaclient/messages/__init__.py:323
+#: ../../uaclient/messages/__init__.py:324
 #, python-brace-format
 msgid ""
 "{service_being_enabled} cannot be enabled with {incompatible_service}.\n"
@@ -751,12 +756,12 @@ msgstr ""
 "Desabilitar {incompatible_service} e prosseguir com a habilitação do "
 "{service_being_enabled}? (y/N) "
 
-#: ../../uaclient/messages/__init__.py:329
+#: ../../uaclient/messages/__init__.py:330
 #, python-brace-format
 msgid "Disabling incompatible service: {service}"
 msgstr "Desabilitando serviço incompatível: {service}"
 
-#: ../../uaclient/messages/__init__.py:332
+#: ../../uaclient/messages/__init__.py:333
 #, python-brace-format
 msgid ""
 "{service_being_enabled} cannot be enabled with {required_service} disabled.\n"
@@ -768,33 +773,33 @@ msgstr ""
 "Habilitar {required_service} e prosseguir com a habilitação do "
 "{service_being_enabled}? (y/N) "
 
-#: ../../uaclient/messages/__init__.py:337
+#: ../../uaclient/messages/__init__.py:338
 #, python-brace-format
 msgid "Enabling required service: {service}"
 msgstr "Habilitando serviço necessário: {service}"
 
-#: ../../uaclient/messages/__init__.py:339
+#: ../../uaclient/messages/__init__.py:340
 #, python-brace-format
 msgid "A reboot is required to complete {operation}."
 msgstr "É necessário reiniciar a máquina para completar a operação {operation}"
 
-#: ../../uaclient/messages/__init__.py:342
+#: ../../uaclient/messages/__init__.py:343
 #, python-brace-format
 msgid "Configuring APT access to {service}"
 msgstr ""
 
 #. DISABLE
-#: ../../uaclient/messages/__init__.py:345
+#: ../../uaclient/messages/__init__.py:346
 #, python-brace-format
 msgid "Removing APT access to {title}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:346
+#: ../../uaclient/messages/__init__.py:347
 #, python-brace-format
 msgid "Could not disable {title}."
 msgstr "Não foi possível desabilitar {title}."
 
-#: ../../uaclient/messages/__init__.py:348
+#: ../../uaclient/messages/__init__.py:349
 #, python-brace-format
 msgid ""
 "{dependent_service} depends on {service_being_disabled}.\n"
@@ -805,55 +810,55 @@ msgstr ""
 "Desabilitar {dependent_service} e prosseguir com a desabilitação do "
 "{service_being_disabled}? (y/N) "
 
-#: ../../uaclient/messages/__init__.py:354
+#: ../../uaclient/messages/__init__.py:355
 #, python-brace-format
 msgid "Disabling dependent service: {required_service}"
 msgstr "Desabilitando serviço dependente: {required_service}"
 
-#: ../../uaclient/messages/__init__.py:357
+#: ../../uaclient/messages/__init__.py:358
 #, python-brace-format
 msgid "Removing apt source file: {filename}"
 msgstr "Removendo arquivo do apt: {filename}"
 
-#: ../../uaclient/messages/__init__.py:359
+#: ../../uaclient/messages/__init__.py:360
 #, python-brace-format
 msgid "Removing apt preferences file: {filename}"
 msgstr "Removendo arquivo de preferência do apt: {filename}"
 
-#: ../../uaclient/messages/__init__.py:362
+#: ../../uaclient/messages/__init__.py:363
 #, fuzzy, python-brace-format
 msgid "Uninstalling all packages installed from {title}"
 msgstr "Desinstalando {packages}"
 
-#: ../../uaclient/messages/__init__.py:367
+#: ../../uaclient/messages/__init__.py:368
 msgid "(The --purge flag is still experimental - use with caution)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:370
+#: ../../uaclient/messages/__init__.py:371
 #, python-brace-format
 msgid "Purging the {service} packages would uninstall the following kernel(s):"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:373
+#: ../../uaclient/messages/__init__.py:374
 #, python-brace-format
 msgid "{kernel_version} is the current running kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:376
+#: ../../uaclient/messages/__init__.py:377
 msgid ""
 "No other valid Ubuntu kernel was found in the system.\n"
 "Removing the package would potentially make the system unbootable.\n"
 "Aborting.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:383
+#: ../../uaclient/messages/__init__.py:384
 msgid ""
 "If you cannot guarantee that other kernels in this system are bootable and\n"
 "working properly, *do not proceed*. You may end up with an unbootable "
 "system.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:392
+#: ../../uaclient/messages/__init__.py:393
 #, python-brace-format
 msgid ""
 "Failed to automatically attach to an Ubuntu Pro subscription {num_attempts} "
@@ -868,7 +873,7 @@ msgstr ""
 "A próxima tentativa está agendada para {next_run_datestring}.\n"
 "Você pode tentar manualmente executando `sudo pro auto-attach`."
 
-#: ../../uaclient/messages/__init__.py:400
+#: ../../uaclient/messages/__init__.py:401
 #, python-brace-format
 msgid ""
 "Failed to automatically attach to an Ubuntu Pro subscription {num_attempts} "
@@ -885,7 +890,7 @@ msgstr ""
 "bug ubuntu-advantage-tools`\n"
 "Você pode tentar manualmente executando `sudo pro auto-attach`."
 
-#: ../../uaclient/messages/__init__.py:408
+#: ../../uaclient/messages/__init__.py:409
 #, python-brace-format
 msgid ""
 "Canonical servers did not recognize this machine as Ubuntu Pro: \"{detail}\""
@@ -893,37 +898,37 @@ msgstr ""
 "Os servidores da Canonical não reconheceram essa máquina como sendo "
 "associada ao Ubuntu Pro: \"{detail}\""
 
-#: ../../uaclient/messages/__init__.py:412
+#: ../../uaclient/messages/__init__.py:413
 msgid "Canonical servers did not recognize this image as Ubuntu Pro"
 msgstr ""
 "Os servidores da Canonical não reconheceram essa imagem como sendo associada "
 "ao Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:414
+#: ../../uaclient/messages/__init__.py:415
 #, python-brace-format
 msgid "the pro lock was held by pid {pid}"
 msgstr "A lock do pro está sendo mantida pelo pid {pid}"
 
-#: ../../uaclient/messages/__init__.py:416
+#: ../../uaclient/messages/__init__.py:417
 #, python-brace-format
 msgid "an error from Canonical servers: \"{error_msg}\""
 msgstr "um erro dos servidores da Canonical: \"{error_msg}\""
 
-#: ../../uaclient/messages/__init__.py:418
+#: ../../uaclient/messages/__init__.py:419
 msgid "a connectivity error"
 msgstr "um erro de conexão"
 
-#: ../../uaclient/messages/__init__.py:419
+#: ../../uaclient/messages/__init__.py:420
 #, python-brace-format
 msgid "an error while reaching {url}"
 msgstr "um error ao acessar {url}"
 
-#: ../../uaclient/messages/__init__.py:423
+#: ../../uaclient/messages/__init__.py:424
 #, python-brace-format
 msgid "Due to contract refresh, '{service}' is now disabled."
 msgstr "Devido à atualização de contrato, '{service}' está agora desabilitado"
 
-#: ../../uaclient/messages/__init__.py:426
+#: ../../uaclient/messages/__init__.py:427
 #, python-brace-format
 msgid ""
 "Unable to disable '{service}' as recommended during contract refresh. "
@@ -932,49 +937,49 @@ msgstr ""
 "Falha ao desabilitar '{service}' conforme esperado após atualização do seu "
 "contrato. O serviço ainda está ativo. Execute `pro status` para confirmar"
 
-#: ../../uaclient/messages/__init__.py:431
+#: ../../uaclient/messages/__init__.py:432
 #, python-brace-format
 msgid "Updating '{service}' on changed directives."
 msgstr "Atualizando '{service}' baseado nas novas diretivas"
 
-#: ../../uaclient/messages/__init__.py:434
+#: ../../uaclient/messages/__init__.py:435
 #, python-brace-format
 msgid "Updating '{service}' apt sources list on changed directives."
 msgstr ""
 "Atualizando a lista de apt sources do '{service}' baseado nas novas diretivas"
 
-#: ../../uaclient/messages/__init__.py:437
+#: ../../uaclient/messages/__init__.py:438
 #, python-brace-format
 msgid "Installing packages on changed directives: {packages}"
 msgstr "Instalando pacotes baseado nas novas diretivas: {packages}"
 
-#: ../../uaclient/messages/__init__.py:447
+#: ../../uaclient/messages/__init__.py:448
 #, python-brace-format
 msgid "Choose: [S]ubscribe at {url} [A]ttach existing token [C]ancel"
 msgstr ""
 "Escolha: [S] para vincular através de {url}; [A] para vincular usando um "
 "token existente; [C] para cancelar:"
 
-#: ../../uaclient/messages/__init__.py:451
+#: ../../uaclient/messages/__init__.py:452
 #, python-brace-format
 msgid "Choose: [E]nable {service} [C]ancel"
 msgstr "Escolha: [E] para habilitar {service}; [C] para cancelar:"
 
-#: ../../uaclient/messages/__init__.py:455
+#: ../../uaclient/messages/__init__.py:456
 #, python-brace-format
 msgid "Choose: [R]enew your subscription (at {url}) [C]ancel"
 msgstr "Escolha: [R]enovar sua assinatura (em {url}); [C]ancelar"
 
-#: ../../uaclient/messages/__init__.py:458
+#: ../../uaclient/messages/__init__.py:459
 #, python-brace-format
 msgid "A fix is available in {fix_stream}."
 msgstr "Uma solução está disponível em {fix_stream}."
 
-#: ../../uaclient/messages/__init__.py:459
+#: ../../uaclient/messages/__init__.py:460
 msgid "The update is not yet installed."
 msgstr "A atualização ainda não está instalada"
 
-#: ../../uaclient/messages/__init__.py:461
+#: ../../uaclient/messages/__init__.py:462
 msgid ""
 "The update is not installed because this system is not attached to a\n"
 "subscription.\n"
@@ -982,7 +987,7 @@ msgstr ""
 "A atualização não pode ser instalada porque o sistema não está vinculado a\n"
 "uma assinatura.\n"
 
-#: ../../uaclient/messages/__init__.py:467
+#: ../../uaclient/messages/__init__.py:468
 msgid ""
 "The update is not installed because this system is attached to an\n"
 "expired subscription.\n"
@@ -990,7 +995,7 @@ msgstr ""
 "A atualização não pode ser instalada porque o sistema está vinculado a uma\n"
 "assinatura vencida.\n"
 
-#: ../../uaclient/messages/__init__.py:473
+#: ../../uaclient/messages/__init__.py:474
 #, python-brace-format
 msgid ""
 "The update is not installed because this system does not have\n"
@@ -1000,11 +1005,11 @@ msgstr ""
 "{service}\n"
 "habilitado.\n"
 
-#: ../../uaclient/messages/__init__.py:478
+#: ../../uaclient/messages/__init__.py:479
 msgid "The update is already installed."
 msgstr "A atualização já está instalada."
 
-#: ../../uaclient/messages/__init__.py:480
+#: ../../uaclient/messages/__init__.py:481
 #, python-brace-format
 msgid ""
 "For easiest security on {title}, use Ubuntu Pro instances.\n"
@@ -1014,73 +1019,73 @@ msgstr ""
 "Ubuntu Pro.\n"
 "Aprenda mais em {cloud_specific_url}"
 
-#: ../../uaclient/messages/__init__.py:485
+#: ../../uaclient/messages/__init__.py:486
 msgid "requested"
 msgstr "requisitado"
 
-#: ../../uaclient/messages/__init__.py:486
+#: ../../uaclient/messages/__init__.py:487
 msgid "related"
 msgstr "relacionado"
 
-#: ../../uaclient/messages/__init__.py:487
+#: ../../uaclient/messages/__init__.py:488
 #, python-brace-format
 msgid " {issue} is resolved."
 msgstr " {issue} resolvida"
 
-#: ../../uaclient/messages/__init__.py:489
+#: ../../uaclient/messages/__init__.py:490
 #, python-brace-format
 msgid " {issue} [{context}] is resolved."
 msgstr "{issue} [{context}] foi resolvida"
 
-#: ../../uaclient/messages/__init__.py:491
+#: ../../uaclient/messages/__init__.py:492
 #, python-brace-format
 msgid " {issue} is not resolved."
 msgstr " {issue} não foi resolvida"
 
-#: ../../uaclient/messages/__init__.py:493
+#: ../../uaclient/messages/__init__.py:494
 #, python-brace-format
 msgid " {issue} [{context}] is not resolved."
 msgstr " {issue} [{context}] não foi resolvida"
 
-#: ../../uaclient/messages/__init__.py:496
+#: ../../uaclient/messages/__init__.py:497
 #, python-brace-format
 msgid " {issue} does not affect your system."
 msgstr " {issue} não afeta o seu sistema."
 
-#: ../../uaclient/messages/__init__.py:499
+#: ../../uaclient/messages/__init__.py:500
 #, python-brace-format
 msgid " {issue} [{context}] does not affect your system."
 msgstr " {issue} [{context}] não afeta o seu sistema."
 
-#: ../../uaclient/messages/__init__.py:503
+#: ../../uaclient/messages/__init__.py:504
 #, python-brace-format
 msgid "{num_pkgs} package is still affected: {pkgs}"
 msgid_plural "{num_pkgs} packages are still affected: {pkgs}"
 msgstr[0] "{num_pkgs} pacote ainda está afetado: {pkgs}"
 msgstr[1] "{num_pkgs} pacotes ainda estão afetados: {pkgs}"
 
-#: ../../uaclient/messages/__init__.py:510
+#: ../../uaclient/messages/__init__.py:511
 #, python-brace-format
 msgid "{count} affected source package is installed: {pkgs}"
 msgid_plural "{count} affected source packages are installed: {pkgs}"
 msgstr[0] "{count} pacote fonte afetado está instalado: {pkgs}"
 msgstr[1] "{count} pacotes fonte afetados estão instalados: {pkgs}"
 
-#: ../../uaclient/messages/__init__.py:516
+#: ../../uaclient/messages/__init__.py:517
 msgid "No affected source packages are installed."
 msgstr "Nenhum pacote fonte afetado está instalado"
 
-#: ../../uaclient/messages/__init__.py:518
+#: ../../uaclient/messages/__init__.py:519
 #, python-brace-format
 msgid "{issue} is resolved."
 msgstr "{issue} foi resolvida"
 
-#: ../../uaclient/messages/__init__.py:520
+#: ../../uaclient/messages/__init__.py:521
 #, python-brace-format
 msgid " {issue} is resolved by livepatch patch version: {version}."
 msgstr " {issue} for resolvida pelo patch {version} do livepatch."
 
-#: ../../uaclient/messages/__init__.py:523
+#: ../../uaclient/messages/__init__.py:524
 #, python-brace-format
 msgid ""
 "{bold}Ubuntu Pro service: {{service}} is not enabled.\n"
@@ -1095,7 +1100,7 @@ msgstr ""
 "este serviço.\n"
 "{{{{ pro enable {{service}} }}}}{end_bold}"
 
-#: ../../uaclient/messages/__init__.py:530
+#: ../../uaclient/messages/__init__.py:531
 #, python-brace-format
 msgid ""
 "{bold}The machine is not attached to an Ubuntu Pro subscription.\n"
@@ -1107,7 +1112,7 @@ msgstr ""
 "para o Ubuntu Pro.\n"
 "{{ pro attach TOKEN }}{end_bold}"
 
-#: ../../uaclient/messages/__init__.py:536
+#: ../../uaclient/messages/__init__.py:537
 #, python-brace-format
 msgid ""
 "{bold}The machine has an expired subscription.\n"
@@ -1122,7 +1127,7 @@ msgstr ""
 "{{ pro detach --assume-yes }}\n"
 "{{ pro attach NEW_TOKEN }}{end_bold}"
 
-#: ../../uaclient/messages/__init__.py:544
+#: ../../uaclient/messages/__init__.py:545
 #, python-brace-format
 msgid ""
 "{bold}WARNING: The option --dry-run is being used.\n"
@@ -1131,7 +1136,7 @@ msgstr ""
 "{bold}ATENÇÂO: a opção --dry-run está sendo usada.\n"
 "Nenhum pacote será instalado na execução deste comando.{end_bold}"
 
-#: ../../uaclient/messages/__init__.py:549
+#: ../../uaclient/messages/__init__.py:550
 #, python-brace-format
 msgid ""
 "Error: Ubuntu Pro service: {service} is not enabled.\n"
@@ -1140,7 +1145,7 @@ msgstr ""
 "Erro: o serviço Ubuntu Pro: {service} não está habilitado.\n"
 "Sem o serviço, não podemos corrigir o sistema."
 
-#: ../../uaclient/messages/__init__.py:554
+#: ../../uaclient/messages/__init__.py:555
 #, python-brace-format
 msgid ""
 "Error: The current Ubuntu Pro subscription is not entitled to: {service}.\n"
@@ -1150,74 +1155,74 @@ msgstr ""
 "Ubuntu Pro.\n"
 "Sem o serviço, não podemos corrigir o sistema."
 
-#: ../../uaclient/messages/__init__.py:559
+#: ../../uaclient/messages/__init__.py:560
 #, python-brace-format
 msgid "{service} is required for upgrade."
 msgstr "{service} é necessário para atualização."
 
-#: ../../uaclient/messages/__init__.py:563
+#: ../../uaclient/messages/__init__.py:564
 #, python-brace-format
 msgid "{service} is required for upgrade, but current subscription is expired."
 msgstr ""
 "{service} é necessário para atualização, mas a atual assinatura está vencida"
 
-#: ../../uaclient/messages/__init__.py:567
+#: ../../uaclient/messages/__init__.py:568
 #, python-brace-format
 msgid "{service} is required for upgrade, but it is not enabled."
 msgstr ""
 "{service} é necessário para atualização, mas o serviço está desabilitado."
 
-#: ../../uaclient/messages/__init__.py:571
+#: ../../uaclient/messages/__init__.py:572
 msgid "APT failed to install the package.\n"
 msgstr "APT falhou ao instalar o pacote.\n"
 
-#: ../../uaclient/messages/__init__.py:576
+#: ../../uaclient/messages/__init__.py:577
 msgid "Sorry, no fix is available yet."
 msgstr "Desculpe, não existe uma correção disponível ainda."
 
-#: ../../uaclient/messages/__init__.py:580
+#: ../../uaclient/messages/__init__.py:581
 msgid "Ubuntu security engineers are investigating this issue."
 msgstr "Engenheiros de segurança do Ubuntu estão investigando o problema."
 
-#: ../../uaclient/messages/__init__.py:584
+#: ../../uaclient/messages/__init__.py:585
 msgid "A fix is coming soon. Try again tomorrow."
 msgstr "Uma correção será entregue em breve. Tente de novo amanhã."
 
-#: ../../uaclient/messages/__init__.py:588
+#: ../../uaclient/messages/__init__.py:589
 msgid "Sorry, no fix is available."
 msgstr "Desculpe, não existe uma correção disponível."
 
-#: ../../uaclient/messages/__init__.py:592
+#: ../../uaclient/messages/__init__.py:593
 msgid "Source package does not exist on this release."
 msgstr "O pacote fonte não existe para esta versão do Ubuntu."
 
-#: ../../uaclient/messages/__init__.py:596
+#: ../../uaclient/messages/__init__.py:597
 msgid "Source package is not affected on this release."
 msgstr "O pacote fonte não é afetado nesta versão do Ubuntu."
 
-#: ../../uaclient/messages/__init__.py:600
+#: ../../uaclient/messages/__init__.py:601
 #, python-brace-format
 msgid "UNKNOWN: {status}"
 msgstr "DESCONHECIDO: {status}"
 
-#: ../../uaclient/messages/__init__.py:604
+#: ../../uaclient/messages/__init__.py:605
 msgid "Associated CVEs:"
 msgstr "CVEs associadas:"
 
-#: ../../uaclient/messages/__init__.py:605
+#: ../../uaclient/messages/__init__.py:606
 msgid "Found Launchpad bugs:"
 msgstr "Bugs do Launchpad encontrados:"
 
-#: ../../uaclient/messages/__init__.py:607
+#: ../../uaclient/messages/__init__.py:608
 #, python-brace-format
 msgid "Fixing requested {issue_id}"
 msgstr "Corrigindo {issue_id}"
 
-#: ../../uaclient/messages/__init__.py:611
+#: ../../uaclient/messages/__init__.py:612
 msgid "Fixing related USNs:"
 msgstr "Corrigindo USNs relacionados"
 
-#: ../../uaclient/messages/__init__.py:615
+#: ../../uaclient/messages/__init__.py:616
 #, python-brace-format
 msgid ""
 "Found related USNs:\n"
@@ -1226,11 +1231,11 @@ msgstr ""
 "USNs relacionadas foram encontradas:\n"
 "- {related_usns}"
 
-#: ../../uaclient/messages/__init__.py:619
+#: ../../uaclient/messages/__init__.py:620
 msgid "Summary:"
 msgstr "Sumário:"
 
-#: ../../uaclient/messages/__init__.py:623
+#: ../../uaclient/messages/__init__.py:624
 #, python-brace-format
 msgid ""
 "Even though a related USN failed to be fixed, note\n"
@@ -1247,21 +1252,21 @@ msgstr ""
 "\n"
 "{url}\n"
 
-#: ../../uaclient/messages/__init__.py:632
+#: ../../uaclient/messages/__init__.py:633
 msgid "Ubuntu standard updates"
 msgstr "Atualizações padrão do Ubuntu"
 
-#: ../../uaclient/messages/__init__.py:633
-#: ../../uaclient/messages/__init__.py:1241
+#: ../../uaclient/messages/__init__.py:634
+#: ../../uaclient/messages/__init__.py:1242
 msgid "Ubuntu Pro: ESM Infra"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:634
-#: ../../uaclient/messages/__init__.py:1227
+#: ../../uaclient/messages/__init__.py:635
+#: ../../uaclient/messages/__init__.py:1228
 msgid "Ubuntu Pro: ESM Apps"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:637
+#: ../../uaclient/messages/__init__.py:638
 msgid ""
 "Package fixes cannot be installed.\n"
 "To install them, run this command as root (try using sudo)"
@@ -1269,12 +1274,12 @@ msgstr ""
 "As atualizações de pacotes não podem ser instaladas.\n"
 "Para instalar os pacotes, execute esse comando como root (tente usando sudo)"
 
-#: ../../uaclient/messages/__init__.py:643
+#: ../../uaclient/messages/__init__.py:644
 #, python-brace-format
 msgid "Enter your token (from {url}) to attach this system:"
 msgstr "Insira seu token (da {url}) para vincular seu sistema:"
 
-#: ../../uaclient/messages/__init__.py:647
+#: ../../uaclient/messages/__init__.py:648
 msgid "Enter your new token to renew Ubuntu Pro subscription on this system:"
 msgstr ""
 "Providencie seu novo token para renovar sua assinatura do Ubuntu Pro neste "
@@ -1283,33 +1288,33 @@ msgstr ""
 #. ##############################################################################
 #. SECURITYSTATUS SUBCOMMAND                              #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:657
+#: ../../uaclient/messages/__init__.py:658
 #, python-brace-format
 msgid "{count} packages installed:"
 msgstr "{count} pacotes instalados:"
 
-#: ../../uaclient/messages/__init__.py:660
+#: ../../uaclient/messages/__init__.py:661
 #, python-brace-format
 msgid "{offset}{count} package from Ubuntu {repository} repository"
 msgid_plural "{offset}{count} packages from Ubuntu {repository} repository"
 msgstr[0] "{offset}{count} pacote do repositório {repository} do Ubuntu"
 msgstr[1] "{offset}{count} pacotes do repositório {repository} do Ubuntu"
 
-#: ../../uaclient/messages/__init__.py:667
+#: ../../uaclient/messages/__init__.py:668
 #, python-brace-format
 msgid "{offset}{count} package from a third party"
 msgid_plural "{offset}{count} packages from third parties"
 msgstr[0] "{offset}{count} pacote de terceiros"
 msgstr[1] "{offset}{count} pacotes de terceiros"
 
-#: ../../uaclient/messages/__init__.py:674
+#: ../../uaclient/messages/__init__.py:675
 #, python-brace-format
 msgid "{offset}{count} package no longer available for download"
 msgid_plural "{offset}{count} packages no longer available for download"
 msgstr[0] "{offset}{count} pacote não mais disponível para download"
 msgstr[1] "{offset}{count} pacotes não mais disponíveis para download"
 
-#: ../../uaclient/messages/__init__.py:681
+#: ../../uaclient/messages/__init__.py:682
 msgid ""
 "To get more information about the packages, run\n"
 "    pro security-status --help\n"
@@ -1319,7 +1324,7 @@ msgstr ""
 "    pro security-status --help\n"
 "para uma lista das opções disponíveis."
 
-#: ../../uaclient/messages/__init__.py:688
+#: ../../uaclient/messages/__init__.py:689
 msgid ""
 " Make sure to run\n"
 "    sudo apt update\n"
@@ -1329,21 +1334,21 @@ msgstr ""
 "    sudo apt update\n"
 "para obter as informações mais recentes dos pacotes direto do apt."
 
-#: ../../uaclient/messages/__init__.py:694
+#: ../../uaclient/messages/__init__.py:695
 #, python-brace-format
 msgid "The system apt information was updated {days} day(s) ago."
 msgstr "As informações do apt foram atualizadas há {days} dia(s) atrás"
 
-#: ../../uaclient/messages/__init__.py:698
+#: ../../uaclient/messages/__init__.py:699
 msgid "The system apt cache may be outdated."
 msgstr "O cache do apt pode estar desatualizado"
 
-#: ../../uaclient/messages/__init__.py:702
+#: ../../uaclient/messages/__init__.py:703
 #, python-brace-format
 msgid "Main/Restricted packages receive updates until {date}."
 msgstr "pacotes Main/Restricted receberão atualizações até {date}."
 
-#: ../../uaclient/messages/__init__.py:705
+#: ../../uaclient/messages/__init__.py:706
 #, python-brace-format
 msgid ""
 "This machine is receiving security patching for Ubuntu Main/Restricted\n"
@@ -1352,15 +1357,15 @@ msgstr ""
 "Esta máquina está recebendo patches de segurança para o repositório\n"
 "Main/Restricted do Ubuntu até {date}"
 
-#: ../../uaclient/messages/__init__.py:711
+#: ../../uaclient/messages/__init__.py:712
 msgid "This machine is attached to an Ubuntu Pro subscription."
 msgstr "Esta máquina está vinculada a uma assinatura do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:714
+#: ../../uaclient/messages/__init__.py:715
 msgid "This machine is NOT attached to an Ubuntu Pro subscription."
 msgstr "Esta máquina NÃO está vinculada a uma assinatura do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:718
+#: ../../uaclient/messages/__init__.py:719
 msgid ""
 "Packages from third parties are not provided by the official Ubuntu\n"
 "archive, for example packages from Personal Package Archives in Launchpad."
@@ -1369,7 +1374,7 @@ msgstr ""
 "por examplo, pacotes de encontrados em Personal Package Archives (PPAs) do "
 "Launchpad."
 
-#: ../../uaclient/messages/__init__.py:723
+#: ../../uaclient/messages/__init__.py:724
 msgid ""
 "Packages that are not available for download may be left over from a\n"
 "previous release of Ubuntu, may have been installed directly from a\n"
@@ -1379,7 +1384,7 @@ msgstr ""
 "versões anteriores do Ubuntu, podem ter sido instalados diretamente por um\n"
 "arquivo .deb, ou de uma fonte que foi desabilitada."
 
-#: ../../uaclient/messages/__init__.py:730
+#: ../../uaclient/messages/__init__.py:731
 msgid ""
 "This machine is NOT receiving security patches because the LTS period has "
 "ended\n"
@@ -1389,7 +1394,7 @@ msgstr ""
 "acabou\n"
 "e esm-infra não está habilitado."
 
-#: ../../uaclient/messages/__init__.py:736
+#: ../../uaclient/messages/__init__.py:737
 #, python-brace-format
 msgid ""
 "Ubuntu Pro with '{service}' enabled provides security updates for\n"
@@ -1398,14 +1403,14 @@ msgstr ""
 "Ubuntu Pro com '{service}' habilitado provê atualizações de segurança\n"
 "para pacotes do {repository} até {year}."
 
-#: ../../uaclient/messages/__init__.py:742
+#: ../../uaclient/messages/__init__.py:743
 #, python-brace-format
 msgid "There is {updates} pending security update."
 msgid_plural "There are {updates} pending security updates."
 msgstr[0] "Existe {updates} atualização de segurança pendente."
 msgstr[1] "Existem {updates} atualizações de segurança pendentes."
 
-#: ../../uaclient/messages/__init__.py:749
+#: ../../uaclient/messages/__init__.py:750
 #, python-brace-format
 msgid ""
 "{repository} packages are receiving security updates from\n"
@@ -1414,7 +1419,7 @@ msgstr ""
 "Pacotes do {repository} estão recebendo atualizações de segurança do\n"
 "Ubuntu Pro com '{service}' habilitado até {year}."
 
-#: ../../uaclient/messages/__init__.py:755
+#: ../../uaclient/messages/__init__.py:756
 #, python-brace-format
 msgid ""
 "You have received {updates} security\n"
@@ -1429,12 +1434,12 @@ msgstr[1] ""
 "Você recebeu {updates} atualizações de\n"
 "segurança."
 
-#: ../../uaclient/messages/__init__.py:765
+#: ../../uaclient/messages/__init__.py:766
 #, python-brace-format
 msgid "Enable {service} with: pro enable {service}"
 msgstr "Habilite {service} com: pro enable {service}"
 
-#: ../../uaclient/messages/__init__.py:767
+#: ../../uaclient/messages/__init__.py:768
 #, python-brace-format
 msgid ""
 "Try Ubuntu Pro with a free personal subscription on up to 5 machines.\n"
@@ -1444,7 +1449,7 @@ msgstr ""
 "máquinas.\n"
 "Saiba mais em {url}\n"
 
-#: ../../uaclient/messages/__init__.py:774
+#: ../../uaclient/messages/__init__.py:775
 #, python-brace-format
 msgid ""
 "For example, run:\n"
@@ -1455,165 +1460,165 @@ msgstr ""
 "    apt-cache show {package}\n"
 "para saber mais sobre este pacote."
 
-#: ../../uaclient/messages/__init__.py:781
+#: ../../uaclient/messages/__init__.py:782
 msgid "You have no packages installed from a third party."
 msgstr "Você não tem pacotes instalados de terceitos."
 
-#: ../../uaclient/messages/__init__.py:784
+#: ../../uaclient/messages/__init__.py:785
 msgid "You have no packages installed that are no longer available."
 msgstr "Você não tem pacotes instalados que não estejam mais disponíveis."
 
-#: ../../uaclient/messages/__init__.py:787
+#: ../../uaclient/messages/__init__.py:788
 msgid "Ubuntu Pro is not available for non-LTS releases."
 msgstr "Ubuntu Pro não está disponível para versões do Ubuntu não LTS."
 
-#: ../../uaclient/messages/__init__.py:790
+#: ../../uaclient/messages/__init__.py:791
 #, python-brace-format
 msgid "Run 'pro help {service}' to learn more"
 msgstr "Execute 'pro help {service}' para saber mais"
 
-#: ../../uaclient/messages/__init__.py:793
+#: ../../uaclient/messages/__init__.py:794
 #, python-brace-format
 msgid "Installed packages with an available {service} update:"
 msgstr "Pacotes instalados com atualizações disponíveis por {service}:"
 
-#: ../../uaclient/messages/__init__.py:796
+#: ../../uaclient/messages/__init__.py:797
 #, python-brace-format
 msgid "Installed packages with an {service} update applied:"
 msgstr "Pacotes instalados com atualizações aplicadas por {service}:"
 
-#: ../../uaclient/messages/__init__.py:798
+#: ../../uaclient/messages/__init__.py:799
 #, python-brace-format
 msgid "Installed packages covered by {service}:"
 msgstr "Pacotes instalados cobertos por {service}:"
 
-#: ../../uaclient/messages/__init__.py:800
+#: ../../uaclient/messages/__init__.py:801
 #, python-brace-format
 msgid "Further installed packages covered by {service}:"
 msgstr "Pacotes adicionais instalados cobertos por {service}:"
 
-#: ../../uaclient/messages/__init__.py:802
+#: ../../uaclient/messages/__init__.py:803
 msgid "Packages:"
 msgstr "Pacotes:"
 
 #. ##############################################################################
 #. STATUS SUBCOMMAND                                 #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:810
+#: ../../uaclient/messages/__init__.py:811
 msgid "SERVICE"
 msgstr "SERVIÇO"
 
-#: ../../uaclient/messages/__init__.py:811
+#: ../../uaclient/messages/__init__.py:812
 msgid "AVAILABLE"
 msgstr "DISPONÍVEL"
 
-#: ../../uaclient/messages/__init__.py:812
+#: ../../uaclient/messages/__init__.py:813
 msgid "ENTITLED"
 msgstr "INCLUÍDO"
 
-#: ../../uaclient/messages/__init__.py:813
+#: ../../uaclient/messages/__init__.py:814
 msgid "AUTO_ENABLED"
 msgstr "AUTO_HABILITADO"
 
-#: ../../uaclient/messages/__init__.py:814
+#: ../../uaclient/messages/__init__.py:815
 msgid "STATUS"
 msgstr "STATUS"
 
-#: ../../uaclient/messages/__init__.py:815
+#: ../../uaclient/messages/__init__.py:816
 msgid "DESCRIPTION"
 msgstr "DESCRIÇÃO"
 
-#: ../../uaclient/messages/__init__.py:816
+#: ../../uaclient/messages/__init__.py:817
 msgid "NOTICES"
 msgstr "NOTÍCIAS"
 
-#: ../../uaclient/messages/__init__.py:817
+#: ../../uaclient/messages/__init__.py:818
 msgid "FEATURES"
 msgstr "FUNCIONALIDADES"
 
-#: ../../uaclient/messages/__init__.py:821
+#: ../../uaclient/messages/__init__.py:822
 msgid "enabled"
 msgstr "habilitado"
 
-#: ../../uaclient/messages/__init__.py:822
+#: ../../uaclient/messages/__init__.py:823
 msgid "disabled"
 msgstr "desabilitado"
 
-#: ../../uaclient/messages/__init__.py:823
+#: ../../uaclient/messages/__init__.py:824
 msgid "n/a"
 msgstr "n/d"
 
-#: ../../uaclient/messages/__init__.py:825
+#: ../../uaclient/messages/__init__.py:826
 msgid "warning"
 msgstr "atenção"
 
-#: ../../uaclient/messages/__init__.py:826
+#: ../../uaclient/messages/__init__.py:827
 msgid "essential"
 msgstr "essencial"
 
-#: ../../uaclient/messages/__init__.py:827
+#: ../../uaclient/messages/__init__.py:828
 msgid "standard"
 msgstr "padrão"
 
-#: ../../uaclient/messages/__init__.py:828
+#: ../../uaclient/messages/__init__.py:829
 msgid "advanced"
 msgstr "avançado"
 
-#: ../../uaclient/messages/__init__.py:830
+#: ../../uaclient/messages/__init__.py:831
 msgid "Unknown/Expired"
 msgstr "Desconhecido/expirado"
 
-#: ../../uaclient/messages/__init__.py:833
+#: ../../uaclient/messages/__init__.py:834
 #, python-brace-format
 msgid "Enable services with: {command}"
 msgstr "Habilite serviços com: {command}"
 
-#: ../../uaclient/messages/__init__.py:835
+#: ../../uaclient/messages/__init__.py:836
 msgid "Account"
 msgstr "Conta"
 
-#: ../../uaclient/messages/__init__.py:836
+#: ../../uaclient/messages/__init__.py:837
 msgid "Subscription"
 msgstr "Assinatura"
 
-#: ../../uaclient/messages/__init__.py:837
+#: ../../uaclient/messages/__init__.py:838
 msgid "Valid until"
 msgstr "Válido até"
 
-#: ../../uaclient/messages/__init__.py:838
+#: ../../uaclient/messages/__init__.py:839
 msgid "Technical support level"
 msgstr "Nível de suporte técnico"
 
-#: ../../uaclient/messages/__init__.py:840
+#: ../../uaclient/messages/__init__.py:841
 msgid "This token is not valid."
 msgstr "Este token não é válido."
 
-#: ../../uaclient/messages/__init__.py:841
+#: ../../uaclient/messages/__init__.py:842
 msgid "No Ubuntu Pro operations are running"
 msgstr "Nenhuma operação Ubuntu Pro está sendo executada"
 
-#: ../../uaclient/messages/__init__.py:844
+#: ../../uaclient/messages/__init__.py:845
 msgid "No Ubuntu Pro services are available to this system."
 msgstr "Nenhum serviço do Ubuntu Pro está disponível neste sistema."
 
-#: ../../uaclient/messages/__init__.py:847
+#: ../../uaclient/messages/__init__.py:848
 msgid "For a list of all Ubuntu Pro services, run 'pro status --all'"
 msgstr ""
 "Para uma lista com todos os serviços do Ubuntu Pro, execute 'pro status --"
 "all'"
 
-#: ../../uaclient/messages/__init__.py:849
+#: ../../uaclient/messages/__init__.py:850
 msgid " * Service has variants"
 msgstr "* Serviço tem variantes"
 
-#: ../../uaclient/messages/__init__.py:851
+#: ../../uaclient/messages/__init__.py:852
 msgid ""
 "For a list of all Ubuntu Pro services and variants, run 'pro status --all'"
 msgstr ""
 "Para uma lista como todos os serviços e variantes do Ubuntu Pro, execute "
 "'pro status --all'"
 
-#: ../../uaclient/messages/__init__.py:856
+#: ../../uaclient/messages/__init__.py:857
 msgid ""
 "A change has been detected in your contract.\n"
 "Please run `sudo pro refresh`."
@@ -1626,93 +1631,93 @@ msgstr ""
 #. ##############################################################################
 #. This encompasses help text for subcommands, flags, and arguments for the CLI
 #. Also, any generic strings about the CLI itself go here.
-#: ../../uaclient/messages/__init__.py:869
+#: ../../uaclient/messages/__init__.py:870
 msgid "Try 'pro --help' for more information."
 msgstr "Tente 'pro --help' para mais informações."
 
-#: ../../uaclient/messages/__init__.py:871
+#: ../../uaclient/messages/__init__.py:872
 #, python-brace-format
 msgid "Use {name} {command} --help for more information about a command."
 msgstr "Use {name} {command} --help para mais informações sobre um comando."
 
-#: ../../uaclient/messages/__init__.py:874
+#: ../../uaclient/messages/__init__.py:875
 msgid "Use pro help <service> to get more details about each service"
 msgstr "Use pro help <service> para obter mais detalhes sobre cada serviço"
 
-#: ../../uaclient/messages/__init__.py:877
+#: ../../uaclient/messages/__init__.py:878
 msgid "Variants:"
 msgstr "Variantes:"
 
-#: ../../uaclient/messages/__init__.py:878
+#: ../../uaclient/messages/__init__.py:879
 msgid "Arguments"
 msgstr "Argumentos"
 
-#: ../../uaclient/messages/__init__.py:879
+#: ../../uaclient/messages/__init__.py:880
 msgid "Flags"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:880
+#: ../../uaclient/messages/__init__.py:881
 msgid "Available Commands"
 msgstr "Comandos Disponíveis"
 
-#: ../../uaclient/messages/__init__.py:882
+#: ../../uaclient/messages/__init__.py:883
 #, python-brace-format
 msgid "output in the specified format (default: {default})"
 msgstr "saída no formato especificado (default: {default})"
 
-#: ../../uaclient/messages/__init__.py:885
+#: ../../uaclient/messages/__init__.py:886
 #, python-brace-format
 msgid "do not prompt for confirmation before performing the {command}"
 msgstr "não peça por confirmação antes de executar {command}"
 
-#: ../../uaclient/messages/__init__.py:888
-#: ../../uaclient/messages/__init__.py:1122
+#: ../../uaclient/messages/__init__.py:889
+#: ../../uaclient/messages/__init__.py:1123
 msgid "Calls the Client API endpoints."
 msgstr "Chama os endpoints da API do Cliente."
 
-#: ../../uaclient/messages/__init__.py:889
+#: ../../uaclient/messages/__init__.py:890
 msgid "API endpoint to call"
 msgstr "API endpoints que podem ser executados"
 
-#: ../../uaclient/messages/__init__.py:891
+#: ../../uaclient/messages/__init__.py:892
 msgid ""
 "For endpoints that support progress updates, show each progress update on a "
 "new line in JSON format"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:895
+#: ../../uaclient/messages/__init__.py:896
 msgid "Options to pass to the API endpoint, formatted as key=value"
 msgstr "Opções para passar ao endpoint da API, formatadas como chave=valor"
 
-#: ../../uaclient/messages/__init__.py:897
+#: ../../uaclient/messages/__init__.py:898
 msgid "arguments in JSON format to the API endpoint"
 msgstr "argumentos em formato JSON para o endpoint da API"
 
-#: ../../uaclient/messages/__init__.py:900
+#: ../../uaclient/messages/__init__.py:901
 msgid "Automatically attach on an Ubuntu Pro cloud instance."
 msgstr "Automaticamente vincular em uma instância cloud do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:904
+#: ../../uaclient/messages/__init__.py:905
 msgid "Collect logs and relevant system information into a tarball."
 msgstr "Coleta logs e outras informações relevantes do sistema em um tarball."
 
-#: ../../uaclient/messages/__init__.py:907
+#: ../../uaclient/messages/__init__.py:908
 msgid "tarball where the logs will be stored. (Defaults to ./pro_logs.tar.gz)"
 msgstr "tarball onde os logs serão guardados. (Valor padrão ./pro_logs.tar.gz)"
 
-#: ../../uaclient/messages/__init__.py:910
+#: ../../uaclient/messages/__init__.py:911
 msgid "Show customizable configuration settings"
 msgstr "Mostra opções personalizáveis da configuração"
 
-#: ../../uaclient/messages/__init__.py:912
+#: ../../uaclient/messages/__init__.py:913
 msgid "Optional key or key(s) to show configuration settings."
 msgstr "Valor ou valores opcionais ao mostrar as configurações."
 
-#: ../../uaclient/messages/__init__.py:915
+#: ../../uaclient/messages/__init__.py:916
 msgid "Set and apply Ubuntu Pro configuration settings"
 msgstr "Define e aplica as configurações do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:918
+#: ../../uaclient/messages/__init__.py:919
 #, python-brace-format
 msgid ""
 "key=value pair to configure for Ubuntu Pro services. Key must be one of: "
@@ -1721,20 +1726,20 @@ msgstr ""
 "par chave=valor para configurar serviços Ubuntu Pro. Chave precisa ser uma "
 "dentre: {options}"
 
-#: ../../uaclient/messages/__init__.py:921
+#: ../../uaclient/messages/__init__.py:922
 msgid "Unset Ubuntu Pro configuration setting"
 msgstr "Desabilitar a configuração do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:923
+#: ../../uaclient/messages/__init__.py:924
 #, python-brace-format
 msgid "configuration key to unset from Ubuntu Pro services. One of: {options}"
 msgstr "chave de configuração Ubuntu Pro para desabilitar. Uma de: {options}"
 
-#: ../../uaclient/messages/__init__.py:925
+#: ../../uaclient/messages/__init__.py:926
 msgid "Manage Ubuntu Pro configuration"
 msgstr "Gerencie a configuração do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:928
+#: ../../uaclient/messages/__init__.py:929
 #, python-brace-format
 msgid ""
 "Attach this machine to an Ubuntu Pro subscription with a token obtained "
@@ -1753,28 +1758,28 @@ msgstr ""
 "Ubuntu Pro por meio\n"
 "de um navegador."
 
-#: ../../uaclient/messages/__init__.py:936
+#: ../../uaclient/messages/__init__.py:937
 msgid "token obtained for Ubuntu Pro authentication"
 msgstr "token obtido para autenticação do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:938
+#: ../../uaclient/messages/__init__.py:939
 msgid "do not enable any recommended services automatically"
 msgstr "não habilite nenhum serviço recomendado automaticamente"
 
-#: ../../uaclient/messages/__init__.py:941
+#: ../../uaclient/messages/__init__.py:942
 msgid ""
 "use the provided attach config file instead of passing the token on the cli"
 msgstr ""
 "use para providenciar um arquivo de configuração ao vincular ao invés de "
 "inserir o token via linha de comando"
 
-#: ../../uaclient/messages/__init__.py:946
+#: ../../uaclient/messages/__init__.py:947
 msgid ""
 "Inspect and resolve CVEs and USNs (Ubuntu Security Notices) on this machine."
 msgstr ""
 "Inspecionar e corrigir CVEs and USNs (Ubuntu Security Notices) nesta máquina."
 
-#: ../../uaclient/messages/__init__.py:950
+#: ../../uaclient/messages/__init__.py:951
 msgid ""
 "Security vulnerability ID to inspect and resolve on this system. Format: CVE-"
 "yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-dd"
@@ -1782,7 +1787,7 @@ msgstr ""
 "ID da Vulnerabilidade de segurança para inspecionar e corrigir neste "
 "sistema. Formato: CVE-yyyy-nnnn, CVE-yyyy-nnnnnnn ou USN-nnnn-dd"
 
-#: ../../uaclient/messages/__init__.py:954
+#: ../../uaclient/messages/__init__.py:955
 msgid ""
 "If used, fix will not actually run but will display everything that will "
 "happen on the machine during the command."
@@ -1790,7 +1795,7 @@ msgstr ""
 "Se usado, fix não vai executar modificações. Ao invés disso, irá mostrar "
 "tudo que irá acontecer na máquina durante a execução real do comando."
 
-#: ../../uaclient/messages/__init__.py:959
+#: ../../uaclient/messages/__init__.py:960
 msgid ""
 "If used, when fixing a USN, the command will not try to also fix related "
 "USNs to the target USN."
@@ -1798,12 +1803,12 @@ msgstr ""
 "Se usado, ao corrigir uma USN, o comando não tentará corrigar as USN "
 "relacionadas à USN principal."
 
-#: ../../uaclient/messages/__init__.py:964
+#: ../../uaclient/messages/__init__.py:965
 msgid ""
 "WARNING: Failed to update ESM cache - package availability may be inaccurate"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:968
+#: ../../uaclient/messages/__init__.py:969
 #, python-brace-format
 msgid ""
 "{bold}WARNING: Unable to update ESM cache when running as non-root,\n"
@@ -1811,7 +1816,7 @@ msgid ""
 "{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:974
+#: ../../uaclient/messages/__init__.py:975
 msgid ""
 "Show security updates for packages in the system, including all\n"
 "available Expanded Security Maintenance (ESM) related content.\n"
@@ -1848,23 +1853,23 @@ msgstr ""
 "completo\n"
 "a respeito dos serviços do Ubuntu Pro, execute 'pro status'.\n"
 
-#: ../../uaclient/messages/__init__.py:994
+#: ../../uaclient/messages/__init__.py:995
 msgid "List and present information about third-party packages"
 msgstr "Lista e mostra informações presentes sobre pacotes de terceiros"
 
-#: ../../uaclient/messages/__init__.py:997
+#: ../../uaclient/messages/__init__.py:998
 msgid "List and present information about unavailable packages"
 msgstr "Lista e mostra informações sobre pacotes indisponíveis"
 
-#: ../../uaclient/messages/__init__.py:1000
+#: ../../uaclient/messages/__init__.py:1001
 msgid "List and present information about esm-infra packages"
 msgstr "Lista e mostra informações sobre pacotes esm-infra"
 
-#: ../../uaclient/messages/__init__.py:1003
+#: ../../uaclient/messages/__init__.py:1004
 msgid "List and present information about esm-apps packages"
 msgstr "Lista e mostra informações sobre pacotes esm-apps"
 
-#: ../../uaclient/messages/__init__.py:1007
+#: ../../uaclient/messages/__init__.py:1008
 msgid ""
 "Refresh three distinct Ubuntu Pro related artifacts in the system:\n"
 "\n"
@@ -1888,75 +1893,75 @@ msgstr ""
 "especificada,\n"
 "todas as opções serão atualizadas.\n"
 
-#: ../../uaclient/messages/__init__.py:1019
+#: ../../uaclient/messages/__init__.py:1020
 msgid "Target to refresh."
 msgstr "Opção para atualizar"
 
-#: ../../uaclient/messages/__init__.py:1022
+#: ../../uaclient/messages/__init__.py:1023
 msgid "Detach this machine from an Ubuntu Pro subscription."
 msgstr "Desvincule esta máquina de uma assinatura do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:1026
+#: ../../uaclient/messages/__init__.py:1027
 msgid "Provide detailed information about Ubuntu Pro services."
 msgstr "Providencia informações detalhadas sobre os serviços do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:1029
+#: ../../uaclient/messages/__init__.py:1030
 #, python-brace-format
 msgid "a service to view help output for. One of: {options}"
 msgstr "serviço para qual informação de ajuda será mostrada. Um de: {options}"
 
-#: ../../uaclient/messages/__init__.py:1031
+#: ../../uaclient/messages/__init__.py:1032
 msgid "Include beta services"
 msgstr "Inclui os serviços beta"
 
-#: ../../uaclient/messages/__init__.py:1033
+#: ../../uaclient/messages/__init__.py:1034
 msgid "Enable an Ubuntu Pro service."
 msgstr "Habilite um serviço Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:1035
+#: ../../uaclient/messages/__init__.py:1036
 #, python-brace-format
 msgid "the name(s) of the Ubuntu Pro services to enable. One of: {options}"
 msgstr "os nome(s)n dos serviços Ubuntu Pro para habilitar. Um de: {options}"
 
-#: ../../uaclient/messages/__init__.py:1038
+#: ../../uaclient/messages/__init__.py:1039
 msgid ""
 "do not auto-install packages. Valid for cc-eal, cis and realtime-kernel."
 msgstr ""
 "não instale pacotes automaticamente. Válido para cc-eal, cis e realtime-"
 "kernel."
 
-#: ../../uaclient/messages/__init__.py:1041
+#: ../../uaclient/messages/__init__.py:1042
 msgid "allow beta service to be enabled"
 msgstr "permita que serviços beta sejam habilitados"
 
-#: ../../uaclient/messages/__init__.py:1043
+#: ../../uaclient/messages/__init__.py:1044
 msgid "The name of the variant to use when enabling the service"
 msgstr "O nome da variante para usar ao habilitar o serviço"
 
-#: ../../uaclient/messages/__init__.py:1046
+#: ../../uaclient/messages/__init__.py:1047
 msgid "Disable an Ubuntu Pro service."
 msgstr "Desabilite um serviço do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:1048
+#: ../../uaclient/messages/__init__.py:1049
 #, python-brace-format
 msgid "the name(s) of the Ubuntu Pro services to disable. One of: {options}"
 msgstr ""
 "os nome(s) do serviços do Ubuntu Pro para desabilitar. Um de: {options}"
 
-#: ../../uaclient/messages/__init__.py:1051
+#: ../../uaclient/messages/__init__.py:1052
 msgid ""
 "disable the service and remove/downgrade related packages (experimental)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1055
+#: ../../uaclient/messages/__init__.py:1056
 msgid "Output system related information related to Pro services"
 msgstr "Mostre informações de sistema relacionados aos serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1057
+#: ../../uaclient/messages/__init__.py:1058
 msgid "does the system need to be rebooted"
 msgstr "se o sistema precisa ser reiniciado"
 
-#: ../../uaclient/messages/__init__.py:1059
+#: ../../uaclient/messages/__init__.py:1060
 msgid ""
 "Report the current reboot-required status for the machine.\n"
 "\n"
@@ -1985,7 +1990,7 @@ msgstr ""
 "  reiniciada, mas você pode averiguar se o reinício pode acontecer no\n"
 "  período de manutenção mais próximo.\n"
 
-#: ../../uaclient/messages/__init__.py:1076
+#: ../../uaclient/messages/__init__.py:1077
 msgid ""
 "Report current status of Ubuntu Pro services on system.\n"
 "\n"
@@ -2057,80 +2062,80 @@ msgstr ""
 "Se a flag --all for usada, serviços beta e indisponíveis também\n"
 "serão listado.\n"
 
-#: ../../uaclient/messages/__init__.py:1111
+#: ../../uaclient/messages/__init__.py:1112
 msgid "Block waiting on pro to complete"
 msgstr "Espera até o pro completar sua operação"
 
-#: ../../uaclient/messages/__init__.py:1113
+#: ../../uaclient/messages/__init__.py:1114
 msgid "simulate the output status using a provided token"
 msgstr "simula a mensagem de status usando um token fornecido"
 
-#: ../../uaclient/messages/__init__.py:1115
+#: ../../uaclient/messages/__init__.py:1116
 msgid "Include unavailable and beta services"
 msgstr "Inclui serviços beta e indisponíveis"
 
-#: ../../uaclient/messages/__init__.py:1117
+#: ../../uaclient/messages/__init__.py:1118
 msgid "show all debug log messages to console"
 msgstr "mostra todas os logs de debug na saída do comando"
 
-#: ../../uaclient/messages/__init__.py:1118
+#: ../../uaclient/messages/__init__.py:1119
 #, python-brace-format
 msgid "show version of {name}"
 msgstr "mostra versão de {name}"
 
-#: ../../uaclient/messages/__init__.py:1120
+#: ../../uaclient/messages/__init__.py:1121
 msgid "attach this machine to an Ubuntu Pro subscription"
 msgstr "vincule esta máquina a uma assinatura Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1123
+#: ../../uaclient/messages/__init__.py:1124
 msgid "automatically attach on supported platforms"
 msgstr "automaticamente vincule está máquina em plataformas suportadas"
 
-#: ../../uaclient/messages/__init__.py:1124
+#: ../../uaclient/messages/__init__.py:1125
 msgid "collect Pro logs and debug information"
 msgstr "coleta logs do Pro e informações de debug"
 
-#: ../../uaclient/messages/__init__.py:1125
+#: ../../uaclient/messages/__init__.py:1126
 msgid "manage Ubuntu Pro configuration on this machine"
 msgstr "gerencia configuração do Ubuntu Pro nesta máquina"
 
-#: ../../uaclient/messages/__init__.py:1127
+#: ../../uaclient/messages/__init__.py:1128
 msgid "remove this machine from an Ubuntu Pro subscription"
 msgstr "desvincula esta máquina de uma assinatura Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1130
+#: ../../uaclient/messages/__init__.py:1131
 msgid "disable a specific Ubuntu Pro service on this machine"
 msgstr "desabilita nesta máquina um serviço do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1133
+#: ../../uaclient/messages/__init__.py:1134
 msgid "enable a specific Ubuntu Pro service on this machine"
 msgstr "habilita nesta máquina um serviço Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1136
+#: ../../uaclient/messages/__init__.py:1137
 msgid "check for and mitigate the impact of a CVE/USN on this system"
 msgstr "checa e corrige os problemas de segurança de um CVE/USN na máquina"
 
-#: ../../uaclient/messages/__init__.py:1139
+#: ../../uaclient/messages/__init__.py:1140
 msgid "list available security updates for the system"
 msgstr "lista atualizações de segurança disponíveis para o sistema"
 
-#: ../../uaclient/messages/__init__.py:1142
+#: ../../uaclient/messages/__init__.py:1143
 msgid "show detailed information about Ubuntu Pro services"
 msgstr "mostra informações detalhadas sobre os serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1144
+#: ../../uaclient/messages/__init__.py:1145
 msgid "refresh Ubuntu Pro services"
 msgstr "atualiza os serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1145
+#: ../../uaclient/messages/__init__.py:1146
 msgid "current status of all Ubuntu Pro services"
 msgstr "status atual de todos os serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1146
+#: ../../uaclient/messages/__init__.py:1147
 msgid "show system information related to Pro services"
 msgstr "mostra informações de sistema relacionados a serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1149
+#: ../../uaclient/messages/__init__.py:1150
 #, python-brace-format
 msgid ""
 "WARNING: this output is intended to be human readable, and subject to "
@@ -2148,15 +2153,15 @@ msgstr ""
 #. ##############################################################################
 #. SERVICE-SPECIFIC MESSAGES                            #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:1162
+#: ../../uaclient/messages/__init__.py:1163
 msgid "Anbox Cloud"
 msgstr "Anbox Cloud"
 
-#: ../../uaclient/messages/__init__.py:1163
+#: ../../uaclient/messages/__init__.py:1164
 msgid "Scalable Android in the cloud"
 msgstr "Android escalável na nuvem"
 
-#: ../../uaclient/messages/__init__.py:1165
+#: ../../uaclient/messages/__init__.py:1166
 #, python-brace-format
 msgid ""
 "Anbox Cloud lets you stream mobile apps securely, at any scale, to any "
@@ -2174,7 +2179,7 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1176
+#: ../../uaclient/messages/__init__.py:1177
 #, python-brace-format
 msgid ""
 "To finish setting up the Anbox Cloud Appliance, run:\n"
@@ -2186,15 +2191,15 @@ msgid ""
 "For more information, see {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1187
+#: ../../uaclient/messages/__init__.py:1188
 msgid "CC EAL2"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1188
+#: ../../uaclient/messages/__init__.py:1189
 msgid "Common Criteria EAL2 Provisioning Packages"
 msgstr "Pacotes de Provisionamento do Common Criteria EAL2"
 
-#: ../../uaclient/messages/__init__.py:1190
+#: ../../uaclient/messages/__init__.py:1191
 msgid ""
 "Common Criteria is an Information Technology Security Evaluation standard\n"
 "(ISO/IEC IS 15408) for computer security certification. Ubuntu 16.04 has "
@@ -2204,29 +2209,29 @@ msgid ""
 "on Intel x86_64, IBM Power8 and IBM Z hardware platforms."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1197
+#: ../../uaclient/messages/__init__.py:1198
 msgid ""
 "(This will download more than 500MB of packages, so may take some time.)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1201
+#: ../../uaclient/messages/__init__.py:1202
 #, python-brace-format
 msgid "Please follow instructions in {filename} to configure EAL2"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1204
+#: ../../uaclient/messages/__init__.py:1205
 msgid "CIS Audit"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1205
+#: ../../uaclient/messages/__init__.py:1206
 msgid "Ubuntu Security Guide"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1206
+#: ../../uaclient/messages/__init__.py:1207
 msgid "Security compliance and audit tools"
 msgstr "Ferramentas de auditoria e conformidade de segurança"
 
-#: ../../uaclient/messages/__init__.py:1208
+#: ../../uaclient/messages/__init__.py:1209
 #, python-brace-format
 msgid ""
 "Ubuntu Security Guide is a tool for hardening and auditing and allows for\n"
@@ -2236,17 +2241,17 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1214
+#: ../../uaclient/messages/__init__.py:1215
 #, python-brace-format
 msgid "Visit {url} to learn how to use CIS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1217
+#: ../../uaclient/messages/__init__.py:1218
 #, python-brace-format
 msgid "Visit {url} for the next steps"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1221
+#: ../../uaclient/messages/__init__.py:1222
 #, python-brace-format
 msgid ""
 "From Ubuntu 20.04 onward 'pro enable cis' has been\n"
@@ -2254,11 +2259,11 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1229
+#: ../../uaclient/messages/__init__.py:1230
 msgid "Expanded Security Maintenance for Applications"
 msgstr "Manutenção de Segurança Expandida para Aplicações"
 
-#: ../../uaclient/messages/__init__.py:1232
+#: ../../uaclient/messages/__init__.py:1233
 #, python-brace-format
 msgid ""
 "Expanded Security Maintenance for Applications is enabled by default on\n"
@@ -2270,11 +2275,11 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1243
+#: ../../uaclient/messages/__init__.py:1244
 msgid "Expanded Security Maintenance for Infrastructure"
 msgstr "Manutenção de Segurança Expandida para Infraestrutura"
 
-#: ../../uaclient/messages/__init__.py:1246
+#: ../../uaclient/messages/__init__.py:1247
 #, python-brace-format
 msgid ""
 "Expanded Security Maintenance for Infrastructure provides access to a "
@@ -2287,15 +2292,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1255
+#: ../../uaclient/messages/__init__.py:1256
 msgid "FIPS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1256
+#: ../../uaclient/messages/__init__.py:1257
 msgid "NIST-certified FIPS crypto packages"
 msgstr "Pacotes FIPS de criptografia certificados pelo NIST"
 
-#: ../../uaclient/messages/__init__.py:1258
+#: ../../uaclient/messages/__init__.py:1259
 #, python-brace-format
 msgid ""
 "Installs FIPS 140 crypto packages for FedRAMP, FISMA and compliance use "
@@ -2306,18 +2311,18 @@ msgid ""
 "choose \"fips-updates\" for maximum security. Find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1265
+#: ../../uaclient/messages/__init__.py:1266
 msgid "Could not determine cloud, defaulting to generic FIPS package."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1268
+#: ../../uaclient/messages/__init__.py:1269
 #, python-brace-format
 msgid ""
 "FIPS kernel is running in a disabled state.\n"
 "  To manually remove fips kernel: {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1274
+#: ../../uaclient/messages/__init__.py:1275
 msgid ""
 "Warning: FIPS kernel is not optimized for your specific cloud.\n"
 "To fix it, run the following commands:\n"
@@ -2328,20 +2333,20 @@ msgid ""
 "    4. sudo reboot\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1286
+#: ../../uaclient/messages/__init__.py:1287
 msgid ""
 "This will install the FIPS packages. The Livepatch service will be "
 "unavailable.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1295
+#: ../../uaclient/messages/__init__.py:1296
 msgid ""
 "This will install the FIPS packages including security updates.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1304
+#: ../../uaclient/messages/__init__.py:1305
 #, python-brace-format
 msgid ""
 "Warning: Enabling {title} in a container.\n"
@@ -2351,14 +2356,14 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1316
+#: ../../uaclient/messages/__init__.py:1317
 #, python-brace-format
 msgid ""
 "This will disable the {title} entitlement but the {title} packages will "
 "remain installed.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1323
+#: ../../uaclient/messages/__init__.py:1324
 #, python-brace-format
 msgid ""
 "This will downgrade the kernel from {current_version} to {new_version}.\n"
@@ -2368,46 +2373,46 @@ msgid ""
 "proceeding.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1330
+#: ../../uaclient/messages/__init__.py:1331
 msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1332
-#: ../../uaclient/messages/__init__.py:1765
+#: ../../uaclient/messages/__init__.py:1333
+#: ../../uaclient/messages/__init__.py:1766
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1334
+#: ../../uaclient/messages/__init__.py:1335
 msgid "This FIPS install is out of date, run: sudo pro enable fips"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1337
+#: ../../uaclient/messages/__init__.py:1338
 msgid "Disabling FIPS requires system reboot to complete operation."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1340
+#: ../../uaclient/messages/__init__.py:1341
 #, python-brace-format
 msgid "{service} {pkg} package could not be installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1343
+#: ../../uaclient/messages/__init__.py:1344
 msgid ""
 "Please run `apt upgrade` to ensure all FIPS packages are updated to the "
 "correct\n"
 "version.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1349
+#: ../../uaclient/messages/__init__.py:1350
 msgid "FIPS Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1351
+#: ../../uaclient/messages/__init__.py:1352
 msgid "FIPS compliant crypto packages with stable security updates"
 msgstr ""
 "Pacotes de criptografia compatíveis com FIPS com atualizações de segurança "
 "estáveis"
 
-#: ../../uaclient/messages/__init__.py:1354
+#: ../../uaclient/messages/__init__.py:1355
 #, python-brace-format
 msgid ""
 "fips-updates installs FIPS 140 crypto packages including all security "
@@ -2416,22 +2421,22 @@ msgid ""
 "You can find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1360
+#: ../../uaclient/messages/__init__.py:1361
 msgid "FIPS Preview"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1362
+#: ../../uaclient/messages/__init__.py:1363
 msgid "Preview of FIPS crypto packages undergoing certification with NIST"
 msgstr ""
 "Prévia de pacotes FIPS de criptografia em processo de certificação pelo NIST"
 
-#: ../../uaclient/messages/__init__.py:1365
+#: ../../uaclient/messages/__init__.py:1366
 msgid ""
 "Installs FIPS crypto packages that are under certification with NIST,\n"
 "for FedRAMP, FISMA and compliance use cases."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1370
+#: ../../uaclient/messages/__init__.py:1371
 msgid ""
 "This will install crypto packages that have been submitted to NIST for "
 "review\n"
@@ -2443,15 +2448,15 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1381
+#: ../../uaclient/messages/__init__.py:1382
 msgid "Landscape"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1383
+#: ../../uaclient/messages/__init__.py:1384
 msgid "Management and administration tool for Ubuntu"
 msgstr "Ferramenta de gerenciamento e administração para o Ubuntu"
 
-#: ../../uaclient/messages/__init__.py:1386
+#: ../../uaclient/messages/__init__.py:1387
 #, python-brace-format
 msgid ""
 "Landscape Client can be installed on this machine and enrolled in "
@@ -2464,22 +2469,22 @@ msgid ""
 "more. Find out more about Landscape at {home_url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1399
+#: ../../uaclient/messages/__init__.py:1400
 msgid ""
 "/etc/landscape/client.conf contains your landscape-client configuration.\n"
 "To re-enable Landscape with the same configuration, run:\n"
 "    sudo pro enable landscape --assume-yes\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1406
+#: ../../uaclient/messages/__init__.py:1407
 msgid "Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1407
+#: ../../uaclient/messages/__init__.py:1408
 msgid "Canonical Livepatch service"
 msgstr "Serviço de Livepatch da Canonical"
 
-#: ../../uaclient/messages/__init__.py:1409
+#: ../../uaclient/messages/__init__.py:1410
 #, python-brace-format
 msgid ""
 "Livepatch provides selected high and critical kernel CVE fixes and other\n"
@@ -2494,50 +2499,50 @@ msgid ""
 "service at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1418
+#: ../../uaclient/messages/__init__.py:1419
 msgid "Current kernel is not supported"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1421
+#: ../../uaclient/messages/__init__.py:1422
 #, python-brace-format
 msgid "Supported livepatch kernels are listed here: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1424
+#: ../../uaclient/messages/__init__.py:1425
 #, python-brace-format
 msgid "Unable to configure livepatch: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1426
+#: ../../uaclient/messages/__init__.py:1427
 msgid "Unable to enable Livepatch: "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1428
+#: ../../uaclient/messages/__init__.py:1429
 msgid "Disabling Livepatch prior to re-attach with new token"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1431
+#: ../../uaclient/messages/__init__.py:1432
 msgid "Livepatch support requires a system reboot across LTS upgrade."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1433
+#: ../../uaclient/messages/__init__.py:1434
 msgid "Installing Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1434
+#: ../../uaclient/messages/__init__.py:1435
 msgid "Setting up Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1436
-#: ../../uaclient/messages/__init__.py:1449
+#: ../../uaclient/messages/__init__.py:1437
+#: ../../uaclient/messages/__init__.py:1450
 msgid "Real-time kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1438
+#: ../../uaclient/messages/__init__.py:1439
 msgid "Ubuntu kernel with PREEMPT_RT patches integrated"
 msgstr "Kernel do Ubuntu com patches PREEMPT_RT integrados"
 
-#: ../../uaclient/messages/__init__.py:1441
+#: ../../uaclient/messages/__init__.py:1442
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated. "
 "It\n"
@@ -2550,35 +2555,35 @@ msgid ""
 "Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1451
+#: ../../uaclient/messages/__init__.py:1452
 msgid "Generic version of the RT kernel (default)"
 msgstr "Versão genérica do kernel RT (padrão)"
 
-#: ../../uaclient/messages/__init__.py:1453
+#: ../../uaclient/messages/__init__.py:1454
 msgid "Real-time NVIDIA Tegra Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1455
+#: ../../uaclient/messages/__init__.py:1456
 msgid "RT kernel optimized for NVIDIA Tegra platform"
 msgstr "Kernel RT otimizado para a plataforma NVIDIA Tegra"
 
-#: ../../uaclient/messages/__init__.py:1457
+#: ../../uaclient/messages/__init__.py:1458
 msgid "Raspberry Pi Real-time for Pi5/Pi4"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1459
+#: ../../uaclient/messages/__init__.py:1460
 msgid "24.04 Real-time kernel optimised for Raspberry Pi"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1461
+#: ../../uaclient/messages/__init__.py:1462
 msgid "Real-time Intel IOTG Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1463
+#: ../../uaclient/messages/__init__.py:1464
 msgid "RT kernel optimized for Intel IOTG platform"
 msgstr "Kernel RT otimizado para a plataforma Intel IOTG"
 
-#: ../../uaclient/messages/__init__.py:1466
+#: ../../uaclient/messages/__init__.py:1467
 #, python-brace-format
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches "
@@ -2591,7 +2596,7 @@ msgid ""
 "Do you want to continue? [ default = Yes ]: (Y/n) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1477
+#: ../../uaclient/messages/__init__.py:1478
 msgid ""
 "This will remove the boot order preference for the Real-time kernel and\n"
 "disable updates to the Real-time kernel.\n"
@@ -2608,15 +2613,15 @@ msgid ""
 "Are you sure? (y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1493
+#: ../../uaclient/messages/__init__.py:1494
 msgid "ROS ESM Security Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1494
+#: ../../uaclient/messages/__init__.py:1495
 msgid "Security Updates for the Robot Operating System"
 msgstr "Atualizações de Segurança para o Robot Operating System"
 
-#: ../../uaclient/messages/__init__.py:1496
+#: ../../uaclient/messages/__init__.py:1497
 #, python-brace-format
 msgid ""
 "ros provides access to a private PPA which includes security-related "
@@ -2629,15 +2634,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1505
+#: ../../uaclient/messages/__init__.py:1506
 msgid "ROS ESM All Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1507
+#: ../../uaclient/messages/__init__.py:1508
 msgid "All Updates for the Robot Operating System"
 msgstr "Todas as Atualizações para o Robot Operating System"
 
-#: ../../uaclient/messages/__init__.py:1510
+#: ../../uaclient/messages/__init__.py:1511
 #, python-brace-format
 msgid ""
 "ros-updates provides access to a private PPA that includes non-security-"
@@ -2650,7 +2655,7 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1581
+#: ../../uaclient/messages/__init__.py:1582
 #, python-brace-format
 msgid ""
 "An unexpected error occurred: {error_msg}\n"
@@ -2658,7 +2663,7 @@ msgid ""
 "If you think this is a bug, please run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1591
+#: ../../uaclient/messages/__init__.py:1592
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2666,7 +2671,7 @@ msgid ""
 "Please install \"ca-certificates\" and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1601
+#: ../../uaclient/messages/__init__.py:1602
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2674,202 +2679,202 @@ msgid ""
 "Please check your openssl configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1610
+#: ../../uaclient/messages/__init__.py:1611
 #, python-brace-format
 msgid "Ignoring unknown argument '{arg}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1616
+#: ../../uaclient/messages/__init__.py:1617
 #, python-brace-format
 msgid ""
 "A new version of the client is available: {version}. Please upgrade to the "
 "latest version to get the new features and bug fixes."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1623
+#: ../../uaclient/messages/__init__.py:1624
 #, python-brace-format
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1628
+#: ../../uaclient/messages/__init__.py:1629
 #, python-brace-format
 msgid "{title} does not support being disabled with --purge"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1634
+#: ../../uaclient/messages/__init__.py:1635
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1641
+#: ../../uaclient/messages/__init__.py:1642
 #, python-brace-format
 msgid "Cannot disable {entitlement_name} with purge: no origin value defined"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1648
+#: ../../uaclient/messages/__init__.py:1649
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1653
+#: ../../uaclient/messages/__init__.py:1654
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1656
+#: ../../uaclient/messages/__init__.py:1657
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1661
+#: ../../uaclient/messages/__init__.py:1662
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1667
+#: ../../uaclient/messages/__init__.py:1668
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1671
+#: ../../uaclient/messages/__init__.py:1672
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1675
+#: ../../uaclient/messages/__init__.py:1676
 #, python-brace-format
 msgid "{title} does not have a suites directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1680
+#: ../../uaclient/messages/__init__.py:1681
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1688
+#: ../../uaclient/messages/__init__.py:1689
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1695
+#: ../../uaclient/messages/__init__.py:1696
 #, python-brace-format
 msgid ""
 "{title} is already enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1703
+#: ../../uaclient/messages/__init__.py:1704
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1709
+#: ../../uaclient/messages/__init__.py:1710
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1715
+#: ../../uaclient/messages/__init__.py:1716
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1723
+#: ../../uaclient/messages/__init__.py:1724
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1731
+#: ../../uaclient/messages/__init__.py:1732
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1738
+#: ../../uaclient/messages/__init__.py:1739
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1746
+#: ../../uaclient/messages/__init__.py:1747
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1753
+#: ../../uaclient/messages/__init__.py:1754
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1759
+#: ../../uaclient/messages/__init__.py:1760
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1769
+#: ../../uaclient/messages/__init__.py:1770
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1772
+#: ../../uaclient/messages/__init__.py:1773
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1776
+#: ../../uaclient/messages/__init__.py:1777
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1781
+#: ../../uaclient/messages/__init__.py:1782
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1789
+#: ../../uaclient/messages/__init__.py:1790
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1798
+#: ../../uaclient/messages/__init__.py:1799
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1806
+#: ../../uaclient/messages/__init__.py:1807
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1810
+#: ../../uaclient/messages/__init__.py:1811
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1815
+#: ../../uaclient/messages/__init__.py:1816
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1823
+#: ../../uaclient/messages/__init__.py:1824
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2879,7 +2884,7 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1832
+#: ../../uaclient/messages/__init__.py:1833
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2888,79 +2893,79 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1842
+#: ../../uaclient/messages/__init__.py:1843
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1848
+#: ../../uaclient/messages/__init__.py:1849
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1857
+#: ../../uaclient/messages/__init__.py:1858
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1864
+#: ../../uaclient/messages/__init__.py:1865
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1871
+#: ../../uaclient/messages/__init__.py:1872
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1876
+#: ../../uaclient/messages/__init__.py:1877
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1880
+#: ../../uaclient/messages/__init__.py:1881
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1885
+#: ../../uaclient/messages/__init__.py:1886
 msgid "ROS packages assume ESM updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1890
+#: ../../uaclient/messages/__init__.py:1891
 msgid "ROS bug-fix updates assume ROS security fix updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1896
+#: ../../uaclient/messages/__init__.py:1897
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1900
+#: ../../uaclient/messages/__init__.py:1901
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1904
+#: ../../uaclient/messages/__init__.py:1905
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1908
+#: ../../uaclient/messages/__init__.py:1909
 msgid "unattended-upgrades package is not installed"
 msgstr "O pacote unattended-upgrades não está instalado"
 
-#: ../../uaclient/messages/__init__.py:1914
+#: ../../uaclient/messages/__init__.py:1915
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1923
+#: ../../uaclient/messages/__init__.py:1924
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1930
+#: ../../uaclient/messages/__init__.py:1931
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2970,28 +2975,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1949
+#: ../../uaclient/messages/__init__.py:1950
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1955
+#: ../../uaclient/messages/__init__.py:1956
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1985
+#: ../../uaclient/messages/__init__.py:1986
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1990
+#: ../../uaclient/messages/__init__.py:1991
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1996
+#: ../../uaclient/messages/__init__.py:1997
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2999,107 +3004,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2006
+#: ../../uaclient/messages/__init__.py:2007
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2013
+#: ../../uaclient/messages/__init__.py:2014
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2018
+#: ../../uaclient/messages/__init__.py:2019
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2022
+#: ../../uaclient/messages/__init__.py:2023
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2026
+#: ../../uaclient/messages/__init__.py:2027
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2031
+#: ../../uaclient/messages/__init__.py:2032
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2036
+#: ../../uaclient/messages/__init__.py:2037
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2041
+#: ../../uaclient/messages/__init__.py:2042
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2047
+#: ../../uaclient/messages/__init__.py:2048
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2053
+#: ../../uaclient/messages/__init__.py:2054
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2057
+#: ../../uaclient/messages/__init__.py:2058
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2063
+#: ../../uaclient/messages/__init__.py:2064
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2071
+#: ../../uaclient/messages/__init__.py:2072
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2077
+#: ../../uaclient/messages/__init__.py:2078
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2086
+#: ../../uaclient/messages/__init__.py:2087
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2093
+#: ../../uaclient/messages/__init__.py:2094
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2100
+#: ../../uaclient/messages/__init__.py:2101
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2105
+#: ../../uaclient/messages/__init__.py:2106
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2111
+#: ../../uaclient/messages/__init__.py:2112
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3107,7 +3112,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2121
+#: ../../uaclient/messages/__init__.py:2122
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3115,7 +3120,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2131
+#: ../../uaclient/messages/__init__.py:2132
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3123,41 +3128,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2141
+#: ../../uaclient/messages/__init__.py:2142
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2148
+#: ../../uaclient/messages/__init__.py:2149
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2154
+#: ../../uaclient/messages/__init__.py:2155
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2160
+#: ../../uaclient/messages/__init__.py:2161
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2165
+#: ../../uaclient/messages/__init__.py:2166
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2171
+#: ../../uaclient/messages/__init__.py:2172
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2179
+#: ../../uaclient/messages/__init__.py:2180
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2188
+#: ../../uaclient/messages/__init__.py:2189
 #, python-brace-format
 msgid ""
 "Cannot {{operation}} services when unattached - nothing to do.\n"
@@ -3166,74 +3171,74 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2205
+#: ../../uaclient/messages/__init__.py:2206
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2210
+#: ../../uaclient/messages/__init__.py:2211
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2215
-#, fuzzy, python-brace-format
+#: ../../uaclient/messages/__init__.py:2216
+#, python-brace-format
 msgid "failed to enable {service}"
-msgstr "Habilite {service} com: pro enable {service}"
+msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2220
-#, fuzzy, python-brace-format
+#: ../../uaclient/messages/__init__.py:2221
+#, python-brace-format
 msgid "failed to disable {service}"
-msgstr "Habilite {service} com: pro enable {service}"
+msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2226
+#: ../../uaclient/messages/__init__.py:2227
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2234
+#: ../../uaclient/messages/__init__.py:2235
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2242
+#: ../../uaclient/messages/__init__.py:2243
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2249
+#: ../../uaclient/messages/__init__.py:2250
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2256
+#: ../../uaclient/messages/__init__.py:2257
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2265
+#: ../../uaclient/messages/__init__.py:2266
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2271
+#: ../../uaclient/messages/__init__.py:2272
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2279
+#: ../../uaclient/messages/__init__.py:2280
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2287
+#: ../../uaclient/messages/__init__.py:2288
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2296
+#: ../../uaclient/messages/__init__.py:2297
 #, python-brace-format
 msgid ""
 "Failed to identify this image as a valid Ubuntu Pro image.\n"
@@ -3241,14 +3246,14 @@ msgid ""
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2306
+#: ../../uaclient/messages/__init__.py:2307
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2313
+#: ../../uaclient/messages/__init__.py:2314
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -3256,16 +3261,16 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2323
+#: ../../uaclient/messages/__init__.py:2324
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2330
+#: ../../uaclient/messages/__init__.py:2331
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2338
+#: ../../uaclient/messages/__init__.py:2339
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
@@ -3274,7 +3279,7 @@ msgstr ""
 "Suporte para auto-attach não está disponível para esta imagem\n"
 "Veja {url}"
 
-#: ../../uaclient/messages/__init__.py:2347
+#: ../../uaclient/messages/__init__.py:2348
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
@@ -3283,18 +3288,18 @@ msgstr ""
 "Suporte para auto-attach não está disponível para {{cloud_type}}\n"
 "Veja: {url}"
 
-#: ../../uaclient/messages/__init__.py:2355
+#: ../../uaclient/messages/__init__.py:2356
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2361
+#: ../../uaclient/messages/__init__.py:2362
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2369
+#: ../../uaclient/messages/__init__.py:2370
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -3305,7 +3310,7 @@ msgstr ""
 "o campo VERSION não tem a informação de versão: {version}\n"
 "e o campo VERSION_CODENAME não está presente"
 
-#: ../../uaclient/messages/__init__.py:2379
+#: ../../uaclient/messages/__init__.py:2380
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -3319,12 +3324,12 @@ msgstr ""
 "\n"
 "$ sudo rm {lock_file_path}"
 
-#: ../../uaclient/messages/__init__.py:2388
+#: ../../uaclient/messages/__init__.py:2389
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr "{source} retornou um json inválido: {out}"
 
-#: ../../uaclient/messages/__init__.py:2394
+#: ../../uaclient/messages/__init__.py:2395
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
@@ -3333,7 +3338,7 @@ msgstr ""
 "Valor inválido para {path_to_value} em /etc/ubuntu-advantage/uaclient.conf."
 "Esperava {expected_value}, mas {value} foi encontrado."
 
-#: ../../uaclient/messages/__init__.py:2403
+#: ../../uaclient/messages/__init__.py:2404
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
@@ -3341,17 +3346,17 @@ msgstr ""
 "Não foi possível associar {key} a {value}: <value> precisa ser um inteiro "
 "positivo."
 
-#: ../../uaclient/messages/__init__.py:2410
+#: ../../uaclient/messages/__init__.py:2411
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr "url inválida no arquivo de configuração. {key}: {value}"
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2416
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr "Não foi possível encontrar o arquivo yaml: {filepath}"
 
-#: ../../uaclient/messages/__init__.py:2421
+#: ../../uaclient/messages/__init__.py:2422
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
@@ -3362,27 +3367,27 @@ msgstr ""
 "pro de apt ao mesmo tempo não é suportado.\n"
 "Cancelando o processo de configuração.\n"
 
-#: ../../uaclient/messages/__init__.py:2431
+#: ../../uaclient/messages/__init__.py:2432
 msgid "Can't load the distro-info database."
 msgstr "Não foi possível carregar o banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2436
+#: ../../uaclient/messages/__init__.py:2437
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 "Não foi possível encontrar a série {series} na banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2441
+#: ../../uaclient/messages/__init__.py:2442
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr "Erro: não é possível usar {option1} junto com {option2}"
 
-#: ../../uaclient/messages/__init__.py:2445
+#: ../../uaclient/messages/__init__.py:2446
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr "Ajuda não disponível para '{name}'"
 
-#: ../../uaclient/messages/__init__.py:2451
+#: ../../uaclient/messages/__init__.py:2452
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
@@ -3391,39 +3396,39 @@ msgstr ""
 "Erro: problema de segurnça \"{issue}\" não foi reconhecido.\n"
 "Use: \"pro fix CVE-yyyy-nnnn\" ou \"pro fix USN-nnnn\""
 
-#: ../../uaclient/messages/__init__.py:2457
+#: ../../uaclient/messages/__init__.py:2458
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr "{arg} precisa ser um de: {choices}"
 
-#: ../../uaclient/messages/__init__.py:2462
+#: ../../uaclient/messages/__init__.py:2463
 #, python-brace-format
 msgid "Empty value provided for {arg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2467
+#: ../../uaclient/messages/__init__.py:2468
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr "Esperava {expected} mas encontrou: {actual}"
 
-#: ../../uaclient/messages/__init__.py:2471
+#: ../../uaclient/messages/__init__.py:2472
 msgid "Unable to process uaclient.conf"
 msgstr "Falha ao processar uaclient.conf"
 
-#: ../../uaclient/messages/__init__.py:2476
+#: ../../uaclient/messages/__init__.py:2477
 msgid "Unable to refresh your subscription"
 msgstr "Falha ao atualizar sua assinatura"
 
-#: ../../uaclient/messages/__init__.py:2481
+#: ../../uaclient/messages/__init__.py:2482
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 "Falha ao atualizar as mensagens de APT e MOTD relacioandas ao Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:2487
+#: ../../uaclient/messages/__init__.py:2488
 msgid "json formatted response requires --assume-yes flag."
 msgstr "resposta formatada em json necessita do paramêtro --assume-yes"
 
-#: ../../uaclient/messages/__init__.py:2495
+#: ../../uaclient/messages/__init__.py:2496
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
@@ -3433,54 +3438,54 @@ msgstr ""
 "Ao invés disso, inclua o token no arquivo de attach-config.\n"
 "    "
 
-#: ../../uaclient/messages/__init__.py:2504
+#: ../../uaclient/messages/__init__.py:2505
 msgid "Cannot provide both --args and --data at the same time"
 msgstr "Não é possível usar --args e --data ao mesmo tempo"
 
-#: ../../uaclient/messages/__init__.py:2509
+#: ../../uaclient/messages/__init__.py:2510
 msgid "Operation cancelled by user"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2515
+#: ../../uaclient/messages/__init__.py:2516
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr "Falha ao executar: {lock_request}.\n"
 
-#: ../../uaclient/messages/__init__.py:2524
+#: ../../uaclient/messages/__init__.py:2525
 msgid "This command must be run as root (try using sudo)."
 msgstr "Esse comando precisa ser executado como root (tente usando sudo)."
 
-#: ../../uaclient/messages/__init__.py:2529
+#: ../../uaclient/messages/__init__.py:2530
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr "Metadados para {issue} não são válidos. Erro: {error_msg}."
 
-#: ../../uaclient/messages/__init__.py:2536
+#: ../../uaclient/messages/__init__.py:2537
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr "Erro: {issue_id} não encontrada."
 
-#: ../../uaclient/messages/__init__.py:2540
+#: ../../uaclient/messages/__init__.py:2541
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr "chave GPG '{keyfile}' não foi encontrada"
 
-#: ../../uaclient/messages/__init__.py:2545
+#: ../../uaclient/messages/__init__.py:2546
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr "'{endpoint}' não é um endpoint válido"
 
-#: ../../uaclient/messages/__init__.py:2550
+#: ../../uaclient/messages/__init__.py:2551
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr "'{arg}' está faltando para endpoint {endpoint}"
 
-#: ../../uaclient/messages/__init__.py:2555
+#: ../../uaclient/messages/__init__.py:2556
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr "{endpoint} não aceita paramêtros"
 
-#: ../../uaclient/messages/__init__.py:2560
+#: ../../uaclient/messages/__init__.py:2561
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
@@ -3489,32 +3494,32 @@ msgstr ""
 "Error ao analisar paramêtro data para API json:\n"
 "{data}"
 
-#: ../../uaclient/messages/__init__.py:2565
+#: ../../uaclient/messages/__init__.py:2566
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr "'{arg}' não está formatado como 'chave=valor'"
 
-#: ../../uaclient/messages/__init__.py:2570
+#: ../../uaclient/messages/__init__.py:2571
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr "Não foi possível determinar a versão: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2575
+#: ../../uaclient/messages/__init__.py:2576
 msgid "features.disable_auto_attach set in config"
 msgstr "features.disable_auto_attach definida na configuração"
 
-#: ../../uaclient/messages/__init__.py:2580
+#: ../../uaclient/messages/__init__.py:2581
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 "Não foi possível determinar o status do unattended-upgrades: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2586
+#: ../../uaclient/messages/__init__.py:2587
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr "Esperava valor com tipo {expected_type}, mas recebeu tipo {got_type}"
 
-#: ../../uaclient/messages/__init__.py:2592
+#: ../../uaclient/messages/__init__.py:2593
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
@@ -3523,7 +3528,7 @@ msgstr ""
 "Valor com tipo incorreto na posição {index}:\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2598
+#: ../../uaclient/messages/__init__.py:2599
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
@@ -3532,19 +3537,19 @@ msgstr ""
 "Valor com tipo incorreto para o campo \"{key}\":\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2605
+#: ../../uaclient/messages/__init__.py:2606
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""
 "Valor fornecido não está presente nos valores permitidos de {enum_class}: "
 "{values}"
 
-#: ../../uaclient/messages/__init__.py:2616
+#: ../../uaclient/messages/__init__.py:2617
 #, python-brace-format
 msgid "Error updating ESM services cache: {error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2622
+#: ../../uaclient/messages/__init__.py:2623
 #, python-brace-format
 msgid ""
 "There is a problem with the resource directives provided by {url}\n"
@@ -3554,19 +3559,18 @@ msgid ""
 "These directives need to be unique for every entitlement."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2631
+#: ../../uaclient/messages/__init__.py:2632
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2637
+#: ../../uaclient/messages/__init__.py:2638
 msgid ""
 "You must use the pro command to purge a service that has installed a kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2644
-#, fuzzy
+#: ../../uaclient/messages/__init__.py:2645
 msgid "The operation is not supported"
-msgstr "A atualização ainda não está instalada"
+msgstr ""
 
 #~ msgid "Detach this machine from Ubuntu Pro services."
 #~ msgstr "Desvincule esta máquina de uma assinatura Ubuntu Pro"

--- a/debian/po/ubuntu-pro.pot
+++ b/debian/po/ubuntu-pro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-08 10:20-0400\n"
+"POT-Creation-Date: 2024-04-25 15:27-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -612,20 +612,25 @@ msgstr ""
 
 #: ../../uaclient/messages/__init__.py:319
 #, python-brace-format
-msgid "{title} enabled"
+msgid "Enabling {title}"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:320
 #, python-brace-format
-msgid "{title} access enabled"
+msgid "{title} enabled"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:321
 #, python-brace-format
+msgid "{title} access enabled"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:322
+#, python-brace-format
 msgid "Could not enable {title}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:323
+#: ../../uaclient/messages/__init__.py:324
 #, python-brace-format
 msgid ""
 "{service_being_enabled} cannot be enabled with {incompatible_service}.\n"
@@ -633,12 +638,12 @@ msgid ""
 "{service_being_enabled}? (y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:329
+#: ../../uaclient/messages/__init__.py:330
 #, python-brace-format
 msgid "Disabling incompatible service: {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:332
+#: ../../uaclient/messages/__init__.py:333
 #, python-brace-format
 msgid ""
 "{service_being_enabled} cannot be enabled with {required_service} disabled.\n"
@@ -646,33 +651,33 @@ msgid ""
 "N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:337
+#: ../../uaclient/messages/__init__.py:338
 #, python-brace-format
 msgid "Enabling required service: {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:339
+#: ../../uaclient/messages/__init__.py:340
 #, python-brace-format
 msgid "A reboot is required to complete {operation}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:342
+#: ../../uaclient/messages/__init__.py:343
 #, python-brace-format
 msgid "Configuring APT access to {service}"
 msgstr ""
 
 #. DISABLE
-#: ../../uaclient/messages/__init__.py:345
+#: ../../uaclient/messages/__init__.py:346
 #, python-brace-format
 msgid "Removing APT access to {title}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:346
+#: ../../uaclient/messages/__init__.py:347
 #, python-brace-format
 msgid "Could not disable {title}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:348
+#: ../../uaclient/messages/__init__.py:349
 #, python-brace-format
 msgid ""
 "{dependent_service} depends on {service_being_disabled}.\n"
@@ -680,55 +685,55 @@ msgid ""
 "(y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:354
+#: ../../uaclient/messages/__init__.py:355
 #, python-brace-format
 msgid "Disabling dependent service: {required_service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:357
+#: ../../uaclient/messages/__init__.py:358
 #, python-brace-format
 msgid "Removing apt source file: {filename}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:359
+#: ../../uaclient/messages/__init__.py:360
 #, python-brace-format
 msgid "Removing apt preferences file: {filename}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:362
+#: ../../uaclient/messages/__init__.py:363
 #, python-brace-format
 msgid "Uninstalling all packages installed from {title}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:367
+#: ../../uaclient/messages/__init__.py:368
 msgid "(The --purge flag is still experimental - use with caution)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:370
+#: ../../uaclient/messages/__init__.py:371
 #, python-brace-format
 msgid "Purging the {service} packages would uninstall the following kernel(s):"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:373
+#: ../../uaclient/messages/__init__.py:374
 #, python-brace-format
 msgid "{kernel_version} is the current running kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:376
+#: ../../uaclient/messages/__init__.py:377
 msgid ""
 "No other valid Ubuntu kernel was found in the system.\n"
 "Removing the package would potentially make the system unbootable.\n"
 "Aborting.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:383
+#: ../../uaclient/messages/__init__.py:384
 msgid ""
 "If you cannot guarantee that other kernels in this system are bootable and\n"
 "working properly, *do not proceed*. You may end up with an unbootable "
 "system.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:392
+#: ../../uaclient/messages/__init__.py:393
 #, python-brace-format
 msgid ""
 "Failed to automatically attach to an Ubuntu Pro subscription {num_attempts} "
@@ -738,7 +743,7 @@ msgid ""
 "You can try manually with `sudo pro auto-attach`."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:400
+#: ../../uaclient/messages/__init__.py:401
 #, python-brace-format
 msgid ""
 "Failed to automatically attach to an Ubuntu Pro subscription {num_attempts} "
@@ -749,183 +754,183 @@ msgid ""
 "You can try manually with `sudo pro auto-attach`."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:408
+#: ../../uaclient/messages/__init__.py:409
 #, python-brace-format
 msgid ""
 "Canonical servers did not recognize this machine as Ubuntu Pro: \"{detail}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:412
+#: ../../uaclient/messages/__init__.py:413
 msgid "Canonical servers did not recognize this image as Ubuntu Pro"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:414
+#: ../../uaclient/messages/__init__.py:415
 #, python-brace-format
 msgid "the pro lock was held by pid {pid}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:416
+#: ../../uaclient/messages/__init__.py:417
 #, python-brace-format
 msgid "an error from Canonical servers: \"{error_msg}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:418
+#: ../../uaclient/messages/__init__.py:419
 msgid "a connectivity error"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:419
+#: ../../uaclient/messages/__init__.py:420
 #, python-brace-format
 msgid "an error while reaching {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:423
+#: ../../uaclient/messages/__init__.py:424
 #, python-brace-format
 msgid "Due to contract refresh, '{service}' is now disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:426
+#: ../../uaclient/messages/__init__.py:427
 #, python-brace-format
 msgid ""
 "Unable to disable '{service}' as recommended during contract refresh. "
 "Service is still active. See `pro status`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:431
+#: ../../uaclient/messages/__init__.py:432
 #, python-brace-format
 msgid "Updating '{service}' on changed directives."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:434
+#: ../../uaclient/messages/__init__.py:435
 #, python-brace-format
 msgid "Updating '{service}' apt sources list on changed directives."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:437
+#: ../../uaclient/messages/__init__.py:438
 #, python-brace-format
 msgid "Installing packages on changed directives: {packages}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:447
+#: ../../uaclient/messages/__init__.py:448
 #, python-brace-format
 msgid "Choose: [S]ubscribe at {url} [A]ttach existing token [C]ancel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:451
+#: ../../uaclient/messages/__init__.py:452
 #, python-brace-format
 msgid "Choose: [E]nable {service} [C]ancel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:455
+#: ../../uaclient/messages/__init__.py:456
 #, python-brace-format
 msgid "Choose: [R]enew your subscription (at {url}) [C]ancel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:458
+#: ../../uaclient/messages/__init__.py:459
 #, python-brace-format
 msgid "A fix is available in {fix_stream}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:459
+#: ../../uaclient/messages/__init__.py:460
 msgid "The update is not yet installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:461
+#: ../../uaclient/messages/__init__.py:462
 msgid ""
 "The update is not installed because this system is not attached to a\n"
 "subscription.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:467
+#: ../../uaclient/messages/__init__.py:468
 msgid ""
 "The update is not installed because this system is attached to an\n"
 "expired subscription.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:473
+#: ../../uaclient/messages/__init__.py:474
 #, python-brace-format
 msgid ""
 "The update is not installed because this system does not have\n"
 "{service} enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:478
+#: ../../uaclient/messages/__init__.py:479
 msgid "The update is already installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:480
+#: ../../uaclient/messages/__init__.py:481
 #, python-brace-format
 msgid ""
 "For easiest security on {title}, use Ubuntu Pro instances.\n"
 "Learn more at {cloud_specific_url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:485
+#: ../../uaclient/messages/__init__.py:486
 msgid "requested"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:486
+#: ../../uaclient/messages/__init__.py:487
 msgid "related"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:487
+#: ../../uaclient/messages/__init__.py:488
 #, python-brace-format
 msgid " {issue} is resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:489
+#: ../../uaclient/messages/__init__.py:490
 #, python-brace-format
 msgid " {issue} [{context}] is resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:491
+#: ../../uaclient/messages/__init__.py:492
 #, python-brace-format
 msgid " {issue} is not resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:493
+#: ../../uaclient/messages/__init__.py:494
 #, python-brace-format
 msgid " {issue} [{context}] is not resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:496
+#: ../../uaclient/messages/__init__.py:497
 #, python-brace-format
 msgid " {issue} does not affect your system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:499
+#: ../../uaclient/messages/__init__.py:500
 #, python-brace-format
 msgid " {issue} [{context}] does not affect your system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:503
+#: ../../uaclient/messages/__init__.py:504
 #, python-brace-format
 msgid "{num_pkgs} package is still affected: {pkgs}"
 msgid_plural "{num_pkgs} packages are still affected: {pkgs}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:510
+#: ../../uaclient/messages/__init__.py:511
 #, python-brace-format
 msgid "{count} affected source package is installed: {pkgs}"
 msgid_plural "{count} affected source packages are installed: {pkgs}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:516
+#: ../../uaclient/messages/__init__.py:517
 msgid "No affected source packages are installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:518
+#: ../../uaclient/messages/__init__.py:519
 #, python-brace-format
 msgid "{issue} is resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:520
+#: ../../uaclient/messages/__init__.py:521
 #, python-brace-format
 msgid " {issue} is resolved by livepatch patch version: {version}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:523
+#: ../../uaclient/messages/__init__.py:524
 #, python-brace-format
 msgid ""
 "{bold}Ubuntu Pro service: {{service}} is not enabled.\n"
@@ -935,7 +940,7 @@ msgid ""
 "{{{{ pro enable {{service}} }}}}{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:530
+#: ../../uaclient/messages/__init__.py:531
 #, python-brace-format
 msgid ""
 "{bold}The machine is not attached to an Ubuntu Pro subscription.\n"
@@ -943,7 +948,7 @@ msgid ""
 "{{ pro attach TOKEN }}{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:536
+#: ../../uaclient/messages/__init__.py:537
 #, python-brace-format
 msgid ""
 "{bold}The machine has an expired subscription.\n"
@@ -953,104 +958,104 @@ msgid ""
 "{{ pro attach NEW_TOKEN }}{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:544
+#: ../../uaclient/messages/__init__.py:545
 #, python-brace-format
 msgid ""
 "{bold}WARNING: The option --dry-run is being used.\n"
 "No packages will be installed when running this command.{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:549
+#: ../../uaclient/messages/__init__.py:550
 #, python-brace-format
 msgid ""
 "Error: Ubuntu Pro service: {service} is not enabled.\n"
 "Without it, we cannot fix the system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:554
+#: ../../uaclient/messages/__init__.py:555
 #, python-brace-format
 msgid ""
 "Error: The current Ubuntu Pro subscription is not entitled to: {service}.\n"
 "Without it, we cannot fix the system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:559
+#: ../../uaclient/messages/__init__.py:560
 #, python-brace-format
 msgid "{service} is required for upgrade."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:563
+#: ../../uaclient/messages/__init__.py:564
 #, python-brace-format
 msgid "{service} is required for upgrade, but current subscription is expired."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:567
+#: ../../uaclient/messages/__init__.py:568
 #, python-brace-format
 msgid "{service} is required for upgrade, but it is not enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:571
+#: ../../uaclient/messages/__init__.py:572
 msgid "APT failed to install the package.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:576
+#: ../../uaclient/messages/__init__.py:577
 msgid "Sorry, no fix is available yet."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:580
+#: ../../uaclient/messages/__init__.py:581
 msgid "Ubuntu security engineers are investigating this issue."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:584
+#: ../../uaclient/messages/__init__.py:585
 msgid "A fix is coming soon. Try again tomorrow."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:588
+#: ../../uaclient/messages/__init__.py:589
 msgid "Sorry, no fix is available."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:592
+#: ../../uaclient/messages/__init__.py:593
 msgid "Source package does not exist on this release."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:596
+#: ../../uaclient/messages/__init__.py:597
 msgid "Source package is not affected on this release."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:600
+#: ../../uaclient/messages/__init__.py:601
 #, python-brace-format
 msgid "UNKNOWN: {status}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:604
+#: ../../uaclient/messages/__init__.py:605
 msgid "Associated CVEs:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:605
+#: ../../uaclient/messages/__init__.py:606
 msgid "Found Launchpad bugs:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:607
+#: ../../uaclient/messages/__init__.py:608
 #, python-brace-format
 msgid "Fixing requested {issue_id}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:611
+#: ../../uaclient/messages/__init__.py:612
 msgid "Fixing related USNs:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:615
+#: ../../uaclient/messages/__init__.py:616
 #, python-brace-format
 msgid ""
 "Found related USNs:\n"
 "- {related_usns}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:619
+#: ../../uaclient/messages/__init__.py:620
 msgid "Summary:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:623
+#: ../../uaclient/messages/__init__.py:624
 #, python-brace-format
 msgid ""
 "Even though a related USN failed to be fixed, note\n"
@@ -1061,149 +1066,149 @@ msgid ""
 "{url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:632
+#: ../../uaclient/messages/__init__.py:633
 msgid "Ubuntu standard updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:633
-#: ../../uaclient/messages/__init__.py:1241
+#: ../../uaclient/messages/__init__.py:634
+#: ../../uaclient/messages/__init__.py:1242
 msgid "Ubuntu Pro: ESM Infra"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:634
-#: ../../uaclient/messages/__init__.py:1227
+#: ../../uaclient/messages/__init__.py:635
+#: ../../uaclient/messages/__init__.py:1228
 msgid "Ubuntu Pro: ESM Apps"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:637
+#: ../../uaclient/messages/__init__.py:638
 msgid ""
 "Package fixes cannot be installed.\n"
 "To install them, run this command as root (try using sudo)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:643
+#: ../../uaclient/messages/__init__.py:644
 #, python-brace-format
 msgid "Enter your token (from {url}) to attach this system:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:647
+#: ../../uaclient/messages/__init__.py:648
 msgid "Enter your new token to renew Ubuntu Pro subscription on this system:"
 msgstr ""
 
 #. ##############################################################################
 #. SECURITYSTATUS SUBCOMMAND                              #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:657
+#: ../../uaclient/messages/__init__.py:658
 #, python-brace-format
 msgid "{count} packages installed:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:660
+#: ../../uaclient/messages/__init__.py:661
 #, python-brace-format
 msgid "{offset}{count} package from Ubuntu {repository} repository"
 msgid_plural "{offset}{count} packages from Ubuntu {repository} repository"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:667
+#: ../../uaclient/messages/__init__.py:668
 #, python-brace-format
 msgid "{offset}{count} package from a third party"
 msgid_plural "{offset}{count} packages from third parties"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:674
+#: ../../uaclient/messages/__init__.py:675
 #, python-brace-format
 msgid "{offset}{count} package no longer available for download"
 msgid_plural "{offset}{count} packages no longer available for download"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:681
+#: ../../uaclient/messages/__init__.py:682
 msgid ""
 "To get more information about the packages, run\n"
 "    pro security-status --help\n"
 "for a list of available options."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:688
+#: ../../uaclient/messages/__init__.py:689
 msgid ""
 " Make sure to run\n"
 "    sudo apt update\n"
 "to get the latest package information from apt."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:694
+#: ../../uaclient/messages/__init__.py:695
 #, python-brace-format
 msgid "The system apt information was updated {days} day(s) ago."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:698
+#: ../../uaclient/messages/__init__.py:699
 msgid "The system apt cache may be outdated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:702
+#: ../../uaclient/messages/__init__.py:703
 #, python-brace-format
 msgid "Main/Restricted packages receive updates until {date}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:705
+#: ../../uaclient/messages/__init__.py:706
 #, python-brace-format
 msgid ""
 "This machine is receiving security patching for Ubuntu Main/Restricted\n"
 "repository until {date}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:711
+#: ../../uaclient/messages/__init__.py:712
 msgid "This machine is attached to an Ubuntu Pro subscription."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:714
+#: ../../uaclient/messages/__init__.py:715
 msgid "This machine is NOT attached to an Ubuntu Pro subscription."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:718
+#: ../../uaclient/messages/__init__.py:719
 msgid ""
 "Packages from third parties are not provided by the official Ubuntu\n"
 "archive, for example packages from Personal Package Archives in Launchpad."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:723
+#: ../../uaclient/messages/__init__.py:724
 msgid ""
 "Packages that are not available for download may be left over from a\n"
 "previous release of Ubuntu, may have been installed directly from a\n"
 ".deb file, or are from a source which has been disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:730
+#: ../../uaclient/messages/__init__.py:731
 msgid ""
 "This machine is NOT receiving security patches because the LTS period has "
 "ended\n"
 "and esm-infra is not enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:736
+#: ../../uaclient/messages/__init__.py:737
 #, python-brace-format
 msgid ""
 "Ubuntu Pro with '{service}' enabled provides security updates for\n"
 "{repository} packages until {year}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:742
+#: ../../uaclient/messages/__init__.py:743
 #, python-brace-format
 msgid "There is {updates} pending security update."
 msgid_plural "There are {updates} pending security updates."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:749
+#: ../../uaclient/messages/__init__.py:750
 #, python-brace-format
 msgid ""
 "{repository} packages are receiving security updates from\n"
 "Ubuntu Pro with '{service}' enabled until {year}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:755
+#: ../../uaclient/messages/__init__.py:756
 #, python-brace-format
 msgid ""
 "You have received {updates} security\n"
@@ -1214,19 +1219,19 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:765
+#: ../../uaclient/messages/__init__.py:766
 #, python-brace-format
 msgid "Enable {service} with: pro enable {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:767
+#: ../../uaclient/messages/__init__.py:768
 #, python-brace-format
 msgid ""
 "Try Ubuntu Pro with a free personal subscription on up to 5 machines.\n"
 "Learn more at {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:774
+#: ../../uaclient/messages/__init__.py:775
 #, python-brace-format
 msgid ""
 "For example, run:\n"
@@ -1234,161 +1239,161 @@ msgid ""
 "to learn more about that package."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:781
+#: ../../uaclient/messages/__init__.py:782
 msgid "You have no packages installed from a third party."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:784
+#: ../../uaclient/messages/__init__.py:785
 msgid "You have no packages installed that are no longer available."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:787
+#: ../../uaclient/messages/__init__.py:788
 msgid "Ubuntu Pro is not available for non-LTS releases."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:790
+#: ../../uaclient/messages/__init__.py:791
 #, python-brace-format
 msgid "Run 'pro help {service}' to learn more"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:793
+#: ../../uaclient/messages/__init__.py:794
 #, python-brace-format
 msgid "Installed packages with an available {service} update:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:796
+#: ../../uaclient/messages/__init__.py:797
 #, python-brace-format
 msgid "Installed packages with an {service} update applied:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:798
+#: ../../uaclient/messages/__init__.py:799
 #, python-brace-format
 msgid "Installed packages covered by {service}:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:800
+#: ../../uaclient/messages/__init__.py:801
 #, python-brace-format
 msgid "Further installed packages covered by {service}:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:802
+#: ../../uaclient/messages/__init__.py:803
 msgid "Packages:"
 msgstr ""
 
 #. ##############################################################################
 #. STATUS SUBCOMMAND                                 #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:810
+#: ../../uaclient/messages/__init__.py:811
 msgid "SERVICE"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:811
+#: ../../uaclient/messages/__init__.py:812
 msgid "AVAILABLE"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:812
+#: ../../uaclient/messages/__init__.py:813
 msgid "ENTITLED"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:813
+#: ../../uaclient/messages/__init__.py:814
 msgid "AUTO_ENABLED"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:814
+#: ../../uaclient/messages/__init__.py:815
 msgid "STATUS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:815
+#: ../../uaclient/messages/__init__.py:816
 msgid "DESCRIPTION"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:816
+#: ../../uaclient/messages/__init__.py:817
 msgid "NOTICES"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:817
+#: ../../uaclient/messages/__init__.py:818
 msgid "FEATURES"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:821
+#: ../../uaclient/messages/__init__.py:822
 msgid "enabled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:822
+#: ../../uaclient/messages/__init__.py:823
 msgid "disabled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:823
+#: ../../uaclient/messages/__init__.py:824
 msgid "n/a"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:825
+#: ../../uaclient/messages/__init__.py:826
 msgid "warning"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:826
+#: ../../uaclient/messages/__init__.py:827
 msgid "essential"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:827
+#: ../../uaclient/messages/__init__.py:828
 msgid "standard"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:828
+#: ../../uaclient/messages/__init__.py:829
 msgid "advanced"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:830
+#: ../../uaclient/messages/__init__.py:831
 msgid "Unknown/Expired"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:833
+#: ../../uaclient/messages/__init__.py:834
 #, python-brace-format
 msgid "Enable services with: {command}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:835
+#: ../../uaclient/messages/__init__.py:836
 msgid "Account"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:836
+#: ../../uaclient/messages/__init__.py:837
 msgid "Subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:837
+#: ../../uaclient/messages/__init__.py:838
 msgid "Valid until"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:838
+#: ../../uaclient/messages/__init__.py:839
 msgid "Technical support level"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:840
+#: ../../uaclient/messages/__init__.py:841
 msgid "This token is not valid."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:841
+#: ../../uaclient/messages/__init__.py:842
 msgid "No Ubuntu Pro operations are running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:844
+#: ../../uaclient/messages/__init__.py:845
 msgid "No Ubuntu Pro services are available to this system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:847
+#: ../../uaclient/messages/__init__.py:848
 msgid "For a list of all Ubuntu Pro services, run 'pro status --all'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:849
+#: ../../uaclient/messages/__init__.py:850
 msgid " * Service has variants"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:851
+#: ../../uaclient/messages/__init__.py:852
 msgid ""
 "For a list of all Ubuntu Pro services and variants, run 'pro status --all'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:856
+#: ../../uaclient/messages/__init__.py:857
 msgid ""
 "A change has been detected in your contract.\n"
 "Please run `sudo pro refresh`."
@@ -1399,113 +1404,113 @@ msgstr ""
 #. ##############################################################################
 #. This encompasses help text for subcommands, flags, and arguments for the CLI
 #. Also, any generic strings about the CLI itself go here.
-#: ../../uaclient/messages/__init__.py:869
+#: ../../uaclient/messages/__init__.py:870
 msgid "Try 'pro --help' for more information."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:871
+#: ../../uaclient/messages/__init__.py:872
 #, python-brace-format
 msgid "Use {name} {command} --help for more information about a command."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:874
+#: ../../uaclient/messages/__init__.py:875
 msgid "Use pro help <service> to get more details about each service"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:877
+#: ../../uaclient/messages/__init__.py:878
 msgid "Variants:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:878
+#: ../../uaclient/messages/__init__.py:879
 msgid "Arguments"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:879
+#: ../../uaclient/messages/__init__.py:880
 msgid "Flags"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:880
+#: ../../uaclient/messages/__init__.py:881
 msgid "Available Commands"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:882
+#: ../../uaclient/messages/__init__.py:883
 #, python-brace-format
 msgid "output in the specified format (default: {default})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:885
+#: ../../uaclient/messages/__init__.py:886
 #, python-brace-format
 msgid "do not prompt for confirmation before performing the {command}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:888
-#: ../../uaclient/messages/__init__.py:1122
+#: ../../uaclient/messages/__init__.py:889
+#: ../../uaclient/messages/__init__.py:1123
 msgid "Calls the Client API endpoints."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:889
+#: ../../uaclient/messages/__init__.py:890
 msgid "API endpoint to call"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:891
+#: ../../uaclient/messages/__init__.py:892
 msgid ""
 "For endpoints that support progress updates, show each progress update on a "
 "new line in JSON format"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:895
+#: ../../uaclient/messages/__init__.py:896
 msgid "Options to pass to the API endpoint, formatted as key=value"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:897
+#: ../../uaclient/messages/__init__.py:898
 msgid "arguments in JSON format to the API endpoint"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:900
+#: ../../uaclient/messages/__init__.py:901
 msgid "Automatically attach on an Ubuntu Pro cloud instance."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:904
+#: ../../uaclient/messages/__init__.py:905
 msgid "Collect logs and relevant system information into a tarball."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:907
+#: ../../uaclient/messages/__init__.py:908
 msgid "tarball where the logs will be stored. (Defaults to ./pro_logs.tar.gz)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:910
+#: ../../uaclient/messages/__init__.py:911
 msgid "Show customizable configuration settings"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:912
+#: ../../uaclient/messages/__init__.py:913
 msgid "Optional key or key(s) to show configuration settings."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:915
+#: ../../uaclient/messages/__init__.py:916
 msgid "Set and apply Ubuntu Pro configuration settings"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:918
+#: ../../uaclient/messages/__init__.py:919
 #, python-brace-format
 msgid ""
 "key=value pair to configure for Ubuntu Pro services. Key must be one of: "
 "{options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:921
+#: ../../uaclient/messages/__init__.py:922
 msgid "Unset Ubuntu Pro configuration setting"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:923
+#: ../../uaclient/messages/__init__.py:924
 #, python-brace-format
 msgid "configuration key to unset from Ubuntu Pro services. One of: {options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:925
+#: ../../uaclient/messages/__init__.py:926
 msgid "Manage Ubuntu Pro configuration"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:928
+#: ../../uaclient/messages/__init__.py:929
 #, python-brace-format
 msgid ""
 "Attach this machine to an Ubuntu Pro subscription with a token obtained "
@@ -1517,48 +1522,48 @@ msgid ""
 "a web browser."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:936
+#: ../../uaclient/messages/__init__.py:937
 msgid "token obtained for Ubuntu Pro authentication"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:938
+#: ../../uaclient/messages/__init__.py:939
 msgid "do not enable any recommended services automatically"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:941
+#: ../../uaclient/messages/__init__.py:942
 msgid ""
 "use the provided attach config file instead of passing the token on the cli"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:946
+#: ../../uaclient/messages/__init__.py:947
 msgid ""
 "Inspect and resolve CVEs and USNs (Ubuntu Security Notices) on this machine."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:950
+#: ../../uaclient/messages/__init__.py:951
 msgid ""
 "Security vulnerability ID to inspect and resolve on this system. Format: CVE-"
 "yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-dd"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:954
+#: ../../uaclient/messages/__init__.py:955
 msgid ""
 "If used, fix will not actually run but will display everything that will "
 "happen on the machine during the command."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:959
+#: ../../uaclient/messages/__init__.py:960
 msgid ""
 "If used, when fixing a USN, the command will not try to also fix related "
 "USNs to the target USN."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:964
+#: ../../uaclient/messages/__init__.py:965
 msgid ""
 "WARNING: Failed to update ESM cache - package availability may be inaccurate"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:968
+#: ../../uaclient/messages/__init__.py:969
 #, python-brace-format
 msgid ""
 "{bold}WARNING: Unable to update ESM cache when running as non-root,\n"
@@ -1566,7 +1571,7 @@ msgid ""
 "{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:974
+#: ../../uaclient/messages/__init__.py:975
 msgid ""
 "Show security updates for packages in the system, including all\n"
 "available Expanded Security Maintenance (ESM) related content.\n"
@@ -1586,23 +1591,23 @@ msgid ""
 "complete status on Ubuntu Pro services, run 'pro status'.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:994
+#: ../../uaclient/messages/__init__.py:995
 msgid "List and present information about third-party packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:997
+#: ../../uaclient/messages/__init__.py:998
 msgid "List and present information about unavailable packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1000
+#: ../../uaclient/messages/__init__.py:1001
 msgid "List and present information about esm-infra packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1003
+#: ../../uaclient/messages/__init__.py:1004
 msgid "List and present information about esm-apps packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1007
+#: ../../uaclient/messages/__init__.py:1008
 msgid ""
 "Refresh three distinct Ubuntu Pro related artifacts in the system:\n"
 "\n"
@@ -1615,72 +1620,72 @@ msgid ""
 "is specified, all targets are refreshed.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1019
+#: ../../uaclient/messages/__init__.py:1020
 msgid "Target to refresh."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1022
+#: ../../uaclient/messages/__init__.py:1023
 msgid "Detach this machine from an Ubuntu Pro subscription."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1026
+#: ../../uaclient/messages/__init__.py:1027
 msgid "Provide detailed information about Ubuntu Pro services."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1029
+#: ../../uaclient/messages/__init__.py:1030
 #, python-brace-format
 msgid "a service to view help output for. One of: {options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1031
+#: ../../uaclient/messages/__init__.py:1032
 msgid "Include beta services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1033
+#: ../../uaclient/messages/__init__.py:1034
 msgid "Enable an Ubuntu Pro service."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1035
+#: ../../uaclient/messages/__init__.py:1036
 #, python-brace-format
 msgid "the name(s) of the Ubuntu Pro services to enable. One of: {options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1038
+#: ../../uaclient/messages/__init__.py:1039
 msgid ""
 "do not auto-install packages. Valid for cc-eal, cis and realtime-kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1041
+#: ../../uaclient/messages/__init__.py:1042
 msgid "allow beta service to be enabled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1043
+#: ../../uaclient/messages/__init__.py:1044
 msgid "The name of the variant to use when enabling the service"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1046
+#: ../../uaclient/messages/__init__.py:1047
 msgid "Disable an Ubuntu Pro service."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1048
+#: ../../uaclient/messages/__init__.py:1049
 #, python-brace-format
 msgid "the name(s) of the Ubuntu Pro services to disable. One of: {options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1051
+#: ../../uaclient/messages/__init__.py:1052
 msgid ""
 "disable the service and remove/downgrade related packages (experimental)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1055
+#: ../../uaclient/messages/__init__.py:1056
 msgid "Output system related information related to Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1057
+#: ../../uaclient/messages/__init__.py:1058
 msgid "does the system need to be rebooted"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1059
+#: ../../uaclient/messages/__init__.py:1060
 msgid ""
 "Report the current reboot-required status for the machine.\n"
 "\n"
@@ -1696,7 +1701,7 @@ msgid ""
 "  nearest maintenance window.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1076
+#: ../../uaclient/messages/__init__.py:1077
 msgid ""
 "Report current status of Ubuntu Pro services on system.\n"
 "\n"
@@ -1732,80 +1737,80 @@ msgid ""
 "listed in the output.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1111
+#: ../../uaclient/messages/__init__.py:1112
 msgid "Block waiting on pro to complete"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1113
+#: ../../uaclient/messages/__init__.py:1114
 msgid "simulate the output status using a provided token"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1115
+#: ../../uaclient/messages/__init__.py:1116
 msgid "Include unavailable and beta services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1117
+#: ../../uaclient/messages/__init__.py:1118
 msgid "show all debug log messages to console"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1118
+#: ../../uaclient/messages/__init__.py:1119
 #, python-brace-format
 msgid "show version of {name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1120
+#: ../../uaclient/messages/__init__.py:1121
 msgid "attach this machine to an Ubuntu Pro subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1123
+#: ../../uaclient/messages/__init__.py:1124
 msgid "automatically attach on supported platforms"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1124
+#: ../../uaclient/messages/__init__.py:1125
 msgid "collect Pro logs and debug information"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1125
+#: ../../uaclient/messages/__init__.py:1126
 msgid "manage Ubuntu Pro configuration on this machine"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1127
+#: ../../uaclient/messages/__init__.py:1128
 msgid "remove this machine from an Ubuntu Pro subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1130
+#: ../../uaclient/messages/__init__.py:1131
 msgid "disable a specific Ubuntu Pro service on this machine"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1133
+#: ../../uaclient/messages/__init__.py:1134
 msgid "enable a specific Ubuntu Pro service on this machine"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1136
+#: ../../uaclient/messages/__init__.py:1137
 msgid "check for and mitigate the impact of a CVE/USN on this system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1139
+#: ../../uaclient/messages/__init__.py:1140
 msgid "list available security updates for the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1142
+#: ../../uaclient/messages/__init__.py:1143
 msgid "show detailed information about Ubuntu Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1144
+#: ../../uaclient/messages/__init__.py:1145
 msgid "refresh Ubuntu Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1145
+#: ../../uaclient/messages/__init__.py:1146
 msgid "current status of all Ubuntu Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1146
+#: ../../uaclient/messages/__init__.py:1147
 msgid "show system information related to Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1149
+#: ../../uaclient/messages/__init__.py:1150
 #, python-brace-format
 msgid ""
 "WARNING: this output is intended to be human readable, and subject to "
@@ -1817,15 +1822,15 @@ msgstr ""
 #. ##############################################################################
 #. SERVICE-SPECIFIC MESSAGES                            #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:1162
+#: ../../uaclient/messages/__init__.py:1163
 msgid "Anbox Cloud"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1163
+#: ../../uaclient/messages/__init__.py:1164
 msgid "Scalable Android in the cloud"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1165
+#: ../../uaclient/messages/__init__.py:1166
 #, python-brace-format
 msgid ""
 "Anbox Cloud lets you stream mobile apps securely, at any scale, to any "
@@ -1843,7 +1848,7 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1176
+#: ../../uaclient/messages/__init__.py:1177
 #, python-brace-format
 msgid ""
 "To finish setting up the Anbox Cloud Appliance, run:\n"
@@ -1855,15 +1860,15 @@ msgid ""
 "For more information, see {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1187
+#: ../../uaclient/messages/__init__.py:1188
 msgid "CC EAL2"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1188
+#: ../../uaclient/messages/__init__.py:1189
 msgid "Common Criteria EAL2 Provisioning Packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1190
+#: ../../uaclient/messages/__init__.py:1191
 msgid ""
 "Common Criteria is an Information Technology Security Evaluation standard\n"
 "(ISO/IEC IS 15408) for computer security certification. Ubuntu 16.04 has "
@@ -1873,29 +1878,29 @@ msgid ""
 "on Intel x86_64, IBM Power8 and IBM Z hardware platforms."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1197
+#: ../../uaclient/messages/__init__.py:1198
 msgid ""
 "(This will download more than 500MB of packages, so may take some time.)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1201
+#: ../../uaclient/messages/__init__.py:1202
 #, python-brace-format
 msgid "Please follow instructions in {filename} to configure EAL2"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1204
+#: ../../uaclient/messages/__init__.py:1205
 msgid "CIS Audit"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1205
+#: ../../uaclient/messages/__init__.py:1206
 msgid "Ubuntu Security Guide"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1206
+#: ../../uaclient/messages/__init__.py:1207
 msgid "Security compliance and audit tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1208
+#: ../../uaclient/messages/__init__.py:1209
 #, python-brace-format
 msgid ""
 "Ubuntu Security Guide is a tool for hardening and auditing and allows for\n"
@@ -1905,17 +1910,17 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1214
+#: ../../uaclient/messages/__init__.py:1215
 #, python-brace-format
 msgid "Visit {url} to learn how to use CIS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1217
+#: ../../uaclient/messages/__init__.py:1218
 #, python-brace-format
 msgid "Visit {url} for the next steps"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1221
+#: ../../uaclient/messages/__init__.py:1222
 #, python-brace-format
 msgid ""
 "From Ubuntu 20.04 onward 'pro enable cis' has been\n"
@@ -1923,11 +1928,11 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1229
+#: ../../uaclient/messages/__init__.py:1230
 msgid "Expanded Security Maintenance for Applications"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1232
+#: ../../uaclient/messages/__init__.py:1233
 #, python-brace-format
 msgid ""
 "Expanded Security Maintenance for Applications is enabled by default on\n"
@@ -1939,11 +1944,11 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1243
+#: ../../uaclient/messages/__init__.py:1244
 msgid "Expanded Security Maintenance for Infrastructure"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1246
+#: ../../uaclient/messages/__init__.py:1247
 #, python-brace-format
 msgid ""
 "Expanded Security Maintenance for Infrastructure provides access to a "
@@ -1956,15 +1961,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1255
+#: ../../uaclient/messages/__init__.py:1256
 msgid "FIPS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1256
+#: ../../uaclient/messages/__init__.py:1257
 msgid "NIST-certified FIPS crypto packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1258
+#: ../../uaclient/messages/__init__.py:1259
 #, python-brace-format
 msgid ""
 "Installs FIPS 140 crypto packages for FedRAMP, FISMA and compliance use "
@@ -1975,18 +1980,18 @@ msgid ""
 "choose \"fips-updates\" for maximum security. Find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1265
+#: ../../uaclient/messages/__init__.py:1266
 msgid "Could not determine cloud, defaulting to generic FIPS package."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1268
+#: ../../uaclient/messages/__init__.py:1269
 #, python-brace-format
 msgid ""
 "FIPS kernel is running in a disabled state.\n"
 "  To manually remove fips kernel: {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1274
+#: ../../uaclient/messages/__init__.py:1275
 msgid ""
 "Warning: FIPS kernel is not optimized for your specific cloud.\n"
 "To fix it, run the following commands:\n"
@@ -1997,20 +2002,20 @@ msgid ""
 "    4. sudo reboot\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1286
+#: ../../uaclient/messages/__init__.py:1287
 msgid ""
 "This will install the FIPS packages. The Livepatch service will be "
 "unavailable.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1295
+#: ../../uaclient/messages/__init__.py:1296
 msgid ""
 "This will install the FIPS packages including security updates.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1304
+#: ../../uaclient/messages/__init__.py:1305
 #, python-brace-format
 msgid ""
 "Warning: Enabling {title} in a container.\n"
@@ -2020,14 +2025,14 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1316
+#: ../../uaclient/messages/__init__.py:1317
 #, python-brace-format
 msgid ""
 "This will disable the {title} entitlement but the {title} packages will "
 "remain installed.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1323
+#: ../../uaclient/messages/__init__.py:1324
 #, python-brace-format
 msgid ""
 "This will downgrade the kernel from {current_version} to {new_version}.\n"
@@ -2037,44 +2042,44 @@ msgid ""
 "proceeding.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1330
+#: ../../uaclient/messages/__init__.py:1331
 msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1332
-#: ../../uaclient/messages/__init__.py:1765
+#: ../../uaclient/messages/__init__.py:1333
+#: ../../uaclient/messages/__init__.py:1766
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1334
+#: ../../uaclient/messages/__init__.py:1335
 msgid "This FIPS install is out of date, run: sudo pro enable fips"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1337
+#: ../../uaclient/messages/__init__.py:1338
 msgid "Disabling FIPS requires system reboot to complete operation."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1340
+#: ../../uaclient/messages/__init__.py:1341
 #, python-brace-format
 msgid "{service} {pkg} package could not be installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1343
+#: ../../uaclient/messages/__init__.py:1344
 msgid ""
 "Please run `apt upgrade` to ensure all FIPS packages are updated to the "
 "correct\n"
 "version.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1349
+#: ../../uaclient/messages/__init__.py:1350
 msgid "FIPS Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1351
+#: ../../uaclient/messages/__init__.py:1352
 msgid "FIPS compliant crypto packages with stable security updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1354
+#: ../../uaclient/messages/__init__.py:1355
 #, python-brace-format
 msgid ""
 "fips-updates installs FIPS 140 crypto packages including all security "
@@ -2083,21 +2088,21 @@ msgid ""
 "You can find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1360
+#: ../../uaclient/messages/__init__.py:1361
 msgid "FIPS Preview"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1362
+#: ../../uaclient/messages/__init__.py:1363
 msgid "Preview of FIPS crypto packages undergoing certification with NIST"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1365
+#: ../../uaclient/messages/__init__.py:1366
 msgid ""
 "Installs FIPS crypto packages that are under certification with NIST,\n"
 "for FedRAMP, FISMA and compliance use cases."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1370
+#: ../../uaclient/messages/__init__.py:1371
 msgid ""
 "This will install crypto packages that have been submitted to NIST for "
 "review\n"
@@ -2109,15 +2114,15 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1381
+#: ../../uaclient/messages/__init__.py:1382
 msgid "Landscape"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1383
+#: ../../uaclient/messages/__init__.py:1384
 msgid "Management and administration tool for Ubuntu"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1386
+#: ../../uaclient/messages/__init__.py:1387
 #, python-brace-format
 msgid ""
 "Landscape Client can be installed on this machine and enrolled in "
@@ -2130,22 +2135,22 @@ msgid ""
 "more. Find out more about Landscape at {home_url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1399
+#: ../../uaclient/messages/__init__.py:1400
 msgid ""
 "/etc/landscape/client.conf contains your landscape-client configuration.\n"
 "To re-enable Landscape with the same configuration, run:\n"
 "    sudo pro enable landscape --assume-yes\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1406
+#: ../../uaclient/messages/__init__.py:1407
 msgid "Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1407
+#: ../../uaclient/messages/__init__.py:1408
 msgid "Canonical Livepatch service"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1409
+#: ../../uaclient/messages/__init__.py:1410
 #, python-brace-format
 msgid ""
 "Livepatch provides selected high and critical kernel CVE fixes and other\n"
@@ -2160,50 +2165,50 @@ msgid ""
 "service at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1418
+#: ../../uaclient/messages/__init__.py:1419
 msgid "Current kernel is not supported"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1421
+#: ../../uaclient/messages/__init__.py:1422
 #, python-brace-format
 msgid "Supported livepatch kernels are listed here: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1424
+#: ../../uaclient/messages/__init__.py:1425
 #, python-brace-format
 msgid "Unable to configure livepatch: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1426
+#: ../../uaclient/messages/__init__.py:1427
 msgid "Unable to enable Livepatch: "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1428
+#: ../../uaclient/messages/__init__.py:1429
 msgid "Disabling Livepatch prior to re-attach with new token"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1431
+#: ../../uaclient/messages/__init__.py:1432
 msgid "Livepatch support requires a system reboot across LTS upgrade."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1433
+#: ../../uaclient/messages/__init__.py:1434
 msgid "Installing Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1434
+#: ../../uaclient/messages/__init__.py:1435
 msgid "Setting up Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1436
-#: ../../uaclient/messages/__init__.py:1449
+#: ../../uaclient/messages/__init__.py:1437
+#: ../../uaclient/messages/__init__.py:1450
 msgid "Real-time kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1438
+#: ../../uaclient/messages/__init__.py:1439
 msgid "Ubuntu kernel with PREEMPT_RT patches integrated"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1441
+#: ../../uaclient/messages/__init__.py:1442
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated. "
 "It\n"
@@ -2216,35 +2221,35 @@ msgid ""
 "Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1451
+#: ../../uaclient/messages/__init__.py:1452
 msgid "Generic version of the RT kernel (default)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1453
+#: ../../uaclient/messages/__init__.py:1454
 msgid "Real-time NVIDIA Tegra Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1455
+#: ../../uaclient/messages/__init__.py:1456
 msgid "RT kernel optimized for NVIDIA Tegra platform"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1457
+#: ../../uaclient/messages/__init__.py:1458
 msgid "Raspberry Pi Real-time for Pi5/Pi4"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1459
+#: ../../uaclient/messages/__init__.py:1460
 msgid "24.04 Real-time kernel optimised for Raspberry Pi"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1461
+#: ../../uaclient/messages/__init__.py:1462
 msgid "Real-time Intel IOTG Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1463
+#: ../../uaclient/messages/__init__.py:1464
 msgid "RT kernel optimized for Intel IOTG platform"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1466
+#: ../../uaclient/messages/__init__.py:1467
 #, python-brace-format
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches "
@@ -2257,7 +2262,7 @@ msgid ""
 "Do you want to continue? [ default = Yes ]: (Y/n) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1477
+#: ../../uaclient/messages/__init__.py:1478
 msgid ""
 "This will remove the boot order preference for the Real-time kernel and\n"
 "disable updates to the Real-time kernel.\n"
@@ -2274,15 +2279,15 @@ msgid ""
 "Are you sure? (y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1493
+#: ../../uaclient/messages/__init__.py:1494
 msgid "ROS ESM Security Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1494
+#: ../../uaclient/messages/__init__.py:1495
 msgid "Security Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1496
+#: ../../uaclient/messages/__init__.py:1497
 #, python-brace-format
 msgid ""
 "ros provides access to a private PPA which includes security-related "
@@ -2295,15 +2300,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1505
+#: ../../uaclient/messages/__init__.py:1506
 msgid "ROS ESM All Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1507
+#: ../../uaclient/messages/__init__.py:1508
 msgid "All Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1510
+#: ../../uaclient/messages/__init__.py:1511
 #, python-brace-format
 msgid ""
 "ros-updates provides access to a private PPA that includes non-security-"
@@ -2316,7 +2321,7 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1581
+#: ../../uaclient/messages/__init__.py:1582
 #, python-brace-format
 msgid ""
 "An unexpected error occurred: {error_msg}\n"
@@ -2324,7 +2329,7 @@ msgid ""
 "If you think this is a bug, please run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1591
+#: ../../uaclient/messages/__init__.py:1592
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2332,7 +2337,7 @@ msgid ""
 "Please install \"ca-certificates\" and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1601
+#: ../../uaclient/messages/__init__.py:1602
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2340,202 +2345,202 @@ msgid ""
 "Please check your openssl configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1610
+#: ../../uaclient/messages/__init__.py:1611
 #, python-brace-format
 msgid "Ignoring unknown argument '{arg}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1616
+#: ../../uaclient/messages/__init__.py:1617
 #, python-brace-format
 msgid ""
 "A new version of the client is available: {version}. Please upgrade to the "
 "latest version to get the new features and bug fixes."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1623
+#: ../../uaclient/messages/__init__.py:1624
 #, python-brace-format
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1628
+#: ../../uaclient/messages/__init__.py:1629
 #, python-brace-format
 msgid "{title} does not support being disabled with --purge"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1634
+#: ../../uaclient/messages/__init__.py:1635
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1641
+#: ../../uaclient/messages/__init__.py:1642
 #, python-brace-format
 msgid "Cannot disable {entitlement_name} with purge: no origin value defined"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1648
+#: ../../uaclient/messages/__init__.py:1649
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1653
+#: ../../uaclient/messages/__init__.py:1654
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1656
+#: ../../uaclient/messages/__init__.py:1657
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1661
+#: ../../uaclient/messages/__init__.py:1662
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1667
+#: ../../uaclient/messages/__init__.py:1668
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1671
+#: ../../uaclient/messages/__init__.py:1672
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1675
+#: ../../uaclient/messages/__init__.py:1676
 #, python-brace-format
 msgid "{title} does not have a suites directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1680
+#: ../../uaclient/messages/__init__.py:1681
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1688
+#: ../../uaclient/messages/__init__.py:1689
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1695
+#: ../../uaclient/messages/__init__.py:1696
 #, python-brace-format
 msgid ""
 "{title} is already enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1703
+#: ../../uaclient/messages/__init__.py:1704
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1709
+#: ../../uaclient/messages/__init__.py:1710
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1715
+#: ../../uaclient/messages/__init__.py:1716
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Minimum kernel version required: {min_kernel}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1723
+#: ../../uaclient/messages/__init__.py:1724
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
 "Supported flavors are: {supported_kernels}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1731
+#: ../../uaclient/messages/__init__.py:1732
 #, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1738
+#: ../../uaclient/messages/__init__.py:1739
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1746
+#: ../../uaclient/messages/__init__.py:1747
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1753
+#: ../../uaclient/messages/__init__.py:1754
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1759
+#: ../../uaclient/messages/__init__.py:1760
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1769
+#: ../../uaclient/messages/__init__.py:1770
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1772
+#: ../../uaclient/messages/__init__.py:1773
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1776
+#: ../../uaclient/messages/__init__.py:1777
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1781
+#: ../../uaclient/messages/__init__.py:1782
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1789
+#: ../../uaclient/messages/__init__.py:1790
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1798
+#: ../../uaclient/messages/__init__.py:1799
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1806
+#: ../../uaclient/messages/__init__.py:1807
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1810
+#: ../../uaclient/messages/__init__.py:1811
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1815
+#: ../../uaclient/messages/__init__.py:1816
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "support."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1823
+#: ../../uaclient/messages/__init__.py:1824
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2545,7 +2550,7 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1832
+#: ../../uaclient/messages/__init__.py:1833
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not supported by livepatch.\n"
@@ -2554,79 +2559,79 @@ msgid ""
 "dismiss this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1842
+#: ../../uaclient/messages/__init__.py:1843
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1848
+#: ../../uaclient/messages/__init__.py:1849
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1857
+#: ../../uaclient/messages/__init__.py:1858
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1864
+#: ../../uaclient/messages/__init__.py:1865
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1871
+#: ../../uaclient/messages/__init__.py:1872
 msgid "Livepatch is not currently supported for the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1876
+#: ../../uaclient/messages/__init__.py:1877
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1880
+#: ../../uaclient/messages/__init__.py:1881
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1885
+#: ../../uaclient/messages/__init__.py:1886
 msgid "ROS packages assume ESM updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1890
+#: ../../uaclient/messages/__init__.py:1891
 msgid "ROS bug-fix updates assume ROS security fix updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1896
+#: ../../uaclient/messages/__init__.py:1897
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1900
+#: ../../uaclient/messages/__init__.py:1901
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1904
+#: ../../uaclient/messages/__init__.py:1905
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1908
+#: ../../uaclient/messages/__init__.py:1909
 msgid "unattended-upgrades package is not installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1914
+#: ../../uaclient/messages/__init__.py:1915
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1923
+#: ../../uaclient/messages/__init__.py:1924
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1930
+#: ../../uaclient/messages/__init__.py:1931
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2636,28 +2641,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1949
+#: ../../uaclient/messages/__init__.py:1950
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1955
+#: ../../uaclient/messages/__init__.py:1956
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1985
+#: ../../uaclient/messages/__init__.py:1986
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1990
+#: ../../uaclient/messages/__init__.py:1991
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1996
+#: ../../uaclient/messages/__init__.py:1997
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2665,107 +2670,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2006
+#: ../../uaclient/messages/__init__.py:2007
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2013
+#: ../../uaclient/messages/__init__.py:2014
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2018
+#: ../../uaclient/messages/__init__.py:2019
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2022
+#: ../../uaclient/messages/__init__.py:2023
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2026
+#: ../../uaclient/messages/__init__.py:2027
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2031
+#: ../../uaclient/messages/__init__.py:2032
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2036
+#: ../../uaclient/messages/__init__.py:2037
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2041
+#: ../../uaclient/messages/__init__.py:2042
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2047
+#: ../../uaclient/messages/__init__.py:2048
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2053
+#: ../../uaclient/messages/__init__.py:2054
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2057
+#: ../../uaclient/messages/__init__.py:2058
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2063
+#: ../../uaclient/messages/__init__.py:2064
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2071
+#: ../../uaclient/messages/__init__.py:2072
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2077
+#: ../../uaclient/messages/__init__.py:2078
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2086
+#: ../../uaclient/messages/__init__.py:2087
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2093
+#: ../../uaclient/messages/__init__.py:2094
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2100
+#: ../../uaclient/messages/__init__.py:2101
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2105
+#: ../../uaclient/messages/__init__.py:2106
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2111
+#: ../../uaclient/messages/__init__.py:2112
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2773,7 +2778,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2121
+#: ../../uaclient/messages/__init__.py:2122
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2781,7 +2786,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2131
+#: ../../uaclient/messages/__init__.py:2132
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2789,41 +2794,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2141
+#: ../../uaclient/messages/__init__.py:2142
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2148
+#: ../../uaclient/messages/__init__.py:2149
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2154
+#: ../../uaclient/messages/__init__.py:2155
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2160
+#: ../../uaclient/messages/__init__.py:2161
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2165
+#: ../../uaclient/messages/__init__.py:2166
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2171
+#: ../../uaclient/messages/__init__.py:2172
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2179
+#: ../../uaclient/messages/__init__.py:2180
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2188
+#: ../../uaclient/messages/__init__.py:2189
 #, python-brace-format
 msgid ""
 "Cannot {{operation}} services when unattached - nothing to do.\n"
@@ -2832,74 +2837,74 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2205
+#: ../../uaclient/messages/__init__.py:2206
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2210
+#: ../../uaclient/messages/__init__.py:2211
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2215
+#: ../../uaclient/messages/__init__.py:2216
 #, python-brace-format
 msgid "failed to enable {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2220
+#: ../../uaclient/messages/__init__.py:2221
 #, python-brace-format
 msgid "failed to disable {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2226
+#: ../../uaclient/messages/__init__.py:2227
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2234
+#: ../../uaclient/messages/__init__.py:2235
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2242
+#: ../../uaclient/messages/__init__.py:2243
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2249
+#: ../../uaclient/messages/__init__.py:2250
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2256
+#: ../../uaclient/messages/__init__.py:2257
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2265
+#: ../../uaclient/messages/__init__.py:2266
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2271
+#: ../../uaclient/messages/__init__.py:2272
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2279
+#: ../../uaclient/messages/__init__.py:2280
 #, python-brace-format
 msgid ""
 "Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2287
+#: ../../uaclient/messages/__init__.py:2288
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2296
+#: ../../uaclient/messages/__init__.py:2297
 #, python-brace-format
 msgid ""
 "Failed to identify this image as a valid Ubuntu Pro image.\n"
@@ -2907,14 +2912,14 @@ msgid ""
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2306
+#: ../../uaclient/messages/__init__.py:2307
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2313
+#: ../../uaclient/messages/__init__.py:2314
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -2922,41 +2927,41 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2323
+#: ../../uaclient/messages/__init__.py:2324
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2330
+#: ../../uaclient/messages/__init__.py:2331
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2338
+#: ../../uaclient/messages/__init__.py:2339
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2347
+#: ../../uaclient/messages/__init__.py:2348
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2355
+#: ../../uaclient/messages/__init__.py:2356
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2361
+#: ../../uaclient/messages/__init__.py:2362
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2369
+#: ../../uaclient/messages/__init__.py:2370
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -2964,7 +2969,7 @@ msgid ""
 "and the VERSION_CODENAME information is not present"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2379
+#: ../../uaclient/messages/__init__.py:2380
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -2973,208 +2978,208 @@ msgid ""
 "$ sudo rm {lock_file_path}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2388
+#: ../../uaclient/messages/__init__.py:2389
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2394
+#: ../../uaclient/messages/__init__.py:2395
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
 "Expected {expected_value}, found {value}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2403
+#: ../../uaclient/messages/__init__.py:2404
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2410
+#: ../../uaclient/messages/__init__.py:2411
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2415
+#: ../../uaclient/messages/__init__.py:2416
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2421
+#: ../../uaclient/messages/__init__.py:2422
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
 "Cancelling config process operation.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2431
+#: ../../uaclient/messages/__init__.py:2432
 msgid "Can't load the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2436
+#: ../../uaclient/messages/__init__.py:2437
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2441
+#: ../../uaclient/messages/__init__.py:2442
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2445
+#: ../../uaclient/messages/__init__.py:2446
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2451
+#: ../../uaclient/messages/__init__.py:2452
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
 "Usage: \"pro fix CVE-yyyy-nnnn\" or \"pro fix USN-nnnn\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2457
+#: ../../uaclient/messages/__init__.py:2458
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2462
+#: ../../uaclient/messages/__init__.py:2463
 #, python-brace-format
 msgid "Empty value provided for {arg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2467
+#: ../../uaclient/messages/__init__.py:2468
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2471
+#: ../../uaclient/messages/__init__.py:2472
 msgid "Unable to process uaclient.conf"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2476
+#: ../../uaclient/messages/__init__.py:2477
 msgid "Unable to refresh your subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2481
+#: ../../uaclient/messages/__init__.py:2482
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2487
+#: ../../uaclient/messages/__init__.py:2488
 msgid "json formatted response requires --assume-yes flag."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2495
+#: ../../uaclient/messages/__init__.py:2496
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
 "    "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2504
+#: ../../uaclient/messages/__init__.py:2505
 msgid "Cannot provide both --args and --data at the same time"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2509
+#: ../../uaclient/messages/__init__.py:2510
 msgid "Operation cancelled by user"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2515
+#: ../../uaclient/messages/__init__.py:2516
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2524
+#: ../../uaclient/messages/__init__.py:2525
 msgid "This command must be run as root (try using sudo)."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2529
+#: ../../uaclient/messages/__init__.py:2530
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2536
+#: ../../uaclient/messages/__init__.py:2537
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2540
+#: ../../uaclient/messages/__init__.py:2541
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2545
+#: ../../uaclient/messages/__init__.py:2546
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2550
+#: ../../uaclient/messages/__init__.py:2551
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2555
+#: ../../uaclient/messages/__init__.py:2556
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2560
+#: ../../uaclient/messages/__init__.py:2561
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
 "{data}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2565
+#: ../../uaclient/messages/__init__.py:2566
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2570
+#: ../../uaclient/messages/__init__.py:2571
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2575
+#: ../../uaclient/messages/__init__.py:2576
 msgid "features.disable_auto_attach set in config"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2580
+#: ../../uaclient/messages/__init__.py:2581
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2586
+#: ../../uaclient/messages/__init__.py:2587
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2592
+#: ../../uaclient/messages/__init__.py:2593
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2598
+#: ../../uaclient/messages/__init__.py:2599
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2605
+#: ../../uaclient/messages/__init__.py:2606
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2616
+#: ../../uaclient/messages/__init__.py:2617
 #, python-brace-format
 msgid "Error updating ESM services cache: {error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2622
+#: ../../uaclient/messages/__init__.py:2623
 #, python-brace-format
 msgid ""
 "There is a problem with the resource directives provided by {url}\n"
@@ -3184,15 +3189,15 @@ msgid ""
 "These directives need to be unique for every entitlement."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2631
+#: ../../uaclient/messages/__init__.py:2632
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2637
+#: ../../uaclient/messages/__init__.py:2638
 msgid ""
 "You must use the pro command to purge a service that has installed a kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2644
+#: ../../uaclient/messages/__init__.py:2645
 msgid "The operation is not supported"
 msgstr ""

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -207,10 +207,6 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Pro
       """
       This machine is now attached to
       """
-    And stderr matches regexp:
-      """
-      Enabling default service esm-infra
-      """
     And I verify that `esm-infra` is enabled
 
     Examples: ubuntu release livepatch status

--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -668,20 +668,20 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     When I attach `contract_token` with sudo
     Then stdout matches regexp:
       """
-      Updating Ubuntu Pro: ESM Infra package lists
+      Enabling Ubuntu Pro: ESM Infra
       Ubuntu Pro: ESM Infra enabled
-      Installing snapd snap
-      Installing canonical-livepatch snap
-      Canonical Livepatch enabled
+      Enabling Livepatch
+      Livepatch enabled
       """
     When I run `pro disable livepatch` with sudo
     And I run `pro enable fips --assume-yes` with sudo
     Then I will see the following on stdout:
       """
       One moment, checking your subscription first
+      Configuring APT access to FIPS
       Updating FIPS package lists
-      Installing FIPS packages
       Updating standard Ubuntu package lists
+      Installing FIPS packages
       FIPS enabled
       A reboot is required to complete install.
       """
@@ -695,6 +695,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
       One moment, checking your subscription first
       Cannot enable Livepatch when FIPS is enabled.
+      Could not enable Livepatch.
       """
     Then I verify that running `pro enable livepatch --format json --assume-yes` `with sudo` exits `1`
     And I will see the following on stdout
@@ -707,11 +708,10 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     When I attach `contract_token` with sudo
     Then stdout matches regexp:
       """
-      Updating Ubuntu Pro: ESM Infra package lists
+      Enabling Ubuntu Pro: ESM Infra
       Ubuntu Pro: ESM Infra enabled
-      Installing snapd snap
-      Installing canonical-livepatch snap
-      Canonical Livepatch enabled
+      Enabling Livepatch
+      Livepatch enabled
       """
     When I append the following on uaclient config:
       """
@@ -722,7 +722,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     And I will see the following on stdout
       """
       One moment, checking your subscription first
-      Cannot enable FIPS when Livepatch is enabled.
+      Cannot enable Livepatch when FIPS is enabled.
+      Could not enable Livepatch.
       """
     Then I verify that running `pro enable fips --assume-yes --format json` `with sudo` exits `1`
     And stdout is a json matching the `ua_operation` schema
@@ -737,13 +738,12 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     When I attach `contract_token` with sudo
     Then stdout matches regexp:
       """
-      Updating Ubuntu Pro: ESM Infra package lists
       Ubuntu Pro: ESM Infra enabled
       """
     And stdout matches regexp:
       """
-      Installing canonical-livepatch snap
-      Canonical Livepatch enabled
+      Enabling Livepatch
+      Livepatch enabled
       """
     When I run `pro enable fips --assume-yes` with sudo
     Then I will see the following on stdout
@@ -781,8 +781,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
     And stdout matches regexp:
       """
-      Installing canonical-livepatch snap
-      Canonical Livepatch enabled
+      Enabling Livepatch
+      Livepatch enabled
       """
     When I run `pro disable livepatch` with sudo
     And I run `pro enable fips-updates --assume-yes` with sudo
@@ -799,7 +799,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     Then I will see the following on stdout
       """
       One moment, checking your subscription first
-      Cannot enable FIPS when FIPS Updates is enabled.
+      Cannot enable Livepatch when FIPS is enabled.
+      Could not enable Livepatch.
       """
 
     Examples: ubuntu release

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -241,7 +241,16 @@ def enable_entitlement_by_name(
         access_only=access_only,
         extra_args=extra_args,
     )
-    return entitlement.enable(api.ProgressWrapper())
+
+    if not silent:
+        event.info(messages.ENABLING_TMPL.format(title=entitlement.title))
+
+    ent_ret, reason = entitlement.enable(api.ProgressWrapper())
+
+    if ent_ret and not silent:
+        event.info(messages.ENABLED_TMPL.format(title=entitlement.title))
+
+    return ent_ret, reason
 
 
 def status(

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -316,6 +316,7 @@ DETACH_SUCCESS = t.gettext("This machine is now detached.")
 REFRESH_CONTRACT_ENABLE = t.gettext(
     "One moment, checking your subscription first"
 )
+ENABLING_TMPL = t.gettext("Enabling {title}")
 ENABLED_TMPL = t.gettext("{title} enabled")
 ACCESS_ENABLED_TMPL = t.gettext("{title} access enabled")
 ENABLE_FAILED = t.gettext("Could not enable {title}.")


### PR DESCRIPTION
## Why is this needed?
Right now, we are no longer showing enable service related messages on attach. That is because on a future refactor, we will start using our APIs for the attach operation and those messages will change. However, while this doesn't happen, it is better to at least inform the user what services are being enabled during attach.

## Test Steps
Run the modified integration tests

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [ ] No
