### PR TITLE
Apparmor allow for /etc/os-release

### DIFF
--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -23,6 +23,10 @@ profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   /etc/apt/** r,
   /etc/default/apport r,
   /etc/ubuntu-advantage/* r,
+  # GH: #3109
+  # Allow reading the os-release file (possibly a symlink to /usr/lib).
+  /{etc/,usr/lib/}os-release r,
+
   /usr/bin/python3.{1,}[0-9] mrix,
 {% if ubuntu_codename in ["focal"] %}
   # "import uuid" in focal triggers an uname call

--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -27,6 +27,9 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
   /etc/apt/** r,
   /etc/machine-id r,
   /etc/ubuntu-advantage/uaclient.conf r,
+  # GH: #3109
+  # Allow reading the os-release file (possibly a symlink to /usr/lib).
+  /{etc/,usr/lib/}os-release r,
 
   /run/ubuntu-advantage/ rw,
   /run/ubuntu-advantage/** rw,


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because...


## Test Steps
Keep `sudo dmesg -wT | grep ubuntu_pro` running in a terminal (in the same VM, if testing in a VM, or in the host, if testing with a LXD container), and then run this on the system being tested (LXD or VM):
```
sudo rm /etc/os-release
sudo cp /usr/lib/os-release /etc
sudo rm -rf /var/lib/apt/periodic/*
sudo systemctl start esm-cache.service
```
there should be no apparmor DENIED message for an access to `/etc/os-release`.

Additionally, for a more surgical test, also run these:
```
sudo rm /etc/os-release
sudo cp /usr/lib/os-release /etc
sudo aa-exec -p ubuntu_pro_esm_cache cat /etc/os-release
```
On a system with the fixed apparmor profile, you should see the contents of /etc/os-release. With the bug, the last command above will return a permission denied error and dmesg will show a corresponding apparmor DENIED error.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No

Launchpad bug: LP: #2065573
Fixes: #3109 