### PR TITLE
Do Not Merge: `pro system certified` command test implementation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-advantage-tools (32~0+hw) noble; urgency=medium
+
+  * toy implementation of the hardware certification command
+
+ -- Renan Rodrigo <renanrodrigo@canonical.com>  Tue, 30 Apr 2024 21:40:21 -0300
+
 ubuntu-advantage-tools (31.2) noble; urgency=medium
 
   * properly rename logrotate conffile to avoid duplicate confiles, keep user changes

--- a/uaclient/cli/certification.py
+++ b/uaclient/cli/certification.py
@@ -1,0 +1,134 @@
+import os
+from datetime import datetime
+
+from uaclient.apt import is_installed, run_apt_command, run_apt_install_command
+from uaclient.exceptions import AnonymousUbuntuProError, UbuntuProError
+from uaclient.messages import NamedMessage
+from uaclient.system import write_file
+from uaclient.util import prompt_for_confirmation, we_are_currently_root
+
+SERIES_NOT_SUPPORTED = ["xenial", "bionic", "focal"]
+
+
+def check_for_hwlib_package() -> bool:
+    if is_installed("hwlib"):
+        return True
+
+    if not we_are_currently_root():
+        print(
+            "To get certification status, the 'hwlib' package "
+            "needs to be installed."
+        )
+        print("Run this command as root, or install it by running:")
+        print("    sudo apt install hwlib")
+        return False
+
+    if not prompt_for_confirmation(
+        "To get certification status, the 'hwlib' package "
+        "needs to be installed.\nDo you want to install it now? (Y/n)",
+        default=True,
+    ):
+        return False
+
+    print("Installing 'hwlib'")
+    try:
+        # In the future, the package will be in the archive, no need for a PPA
+        run_apt_command(["apt-add-repository", "ppa:nhutsko/ppa", "-y"])
+        run_apt_install_command(
+            ["hwlib"],
+            apt_options=[
+                "--allow-downgrades",
+                '-o Dpkg::Options::="--force-confdef"',
+                '-o Dpkg::Options::="--force-confold"',
+            ],
+            override_env_vars={"DEBIAN_FRONTEND": "noninteractive"},
+        )
+    except UbuntuProError:
+        # The actual implementation will have proper exceptions
+        raise AnonymousUbuntuProError(
+            named_msg=NamedMessage(
+                "could-not-install-hwlib",
+                "Error trying to install the 'hwlib' package.\n"
+                "Try to install it by running:"
+                "    sudo apt install hwlib",
+            )
+        )
+
+    return True
+
+
+def check_for_data_collection_consent() -> bool:
+    # In the future, there will be a hwlib api to check for this instead of
+    # just checking for the file.
+    if os.path.exists("/var/lib/hwlib/consent"):
+        return True
+
+    if not we_are_currently_root():
+        # In the future, there will be a URL here with the details
+        # about data collection.
+        print(
+            "To check for certification status, data from your system needs to"
+            " be sent to our servers. Details about the data can be checked in"
+            " <URL>."
+        )
+        print(
+            "To agree with sending hardware data, "
+            "please run this command as root."
+        )
+        return False
+
+    if not prompt_for_confirmation(
+        "To check for certification status, data from your system needs to"
+        " be sent to our servers. Details about the data can be checked in"
+        " <URL>.\n"
+        "Do you agree with sending hardware data for checking? (y/N)"
+    ):
+        print(
+            "The client needs user consent to check "
+            "for the certification status."
+        )
+        return False
+
+    write_file("/var/lib/hwlib/consent", datetime.now().isoformat())
+    return True
+
+
+def get_certification_status() -> str:
+    try:
+        import hwlib  # type: ignore
+    except ImportError:
+        raise AnonymousUbuntuProError(
+            named_msg=NamedMessage(
+                "import-hwlib-without-installing",
+                "Trying to import 'hwlib' but it is not installed."
+                "Please install the package and try again.",
+            )
+        )
+
+    # In the future, the empty string here will not be mandatory -
+    # it will be a default, configurable in the
+    # hwlib side. We should not hardcode anything here.
+    response = hwlib.get_certification_status("")
+
+    status = response.get("status", None)
+    if status is None:
+        raise AnonymousUbuntuProError(
+            named_msg=NamedMessage(
+                "no-status-from-hwlib",
+                "The 'hwlib' client did not return a valid status "
+                "for certification.\nThis error message can be more "
+                "descriptive in the future on what to check for."
+            )
+        )
+
+    if status == "Not Seen":
+        # We intentionally give no additional details here.
+        return "No"
+    elif status == "Partially Certified":
+        # For a partially certified system, we can give a list of which
+        # hardware is actually certified.
+        return "Partially"
+    else:
+        # In the future, besides saying yes, hwlib will give us a link
+        # to the certification page which will cover everything.
+        return "Yes"

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1053,6 +1053,21 @@ for the machine regarding reboot:
 """
 )
 
+CLI_SYSTEM_CERTIFIED = t.gettext("is this machine Ubuntu certified")
+CLI_SYSTEM_CERTIFIED_DESC = t.gettext(
+    """\
+Report the current certification status for the machine.
+
+This command will output one of the three following states
+for the machine regarding certification:
+
+* Yes: This machine is Ubuntu certified
+* No: This machine is not Ubuntu certified
+* Partially: Some pieces of hardware on this machine have been
+  certified for Ubuntu, but not the whole system.
+"""
+)
+
 CLI_STATUS_DESC = t.gettext(
     """\
 Report current status of Ubuntu Pro services on system.

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -14,7 +14,7 @@ from uaclient.defaults import CANDIDATE_CACHE_PATH, UAC_RUN_PATH
 from uaclient.exceptions import ProcessExecutionError
 from uaclient.system import subp
 
-__VERSION__ = "31.2"
+__VERSION__ = "32~0+hw"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 


### PR DESCRIPTION
## Why is this needed?
This is the diff with the code that was built and uploaded to https://launchpad.net/~ua-client/+archive/ubuntu/pro-hw-cert as part of SC-1665.

This diff implements an entrypoint in the Pro Client to verify if your system is Ubuntu Certified.

Please note:
- This is a stunt implementation, a toy version to test out how the UX will look like when running the command.
- Note I say `stunt` and not `stub` implementation for two reasons
  - to look cooler and funnier
  - because it actually implements some integration with the actual `hwlib` dependency so this is not purely a mock.
- The code has comments describing some expectation on how some things will improve in the future. Those expectations need to be fulfilled in the certifications side for us to be really happy.
- There are no unit or integration tests - those will be added when this actually becomes more real
- There are some simplifications in the implementations (like messages should actually go to the messages module, and proper exceptions need to be defined and raised) - forgive me, for I have sinned. I mean, this will be properly fixed when this becomes more real.

This will become more real when `hwlib` is ready (or at least readier) to land in the archive, with a well defined plan in mind about availability in different releases. Until then, iterations will be code-documented in this PR and published directly to our test-stage PPA.

## Test Steps
Install the package [from the PPA](https://launchpad.net/~ua-client/+archive/ubuntu/pro-hw-cert) and run the `pro system certified` command.
- On X, B, F you will get an error because this was intended to work from J
- On J and N you will get an error when trying to install the package, as the `hwlib` implementation was done only for `mantic` at the time of this writing. Of course if the package appears on J, N in the future, this will change.
- On M you will be able to test the whole flow. Try running it as non-root vs root, and responding no, then yes to the questions in the flow. This should match the previously specified flowchart in US098.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [x] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [x] Yes - in the future we will know better
 - [ ] No
