### PR TITLE
drop support for beta functionality

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -281,7 +281,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
       This command must be run as root (try using sudo).
       """
-    And I verify that running `pro enable esm-apps --beta` `with sudo` exits `1`
+    And I verify that running `pro enable esm-apps` `with sudo` exits `1`
     And I will see the following on stdout:
       """
       One moment, checking your subscription first

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -9,7 +9,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
       This command must be run as root (try using sudo).
       """
-    Then I verify that running `pro enable realtime-kernel --beta` `with sudo` exits `1`
+    Then I verify that running `pro enable realtime-kernel` `with sudo` exits `1`
     Then I will see the following on stdout:
       """
       One moment, checking your subscription first
@@ -29,7 +29,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
       This command must be run as root (try using sudo).
       """
-    Then I verify that running `pro enable realtime-kernel --beta` `with sudo` exits `1`
+    Then I verify that running `pro enable realtime-kernel` `with sudo` exits `1`
     Then I will see the following on stdout:
       """
       One moment, checking your subscription first

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -83,7 +83,6 @@ def _enable_default_services(
             ent_ret, reason = enable_entitlement_by_name(
                 cfg=cfg,
                 name=enable_by_default_service.name,
-                allow_beta=True,
                 variant=enable_by_default_service.variant,
                 silent=silent,
             )
@@ -218,7 +217,6 @@ def enable_entitlement_by_name(
     cfg: config.UAConfig,
     name: str,
     *,
-    allow_beta: bool = False,
     access_only: bool = False,
     variant: str = "",
     silent: bool = False,
@@ -234,7 +232,6 @@ def enable_entitlement_by_name(
         cfg=cfg,
         name=name,
         variant=variant,
-        allow_beta=allow_beta,
         access_only=access_only,
         extra_args=extra_args,
     )

--- a/uaclient/api/tests/test_api_u_pro_attach_auto_full_auto_attach_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_attach_auto_full_auto_attach_v1.py
@@ -24,36 +24,31 @@ class TestEnableServicesByName:
     @pytest.mark.parametrize(
         [
             "services",
-            "allow_beta",
             "enable_side_effect",
             "expected_enable_call_args",
             "expected_ret",
         ],
         [
-            # success one service, allow beta
+            # success one service
             (
                 ["esm-infra"],
-                True,
                 [(True, None)],
-                [mock.call(mock.ANY, "esm-infra", allow_beta=True)],
+                [mock.call(mock.ANY, "esm-infra")],
                 [],
             ),
-            # success multi service, no allow beta
+            # success multi service
             (
                 ["esm-apps", "esm-infra", "livepatch"],
-                False,
                 [(True, None), (True, None), (True, None)],
                 [
-                    mock.call(mock.ANY, "esm-apps", allow_beta=False),
+                    mock.call(mock.ANY, "esm-apps"),
                     mock.call(
                         mock.ANY,
                         "esm-infra",
-                        allow_beta=False,
                     ),
                     mock.call(
                         mock.ANY,
                         "livepatch",
-                        allow_beta=False,
                     ),
                 ],
                 [],
@@ -61,7 +56,6 @@ class TestEnableServicesByName:
             # fail via user facing error
             (
                 ["esm-apps", "esm-infra", "livepatch"],
-                False,
                 [
                     (True, None),
                     exceptions.EntitlementNotFoundError(
@@ -70,16 +64,14 @@ class TestEnableServicesByName:
                     fakes.FakeUbuntuProError(),
                 ],
                 [
-                    mock.call(mock.ANY, "esm-apps", allow_beta=False),
+                    mock.call(mock.ANY, "esm-apps"),
                     mock.call(
                         mock.ANY,
                         "esm-infra",
-                        allow_beta=False,
                     ),
                     mock.call(
                         mock.ANY,
                         "livepatch",
-                        allow_beta=False,
                     ),
                 ],
                 [
@@ -95,7 +87,6 @@ class TestEnableServicesByName:
             # fail via return
             (
                 ["esm-apps", "esm-infra", "livepatch"],
-                False,
                 [
                     (True, None),
                     (False, None),
@@ -108,16 +99,14 @@ class TestEnableServicesByName:
                     ),
                 ],
                 [
-                    mock.call(mock.ANY, "esm-apps", allow_beta=False),
+                    mock.call(mock.ANY, "esm-apps"),
                     mock.call(
                         mock.ANY,
                         "esm-infra",
-                        allow_beta=False,
                     ),
                     mock.call(
                         mock.ANY,
                         "livepatch",
-                        allow_beta=False,
                     ),
                 ],
                 [
@@ -135,13 +124,12 @@ class TestEnableServicesByName:
         self,
         m_enable_entitlement_by_name,
         services,
-        allow_beta,
         enable_side_effect,
         expected_enable_call_args,
         expected_ret,
     ):
         m_enable_entitlement_by_name.side_effect = enable_side_effect
-        ret = _enable_services_by_name(mock.MagicMock(), services, allow_beta)
+        ret = _enable_services_by_name(mock.MagicMock(), services)
         assert (
             m_enable_entitlement_by_name.call_args_list
             == expected_enable_call_args
@@ -174,7 +162,7 @@ class TestFullAutoAttachV1:
     ):
         cfg = FakeConfig()
 
-        def enable_ent_side_effect(cfg, name, allow_beta):
+        def enable_ent_side_effect(cfg, name):
             if name != "wrong":
                 return (True, None)
 
@@ -299,7 +287,7 @@ class TestFullAutoAttachV1:
                 False,
                 [mock.call(mock.ANY, mock.ANY, allow_enable=False)],
                 [[]],
-                [mock.call(mock.ANY, ["cis"], allow_beta=False)],
+                [mock.call(mock.ANY, ["cis"])],
                 does_not_raise(),
                 True,
                 None,
@@ -312,7 +300,7 @@ class TestFullAutoAttachV1:
                 False,
                 [mock.call(mock.ANY, mock.ANY, allow_enable=False)],
                 [[]],
-                [mock.call(mock.ANY, ["cis"], allow_beta=True)],
+                [mock.call(mock.ANY, ["cis"])],
                 does_not_raise(),
                 True,
                 None,
@@ -326,8 +314,8 @@ class TestFullAutoAttachV1:
                 [mock.call(mock.ANY, mock.ANY, allow_enable=False)],
                 [[], []],
                 [
-                    mock.call(mock.ANY, ["fips"], allow_beta=False),
-                    mock.call(mock.ANY, ["cis"], allow_beta=True),
+                    mock.call(mock.ANY, ["fips"]),
+                    mock.call(mock.ANY, ["cis"]),
                 ],
                 does_not_raise(),
                 True,
@@ -345,8 +333,8 @@ class TestFullAutoAttachV1:
                     [("cis", messages.NamedMessage("three", "four"))],
                 ],
                 [
-                    mock.call(mock.ANY, ["fips"], allow_beta=False),
-                    mock.call(mock.ANY, ["cis"], allow_beta=True),
+                    mock.call(mock.ANY, ["fips"]),
+                    mock.call(mock.ANY, ["cis"]),
                 ],
                 pytest.raises(exceptions.EntitlementsNotEnabledError),
                 True,

--- a/uaclient/api/tests/test_api_u_pro_services_enable_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_services_enable_v1.py
@@ -226,7 +226,6 @@ class TestEnable:
                     cfg=cfg,
                     name=options.service,
                     variant=options.variant or "",
-                    allow_beta=True,
                     access_only=options.access_only,
                 )
             ]

--- a/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
@@ -38,14 +38,12 @@ class FullAutoAttachResult(DataObject, AdditionalInfo):
 
 
 def _enable_services_by_name(
-    cfg: UAConfig, services: List[str], allow_beta: bool
+    cfg: UAConfig, services: List[str]
 ) -> List[Tuple[str, messages.NamedMessage]]:
     failed_services = []
     for name in order_entitlements_for_enabling(cfg, services):
         try:
-            ent_ret, reason = actions.enable_entitlement_by_name(
-                cfg, name, allow_beta=allow_beta
-            )
+            ent_ret, reason = actions.enable_entitlement_by_name(cfg, name)
         except exceptions.UbuntuProError as e:
             failed_services.append(
                 (name, messages.NamedMessage(e.msg_code or "unknown", e.msg))
@@ -117,13 +115,9 @@ def _full_auto_attach_in_lock(
 
     failed = []
     if options.enable is not None:
-        failed += _enable_services_by_name(
-            cfg, options.enable, allow_beta=False
-        )
+        failed += _enable_services_by_name(cfg, options.enable)
     if options.enable_beta is not None:
-        failed += _enable_services_by_name(
-            cfg, options.enable_beta, allow_beta=True
-        )
+        failed += _enable_services_by_name(cfg, options.enable_beta)
 
     contract_client = contract.UAContractClient(cfg)
     contract_client.update_activity_token()

--- a/uaclient/api/u/pro/services/enable/v1.py
+++ b/uaclient/api/u/pro/services/enable/v1.py
@@ -100,7 +100,6 @@ def _enable(
         cfg=cfg,
         name=options.service,
         variant=options.variant or "",
-        allow_beta=True,
         access_only=options.access_only,
     )
 

--- a/uaclient/cli/disable.py
+++ b/uaclient/cli/disable.py
@@ -191,9 +191,7 @@ def action_disable(args, *, cfg, **kwargs):
     if entitlements_not_found:
         ret = False
         valid_names = (
-            "Try "
-            + ", ".join(entitlements.valid_services(cfg=cfg, allow_beta=True))
-            + "."
+            "Try " + ", ".join(entitlements.valid_services(cfg=cfg)) + "."
         )
         service_msg = "\n".join(
             textwrap.wrap(

--- a/uaclient/cli/enable.py
+++ b/uaclient/cli/enable.py
@@ -44,7 +44,6 @@ _EnableOneServiceResult = NamedTuple(
 
 def _enable_landscape(
     cfg: config.UAConfig,
-    allow_beta: bool,
     access_only: bool,
     extra_args,
     progress_object: Optional[api.AbstractProgress] = None,
@@ -58,7 +57,6 @@ def _enable_landscape(
     progress = api.ProgressWrapper(progress_object)
     landscape = entitlements.LandscapeEntitlement(
         cfg,
-        allow_beta=allow_beta,
         called_name="landscape",
         access_only=access_only,
         extra_args=extra_args,
@@ -179,7 +177,6 @@ def _enable_one_service(
     cfg: config.UAConfig,
     ent_name: str,
     variant: str,
-    allow_beta: bool,
     access_only: bool,
     assume_yes: bool,
     json_output: bool,
@@ -194,7 +191,6 @@ def _enable_one_service(
         cfg,
         ent_name,
         variant=variant,
-        allow_beta=allow_beta,
         access_only=access_only,
         extra_args=extra_args,
     )
@@ -262,7 +258,6 @@ def _enable_one_service(
         if real_name == "landscape":
             enable_result = _enable_landscape(
                 cfg,
-                allow_beta,
                 access_only,
                 extra_args=extra_args,
                 progress_object=progress,
@@ -427,7 +422,6 @@ def action_enable(args, *, cfg, **kwargs) -> int:
             cfg,
             ent_name,
             variant,
-            args.beta,
             access_only,
             assume_yes,
             json_output,
@@ -449,7 +443,7 @@ def action_enable(args, *, cfg, **kwargs) -> int:
         ret = False
         failed_services += entitlements_not_found
         err = entitlements.create_enable_entitlements_not_found_error(
-            entitlements_not_found, cfg=cfg, allow_beta=args.beta
+            entitlements_not_found, cfg=cfg
         )
         interactive_only_print(err.msg)
         errors.append(

--- a/uaclient/cli/tests/test_cli.py
+++ b/uaclient/cli/tests/test_cli.py
@@ -129,7 +129,6 @@ class TestCLIParser:
             presentation_name="test",
             description=BIG_DESC,
             help_doc_url=BIG_URL,
-            is_beta=False,
         )
         m_get_user_log_file.return_value = tmpdir.join("user.log").strpath
         default_get_user_log_file = tmpdir.join("default.log").strpath
@@ -239,11 +238,10 @@ class TestCLIParser:
             (status.ContractStatus.UNENTITLED, "no"),
         ),
     )
-    @pytest.mark.parametrize("is_beta", (True, False))
     @mock.patch("uaclient.status.get_available_resources")
     @mock.patch("uaclient.status._is_attached")
     def test_help_command_when_attached(
-        self, m_attached, m_available_resources, ent_status, ent_msg, is_beta
+        self, m_attached, m_available_resources, ent_status, ent_msg
     ):
         """Test help command for a valid service in an attached pro client."""
         m_args = mock.MagicMock()
@@ -255,9 +253,7 @@ class TestCLIParser:
         m_ent_help_info = mock.PropertyMock(
             return_value="Test service\nService is being tested"
         )
-        m_is_beta = mock.PropertyMock(return_value=is_beta)
         m_entitlement_obj = mock.MagicMock()
-        type(m_entitlement_obj).is_beta = m_is_beta
         type(m_entitlement_obj).help_info = m_ent_help_info
 
         m_entitlement_obj.contract_status.return_value = ent_status
@@ -278,16 +274,12 @@ class TestCLIParser:
         status_msg = "enabled" if ent_msg == "yes" else "—"
         ufs_call_count = 1 if ent_msg == "yes" else 0
         ent_name_call_count = 2 if ent_msg == "yes" else 1
-        is_beta_call_count = 1 if status_msg == "enabled" else 0
 
         expected_msgs = [
             "Name:\ntest",
             "Entitled:\n{}".format(ent_msg),
             "Status:\n{}".format(status_msg),
         ]
-
-        if is_beta and status_msg == "enabled":
-            expected_msgs.append("Beta:\nTrue")
 
         expected_msgs.append(
             "Help:\nTest service\nService is being tested\n\n"
@@ -309,7 +301,6 @@ class TestCLIParser:
         assert 1 == m_available_resources.call_count
         assert 1 == m_attached.call_count
         assert 1 == m_ent_desc.call_count
-        assert is_beta_call_count == m_is_beta.call_count
         assert ent_name_call_count == m_ent_name.call_count
         assert 1 == m_entitlement_obj.contract_status.call_count
         assert (

--- a/uaclient/cli/tests/test_cli_attach.py
+++ b/uaclient/cli/tests/test_cli_attach.py
@@ -504,9 +504,7 @@ class TestActionAttach:
             mock.call(mock.ANY, token="faketoken", allow_enable=False)
         ] == m_attach_with_token.call_args_list
         if auto_enable:
-            assert [
-                mock.call(cfg, "cis", allow_beta=True)
-            ] == m_enable.call_args_list
+            assert [mock.call(cfg, "cis")] == m_enable.call_args_list
         else:
             assert [] == m_enable.call_args_list
         assert 1 == m_update_activity_token.call_count

--- a/uaclient/cli/tests/test_cli_disable.py
+++ b/uaclient/cli/tests/test_cli_disable.py
@@ -25,9 +25,7 @@ def all_service_msg(FakeConfig):
     ALL_SERVICE_MSG = "\n".join(
         textwrap.wrap(
             "Try "
-            + ", ".join(
-                entitlements.valid_services(cfg=FakeConfig(), allow_beta=True)
-            )
+            + ", ".join(entitlements.valid_services(cfg=FakeConfig()))
             + ".",
             width=80,
             break_long_words=False,

--- a/uaclient/cli/tests/test_cli_enable.py
+++ b/uaclient/cli/tests/test_cli_enable.py
@@ -279,7 +279,6 @@ class TestActionEnable:
                     variant="",
                     access_only=False,
                     assume_yes=True,
-                    beta=False,
                 ),
                 {},
                 None,
@@ -304,7 +303,6 @@ class TestActionEnable:
                         "three",
                         "",
                         False,
-                        False,
                         True,
                         True,
                         None,
@@ -316,7 +314,6 @@ class TestActionEnable:
                         "two",
                         "",
                         False,
-                        False,
                         True,
                         True,
                         None,
@@ -327,7 +324,6 @@ class TestActionEnable:
                         mock.ANY,
                         "one",
                         "",
-                        False,
                         False,
                         True,
                         True,
@@ -363,7 +359,6 @@ class TestActionEnable:
                     variant="",
                     access_only=False,
                     assume_yes=True,
-                    beta=False,
                 ),
                 {},
                 None,
@@ -381,7 +376,6 @@ class TestActionEnable:
                         mock.ANY,
                         "two",
                         "",
-                        False,
                         False,
                         True,
                         True,
@@ -429,7 +423,6 @@ class TestActionEnable:
                     variant="",
                     access_only=False,
                     assume_yes=True,
-                    beta=False,
                 ),
                 {},
                 None,
@@ -453,7 +446,6 @@ class TestActionEnable:
                         "two",
                         "",
                         False,
-                        False,
                         True,
                         True,
                         None,
@@ -464,7 +456,6 @@ class TestActionEnable:
                         mock.ANY,
                         "one",
                         "",
-                        False,
                         False,
                         True,
                         True,
@@ -581,7 +572,6 @@ class TestActionEnable:
                 {
                     "ent_name": "one",
                     "variant": "",
-                    "allow_beta": False,
                     "access_only": False,
                     "assume_yes": False,
                     "json_output": False,
@@ -614,7 +604,6 @@ class TestActionEnable:
                 {
                     "ent_name": "one",
                     "variant": "",
-                    "allow_beta": False,
                     "access_only": False,
                     "assume_yes": False,
                     "json_output": False,
@@ -647,7 +636,6 @@ class TestActionEnable:
                 {
                     "ent_name": "landscape",
                     "variant": "",
-                    "allow_beta": mock.sentinel.allow_beta,
                     "access_only": mock.sentinel.access_only,
                     "assume_yes": mock.sentinel.assume_yes,
                     "json_output": False,
@@ -667,7 +655,6 @@ class TestActionEnable:
                 [
                     mock.call(
                         mock.ANY,
-                        mock.sentinel.allow_beta,
                         mock.sentinel.access_only,
                         extra_args=mock.sentinel.extra_args,
                         progress_object=mock.sentinel.cli_progress,
@@ -684,7 +671,6 @@ class TestActionEnable:
                 {
                     "ent_name": "one",
                     "variant": mock.sentinel.variant,
-                    "allow_beta": mock.sentinel.allow_beta,
                     "access_only": mock.sentinel.access_only,
                     "assume_yes": mock.sentinel.assume_yes,
                     "json_output": False,
@@ -723,7 +709,6 @@ class TestActionEnable:
                 {
                     "ent_name": "one",
                     "variant": mock.sentinel.variant,
-                    "allow_beta": mock.sentinel.allow_beta,
                     "access_only": mock.sentinel.access_only,
                     "assume_yes": mock.sentinel.assume_yes,
                     "json_output": True,
@@ -855,7 +840,6 @@ class TestActionEnable:
         with expected_raises:
             assert expected_result == _enable_landscape(
                 FakeConfig,
-                mock.sentinel.allow_beta,
                 mock.sentinel.access_only,
                 mock.sentinel.extra_args,
                 None,
@@ -863,7 +847,6 @@ class TestActionEnable:
         assert [
             mock.call(
                 mock.ANY,
-                allow_beta=mock.sentinel.allow_beta,
                 called_name="landscape",
                 access_only=mock.sentinel.access_only,
                 extra_args=mock.sentinel.extra_args,

--- a/uaclient/cli/tests/test_cli_status.py
+++ b/uaclient/cli/tests/test_cli_status.py
@@ -136,7 +136,6 @@ Enable services with: pro enable <service>
 Technical support level: n/a
 """  # noqa: E501
 
-# Omit beta services from status
 ATTACHED_STATUS = """\
 SERVICE          ENTITLED  STATUS       DESCRIPTION
 esm-apps         no        {dash}            Expanded Security Maintenance for Applications

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -101,7 +101,6 @@ def entitlement_factory(tmpdir, FakeConfig, fake_machine_token_file):
         obligations: Dict[str, Any] = None,
         overrides: List[Dict[str, Any]] = None,
         entitled: bool = True,
-        allow_beta: bool = False,
         called_name: str = "",
         access_only: bool = False,
         purge: bool = False,
@@ -135,7 +134,6 @@ def entitlement_factory(tmpdir, FakeConfig, fake_machine_token_file):
             )
 
         args = {
-            "allow_beta": allow_beta or cfg.features.get("allow_beta"),
             "called_name": called_name,
             "access_only": access_only,
             "purge": purge,

--- a/uaclient/entitlements/tests/test_entitlements.py
+++ b/uaclient/entitlements/tests/test_entitlements.py
@@ -9,22 +9,13 @@ from uaclient.entitlements.entitlement_status import ApplicabilityStatus
 
 class TestValidServices:
     @pytest.mark.parametrize("show_all_names", ((True), (False)))
-    @pytest.mark.parametrize("allow_beta", ((True), (False)))
-    @pytest.mark.parametrize("is_beta", ((True), (False)))
-    @mock.patch("uaclient.entitlements.is_config_value_true")
     def test_valid_services(
         self,
-        m_is_config_value,
         show_all_names,
-        allow_beta,
-        is_beta,
         FakeConfig,
     ):
-        m_is_config_value.return_value = allow_beta
-
         m_cls_1 = mock.MagicMock()
         m_inst_1 = mock.MagicMock()
-        m_cls_1.is_beta = False
         type(m_cls_1).name = mock.PropertyMock(return_value="ent1")
         m_inst_1.presentation_name = "ent1"
         m_inst_1.valid_names = ["ent1", "othername"]
@@ -32,7 +23,6 @@ class TestValidServices:
 
         m_cls_2 = mock.MagicMock()
         m_inst_2 = mock.MagicMock()
-        m_cls_2.is_beta = is_beta
         type(m_cls_2).name = mock.PropertyMock(return_value="ent2")
         m_inst_2.presentation_name = "ent2"
         m_inst_2.valid_names = ["ent2"]
@@ -41,9 +31,7 @@ class TestValidServices:
         ents = {m_cls_1, m_cls_2}
 
         with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
-            expected_services = ["ent1"]
-            if allow_beta or not is_beta:
-                expected_services.append("ent2")
+            expected_services = ["ent1", "ent2"]
             if show_all_names:
                 expected_services.append("othername")
 

--- a/uaclient/files/tests/test_machine_token.py
+++ b/uaclient/files/tests/test_machine_token.py
@@ -12,7 +12,7 @@ from uaclient.files.machine_token import MachineTokenFile
 def all_resources_available(FakeConfig):
     resources = [
         {"name": name, "available": True}
-        for name in valid_services(cfg=FakeConfig(), allow_beta=True)
+        for name in valid_services(cfg=FakeConfig())
     ]
     return resources
 
@@ -21,7 +21,7 @@ def all_resources_available(FakeConfig):
 def all_resources_entitled(FakeConfig):
     resources = [
         {"type": name, "entitled": True}
-        for name in valid_services(cfg=FakeConfig(), allow_beta=True)
+        for name in valid_services(cfg=FakeConfig())
     ]
     return resources
 
@@ -30,7 +30,7 @@ def all_resources_entitled(FakeConfig):
 def no_resources_entitled(FakeConfig):
     resources = [
         {"type": name, "entitled": False}
-        for name in valid_services(cfg=FakeConfig(), allow_beta=True)
+        for name in valid_services(cfg=FakeConfig())
     ]
     return resources
 
@@ -39,7 +39,7 @@ def no_resources_entitled(FakeConfig):
 def resp_only_fips_resource_available(FakeConfig):
     resources = [
         {"name": name, "available": name == "fips"}
-        for name in valid_services(cfg=FakeConfig(), allow_beta=True)
+        for name in valid_services(cfg=FakeConfig())
     ]
     return resources
 


### PR DESCRIPTION
## Why is this needed?
The Pro client doesn't support any beta services at the moment. Additionally, we want to update our beta service logic for the next beta service we support. Due to that, we are removing the current code for beta support. However, we are keeping the beta related CLI entrypoints for compatibility reasons.

## Test Steps
Verify that none of our tests are impacted by this

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
