### PR TITLE
tests: change the Azure VM size on CI to B2s

### DIFF
--- a/features/cloud.py
+++ b/features/cloud.py
@@ -533,7 +533,7 @@ class Azure(Cloud):
         )
         inst = self.api.launch(
             image_id=image_name,
-            instance_type="Standard_A2_v2",
+            instance_type="Standard_B2s",
             user_data=user_data,
             inbound_ports=inbound_ports,
         )


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because the A2_v2 VMs we have been launching is not compatible with the latest daily noble images provided by pycloudlib.

Discarded Ideas:
- Changing the daily image on pycloudlib to `gen-1`: could affect other users of the lib for no good reason
- Passing the image string ourselves instead of querying pycloudlib: a different flow in our code for no good reason. And `gen-2` should be the default from now on.
- Opening an issue against pycloudlib to ask for images of different generations: could take potentially a lot of time there, and would still be a different code flow for us for no plausible reason.

Fixes: #3121

## Test Steps
From a branch with this patch:
`tox -e behave -- -D releases=noble -D machine_types=azure.generic`
Not sure if it passes but all machines get created.

Also, testing other images for other releases shows they are all supported on the new instance type.

## Checklist
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in:

## Does this PR require extra reviews?
 - [x] Yes - @paride could see it even after merged for an opinion :D
 - [ ] No
