### PR TITLE
tests: fix APT news tests for bionic

### DIFF
--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -79,6 +79,7 @@ Feature: APT Messages
   @uses.config.contract_token
   Scenario Outline: APT Hook advertises esm-infra on upgrade
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I remove support for `backports` in APT
     When I apt update
     When I apt upgrade
     When I apt autoremove
@@ -200,6 +201,7 @@ Feature: APT Messages
   Scenario Outline: APT News
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo
+    When I remove support for `backports` in APT
     When I apt upgrade including phased updates
     When I apt autoremove
     When I apt install `jq`
@@ -685,6 +687,7 @@ Feature: APT Messages
   @uses.config.contract_token
   Scenario Outline: APT news selectors
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I remove support for `backports` in APT
     When I attach `contract_token` with sudo
     When I apt upgrade including phased updates
     When I apt autoremove

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -204,6 +204,9 @@ Feature: APT Messages
     When I apt autoremove
     When I apt install `jq`
     When I run `pro detach --assume-yes` with sudo
+    # We are doing this because ESM pin might prevent some packages to be upgraded (i.e.
+    # distro-info-data)
+    When I apt upgrade
     Given a `focal` `<machine_type>` machine named `apt-news-server`
     When I apt install `nginx` on the `apt-news-server` machine
     When I run `sed -i "s/gzip on;/gzip on;\n\tgzip_min_length 1;\n\tgzip_types application\/json;\n/" /etc/nginx/nginx.conf` `with sudo` on the `apt-news-server` machine
@@ -687,6 +690,9 @@ Feature: APT Messages
     When I apt autoremove
     When I apt install `jq`
     When I run `pro detach --assume-yes` with sudo
+    # We are doing this because ESM pin might prevent some packages to be upgraded (i.e.
+    # distro-info-data)
+    When I apt upgrade
     Given a `mantic` `<machine_type>` machine named `apt-news-server`
     When I apt install `nginx` on the `apt-news-server` machine
     When I run `sed -i "s/gzip on;/gzip on;\n\tgzip_min_length 1;\n\tgzip_types application\/json;\n/" /etc/nginx/nginx.conf` `with sudo` on the `apt-news-server` machine

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -532,6 +532,8 @@ Feature: Ua fix command behaviour
 
       Choose: \[E\]nable esm-infra \[C\]ancel
       > .*\{ pro enable esm-infra \}.*
+      Enabling Ubuntu Pro: ESM Infra
+      Ubuntu Pro: ESM Infra enabled
       .*\{ apt update && apt install --only-upgrade -y gzip \}.*
 
       .*✔.* USN-5378-4 is resolved.

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -221,6 +221,19 @@ def given_a_sut_machine(context, series, machine_type):
         "--- instance ip: {}".format(context.machines[SUT].instance.ip)
     )
 
+    # There is a problem on Xenial where distro-info-data was incorrectly
+    # saying that Xenial was only supported until 2024. The fix was
+    # SRUed to Xenial, but now we need to guarantee that we run our tests
+    # on the latest version of that package. Additionally, we don't see
+    # a problem of always upgrading that package for every release.
+    when_i_run_command(
+        context,
+        "apt install distro-info-data -y",
+        "with sudo",
+    )
+    # And this will kick of the ESM cache setup
+    when_i_apt_update(context)
+
 
 @given(
     "a `{series}` `{machine_type}` machine with ubuntu-advantage-tools installed adding this cloud-init user_data"  # noqa: E501

--- a/features/steps/packages.py
+++ b/features/steps/packages.py
@@ -16,6 +16,17 @@ def when_i_autoremove(context):
     )
 
 
+@when("I remove support for `{pocket}` in APT")
+def when_i_remove_support_for_pocket(context, pocket):
+    when_i_run_command(
+        context,
+        "sed -i '/{}/d' /etc/apt/sources.list".format(pocket),
+        "with sudo",
+    )
+
+    when_i_apt_update(context)
+
+
 @when("I apt dist-upgrade")
 def when_i_dist_update(context):
     when_i_run_command(


### PR DESCRIPTION
## Why is this needed?
On Bionic, the distro-info-data package version is bigger than what we have on ESM. Therefore, if we upgrade when attached, we will get the ESM version, due to the pin file. After we detach and run apt upgrade, distro-info-data will then be upgraded. Since our tests required that we have no packages to upgrade when checking the apt news messages, we are now adding an additional apt upgrade step after we detach just to get rid of this issue.

## Test Steps
Check that the APT News bionic tests are now passing

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
