### PR TITLE
Apparmor dpkg foreign arch

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -178,6 +178,9 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
 
     /{,usr/}bin/dpkg mr,
 
+    # LP: #2067810
+    /var/lib/dpkg/** r,
+
   }
 
   profile ubuntu_distro_info flags=(attach_disconnected) {
@@ -212,6 +215,9 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     /{,usr/}lib/apt/methods/store mr,
 
     /usr/share/dpkg/** r,
+
+    # LP: #2067810
+    /var/lib/dpkg/** r,
 
     /var/lib/ubuntu-advantage/apt-esm/** rwk,
 
@@ -251,6 +257,9 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     # Note: observed only in xenial tests, but makes sense for all releases
     /etc/apt/** r,
     /var/lib/apt/** r,
+
+    # LP: #2067810
+    /var/lib/dpkg/** r,
 
   }
 

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -116,6 +116,14 @@ def given_a_machine(
             context, "python3-coverage", machine_name=machine_name
         )
 
+    # trigger GH: #3137
+    when_i_run_command(
+        context,
+        "touch /var/lib/dpkg/arch",
+        "with sudo",
+        machine_name=machine_name,
+    )
+
     if cleanup:
 
         def cleanup_instance():


### PR DESCRIPTION
## Why is this needed?
Systems with a `/var/lib/dpkg/arch` file will trigger an apparmor DENIED log entry when the esm-cache service tries to access that file. So far we found the following commands that will attempt that:
- apt-cache policy
- dpkg --print-foreign-architectures

The `/var/lib/dpkg/arch` file can be created, probably among other scenarios, when a subarchitecture is added. For example, on amd64 systems, it's quite common to also have i386 added via the command `sudo dpkg --add-architecture i386`. That is enough to create `/var/lib/dpkg/arch` populated with both am64 and i386, and trigger this bug.

We don't know yet (TBD) the implications of this DENIED error. The output of `apt-cache policy` remains the same, attached or unattached, with and without the apparmor fix.

LP: #2067810
Fixes: #3137

-->

## Test Steps
```
touch /var/lib/dpkg/arch
aa-exec -p ubuntu_pro_esm_cache//dpkg dpkg --print-foreign-architectures
```
Or, for a more realistic scenario on amd64:
```
sudo dpkg --add-architecture i386
sudo rm -rf /var/lib/apt/periodic/*
sudo systemctl start esm-cache.service
```

In both cases, observe `dmesg -wT | grep ubuntu_pro | grep DENIED`.

We should probably add a `/var/lib/dpkg/arch` file to our tests to be sure there is nothing else that needs to access it... I might amend this PR with that, but it does not block immediate reviews and GH test runs.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
