### PR TITLE
test: disable deprecation warnings on pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,7 @@ ignore = E203,E251,W503
 
 [pytest]
 log_format = %(filename)-25s %(lineno)4d %(levelname)-8s %(message)s
+filterwarnings = ignore::DeprecationWarning
 
 [behave]
 logging_level=info


### PR DESCRIPTION
## Why is this needed?
Due to our Xenial support, we have deprecated warnings our pytest tests. Since we are aware of that,
we are remove those deprecation warnings when running the command


## Test Steps
Run `tox -e test` and verify that the deprecation warnings are not there anymore

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
