### PR TITLE
apt-news: package selectors should be ORed together

### DIFF
--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -952,6 +952,36 @@ Feature: APT Messages
       # two
       #
       """
+    # Still displayed if one package selector fails
+    When I create the file `/var/www/html/aptnews.json` on the `apt-news-server` machine with the following:
+      """
+      {
+        "messages": [
+          {
+            "begin": "$behave_var{today}",
+            "selectors": {
+              "packages": [
+                  ["<package>", "==", "<installed_version>"],
+                  ["linux", "<", "1"]
+              ]
+            },
+            "lines": [
+              "one",
+              "two"
+            ]
+          }
+        ]
+      }
+      """
+    And I run `pro refresh messages` with sudo
+    And I apt upgrade
+    Then stdout contains substring:
+      """
+      #
+      # one
+      # two
+      #
+      """
     # Testing multiple selectors together
     When I create the file `/var/www/html/aptnews.json` on the `apt-news-server` machine with the following:
       """

--- a/uaclient/tests/test_apt_news.py
+++ b/uaclient/tests/test_apt_news.py
@@ -20,7 +20,7 @@ class TestAptNews:
             "cloud_type",
             "attached",
             "architecture",
-            "package_version",
+            "package_version_side_effect",
             "expected",
         ],
         [
@@ -131,7 +131,7 @@ class TestAptNews:
                 (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 True,
                 None,
-                "1.0.0",
+                ["1.0.0"],
                 True,
             ),
             (
@@ -142,7 +142,7 @@ class TestAptNews:
                 (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 True,
                 None,
-                None,
+                [None],
                 False,
             ),
             (
@@ -153,7 +153,7 @@ class TestAptNews:
                 (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 False,
                 None,
-                "1.0.0",
+                ["1.0.0"],
                 False,
             ),
             (
@@ -164,7 +164,7 @@ class TestAptNews:
                 (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 False,
                 None,
-                "1.0.1",
+                ["1.0.1"],
                 False,
             ),
             (
@@ -175,7 +175,7 @@ class TestAptNews:
                 (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 False,
                 None,
-                "1.0.1",
+                ["1.0.1"],
                 True,
             ),
             (
@@ -186,7 +186,7 @@ class TestAptNews:
                 (None, NoCloudTypeReason.NO_CLOUD_DETECTED),
                 False,
                 None,
-                "0.0.1",
+                ["0.0.1"],
                 True,
             ),
             (
@@ -201,7 +201,7 @@ class TestAptNews:
                 ("aws", None),
                 False,
                 "arm4",
-                "0.0.7",
+                ["0.0.7"],
                 False,
             ),
             (
@@ -216,7 +216,26 @@ class TestAptNews:
                 ("gce", None),
                 False,
                 "amd64",
-                "1.0.1",
+                ["1.0.1"],
+                True,
+            ),
+            (
+                apt_news.AptNewsMessageSelectors(
+                    codenames=["bionic"],
+                    pro=False,
+                    clouds=["gce"],
+                    architectures=["amd64"],
+                    packages=[
+                        ["does-not-match", "<", "4~"],
+                        ["matches", ">", "1.0.0"],
+                        ["not-installed", "<", "1"],
+                    ],
+                ),
+                "bionic",
+                ("gce", None),
+                False,
+                "amd64",
+                ["4", "1.0.1", None],
                 True,
             ),
         ],
@@ -236,7 +255,7 @@ class TestAptNews:
         cloud_type,
         attached,
         architecture,
-        package_version,
+        package_version_side_effect,
         expected,
         FakeConfig,
     ):
@@ -247,7 +266,7 @@ class TestAptNews:
         m_get_platform_info.return_value = mock.MagicMock(series=series)
         m_get_cloud_type.return_value = cloud_type
         m_get_dpkg_arch.return_value = architecture
-        m_get_pkg_version.return_value = package_version
+        m_get_pkg_version.side_effect = package_version_side_effect
         assert expected == apt_news.do_selectors_apply(cfg, selectors)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
Sorry @lucasmoura @athos-ribeiro I noticed a difference between this new feature as implemented and the spec

Fixes: #3088

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
The new test fails before the change and passes after this change.

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
