### PR TITLE
apparmor: deal with usr-merge consequences

### DIFF
--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -28,10 +28,10 @@ profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   /{etc/,usr/lib/}os-release r,
 
   /usr/bin/python3.{1,}[0-9] mrix,
-{% if ubuntu_codename in ["focal"] %}
   # "import uuid" in focal triggers an uname call
-  /usr/bin/uname mrix,
-{% endif %}
+  # And also see LP: #2067319
+  /{,usr/}bin/uname mrix,
+
   /usr/lib/apt/methods/http mrix,
   /usr/lib/apt/methods/https mrix,
   /usr/lib/ubuntu-advantage/apt_news.py r,

--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -25,16 +25,16 @@ profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   /etc/ubuntu-advantage/* r,
   # GH: #3109
   # Allow reading the os-release file (possibly a symlink to /usr/lib).
-  /{etc/,usr/lib/}os-release r,
+  /{etc/,usr/lib/,lib/}os-release r,
 
-  /usr/bin/python3.{1,}[0-9] mrix,
+  /{,usr/}bin/python3.{1,}[0-9] mrix,
   # "import uuid" in focal triggers an uname call
   # And also see LP: #2067319
   /{,usr/}bin/uname mrix,
 
-  /usr/lib/apt/methods/http mrix,
-  /usr/lib/apt/methods/https mrix,
-  /usr/lib/ubuntu-advantage/apt_news.py r,
+  /{,usr/}lib/apt/methods/http mrix,
+  /{,usr/}lib/apt/methods/https mrix,
+  /{,usr/}lib/ubuntu-advantage/apt_news.py r,
   /usr/share/dpkg/* r,
   /var/log/ubuntu-advantage.log rw,
   /var/lib/ubuntu-advantage/** r,

--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -41,10 +41,11 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
   /usr/bin/apt-cache mrix,
   /usr/bin/ischroot mrix,
   /usr/bin/python3.{1,}[0-9] mrix,
-  /usr/bin/uname mrix,
+  # LP: #2067319
+  /{,usr/}bin/uname mrix,
 
   /usr/bin/cloud-id Cx -> cloud_id,
-  # in bionic, it's /bin/ps, so let's match both
+  # LP: #2067319
   /{,usr/}bin/ps Cx -> ps,
   /usr/bin/systemd-detect-virt Px -> ubuntu_pro_esm_cache_systemd_detect_virt,
   /usr/bin/dpkg Cx -> dpkg,
@@ -99,7 +100,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     # GH: #3119
     ptrace (read,trace),
 
-    # in bionic, it's /bin/ps, so let's match both
+    # LP: #2067319
     /{,usr/}bin/ps mrix,
 
     /dev/tty r,
@@ -137,13 +138,15 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     /usr/bin/ r,
     /usr/bin/cloud-id r,
     /usr/bin/python3.{1,}[0-9] mrix,
-    /usr/bin/uname mrix,
+    # LP: #2067319
+    /{,usr/}bin/uname mrix,
 
     /usr/share/dpkg/** r,
 
     # workarounds for
     # https://gitlab.com/apparmor/apparmor/-/issues/346
-    /usr/bin/systemctl Px -> ubuntu_pro_esm_cache_systemctl,
+    # LP: #2067319
+    /{,usr/}bin/systemctl Px -> ubuntu_pro_esm_cache_systemctl,
     /usr/bin/systemd-detect-virt Px -> ubuntu_pro_esm_cache_systemd_detect_virt,
 
     /var/lib/cloud/** r,
@@ -273,7 +276,8 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     unix bind addr=@*/bus/systemctl/{,system},
 {% endif %}
 
