### PR TITLE
apport: update path for timer jobs status file

### DIFF
--- a/apport/source_ubuntu-advantage-tools.py
+++ b/apport/source_ubuntu-advantage-tools.py
@@ -3,8 +3,9 @@ import tempfile
 
 from apport.hookutils import attach_file_if_exists
 from uaclient import defaults
-from uaclient.actions import collect_logs, APPARMOR_PROFILES
+from uaclient.actions import APPARMOR_PROFILES, collect_logs
 from uaclient.config import UAConfig
+from uaclient.files.state_files import timer_jobs_state_file
 
 
 def add_info(report, ui=None):
@@ -26,7 +27,7 @@ def add_info(report, ui=None):
             *apparmor_files,
             os.path.basename(cfg.cfg_path),
             os.path.basename(cfg.log_file),
-            os.path.basename(cfg.data_path("jobs-status")),
+            os.path.basename(timer_jobs_state_file.path),
             os.path.basename(defaults.CONFIG_DEFAULTS["log_file"]),
         }
         for f in auto_include_log_files:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-advantage-tools (32.1) oracular; urgency=medium
+
+  * d/apparmor: allow access for /etc/os-release on all supported
+    profiles (LP: #2065573)
+  * apport: get path for timer job status from the correct place (LP: #2065616)
+
+ -- Lucas Moura <lucas.moura@canonical.com>  Tue, 14 May 2024 11:22:35 +0200
+
 ubuntu-advantage-tools (32) oracular; urgency=medium
 
   * d/postinst: ensure migrations happen in correct package postinst (GH: #2982)

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -15,7 +15,7 @@ from uaclient.defaults import CANDIDATE_CACHE_PATH, UAC_RUN_PATH
 from uaclient.exceptions import ProcessExecutionError
 from uaclient.system import subp
 
-__VERSION__ = "32"
+__VERSION__ = "32.1"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 


### PR DESCRIPTION
## Why is this needed?
The path for the timer jobs status file is no longer being managed by the config module. Because of that, we need to update our apport script to fetch that data from the correct place. (LP: #2065616)


## Test Steps
Run `ubuntu-bug ubuntu-advantage-tools` and check that it doesn't crash

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
