### PR TITLE
chore: bump pycloudlib version

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -2,9 +2,8 @@
 behave
 jsonschema
 PyHamcrest
-pycloudlib==1!6.5.0
+pycloudlib==1!7.1.0
 requests
 toml==0.10
 
 ipdb
-


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we need to test Noble Pro on Azure

## Test Steps
trigger Noble Pro integration tests on Azure
see they running

## Checklist

 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: 

## Does this PR require extra reviews?
 - [ ] Yes
 - [x] No
