### PR TITLE
docs: IENG-1037 reference RTU docs to remove duplication

### DIFF
--- a/docs/howtoguides/enable_realtime_kernel.rst
+++ b/docs/howtoguides/enable_realtime_kernel.rst
@@ -10,8 +10,8 @@ The `real-time kernel <realtime_>`_ is currently supported on Ubuntu
 22.04 LTS (Jammy) and 24.04 LTS (Noble). For more information, feel free to
 `contact our real-time team`_.
 
-Enable and auto-install
-=======================
+Enable and install
+==================
 
 .. important:: 
 
@@ -20,63 +20,8 @@ Enable and auto-install
     real-time kernel, refer to the
     :doc:`services compatibility matrix <../references/compatibility_matrix>`.
 
-To ``enable`` the real-time kernel through the Ubuntu Pro Client, please run:
-
-.. code-block:: bash
-
-    $ sudo pro enable realtime-kernel
-
-You'll need to acknowledge a warning, and then you should see output like the
-following, indicating that the real-time kernel package has been installed.
-
-.. code-block:: text
-
-    One moment, checking your subscription first
-    The Real-time kernel is a beta version of the 22.04 Ubuntu kernel with the
-    PREEMPT_RT patchset integrated for x86_64 and ARM64.
-
-    This will change your kernel. You will need to manually configure grub to
-    revert back to your original kernel after enabling real-time.
-
-    Do you want to continue? [ default = Yes ]: (Y/n) yes
-    Updating package lists
-    Installing Real-time kernel packages
-    Real-time kernel enabled
-    A reboot is required to complete install.
-
-After rebooting you'll be running the real-time kernel!
-
-Enable and manually install
-===========================
-
-.. important::
-
-    The ``--access-only`` flag was introduced in Pro Client version 27.11
-
-If you would like to enable access to the real-time kernel APT repository but
-not install the kernel right away, use the ``--access-only`` flag when you
-enable it, as follows:
-
-.. code-block:: bash
-
-    $ sudo pro enable realtime-kernel --access-only
-
-With this extra flag you'll see output like this:
-
-.. code-block:: text
-
-    One moment, checking your subscription first
-    Updating package lists
-    Skipping installing packages: ubuntu-realtime
-    Real-time kernel access enabled
-
-To install the kernel you can then run:
-
-.. code-block:: bash
-
-    $ sudo apt install ubuntu-realtime
-
-You'll need to reboot after installing to boot into the real-time kernel.
+Refer to the `Real-time Ubuntu documentation`_ for instructions on how to enable
+the real-time kernel on Ubuntu Pro.
 
 Notes
 =====
@@ -90,3 +35,4 @@ Notes
 .. include:: ../links.txt
 
 .. _contact our real-time team: https://ubuntu.com/kernel/real-time/contact-us
+.. _Real-time Ubuntu documentation: https://canonical-real-time-ubuntu-documentation.readthedocs-hosted.com/en/latest/how-to/enable-real-time-ubuntu/


### PR DESCRIPTION
## Why is this needed?

We would like to keep a single source of information for enabling the real-time Ubuntu feature; this will make it easier to maintain and avoid information going out-of-sync.
We propose to keep the full instructions in the [Real-time Ubuntu docs](https://canonical-real-time-ubuntu-documentation.readthedocs-hosted.com/en/latest/how-to/enable-real-time-ubuntu/), to be referenced where needed from the [Ubuntu Pro Client docs](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/enable_realtime_kernel/).

I know this might be part of a bigger discussion on overlapping content / upstream references, but submitting this PR anyway since it is easier to have something concrete to discuss.

## Test Steps

N/A

## Checklist

N/A

## Does this PR require extra reviews?

Yes. @farshidtz from the RTU team.

Thanks!

[IENG-1037]: https://warthogs.atlassian.net/browse/IENG-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQU