### PR TITLE
Add anchor link to trusty page

### DIFF
--- a/docs/howtoguides/trusty_legacy_support.rst
+++ b/docs/howtoguides/trusty_legacy_support.rst
@@ -1,3 +1,5 @@
+.. _enable_trusty:
+
 How to enable esm-infra-legacy on Trusty
 *****************************************
 


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because...we overlooked including a header anchor link
when creating the page
