### PR TITLE
apparmor esm_cache: add rules for violations detected during tests

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -96,7 +96,8 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     capability dac_read_search,
     capability dac_override,
 
-    ptrace read,
+    # GH: #3119
+    ptrace (read,trace),
 
     # in bionic, it's /bin/ps, so let's match both
     /{,usr/}bin/ps mrix,
@@ -278,9 +279,12 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     /run/systemd/** r,
 
     @{PROC}/cmdline r,
-    @{PROC}/1/cmdline r,
+    # GH: #3119
+    @{PROC}/1/* r,
     @{PROC}/@{pid}/stat r,
     @{PROC}/sys/kernel/osrelease r,
+    # GH: 3119
+    /sys/firmware/efi/efivars/** r,
   }
 
   profile ubuntu_pro_esm_cache_systemd_detect_virt flags=(attach_disconnected) {
@@ -297,6 +301,8 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     /run/systemd/** r,
 
     /sys/devices/virtual/** r,
+    # GH: #3119
+    /sys/firmware/efi/efivars/** r,
     @{PROC}/@{pid}/status r,
     @{PROC}/@{pid}/stat r,
     @{PROC}/1/environ r,

--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -293,7 +293,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     capability sys_ptrace,
 
     ptrace read peer=unconfined,
-{% if ubuntu_codename ["xenial"] %}
+{% if ubuntu_codename in ["xenial"] %}
     ptrace trace peer=unconfined,
 {% endif %}
     /usr/bin/systemd-detect-virt mr,


### PR DESCRIPTION
Fixes: #3119

## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because...

## Test Steps
Run behave lxd-vm tests on xenial and focal, which are the affected version from the linked github issue.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
