### PR TITLE
Add 24.04 to supported list

### DIFF
--- a/docs/howtoguides/enable_realtime_kernel.rst
+++ b/docs/howtoguides/enable_realtime_kernel.rst
@@ -6,8 +6,8 @@ How to manage real-time kernel
 Pre-requisites
 ==============
 
-The `real-time kernel <realtime_>`_ is currently only supported on Ubuntu
-22.04 LTS (Jammy). For more information, feel free to
+The `real-time kernel <realtime_>`_ is currently supported on Ubuntu
+22.04 LTS (Jammy) and 24.04 LTS (Noble). For more information, feel free to
 `contact our real-time team`_.
 
 Enable and auto-install


### PR DESCRIPTION
Mirroring [this PR](https://github.com/canonical/ubuntu-pro-docs/pull/42) - filed against the Pro Handbook - into the Pro Client docs since it's one of the pages we maintain here. 