-    /usr/bin/systemctl mr,
+    # LP: #2067319
+    /{,usr/}bin/systemctl mr,
 
     /run/systemd/private rw,
     /run/systemd/** r,

--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -29,7 +29,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
   /etc/ubuntu-advantage/uaclient.conf r,
   # GH: #3109
   # Allow reading the os-release file (possibly a symlink to /usr/lib).
-  /{etc/,usr/lib/}os-release r,
+  /{etc/,usr/lib/,lib/}os-release r,
 
   /run/ubuntu-advantage/ rw,
   /run/ubuntu-advantage/** rw,
@@ -37,25 +37,25 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
   /run/systemd/container/ r,
   /run/systemd/container/** r,
 
-  /usr/bin/apt mrix,
-  /usr/bin/apt-cache mrix,
-  /usr/bin/ischroot mrix,
-  /usr/bin/python3.{1,}[0-9] mrix,
+  /{,usr/}bin/apt mrix,
+  /{,usr/}bin/apt-cache mrix,
+  /{,usr/}bin/ischroot mrix,
+  /{,usr/}bin/python3.{1,}[0-9] mrix,
   # LP: #2067319
   /{,usr/}bin/uname mrix,
 
-  /usr/bin/cloud-id Cx -> cloud_id,
+  /{,usr/}bin/cloud-id Cx -> cloud_id,
   # LP: #2067319
   /{,usr/}bin/ps Cx -> ps,
-  /usr/bin/systemd-detect-virt Px -> ubuntu_pro_esm_cache_systemd_detect_virt,
-  /usr/bin/dpkg Cx -> dpkg,
-  /usr/bin/ubuntu-distro-info Cx -> ubuntu_distro_info,
-  /usr/lib/apt/methods/gpgv Cx -> apt_methods_gpgv,
-  /usr/lib/apt/methods/http Cx -> apt_methods,
-  /usr/lib/apt/methods/https Cx -> apt_methods,
-  /usr/lib/apt/methods/store Cx -> apt_methods,
+  /{,usr/}bin/systemd-detect-virt Px -> ubuntu_pro_esm_cache_systemd_detect_virt,
+  /{,usr/}bin/dpkg Cx -> dpkg,
+  /{,usr/}bin/ubuntu-distro-info Cx -> ubuntu_distro_info,
+  /{,usr/}lib/apt/methods/gpgv Cx -> apt_methods_gpgv,
+  /{,usr/}lib/apt/methods/http Cx -> apt_methods,
+  /{,usr/}lib/apt/methods/https Cx -> apt_methods,
+  /{,usr/}lib/apt/methods/store Cx -> apt_methods,
   # when there is no status.json cached, esm-cache.service will invoke "snap status"
-  /usr/bin/snap PUx,
+  /{,usr/}bin/snap PUx,
 
   /usr/share/dpkg/** r,
   /usr/share/keyrings/* r,
@@ -135,9 +135,9 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
 
     /run/cloud-init/** r,
 
-    /usr/bin/ r,
-    /usr/bin/cloud-id r,
-    /usr/bin/python3.{1,}[0-9] mrix,
+    /{,usr/}bin/ r,
+    /{,usr/}bin/cloud-id r,
+    /{,usr/}bin/python3.{1,}[0-9] mrix,
     # LP: #2067319
     /{,usr/}bin/uname mrix,
 
@@ -147,7 +147,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     # https://gitlab.com/apparmor/apparmor/-/issues/346
     # LP: #2067319
     /{,usr/}bin/systemctl Px -> ubuntu_pro_esm_cache_systemctl,
-    /usr/bin/systemd-detect-virt Px -> ubuntu_pro_esm_cache_systemd_detect_virt,
+    /{,usr/}bin/systemd-detect-virt Px -> ubuntu_pro_esm_cache_systemd_detect_virt,
 
     /var/lib/cloud/** r,
 
@@ -176,14 +176,14 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
 
     /etc/dpkg/** r,
 
-    /usr/bin/dpkg mr,
+    /{,usr/}bin/dpkg mr,
 
   }
 
   profile ubuntu_distro_info flags=(attach_disconnected) {
     include <abstractions/base>
 
-    /usr/bin/ubuntu-distro-info mr,
+    /{,usr/}bin/ubuntu-distro-info mr,
 
     /usr/share/distro-info/** r,
 
@@ -206,10 +206,10 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     / r,
     /etc/dpkg/** r,
 
-    /usr/lib/apt/methods/gpgv mr,
-    /usr/lib/apt/methods/http mr,
-    /usr/lib/apt/methods/https mr,
-    /usr/lib/apt/methods/store mr,
+    /{,usr/}lib/apt/methods/gpgv mr,
+    /{,usr/}lib/apt/methods/http mr,
+    /{,usr/}lib/apt/methods/https mr,
+    /{,usr/}lib/apt/methods/store mr,
 
     /usr/share/dpkg/** r,
 
@@ -238,7 +238,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     # tail, cut, sed, etc
     /{,usr/}bin/* mrix,
 
-    /usr/lib/apt/methods/gpgv mr,
+    /{,usr/}lib/apt/methods/gpgv mr,
 
     /usr/share/dpkg/** r,
     /usr/share/keyrings/* r,
@@ -300,7 +300,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
 {% if ubuntu_codename in ["xenial"] %}
     ptrace trace peer=unconfined,
 {% endif %}
-    /usr/bin/systemd-detect-virt mr,
+    /{,usr/}bin/systemd-detect-virt mr,
 
     /run/systemd/** r,
 


### PR DESCRIPTION
Focal systems that were upgraded from bionic are experiencing a series of apparmor DENIED messages that have one thing in common: execution of binaries in `/sbin` or `/bin`.

This happens because of the [usr-merge](https://wiki.debian.org/UsrMerge) effort. On fresh focal systems, we have symlinks replacing top-level directories like /bin, /sbin, and others:

root@f-pristine:~# ls -la /{bin,lib,lib*,sbin}
lrwxrwxrwx 1 root root 7 May 24 21:40 /bin -> usr/bin
lrwxrwxrwx 1 root root 7 May 24 21:40 /lib -> usr/lib
lrwxrwxrwx 1 root root 7 May 24 21:40 /lib -> usr/lib
lrwxrwxrwx 1 root root 9 May 24 21:40 /lib32 -> usr/lib32
lrwxrwxrwx 1 root root 9 May 24 21:40 /lib64 -> usr/lib64
lrwxrwxrwx 1 root root 10 May 24 21:40 /libx32 -> usr/libx32
lrwxrwxrwx 1 root root 8 May 24 21:40 /sbin -> usr/sbin

And the apparmor profile for focal systems expects that directory layout.

In bionic, these are actual directories:
root@b-pristine:~# ls -lad /{bin,lib,lib*,sbin}
drwxr-xr-x 1 root root 2472 Jun 7 2023 /bin
drwxr-xr-x 1 root root 438 Jun 7 2023 /lib
drwxr-xr-x 1 root root 438 Jun 7 2023 /lib
drwxr-xr-x 1 root root 40 Jun 7 2023 /lib64
drwxr-xr-x 1 root root 3694 Jun 7 2023 /sbin

In a focal system that was upgraded from bionic, the usr-merge is not done, and this focal system will retain the bionic top-level directories. Binaries which were previously allowed to be executed in `/sbin` and `/bin` now will be denied, because in this upgraded focal system they remain in `/bin` and `/sbin`, and the focal apparmor profile was expecting them to be in `/usr/bin` and `/usr/sbin`.

LP: #2067319

## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because...

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
- Deploy a bionic system
- install and attach pro
- release-upgrade to focal
- reboot, remove `/var/lib/apt/periodic/*` and run apt-get update
- confirm no apparmor DENIED messages in dmesg, specifically related to binaries executed in `/bin/` or `/sbin/` directories

There is also a PPA with this change, built for all ubuntu releases:

https://launchpad.net/~ahasenack/+archive/ubuntu/uat-test/+packages

Note: this ppa didn't change `version.py`, just the apparmor profiles.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
