### PR TITLE
realtime: auto-select raspi variant when appropriate

### DIFF
--- a/debian/po/pt_BR.po
+++ b/debian/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-06 15:29-0400\n"
+"POT-Creation-Date: 2024-06-10 14:00-0400\n"
 "PO-Revision-Date: 2023-09-25 12:29-0400\n"
 "Last-Translator: Lucas Moura <lucas.moura@canonical.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-translation@lists.sourceforge."
@@ -788,18 +788,25 @@ msgstr "É necessário reiniciar a máquina para completar a operação {operati
 msgid "Configuring APT access to {service}"
 msgstr ""
 
+#: ../../uaclient/messages/__init__.py:345
+#, python-brace-format
+msgid ""
+"No variant specified. To specify a variant, use the variant option.\n"
+"Auto-selecting {variant} variant. Proceed? (y/N) "
+msgstr ""
+
 #. DISABLE
-#: ../../uaclient/messages/__init__.py:346
+#: ../../uaclient/messages/__init__.py:351
 #, python-brace-format
 msgid "Removing APT access to {title}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:347
+#: ../../uaclient/messages/__init__.py:352
 #, python-brace-format
 msgid "Could not disable {title}."
 msgstr "Não foi possível desabilitar {title}."
 
-#: ../../uaclient/messages/__init__.py:349
+#: ../../uaclient/messages/__init__.py:354
 #, python-brace-format
 msgid ""
 "{dependent_service} depends on {service_being_disabled}.\n"
@@ -810,55 +817,55 @@ msgstr ""
 "Desabilitar {dependent_service} e prosseguir com a desabilitação do "
 "{service_being_disabled}? (y/N) "
 
-#: ../../uaclient/messages/__init__.py:355
+#: ../../uaclient/messages/__init__.py:360
 #, python-brace-format
 msgid "Disabling dependent service: {required_service}"
 msgstr "Desabilitando serviço dependente: {required_service}"
 
-#: ../../uaclient/messages/__init__.py:358
+#: ../../uaclient/messages/__init__.py:363
 #, python-brace-format
 msgid "Removing apt source file: {filename}"
 msgstr "Removendo arquivo do apt: {filename}"
 
-#: ../../uaclient/messages/__init__.py:360
+#: ../../uaclient/messages/__init__.py:365
 #, python-brace-format
 msgid "Removing apt preferences file: {filename}"
 msgstr "Removendo arquivo de preferência do apt: {filename}"
 
-#: ../../uaclient/messages/__init__.py:363
+#: ../../uaclient/messages/__init__.py:368
 #, python-brace-format
 msgid "Uninstalling all packages installed from {title}"
 msgstr "Desinstalando todos os pacotes instalados por {title}"
 
-#: ../../uaclient/messages/__init__.py:368
+#: ../../uaclient/messages/__init__.py:373
 msgid "(The --purge flag is still experimental - use with caution)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:371
+#: ../../uaclient/messages/__init__.py:376
 #, python-brace-format
 msgid "Purging the {service} packages would uninstall the following kernel(s):"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:374
+#: ../../uaclient/messages/__init__.py:379
 #, python-brace-format
 msgid "{kernel_version} is the current running kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:377
+#: ../../uaclient/messages/__init__.py:382
 msgid ""
 "No other valid Ubuntu kernel was found in the system.\n"
 "Removing the package would potentially make the system unbootable.\n"
 "Aborting.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:384
+#: ../../uaclient/messages/__init__.py:389
 msgid ""
 "If you cannot guarantee that other kernels in this system are bootable and\n"
 "working properly, *do not proceed*. You may end up with an unbootable "
 "system.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:393
+#: ../../uaclient/messages/__init__.py:398
 #, python-brace-format
 msgid ""
 "Failed to automatically attach to an Ubuntu Pro subscription {num_attempts} "
@@ -873,7 +880,7 @@ msgstr ""
 "A próxima tentativa está agendada para {next_run_datestring}.\n"
 "Você pode tentar manualmente executando `sudo pro auto-attach`."
 
-#: ../../uaclient/messages/__init__.py:401
+#: ../../uaclient/messages/__init__.py:406
 #, python-brace-format
 msgid ""
 "Failed to automatically attach to an Ubuntu Pro subscription {num_attempts} "
@@ -890,7 +897,7 @@ msgstr ""
 "bug ubuntu-advantage-tools`\n"
 "Você pode tentar manualmente executando `sudo pro auto-attach`."
 
-#: ../../uaclient/messages/__init__.py:409
+#: ../../uaclient/messages/__init__.py:414
 #, python-brace-format
 msgid ""
 "Canonical servers did not recognize this machine as Ubuntu Pro: \"{detail}\""
@@ -898,37 +905,37 @@ msgstr ""
 "Os servidores da Canonical não reconheceram essa máquina como sendo "
 "associada ao Ubuntu Pro: \"{detail}\""
 
-#: ../../uaclient/messages/__init__.py:413
+#: ../../uaclient/messages/__init__.py:418
 msgid "Canonical servers did not recognize this image as Ubuntu Pro"
 msgstr ""
 "Os servidores da Canonical não reconheceram essa imagem como sendo associada "
 "ao Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:415
+#: ../../uaclient/messages/__init__.py:420
 #, python-brace-format
 msgid "the pro lock was held by pid {pid}"
 msgstr "A lock do pro está sendo mantida pelo pid {pid}"
 
-#: ../../uaclient/messages/__init__.py:417
+#: ../../uaclient/messages/__init__.py:422
 #, python-brace-format
 msgid "an error from Canonical servers: \"{error_msg}\""
 msgstr "um erro dos servidores da Canonical: \"{error_msg}\""
 
-#: ../../uaclient/messages/__init__.py:419
+#: ../../uaclient/messages/__init__.py:424
 msgid "a connectivity error"
 msgstr "um erro de conexão"
 
-#: ../../uaclient/messages/__init__.py:420
+#: ../../uaclient/messages/__init__.py:425
 #, python-brace-format
 msgid "an error while reaching {url}"
 msgstr "um error ao acessar {url}"
 
-#: ../../uaclient/messages/__init__.py:424
+#: ../../uaclient/messages/__init__.py:429
 #, python-brace-format
 msgid "Due to contract refresh, '{service}' is now disabled."
 msgstr "Devido à atualização de contrato, '{service}' está agora desabilitado"
 
-#: ../../uaclient/messages/__init__.py:427
+#: ../../uaclient/messages/__init__.py:432
 #, python-brace-format
 msgid ""
 "Unable to disable '{service}' as recommended during contract refresh. "
@@ -937,49 +944,49 @@ msgstr ""
 "Falha ao desabilitar '{service}' conforme esperado após atualização do seu "
 "contrato. O serviço ainda está ativo. Execute `pro status` para confirmar"
 
-#: ../../uaclient/messages/__init__.py:432
+#: ../../uaclient/messages/__init__.py:437
 #, python-brace-format
 msgid "Updating '{service}' on changed directives."
 msgstr "Atualizando '{service}' baseado nas novas diretivas"
 
-#: ../../uaclient/messages/__init__.py:435
+#: ../../uaclient/messages/__init__.py:440
 #, python-brace-format
 msgid "Updating '{service}' apt sources list on changed directives."
 msgstr ""
 "Atualizando a lista de apt sources do '{service}' baseado nas novas diretivas"
 
-#: ../../uaclient/messages/__init__.py:438
+#: ../../uaclient/messages/__init__.py:443
 #, python-brace-format
 msgid "Installing packages on changed directives: {packages}"
 msgstr "Instalando pacotes baseado nas novas diretivas: {packages}"
 
-#: ../../uaclient/messages/__init__.py:448
+#: ../../uaclient/messages/__init__.py:453
 #, python-brace-format
 msgid "Choose: [S]ubscribe at {url} [A]ttach existing token [C]ancel"
 msgstr ""
 "Escolha: [S] para vincular através de {url}; [A] para vincular usando um "
 "token existente; [C] para cancelar:"
 
-#: ../../uaclient/messages/__init__.py:452
+#: ../../uaclient/messages/__init__.py:457
 #, python-brace-format
 msgid "Choose: [E]nable {service} [C]ancel"
 msgstr "Escolha: [E] para habilitar {service}; [C] para cancelar:"
 
-#: ../../uaclient/messages/__init__.py:456
+#: ../../uaclient/messages/__init__.py:461
 #, python-brace-format
 msgid "Choose: [R]enew your subscription (at {url}) [C]ancel"
 msgstr "Escolha: [R]enovar sua assinatura (em {url}); [C]ancelar"
 
-#: ../../uaclient/messages/__init__.py:459
+#: ../../uaclient/messages/__init__.py:464
 #, python-brace-format
 msgid "A fix is available in {fix_stream}."
 msgstr "Uma solução está disponível em {fix_stream}."
 
-#: ../../uaclient/messages/__init__.py:460
+#: ../../uaclient/messages/__init__.py:465
 msgid "The update is not yet installed."
 msgstr "A atualização ainda não está instalada"
 
-#: ../../uaclient/messages/__init__.py:462
+#: ../../uaclient/messages/__init__.py:467
 msgid ""
 "The update is not installed because this system is not attached to a\n"
 "subscription.\n"
@@ -987,7 +994,7 @@ msgstr ""
 "A atualização não pode ser instalada porque o sistema não está vinculado a\n"
 "uma assinatura.\n"
 
-#: ../../uaclient/messages/__init__.py:468
+#: ../../uaclient/messages/__init__.py:473
 msgid ""
 "The update is not installed because this system is attached to an\n"
 "expired subscription.\n"
@@ -995,7 +1002,7 @@ msgstr ""
 "A atualização não pode ser instalada porque o sistema está vinculado a uma\n"
 "assinatura vencida.\n"
 
-#: ../../uaclient/messages/__init__.py:474
+#: ../../uaclient/messages/__init__.py:479
 #, python-brace-format
 msgid ""
 "The update is not installed because this system does not have\n"
@@ -1005,11 +1012,11 @@ msgstr ""
 "{service}\n"
 "habilitado.\n"
 
-#: ../../uaclient/messages/__init__.py:479
+#: ../../uaclient/messages/__init__.py:484
 msgid "The update is already installed."
 msgstr "A atualização já está instalada."
 
-#: ../../uaclient/messages/__init__.py:481
+#: ../../uaclient/messages/__init__.py:486
 #, python-brace-format
 msgid ""
 "For easiest security on {title}, use Ubuntu Pro instances.\n"
@@ -1019,73 +1026,73 @@ msgstr ""
 "Ubuntu Pro.\n"
 "Aprenda mais em {cloud_specific_url}"
 
-#: ../../uaclient/messages/__init__.py:486
+#: ../../uaclient/messages/__init__.py:491
 msgid "requested"
 msgstr "requisitado"
 
-#: ../../uaclient/messages/__init__.py:487
+#: ../../uaclient/messages/__init__.py:492
 msgid "related"
 msgstr "relacionado"
 
-#: ../../uaclient/messages/__init__.py:488
+#: ../../uaclient/messages/__init__.py:493
 #, python-brace-format
 msgid " {issue} is resolved."
 msgstr " {issue} resolvida"
 
-#: ../../uaclient/messages/__init__.py:490
+#: ../../uaclient/messages/__init__.py:495
 #, python-brace-format
 msgid " {issue} [{context}] is resolved."
 msgstr "{issue} [{context}] foi resolvida"
 
-#: ../../uaclient/messages/__init__.py:492
+#: ../../uaclient/messages/__init__.py:497
 #, python-brace-format
 msgid " {issue} is not resolved."
 msgstr " {issue} não foi resolvida"
 
-#: ../../uaclient/messages/__init__.py:494
+#: ../../uaclient/messages/__init__.py:499
 #, python-brace-format
 msgid " {issue} [{context}] is not resolved."
 msgstr " {issue} [{context}] não foi resolvida"
 
-#: ../../uaclient/messages/__init__.py:497
+#: ../../uaclient/messages/__init__.py:502
 #, python-brace-format
 msgid " {issue} does not affect your system."
 msgstr " {issue} não afeta o seu sistema."
 
-#: ../../uaclient/messages/__init__.py:500
+#: ../../uaclient/messages/__init__.py:505
 #, python-brace-format
 msgid " {issue} [{context}] does not affect your system."
 msgstr " {issue} [{context}] não afeta o seu sistema."
 
-#: ../../uaclient/messages/__init__.py:504
+#: ../../uaclient/messages/__init__.py:509
 #, python-brace-format
 msgid "{num_pkgs} package is still affected: {pkgs}"
 msgid_plural "{num_pkgs} packages are still affected: {pkgs}"
 msgstr[0] "{num_pkgs} pacote ainda está afetado: {pkgs}"
 msgstr[1] "{num_pkgs} pacotes ainda estão afetados: {pkgs}"
 
-#: ../../uaclient/messages/__init__.py:511
+#: ../../uaclient/messages/__init__.py:516
 #, python-brace-format
 msgid "{count} affected source package is installed: {pkgs}"
 msgid_plural "{count} affected source packages are installed: {pkgs}"
 msgstr[0] "{count} pacote fonte afetado está instalado: {pkgs}"
 msgstr[1] "{count} pacotes fonte afetados estão instalados: {pkgs}"
 
-#: ../../uaclient/messages/__init__.py:517
+#: ../../uaclient/messages/__init__.py:522
 msgid "No affected source packages are installed."
 msgstr "Nenhum pacote fonte afetado está instalado"
 
-#: ../../uaclient/messages/__init__.py:519
+#: ../../uaclient/messages/__init__.py:524
 #, python-brace-format
 msgid "{issue} is resolved."
 msgstr "{issue} foi resolvida"
 
-#: ../../uaclient/messages/__init__.py:521
+#: ../../uaclient/messages/__init__.py:526
 #, python-brace-format
 msgid " {issue} is resolved by livepatch patch version: {version}."
 msgstr " {issue} for resolvida pelo patch {version} do livepatch."
 
-#: ../../uaclient/messages/__init__.py:524
+#: ../../uaclient/messages/__init__.py:529
 #, python-brace-format
 msgid ""
 "{bold}Ubuntu Pro service: {{service}} is not enabled.\n"
@@ -1100,7 +1107,7 @@ msgstr ""
 "este serviço.\n"
 "{{{{ pro enable {{service}} }}}}{end_bold}"
 
-#: ../../uaclient/messages/__init__.py:531
+#: ../../uaclient/messages/__init__.py:536
 #, fuzzy, python-brace-format
 msgid ""
 "{bold}The machine is not attached to an Ubuntu Pro subscription.\n"
@@ -1113,7 +1120,7 @@ msgstr ""
 "para o Ubuntu Pro.\n"
 "{{ pro attach TOKEN }}{end_bold}"
 
-#: ../../uaclient/messages/__init__.py:538
+#: ../../uaclient/messages/__init__.py:543
 #, fuzzy, python-brace-format
 msgid ""
 "{bold}The machine has an expired subscription.\n"
@@ -1128,7 +1135,7 @@ msgstr ""
 "{{ pro detach --assume-yes }}\n"
 "{{ pro attach NEW_TOKEN }}{end_bold}"
 
-#: ../../uaclient/messages/__init__.py:546
+#: ../../uaclient/messages/__init__.py:551
 #, python-brace-format
 msgid ""
 "{bold}WARNING: The option --dry-run is being used.\n"
@@ -1137,7 +1144,7 @@ msgstr ""
 "{bold}ATENÇÂO: a opção --dry-run está sendo usada.\n"
 "Nenhum pacote será instalado na execução deste comando.{end_bold}"
 
-#: ../../uaclient/messages/__init__.py:551
+#: ../../uaclient/messages/__init__.py:556
 #, python-brace-format
 msgid ""
 "Error: Ubuntu Pro service: {service} is not enabled.\n"
@@ -1146,7 +1153,7 @@ msgstr ""
 "Erro: o serviço Ubuntu Pro: {service} não está habilitado.\n"
 "Sem o serviço, não podemos corrigir o sistema."
 
-#: ../../uaclient/messages/__init__.py:556
+#: ../../uaclient/messages/__init__.py:561
 #, python-brace-format
 msgid ""
 "Error: The current Ubuntu Pro subscription is not entitled to: {service}.\n"
@@ -1156,74 +1163,74 @@ msgstr ""
 "Ubuntu Pro.\n"
 "Sem o serviço, não podemos corrigir o sistema."
 
-#: ../../uaclient/messages/__init__.py:561
+#: ../../uaclient/messages/__init__.py:566
 #, python-brace-format
 msgid "{service} is required for upgrade."
 msgstr "{service} é necessário para atualização."
 
-#: ../../uaclient/messages/__init__.py:565
+#: ../../uaclient/messages/__init__.py:570
 #, python-brace-format
 msgid "{service} is required for upgrade, but current subscription is expired."
 msgstr ""
 "{service} é necessário para atualização, mas a atual assinatura está vencida"
 
-#: ../../uaclient/messages/__init__.py:569
+#: ../../uaclient/messages/__init__.py:574
 #, python-brace-format
 msgid "{service} is required for upgrade, but it is not enabled."
 msgstr ""
 "{service} é necessário para atualização, mas o serviço está desabilitado."
 
-#: ../../uaclient/messages/__init__.py:573
+#: ../../uaclient/messages/__init__.py:578
 msgid "APT failed to install the package.\n"
 msgstr "APT falhou ao instalar o pacote.\n"
 
-#: ../../uaclient/messages/__init__.py:578
+#: ../../uaclient/messages/__init__.py:583
 msgid "Sorry, no fix is available yet."
 msgstr "Desculpe, não existe uma correção disponível ainda."
 
-#: ../../uaclient/messages/__init__.py:582
+#: ../../uaclient/messages/__init__.py:587
 msgid "Ubuntu security engineers are investigating this issue."
 msgstr "Engenheiros de segurança do Ubuntu estão investigando o problema."
 
-#: ../../uaclient/messages/__init__.py:586
+#: ../../uaclient/messages/__init__.py:591
 msgid "A fix is coming soon. Try again tomorrow."
 msgstr "Uma correção será entregue em breve. Tente de novo amanhã."
 
-#: ../../uaclient/messages/__init__.py:590
+#: ../../uaclient/messages/__init__.py:595
 msgid "Sorry, no fix is available."
 msgstr "Desculpe, não existe uma correção disponível."
 
-#: ../../uaclient/messages/__init__.py:594
+#: ../../uaclient/messages/__init__.py:599
 msgid "Source package does not exist on this release."
 msgstr "O pacote fonte não existe para esta versão do Ubuntu."
 
-#: ../../uaclient/messages/__init__.py:598
+#: ../../uaclient/messages/__init__.py:603
 msgid "Source package is not affected on this release."
 msgstr "O pacote fonte não é afetado nesta versão do Ubuntu."
 
-#: ../../uaclient/messages/__init__.py:602
+#: ../../uaclient/messages/__init__.py:607
 #, python-brace-format
 msgid "UNKNOWN: {status}"
 msgstr "DESCONHECIDO: {status}"
 
-#: ../../uaclient/messages/__init__.py:606
+#: ../../uaclient/messages/__init__.py:611
 msgid "Associated CVEs:"
 msgstr "CVEs associadas:"
 
-#: ../../uaclient/messages/__init__.py:607
+#: ../../uaclient/messages/__init__.py:612
 msgid "Found Launchpad bugs:"
 msgstr "Bugs do Launchpad encontrados:"
 
-#: ../../uaclient/messages/__init__.py:609
+#: ../../uaclient/messages/__init__.py:614
 #, python-brace-format
 msgid "Fixing requested {issue_id}"
 msgstr "Corrigindo {issue_id}"
 
-#: ../../uaclient/messages/__init__.py:613
+#: ../../uaclient/messages/__init__.py:618
 msgid "Fixing related USNs:"
 msgstr "Corrigindo USNs relacionados"
 
-#: ../../uaclient/messages/__init__.py:617
+#: ../../uaclient/messages/__init__.py:622
 #, python-brace-format
 msgid ""
 "Found related USNs:\n"
@@ -1232,11 +1239,11 @@ msgstr ""
 "USNs relacionadas foram encontradas:\n"
 "- {related_usns}"
 
-#: ../../uaclient/messages/__init__.py:621
+#: ../../uaclient/messages/__init__.py:626
 msgid "Summary:"
 msgstr "Sumário:"
 
-#: ../../uaclient/messages/__init__.py:625
+#: ../../uaclient/messages/__init__.py:630
 #, python-brace-format
 msgid ""
 "Even though a related USN failed to be fixed, note\n"
@@ -1253,21 +1260,21 @@ msgstr ""
 "\n"
 "{url}\n"
 
-#: ../../uaclient/messages/__init__.py:634
+#: ../../uaclient/messages/__init__.py:639
 msgid "Ubuntu standard updates"
 msgstr "Atualizações padrão do Ubuntu"
 
-#: ../../uaclient/messages/__init__.py:635
-#: ../../uaclient/messages/__init__.py:1243
+#: ../../uaclient/messages/__init__.py:640
+#: ../../uaclient/messages/__init__.py:1248
 msgid "Ubuntu Pro: ESM Infra"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:636
-#: ../../uaclient/messages/__init__.py:1229
+#: ../../uaclient/messages/__init__.py:641
+#: ../../uaclient/messages/__init__.py:1234
 msgid "Ubuntu Pro: ESM Apps"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:639
+#: ../../uaclient/messages/__init__.py:644
 msgid ""
 "Package fixes cannot be installed.\n"
 "To install them, run this command as root (try using sudo)"
@@ -1275,12 +1282,12 @@ msgstr ""
 "As atualizações de pacotes não podem ser instaladas.\n"
 "Para instalar os pacotes, execute esse comando como root (tente usando sudo)"
 
-#: ../../uaclient/messages/__init__.py:645
+#: ../../uaclient/messages/__init__.py:650
 #, python-brace-format
 msgid "Enter your token (from {url}) to attach this system:"
 msgstr "Insira seu token (da {url}) para vincular seu sistema:"
 
-#: ../../uaclient/messages/__init__.py:649
+#: ../../uaclient/messages/__init__.py:654
 msgid "Enter your new token to renew Ubuntu Pro subscription on this system:"
 msgstr ""
 "Providencie seu novo token para renovar sua assinatura do Ubuntu Pro neste "
@@ -1289,33 +1296,33 @@ msgstr ""
 #. ##############################################################################
 #. SECURITYSTATUS SUBCOMMAND                              #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:659
+#: ../../uaclient/messages/__init__.py:664
 #, python-brace-format
 msgid "{count} packages installed:"
 msgstr "{count} pacotes instalados:"
 
-#: ../../uaclient/messages/__init__.py:662
+#: ../../uaclient/messages/__init__.py:667
 #, python-brace-format
 msgid "{offset}{count} package from Ubuntu {repository} repository"
 msgid_plural "{offset}{count} packages from Ubuntu {repository} repository"
 msgstr[0] "{offset}{count} pacote do repositório {repository} do Ubuntu"
 msgstr[1] "{offset}{count} pacotes do repositório {repository} do Ubuntu"
 
-#: ../../uaclient/messages/__init__.py:669
+#: ../../uaclient/messages/__init__.py:674
 #, python-brace-format
 msgid "{offset}{count} package from a third party"
 msgid_plural "{offset}{count} packages from third parties"
 msgstr[0] "{offset}{count} pacote de terceiros"
 msgstr[1] "{offset}{count} pacotes de terceiros"
 
-#: ../../uaclient/messages/__init__.py:676
+#: ../../uaclient/messages/__init__.py:681
 #, python-brace-format
 msgid "{offset}{count} package no longer available for download"
 msgid_plural "{offset}{count} packages no longer available for download"
 msgstr[0] "{offset}{count} pacote não mais disponível para download"
 msgstr[1] "{offset}{count} pacotes não mais disponíveis para download"
 
-#: ../../uaclient/messages/__init__.py:683
+#: ../../uaclient/messages/__init__.py:688
 msgid ""
 "To get more information about the packages, run\n"
 "    pro security-status --help\n"
@@ -1325,7 +1332,7 @@ msgstr ""
 "    pro security-status --help\n"
 "para uma lista das opções disponíveis."
 
-#: ../../uaclient/messages/__init__.py:690
+#: ../../uaclient/messages/__init__.py:695
 msgid ""
 " Make sure to run\n"
 "    sudo apt update\n"
@@ -1335,21 +1342,21 @@ msgstr ""
 "    sudo apt update\n"
 "para obter as informações mais recentes dos pacotes direto do apt."
 
-#: ../../uaclient/messages/__init__.py:696
+#: ../../uaclient/messages/__init__.py:701
 #, python-brace-format
 msgid "The system apt information was updated {days} day(s) ago."
 msgstr "As informações do apt foram atualizadas há {days} dia(s) atrás"
 
-#: ../../uaclient/messages/__init__.py:700
+#: ../../uaclient/messages/__init__.py:705
 msgid "The system apt cache may be outdated."
 msgstr "O cache do apt pode estar desatualizado"
 
-#: ../../uaclient/messages/__init__.py:704
+#: ../../uaclient/messages/__init__.py:709
 #, python-brace-format
 msgid "Main/Restricted packages receive updates until {date}."
 msgstr "pacotes Main/Restricted receberão atualizações até {date}."
 
-#: ../../uaclient/messages/__init__.py:707
+#: ../../uaclient/messages/__init__.py:712
 #, python-brace-format
 msgid ""
 "This machine is receiving security patching for Ubuntu Main/Restricted\n"
@@ -1358,15 +1365,15 @@ msgstr ""
 "Esta máquina está recebendo patches de segurança para o repositório\n"
 "Main/Restricted do Ubuntu até {date}"
 
-#: ../../uaclient/messages/__init__.py:713
+#: ../../uaclient/messages/__init__.py:718
 msgid "This machine is attached to an Ubuntu Pro subscription."
 msgstr "Esta máquina está vinculada a uma assinatura do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:716
+#: ../../uaclient/messages/__init__.py:721
 msgid "This machine is NOT attached to an Ubuntu Pro subscription."
 msgstr "Esta máquina NÃO está vinculada a uma assinatura do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:720
+#: ../../uaclient/messages/__init__.py:725
 msgid ""
 "Packages from third parties are not provided by the official Ubuntu\n"
 "archive, for example packages from Personal Package Archives in Launchpad."
@@ -1375,7 +1382,7 @@ msgstr ""
 "por examplo, pacotes de encontrados em Personal Package Archives (PPAs) do "
 "Launchpad."
 
-#: ../../uaclient/messages/__init__.py:725
+#: ../../uaclient/messages/__init__.py:730
 msgid ""
 "Packages that are not available for download may be left over from a\n"
 "previous release of Ubuntu, may have been installed directly from a\n"
@@ -1385,7 +1392,7 @@ msgstr ""
 "versões anteriores do Ubuntu, podem ter sido instalados diretamente por um\n"
 "arquivo .deb, ou de uma fonte que foi desabilitada."
 
-#: ../../uaclient/messages/__init__.py:732
+#: ../../uaclient/messages/__init__.py:737
 msgid ""
 "This machine is NOT receiving security patches because the LTS period has "
 "ended\n"
@@ -1395,7 +1402,7 @@ msgstr ""
 "acabou\n"
 "e esm-infra não está habilitado."
 
-#: ../../uaclient/messages/__init__.py:738
+#: ../../uaclient/messages/__init__.py:743
 #, python-brace-format
 msgid ""
 "Ubuntu Pro with '{service}' enabled provides security updates for\n"
@@ -1404,14 +1411,14 @@ msgstr ""
 "Ubuntu Pro com '{service}' habilitado provê atualizações de segurança\n"
 "para pacotes do {repository} até {year}."
 
-#: ../../uaclient/messages/__init__.py:744
+#: ../../uaclient/messages/__init__.py:749
 #, python-brace-format
 msgid "There is {updates} pending security update."
 msgid_plural "There are {updates} pending security updates."
 msgstr[0] "Existe {updates} atualização de segurança pendente."
 msgstr[1] "Existem {updates} atualizações de segurança pendentes."
 
-#: ../../uaclient/messages/__init__.py:751
+#: ../../uaclient/messages/__init__.py:756
 #, python-brace-format
 msgid ""
 "{repository} packages are receiving security updates from\n"
@@ -1420,7 +1427,7 @@ msgstr ""
 "Pacotes do {repository} estão recebendo atualizações de segurança do\n"
 "Ubuntu Pro com '{service}' habilitado até {year}."
 
-#: ../../uaclient/messages/__init__.py:757
+#: ../../uaclient/messages/__init__.py:762
 #, python-brace-format
 msgid ""
 "You have received {updates} security\n"
@@ -1435,12 +1442,12 @@ msgstr[1] ""
 "Você recebeu {updates} atualizações de\n"
 "segurança."
 
-#: ../../uaclient/messages/__init__.py:767
+#: ../../uaclient/messages/__init__.py:772
 #, python-brace-format
 msgid "Enable {service} with: pro enable {service}"
 msgstr "Habilite {service} com: pro enable {service}"
 
-#: ../../uaclient/messages/__init__.py:769
+#: ../../uaclient/messages/__init__.py:774
 #, python-brace-format
 msgid ""
 "Try Ubuntu Pro with a free personal subscription on up to 5 machines.\n"
@@ -1450,7 +1457,7 @@ msgstr ""
 "máquinas.\n"
 "Saiba mais em {url}\n"
 
-#: ../../uaclient/messages/__init__.py:776
+#: ../../uaclient/messages/__init__.py:781
 #, python-brace-format
 msgid ""
 "For example, run:\n"
@@ -1461,165 +1468,165 @@ msgstr ""
 "    apt-cache show {package}\n"
 "para saber mais sobre este pacote."
 
-#: ../../uaclient/messages/__init__.py:783
+#: ../../uaclient/messages/__init__.py:788
 msgid "You have no packages installed from a third party."
 msgstr "Você não tem pacotes instalados de terceitos."
 
-#: ../../uaclient/messages/__init__.py:786
+#: ../../uaclient/messages/__init__.py:791
 msgid "You have no packages installed that are no longer available."
 msgstr "Você não tem pacotes instalados que não estejam mais disponíveis."
 
-#: ../../uaclient/messages/__init__.py:789
+#: ../../uaclient/messages/__init__.py:794
 msgid "Ubuntu Pro is not available for non-LTS releases."
 msgstr "Ubuntu Pro não está disponível para versões do Ubuntu não LTS."
 
-#: ../../uaclient/messages/__init__.py:792
+#: ../../uaclient/messages/__init__.py:797
 #, python-brace-format
 msgid "Run 'pro help {service}' to learn more"
 msgstr "Execute 'pro help {service}' para saber mais"
 
-#: ../../uaclient/messages/__init__.py:795
+#: ../../uaclient/messages/__init__.py:800
 #, python-brace-format
 msgid "Installed packages with an available {service} update:"
 msgstr "Pacotes instalados com atualizações disponíveis por {service}:"
 
-#: ../../uaclient/messages/__init__.py:798
+#: ../../uaclient/messages/__init__.py:803
 #, python-brace-format
 msgid "Installed packages with an {service} update applied:"
 msgstr "Pacotes instalados com atualizações aplicadas por {service}:"
 
-#: ../../uaclient/messages/__init__.py:800
+#: ../../uaclient/messages/__init__.py:805
 #, python-brace-format
 msgid "Installed packages covered by {service}:"
 msgstr "Pacotes instalados cobertos por {service}:"
 
-#: ../../uaclient/messages/__init__.py:802
+#: ../../uaclient/messages/__init__.py:807
 #, python-brace-format
 msgid "Further installed packages covered by {service}:"
 msgstr "Pacotes adicionais instalados cobertos por {service}:"
 
-#: ../../uaclient/messages/__init__.py:804
+#: ../../uaclient/messages/__init__.py:809
 msgid "Packages:"
 msgstr "Pacotes:"
 
 #. ##############################################################################
 #. STATUS SUBCOMMAND                                 #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:812
+#: ../../uaclient/messages/__init__.py:817
 msgid "SERVICE"
 msgstr "SERVIÇO"
 
-#: ../../uaclient/messages/__init__.py:813
+#: ../../uaclient/messages/__init__.py:818
 msgid "AVAILABLE"
 msgstr "DISPONÍVEL"
 
-#: ../../uaclient/messages/__init__.py:814
+#: ../../uaclient/messages/__init__.py:819
 msgid "ENTITLED"
 msgstr "INCLUÍDO"
 
-#: ../../uaclient/messages/__init__.py:815
+#: ../../uaclient/messages/__init__.py:820
 msgid "AUTO_ENABLED"
 msgstr "AUTO_HABILITADO"
 
-#: ../../uaclient/messages/__init__.py:816
+#: ../../uaclient/messages/__init__.py:821
 msgid "STATUS"
 msgstr "STATUS"
 
-#: ../../uaclient/messages/__init__.py:817
+#: ../../uaclient/messages/__init__.py:822
 msgid "DESCRIPTION"
 msgstr "DESCRIÇÃO"
 
-#: ../../uaclient/messages/__init__.py:818
+#: ../../uaclient/messages/__init__.py:823
 msgid "NOTICES"
 msgstr "NOTÍCIAS"
 
-#: ../../uaclient/messages/__init__.py:819
+#: ../../uaclient/messages/__init__.py:824
 msgid "FEATURES"
 msgstr "FUNCIONALIDADES"
 
-#: ../../uaclient/messages/__init__.py:823
+#: ../../uaclient/messages/__init__.py:828
 msgid "enabled"
 msgstr "habilitado"
 
-#: ../../uaclient/messages/__init__.py:824
+#: ../../uaclient/messages/__init__.py:829
 msgid "disabled"
 msgstr "desabilitado"
 
-#: ../../uaclient/messages/__init__.py:825
+#: ../../uaclient/messages/__init__.py:830
 msgid "n/a"
 msgstr "n/d"
 
-#: ../../uaclient/messages/__init__.py:827
+#: ../../uaclient/messages/__init__.py:832
 msgid "warning"
 msgstr "atenção"
 
-#: ../../uaclient/messages/__init__.py:828
+#: ../../uaclient/messages/__init__.py:833
 msgid "essential"
 msgstr "essencial"
 
-#: ../../uaclient/messages/__init__.py:829
+#: ../../uaclient/messages/__init__.py:834
 msgid "standard"
 msgstr "padrão"
 
-#: ../../uaclient/messages/__init__.py:830
+#: ../../uaclient/messages/__init__.py:835
 msgid "advanced"
 msgstr "avançado"
 
-#: ../../uaclient/messages/__init__.py:832
+#: ../../uaclient/messages/__init__.py:837
 msgid "Unknown/Expired"
 msgstr "Desconhecido/expirado"
 
-#: ../../uaclient/messages/__init__.py:835
+#: ../../uaclient/messages/__init__.py:840
 #, python-brace-format
 msgid "Enable services with: {command}"
 msgstr "Habilite serviços com: {command}"
 
-#: ../../uaclient/messages/__init__.py:837
+#: ../../uaclient/messages/__init__.py:842
 msgid "Account"
 msgstr "Conta"
 
-#: ../../uaclient/messages/__init__.py:838
+#: ../../uaclient/messages/__init__.py:843
 msgid "Subscription"
 msgstr "Assinatura"
 
-#: ../../uaclient/messages/__init__.py:839
+#: ../../uaclient/messages/__init__.py:844
 msgid "Valid until"
 msgstr "Válido até"
 
-#: ../../uaclient/messages/__init__.py:840
+#: ../../uaclient/messages/__init__.py:845
 msgid "Technical support level"
 msgstr "Nível de suporte técnico"
 
-#: ../../uaclient/messages/__init__.py:842
+#: ../../uaclient/messages/__init__.py:847
 msgid "This token is not valid."
 msgstr "Este token não é válido."
 
-#: ../../uaclient/messages/__init__.py:843
+#: ../../uaclient/messages/__init__.py:848
 msgid "No Ubuntu Pro operations are running"
 msgstr "Nenhuma operação Ubuntu Pro está sendo executada"
 
-#: ../../uaclient/messages/__init__.py:846
+#: ../../uaclient/messages/__init__.py:851
 msgid "No Ubuntu Pro services are available to this system."
 msgstr "Nenhum serviço do Ubuntu Pro está disponível neste sistema."
 
-#: ../../uaclient/messages/__init__.py:849
+#: ../../uaclient/messages/__init__.py:854
 msgid "For a list of all Ubuntu Pro services, run 'pro status --all'"
 msgstr ""
 "Para uma lista com todos os serviços do Ubuntu Pro, execute 'pro status --"
 "all'"
 
-#: ../../uaclient/messages/__init__.py:851
+#: ../../uaclient/messages/__init__.py:856
 msgid " * Service has variants"
 msgstr "* Serviço tem variantes"
 
-#: ../../uaclient/messages/__init__.py:853
+#: ../../uaclient/messages/__init__.py:858
 msgid ""
 "For a list of all Ubuntu Pro services and variants, run 'pro status --all'"
 msgstr ""
 "Para uma lista como todos os serviços e variantes do Ubuntu Pro, execute "
 "'pro status --all'"
 
-#: ../../uaclient/messages/__init__.py:858
+#: ../../uaclient/messages/__init__.py:863
 msgid ""
 "A change has been detected in your contract.\n"
 "Please run `sudo pro refresh`."
@@ -1632,93 +1639,93 @@ msgstr ""
 #. ##############################################################################
 #. This encompasses help text for subcommands, flags, and arguments for the CLI
 #. Also, any generic strings about the CLI itself go here.
-#: ../../uaclient/messages/__init__.py:871
+#: ../../uaclient/messages/__init__.py:876
 msgid "Try 'pro --help' for more information."
 msgstr "Tente 'pro --help' para mais informações."
 
-#: ../../uaclient/messages/__init__.py:873
+#: ../../uaclient/messages/__init__.py:878
 #, python-brace-format
 msgid "Use {name} {command} --help for more information about a command."
 msgstr "Use {name} {command} --help para mais informações sobre um comando."
 
-#: ../../uaclient/messages/__init__.py:876
+#: ../../uaclient/messages/__init__.py:881
 msgid "Use pro help <service> to get more details about each service"
 msgstr "Use pro help <service> para obter mais detalhes sobre cada serviço"
 
-#: ../../uaclient/messages/__init__.py:879
+#: ../../uaclient/messages/__init__.py:884
 msgid "Variants:"
 msgstr "Variantes:"
 
-#: ../../uaclient/messages/__init__.py:880
+#: ../../uaclient/messages/__init__.py:885
 msgid "Arguments"
 msgstr "Argumentos"
 
-#: ../../uaclient/messages/__init__.py:881
+#: ../../uaclient/messages/__init__.py:886
 msgid "Flags"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:882
+#: ../../uaclient/messages/__init__.py:887
 msgid "Available Commands"
 msgstr "Comandos Disponíveis"
 
-#: ../../uaclient/messages/__init__.py:884
+#: ../../uaclient/messages/__init__.py:889
 #, python-brace-format
 msgid "output in the specified format (default: {default})"
 msgstr "saída no formato especificado (default: {default})"
 
-#: ../../uaclient/messages/__init__.py:887
+#: ../../uaclient/messages/__init__.py:892
 #, python-brace-format
 msgid "do not prompt for confirmation before performing the {command}"
 msgstr "não peça por confirmação antes de executar {command}"
 
-#: ../../uaclient/messages/__init__.py:890
-#: ../../uaclient/messages/__init__.py:1124
+#: ../../uaclient/messages/__init__.py:895
+#: ../../uaclient/messages/__init__.py:1129
 msgid "Calls the Client API endpoints."
 msgstr "Chama os endpoints da API do Cliente."
 
-#: ../../uaclient/messages/__init__.py:891
+#: ../../uaclient/messages/__init__.py:896
 msgid "API endpoint to call"
 msgstr "API endpoints que podem ser executados"
 
-#: ../../uaclient/messages/__init__.py:893
+#: ../../uaclient/messages/__init__.py:898
 msgid ""
 "For endpoints that support progress updates, show each progress update on a "
 "new line in JSON format"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:897
+#: ../../uaclient/messages/__init__.py:902
 msgid "Options to pass to the API endpoint, formatted as key=value"
 msgstr "Opções para passar ao endpoint da API, formatadas como chave=valor"
 
-#: ../../uaclient/messages/__init__.py:899
+#: ../../uaclient/messages/__init__.py:904
 msgid "arguments in JSON format to the API endpoint"
 msgstr "argumentos em formato JSON para o endpoint da API"
 
-#: ../../uaclient/messages/__init__.py:902
+#: ../../uaclient/messages/__init__.py:907
 msgid "Automatically attach on an Ubuntu Pro cloud instance."
 msgstr "Automaticamente vincular em uma instância cloud do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:906
+#: ../../uaclient/messages/__init__.py:911
 msgid "Collect logs and relevant system information into a tarball."
 msgstr "Coleta logs e outras informações relevantes do sistema em um tarball."
 
-#: ../../uaclient/messages/__init__.py:909
+#: ../../uaclient/messages/__init__.py:914
 msgid "tarball where the logs will be stored. (Defaults to ./pro_logs.tar.gz)"
 msgstr "tarball onde os logs serão guardados. (Valor padrão ./pro_logs.tar.gz)"
 
-#: ../../uaclient/messages/__init__.py:912
+#: ../../uaclient/messages/__init__.py:917
 msgid "Show customizable configuration settings"
 msgstr "Mostra opções personalizáveis da configuração"
 
-#: ../../uaclient/messages/__init__.py:914
+#: ../../uaclient/messages/__init__.py:919
 msgid "Optional key or key(s) to show configuration settings."
 msgstr "Valor ou valores opcionais ao mostrar as configurações."
 
-#: ../../uaclient/messages/__init__.py:917
+#: ../../uaclient/messages/__init__.py:922
 msgid "Set and apply Ubuntu Pro configuration settings"
 msgstr "Define e aplica as configurações do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:920
+#: ../../uaclient/messages/__init__.py:925
 #, python-brace-format
 msgid ""
 "key=value pair to configure for Ubuntu Pro services. Key must be one of: "
@@ -1727,20 +1734,20 @@ msgstr ""
 "par chave=valor para configurar serviços Ubuntu Pro. Chave precisa ser uma "
 "dentre: {options}"
 
-#: ../../uaclient/messages/__init__.py:923
+#: ../../uaclient/messages/__init__.py:928
 msgid "Unset Ubuntu Pro configuration setting"
 msgstr "Desabilitar a configuração do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:925
+#: ../../uaclient/messages/__init__.py:930
 #, python-brace-format
 msgid "configuration key to unset from Ubuntu Pro services. One of: {options}"
 msgstr "chave de configuração Ubuntu Pro para desabilitar. Uma de: {options}"
 
-#: ../../uaclient/messages/__init__.py:927
+#: ../../uaclient/messages/__init__.py:932
 msgid "Manage Ubuntu Pro configuration"
 msgstr "Gerencie a configuração do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:930
+#: ../../uaclient/messages/__init__.py:935
 #, python-brace-format
 msgid ""
 "Attach this machine to an Ubuntu Pro subscription with a token obtained "
@@ -1759,28 +1766,28 @@ msgstr ""
 "Ubuntu Pro por meio\n"
 "de um navegador."
 
-#: ../../uaclient/messages/__init__.py:938
+#: ../../uaclient/messages/__init__.py:943
 msgid "token obtained for Ubuntu Pro authentication"
 msgstr "token obtido para autenticação do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:940
+#: ../../uaclient/messages/__init__.py:945
 msgid "do not enable any recommended services automatically"
 msgstr "não habilite nenhum serviço recomendado automaticamente"
 
-#: ../../uaclient/messages/__init__.py:943
+#: ../../uaclient/messages/__init__.py:948
 msgid ""
 "use the provided attach config file instead of passing the token on the cli"
 msgstr ""
 "use para providenciar um arquivo de configuração ao vincular ao invés de "
 "inserir o token via linha de comando"
 
-#: ../../uaclient/messages/__init__.py:948
+#: ../../uaclient/messages/__init__.py:953
 msgid ""
 "Inspect and resolve CVEs and USNs (Ubuntu Security Notices) on this machine."
 msgstr ""
 "Inspecionar e corrigir CVEs and USNs (Ubuntu Security Notices) nesta máquina."
 
-#: ../../uaclient/messages/__init__.py:952
+#: ../../uaclient/messages/__init__.py:957
 msgid ""
 "Security vulnerability ID to inspect and resolve on this system. Format: CVE-"
 "yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-dd"
@@ -1788,7 +1795,7 @@ msgstr ""
 "ID da Vulnerabilidade de segurança para inspecionar e corrigir neste "
 "sistema. Formato: CVE-yyyy-nnnn, CVE-yyyy-nnnnnnn ou USN-nnnn-dd"
 
-#: ../../uaclient/messages/__init__.py:956
+#: ../../uaclient/messages/__init__.py:961
 msgid ""
 "If used, fix will not actually run but will display everything that will "
 "happen on the machine during the command."
@@ -1796,7 +1803,7 @@ msgstr ""
 "Se usado, fix não vai executar modificações. Ao invés disso, irá mostrar "
 "tudo que irá acontecer na máquina durante a execução real do comando."
 
-#: ../../uaclient/messages/__init__.py:961
+#: ../../uaclient/messages/__init__.py:966
 msgid ""
 "If used, when fixing a USN, the command will not try to also fix related "
 "USNs to the target USN."
@@ -1804,12 +1811,12 @@ msgstr ""
 "Se usado, ao corrigir uma USN, o comando não tentará corrigar as USN "
 "relacionadas à USN principal."
 
-#: ../../uaclient/messages/__init__.py:966
+#: ../../uaclient/messages/__init__.py:971
 msgid ""
 "WARNING: Failed to update ESM cache - package availability may be inaccurate"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:970
+#: ../../uaclient/messages/__init__.py:975
 #, python-brace-format
 msgid ""
 "{bold}WARNING: Unable to update ESM cache when running as non-root,\n"
@@ -1817,7 +1824,7 @@ msgid ""
 "{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:976
+#: ../../uaclient/messages/__init__.py:981
 msgid ""
 "Show security updates for packages in the system, including all\n"
 "available Expanded Security Maintenance (ESM) related content.\n"
@@ -1854,23 +1861,23 @@ msgstr ""
 "completo\n"
 "a respeito dos serviços do Ubuntu Pro, execute 'pro status'.\n"
 
-#: ../../uaclient/messages/__init__.py:996
+#: ../../uaclient/messages/__init__.py:1001
 msgid "List and present information about third-party packages"
 msgstr "Lista e mostra informações presentes sobre pacotes de terceiros"
 
-#: ../../uaclient/messages/__init__.py:999
+#: ../../uaclient/messages/__init__.py:1004
 msgid "List and present information about unavailable packages"
 msgstr "Lista e mostra informações sobre pacotes indisponíveis"
 
-#: ../../uaclient/messages/__init__.py:1002
+#: ../../uaclient/messages/__init__.py:1007
 msgid "List and present information about esm-infra packages"
 msgstr "Lista e mostra informações sobre pacotes esm-infra"
 
-#: ../../uaclient/messages/__init__.py:1005
+#: ../../uaclient/messages/__init__.py:1010
 msgid "List and present information about esm-apps packages"
 msgstr "Lista e mostra informações sobre pacotes esm-apps"
 
-#: ../../uaclient/messages/__init__.py:1009
+#: ../../uaclient/messages/__init__.py:1014
 msgid ""
 "Refresh three distinct Ubuntu Pro related artifacts in the system:\n"
 "\n"
@@ -1894,75 +1901,75 @@ msgstr ""
 "especificada,\n"
 "todas as opções serão atualizadas.\n"
 
-#: ../../uaclient/messages/__init__.py:1021
+#: ../../uaclient/messages/__init__.py:1026
 msgid "Target to refresh."
 msgstr "Opção para atualizar"
 
-#: ../../uaclient/messages/__init__.py:1024
+#: ../../uaclient/messages/__init__.py:1029
 msgid "Detach this machine from an Ubuntu Pro subscription."
 msgstr "Desvincule esta máquina de uma assinatura do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:1028
+#: ../../uaclient/messages/__init__.py:1033
 msgid "Provide detailed information about Ubuntu Pro services."
 msgstr "Providencia informações detalhadas sobre os serviços do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:1031
+#: ../../uaclient/messages/__init__.py:1036
 #, python-brace-format
 msgid "a service to view help output for. One of: {options}"
 msgstr "serviço para qual informação de ajuda será mostrada. Um de: {options}"
 
-#: ../../uaclient/messages/__init__.py:1033
+#: ../../uaclient/messages/__init__.py:1038
 msgid "Include beta services"
 msgstr "Inclui os serviços beta"
 
-#: ../../uaclient/messages/__init__.py:1035
+#: ../../uaclient/messages/__init__.py:1040
 msgid "Enable an Ubuntu Pro service."
 msgstr "Habilite um serviço Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:1037
+#: ../../uaclient/messages/__init__.py:1042
 #, python-brace-format
 msgid "the name(s) of the Ubuntu Pro services to enable. One of: {options}"
 msgstr "os nome(s)n dos serviços Ubuntu Pro para habilitar. Um de: {options}"
 
-#: ../../uaclient/messages/__init__.py:1040
+#: ../../uaclient/messages/__init__.py:1045
 msgid ""
 "do not auto-install packages. Valid for cc-eal, cis and realtime-kernel."
 msgstr ""
 "não instale pacotes automaticamente. Válido para cc-eal, cis e realtime-"
 "kernel."
 
-#: ../../uaclient/messages/__init__.py:1043
+#: ../../uaclient/messages/__init__.py:1048
 msgid "allow beta service to be enabled"
 msgstr "permita que serviços beta sejam habilitados"
 
-#: ../../uaclient/messages/__init__.py:1045
+#: ../../uaclient/messages/__init__.py:1050
 msgid "The name of the variant to use when enabling the service"
 msgstr "O nome da variante para usar ao habilitar o serviço"
 
-#: ../../uaclient/messages/__init__.py:1048
+#: ../../uaclient/messages/__init__.py:1053
 msgid "Disable an Ubuntu Pro service."
 msgstr "Desabilite um serviço do Ubuntu Pro."
 
-#: ../../uaclient/messages/__init__.py:1050
+#: ../../uaclient/messages/__init__.py:1055
 #, python-brace-format
 msgid "the name(s) of the Ubuntu Pro services to disable. One of: {options}"
 msgstr ""
 "os nome(s) do serviços do Ubuntu Pro para desabilitar. Um de: {options}"
 
-#: ../../uaclient/messages/__init__.py:1053
+#: ../../uaclient/messages/__init__.py:1058
 msgid ""
 "disable the service and remove/downgrade related packages (experimental)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1057
+#: ../../uaclient/messages/__init__.py:1062
 msgid "Output system related information related to Pro services"
 msgstr "Mostre informações de sistema relacionados aos serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1059
+#: ../../uaclient/messages/__init__.py:1064
 msgid "does the system need to be rebooted"
 msgstr "se o sistema precisa ser reiniciado"
 
-#: ../../uaclient/messages/__init__.py:1061
+#: ../../uaclient/messages/__init__.py:1066
 msgid ""
 "Report the current reboot-required status for the machine.\n"
 "\n"
@@ -1991,7 +1998,7 @@ msgstr ""
 "  reiniciada, mas você pode averiguar se o reinício pode acontecer no\n"
 "  período de manutenção mais próximo.\n"
 
-#: ../../uaclient/messages/__init__.py:1078
+#: ../../uaclient/messages/__init__.py:1083
 msgid ""
 "Report current status of Ubuntu Pro services on system.\n"
 "\n"
@@ -2063,80 +2070,80 @@ msgstr ""
 "Se a flag --all for usada, serviços beta e indisponíveis também\n"
 "serão listado.\n"
 
-#: ../../uaclient/messages/__init__.py:1113
+#: ../../uaclient/messages/__init__.py:1118
 msgid "Block waiting on pro to complete"
 msgstr "Espera até o pro completar sua operação"
 
-#: ../../uaclient/messages/__init__.py:1115
+#: ../../uaclient/messages/__init__.py:1120
 msgid "simulate the output status using a provided token"
 msgstr "simula a mensagem de status usando um token fornecido"
 
-#: ../../uaclient/messages/__init__.py:1117
+#: ../../uaclient/messages/__init__.py:1122
 msgid "Include unavailable and beta services"
 msgstr "Inclui serviços beta e indisponíveis"
 
-#: ../../uaclient/messages/__init__.py:1119
+#: ../../uaclient/messages/__init__.py:1124
 msgid "show all debug log messages to console"
 msgstr "mostra todas os logs de debug na saída do comando"
 
-#: ../../uaclient/messages/__init__.py:1120
+#: ../../uaclient/messages/__init__.py:1125
 #, python-brace-format
 msgid "show version of {name}"
 msgstr "mostra versão de {name}"
 
-#: ../../uaclient/messages/__init__.py:1122
+#: ../../uaclient/messages/__init__.py:1127
 msgid "attach this machine to an Ubuntu Pro subscription"
 msgstr "vincule esta máquina a uma assinatura Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1125
+#: ../../uaclient/messages/__init__.py:1130
 msgid "automatically attach on supported platforms"
 msgstr "automaticamente vincule está máquina em plataformas suportadas"
 
-#: ../../uaclient/messages/__init__.py:1126
+#: ../../uaclient/messages/__init__.py:1131
 msgid "collect Pro logs and debug information"
 msgstr "coleta logs do Pro e informações de debug"
 
-#: ../../uaclient/messages/__init__.py:1127
+#: ../../uaclient/messages/__init__.py:1132
 msgid "manage Ubuntu Pro configuration on this machine"
 msgstr "gerencia configuração do Ubuntu Pro nesta máquina"
 
-#: ../../uaclient/messages/__init__.py:1129
+#: ../../uaclient/messages/__init__.py:1134
 msgid "remove this machine from an Ubuntu Pro subscription"
 msgstr "desvincula esta máquina de uma assinatura Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1132
+#: ../../uaclient/messages/__init__.py:1137
 msgid "disable a specific Ubuntu Pro service on this machine"
 msgstr "desabilita nesta máquina um serviço do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1135
+#: ../../uaclient/messages/__init__.py:1140
 msgid "enable a specific Ubuntu Pro service on this machine"
 msgstr "habilita nesta máquina um serviço Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1138
+#: ../../uaclient/messages/__init__.py:1143
 msgid "check for and mitigate the impact of a CVE/USN on this system"
 msgstr "checa e corrige os problemas de segurança de um CVE/USN na máquina"
 
-#: ../../uaclient/messages/__init__.py:1141
+#: ../../uaclient/messages/__init__.py:1146
 msgid "list available security updates for the system"
 msgstr "lista atualizações de segurança disponíveis para o sistema"
 
-#: ../../uaclient/messages/__init__.py:1144
+#: ../../uaclient/messages/__init__.py:1149
 msgid "show detailed information about Ubuntu Pro services"
 msgstr "mostra informações detalhadas sobre os serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1146
+#: ../../uaclient/messages/__init__.py:1151
 msgid "refresh Ubuntu Pro services"
 msgstr "atualiza os serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1147
+#: ../../uaclient/messages/__init__.py:1152
 msgid "current status of all Ubuntu Pro services"
 msgstr "status atual de todos os serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1148
+#: ../../uaclient/messages/__init__.py:1153
 msgid "show system information related to Pro services"
 msgstr "mostra informações de sistema relacionados a serviços do Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:1151
+#: ../../uaclient/messages/__init__.py:1156
 #, python-brace-format
 msgid ""
 "WARNING: this output is intended to be human readable, and subject to "
@@ -2154,15 +2161,15 @@ msgstr ""
 #. ##############################################################################
 #. SERVICE-SPECIFIC MESSAGES                            #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:1164
+#: ../../uaclient/messages/__init__.py:1169
 msgid "Anbox Cloud"
 msgstr "Anbox Cloud"
 
-#: ../../uaclient/messages/__init__.py:1165
+#: ../../uaclient/messages/__init__.py:1170
 msgid "Scalable Android in the cloud"
 msgstr "Android escalável na nuvem"
 
-#: ../../uaclient/messages/__init__.py:1167
+#: ../../uaclient/messages/__init__.py:1172
 #, python-brace-format
 msgid ""
 "Anbox Cloud lets you stream mobile apps securely, at any scale, to any "
@@ -2180,7 +2187,7 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1178
+#: ../../uaclient/messages/__init__.py:1183
 #, python-brace-format
 msgid ""
 "To finish setting up the Anbox Cloud Appliance, run:\n"
@@ -2192,15 +2199,15 @@ msgid ""
 "For more information, see {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1189
+#: ../../uaclient/messages/__init__.py:1194
 msgid "CC EAL2"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1190
+#: ../../uaclient/messages/__init__.py:1195
 msgid "Common Criteria EAL2 Provisioning Packages"
 msgstr "Pacotes de Provisionamento do Common Criteria EAL2"
 
-#: ../../uaclient/messages/__init__.py:1192
+#: ../../uaclient/messages/__init__.py:1197
 msgid ""
 "Common Criteria is an Information Technology Security Evaluation standard\n"
 "(ISO/IEC IS 15408) for computer security certification. Ubuntu 16.04 has "
@@ -2210,29 +2217,29 @@ msgid ""
 "on Intel x86_64, IBM Power8 and IBM Z hardware platforms."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1199
+#: ../../uaclient/messages/__init__.py:1204
 msgid ""
 "(This will download more than 500MB of packages, so may take some time.)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1203
+#: ../../uaclient/messages/__init__.py:1208
 #, python-brace-format
 msgid "Please follow instructions in {filename} to configure EAL2"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1206
+#: ../../uaclient/messages/__init__.py:1211
 msgid "CIS Audit"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1207
+#: ../../uaclient/messages/__init__.py:1212
 msgid "Ubuntu Security Guide"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1208
+#: ../../uaclient/messages/__init__.py:1213
 msgid "Security compliance and audit tools"
 msgstr "Ferramentas de auditoria e conformidade de segurança"
 
-#: ../../uaclient/messages/__init__.py:1210
+#: ../../uaclient/messages/__init__.py:1215
 #, python-brace-format
 msgid ""
 "Ubuntu Security Guide is a tool for hardening and auditing and allows for\n"
@@ -2242,17 +2249,17 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1216
+#: ../../uaclient/messages/__init__.py:1221
 #, python-brace-format
 msgid "Visit {url} to learn how to use CIS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1219
+#: ../../uaclient/messages/__init__.py:1224
 #, python-brace-format
 msgid "Visit {url} for the next steps"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1223
+#: ../../uaclient/messages/__init__.py:1228
 #, python-brace-format
 msgid ""
 "From Ubuntu 20.04 onward 'pro enable cis' has been\n"
@@ -2260,11 +2267,11 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1231
+#: ../../uaclient/messages/__init__.py:1236
 msgid "Expanded Security Maintenance for Applications"
 msgstr "Manutenção de Segurança Expandida para Aplicações"
 
-#: ../../uaclient/messages/__init__.py:1234
+#: ../../uaclient/messages/__init__.py:1239
 #, python-brace-format
 msgid ""
 "Expanded Security Maintenance for Applications is enabled by default on\n"
@@ -2276,11 +2283,11 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1245
+#: ../../uaclient/messages/__init__.py:1250
 msgid "Expanded Security Maintenance for Infrastructure"
 msgstr "Manutenção de Segurança Expandida para Infraestrutura"
 
-#: ../../uaclient/messages/__init__.py:1248
+#: ../../uaclient/messages/__init__.py:1253
 #, python-brace-format
 msgid ""
 "Expanded Security Maintenance for Infrastructure provides access to a "
@@ -2293,15 +2300,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1257
+#: ../../uaclient/messages/__init__.py:1262
 msgid "FIPS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1258
+#: ../../uaclient/messages/__init__.py:1263
 msgid "NIST-certified FIPS crypto packages"
 msgstr "Pacotes FIPS de criptografia certificados pelo NIST"
 
-#: ../../uaclient/messages/__init__.py:1260
+#: ../../uaclient/messages/__init__.py:1265
 #, python-brace-format
 msgid ""
 "Installs FIPS 140 crypto packages for FedRAMP, FISMA and compliance use "
@@ -2312,18 +2319,18 @@ msgid ""
 "choose \"fips-updates\" for maximum security. Find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1267
+#: ../../uaclient/messages/__init__.py:1272
 msgid "Could not determine cloud, defaulting to generic FIPS package."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1270
+#: ../../uaclient/messages/__init__.py:1275
 #, python-brace-format
 msgid ""
 "FIPS kernel is running in a disabled state.\n"
 "  To manually remove fips kernel: {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1276
+#: ../../uaclient/messages/__init__.py:1281
 msgid ""
 "Warning: FIPS kernel is not optimized for your specific cloud.\n"
 "To fix it, run the following commands:\n"
@@ -2334,20 +2341,20 @@ msgid ""
 "    4. sudo reboot\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1288
+#: ../../uaclient/messages/__init__.py:1293
 msgid ""
 "This will install the FIPS packages. The Livepatch service will be "
 "unavailable.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1297
+#: ../../uaclient/messages/__init__.py:1302
 msgid ""
 "This will install the FIPS packages including security updates.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1306
+#: ../../uaclient/messages/__init__.py:1311
 #, python-brace-format
 msgid ""
 "Warning: Enabling {title} in a container.\n"
@@ -2357,14 +2364,14 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1318
+#: ../../uaclient/messages/__init__.py:1323
 #, python-brace-format
 msgid ""
 "This will disable the {title} entitlement but the {title} packages will "
 "remain installed.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1325
+#: ../../uaclient/messages/__init__.py:1330
 #, python-brace-format
 msgid ""
 "This will downgrade the kernel from {current_version} to {new_version}.\n"
@@ -2374,51 +2381,51 @@ msgid ""
 "proceeding.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1332
+#: ../../uaclient/messages/__init__.py:1337
 msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1334
-#: ../../uaclient/messages/__init__.py:1774
+#: ../../uaclient/messages/__init__.py:1339
+#: ../../uaclient/messages/__init__.py:1782
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1336
+#: ../../uaclient/messages/__init__.py:1341
 msgid "This FIPS install is out of date, run: sudo pro enable fips"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1339
+#: ../../uaclient/messages/__init__.py:1344
 msgid "Disabling FIPS requires system reboot to complete operation."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1342
+#: ../../uaclient/messages/__init__.py:1347
 #, python-brace-format
 msgid "{service} {pkg} package could not be installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1345
+#: ../../uaclient/messages/__init__.py:1350
 msgid ""
 "Please run `apt upgrade` to ensure all FIPS packages are updated to the "
 "correct\n"
 "version.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1352
+#: ../../uaclient/messages/__init__.py:1357
 #, python-brace-format
 msgid "Failure occurred while upgrading packages to {service} versions."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1358
+#: ../../uaclient/messages/__init__.py:1363
 msgid "FIPS Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1360
+#: ../../uaclient/messages/__init__.py:1365
 msgid "FIPS compliant crypto packages with stable security updates"
 msgstr ""
 "Pacotes de criptografia compatíveis com FIPS com atualizações de segurança "
 "estáveis"
 
-#: ../../uaclient/messages/__init__.py:1363
+#: ../../uaclient/messages/__init__.py:1368
 #, python-brace-format
 msgid ""
 "fips-updates installs FIPS 140 crypto packages including all security "
@@ -2427,22 +2434,22 @@ msgid ""
 "You can find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1369
+#: ../../uaclient/messages/__init__.py:1374
 msgid "FIPS Preview"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1371
+#: ../../uaclient/messages/__init__.py:1376
 msgid "Preview of FIPS crypto packages undergoing certification with NIST"
 msgstr ""
 "Prévia de pacotes FIPS de criptografia em processo de certificação pelo NIST"
 
-#: ../../uaclient/messages/__init__.py:1374
+#: ../../uaclient/messages/__init__.py:1379
 msgid ""
 "Installs FIPS crypto packages that are under certification with NIST,\n"
 "for FedRAMP, FISMA and compliance use cases."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1379
+#: ../../uaclient/messages/__init__.py:1384
 msgid ""
 "This will install crypto packages that have been submitted to NIST for "
 "review\n"
@@ -2454,15 +2461,15 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1390
+#: ../../uaclient/messages/__init__.py:1395
 msgid "Landscape"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1392
+#: ../../uaclient/messages/__init__.py:1397
 msgid "Management and administration tool for Ubuntu"
 msgstr "Ferramenta de gerenciamento e administração para o Ubuntu"
 
-#: ../../uaclient/messages/__init__.py:1395
+#: ../../uaclient/messages/__init__.py:1400
 #, python-brace-format
 msgid ""
 "Landscape Client can be installed on this machine and enrolled in "
@@ -2475,22 +2482,22 @@ msgid ""
 "more. Find out more about Landscape at {home_url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1408
+#: ../../uaclient/messages/__init__.py:1413
 msgid ""
 "/etc/landscape/client.conf contains your landscape-client configuration.\n"
 "To re-enable Landscape with the same configuration, run:\n"
 "    sudo pro enable landscape --assume-yes\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1415
+#: ../../uaclient/messages/__init__.py:1420
 msgid "Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1416
+#: ../../uaclient/messages/__init__.py:1421
 msgid "Canonical Livepatch service"
 msgstr "Serviço de Livepatch da Canonical"
 
-#: ../../uaclient/messages/__init__.py:1418
+#: ../../uaclient/messages/__init__.py:1423
 #, python-brace-format
 msgid ""
 "Livepatch provides selected high and critical kernel CVE fixes and other\n"
@@ -2505,50 +2512,50 @@ msgid ""
 "service at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1427
+#: ../../uaclient/messages/__init__.py:1432
 msgid "Current kernel is not covered by livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1430
+#: ../../uaclient/messages/__init__.py:1435
 #, python-brace-format
 msgid "Kernels covered by livepatch are listed here: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1433
+#: ../../uaclient/messages/__init__.py:1438
 #, python-brace-format
 msgid "Unable to configure livepatch: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1435
+#: ../../uaclient/messages/__init__.py:1440
 msgid "Unable to enable Livepatch: "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1437
+#: ../../uaclient/messages/__init__.py:1442
 msgid "Disabling Livepatch prior to re-attach with new token"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1440
+#: ../../uaclient/messages/__init__.py:1445
 msgid "Livepatch coverage requires a system reboot across LTS upgrade."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1442
+#: ../../uaclient/messages/__init__.py:1447
 msgid "Installing Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1443
+#: ../../uaclient/messages/__init__.py:1448
 msgid "Setting up Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1445
-#: ../../uaclient/messages/__init__.py:1458
+#: ../../uaclient/messages/__init__.py:1450
+#: ../../uaclient/messages/__init__.py:1463
 msgid "Real-time kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1447
+#: ../../uaclient/messages/__init__.py:1452
 msgid "Ubuntu kernel with PREEMPT_RT patches integrated"
 msgstr "Kernel do Ubuntu com patches PREEMPT_RT integrados"
 
-#: ../../uaclient/messages/__init__.py:1450
+#: ../../uaclient/messages/__init__.py:1455
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated. "
 "It\n"
@@ -2561,35 +2568,35 @@ msgid ""
 "Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1460
+#: ../../uaclient/messages/__init__.py:1465
 msgid "Generic version of the RT kernel (default)"
 msgstr "Versão genérica do kernel RT (padrão)"
 
-#: ../../uaclient/messages/__init__.py:1462
+#: ../../uaclient/messages/__init__.py:1467
 msgid "Real-time NVIDIA Tegra Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1464
+#: ../../uaclient/messages/__init__.py:1469
 msgid "RT kernel optimized for NVIDIA Tegra platform"
 msgstr "Kernel RT otimizado para a plataforma NVIDIA Tegra"
 
-#: ../../uaclient/messages/__init__.py:1466
+#: ../../uaclient/messages/__init__.py:1471
 msgid "Raspberry Pi Real-time for Pi5/Pi4"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1468
+#: ../../uaclient/messages/__init__.py:1473
 msgid "24.04 Real-time kernel optimised for Raspberry Pi"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1470
+#: ../../uaclient/messages/__init__.py:1475
 msgid "Real-time Intel IOTG Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1472
+#: ../../uaclient/messages/__init__.py:1477
 msgid "RT kernel optimized for Intel IOTG platform"
 msgstr "Kernel RT otimizado para a plataforma Intel IOTG"
 
-#: ../../uaclient/messages/__init__.py:1475
+#: ../../uaclient/messages/__init__.py:1480
 #, python-brace-format
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches "
@@ -2602,7 +2609,7 @@ msgid ""
 "Do you want to continue? [ default = Yes ]: (Y/n) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1486
+#: ../../uaclient/messages/__init__.py:1491
 msgid ""
 "This will remove the boot order preference for the Real-time kernel and\n"
 "disable updates to the Real-time kernel.\n"
@@ -2619,15 +2626,15 @@ msgid ""
 "Are you sure? (y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1502
+#: ../../uaclient/messages/__init__.py:1507
 msgid "ROS ESM Security Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1503
+#: ../../uaclient/messages/__init__.py:1508
 msgid "Security Updates for the Robot Operating System"
 msgstr "Atualizações de Segurança para o Robot Operating System"
 
-#: ../../uaclient/messages/__init__.py:1505
+#: ../../uaclient/messages/__init__.py:1510
 #, python-brace-format
 msgid ""
 "ros provides access to a private PPA which includes security-related "
@@ -2640,15 +2647,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1514
+#: ../../uaclient/messages/__init__.py:1519
 msgid "ROS ESM All Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1516
+#: ../../uaclient/messages/__init__.py:1521
 msgid "All Updates for the Robot Operating System"
 msgstr "Todas as Atualizações para o Robot Operating System"
 
-#: ../../uaclient/messages/__init__.py:1519
+#: ../../uaclient/messages/__init__.py:1524
 #, python-brace-format
 msgid ""
 "ros-updates provides access to a private PPA that includes non-security-"
@@ -2661,7 +2668,7 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1590
+#: ../../uaclient/messages/__init__.py:1595
 #, python-brace-format
 msgid ""
 "An unexpected error occurred: {error_msg}\n"
@@ -2669,7 +2676,7 @@ msgid ""
 "If you think this is a bug, please run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1600
+#: ../../uaclient/messages/__init__.py:1605
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2677,7 +2684,7 @@ msgid ""
 "Please install \"ca-certificates\" and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1610
+#: ../../uaclient/messages/__init__.py:1615
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2685,202 +2692,207 @@ msgid ""
 "Please check your openssl configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1619
+#: ../../uaclient/messages/__init__.py:1624
 #, python-brace-format
 msgid "Ignoring unknown argument '{arg}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1625
+#: ../../uaclient/messages/__init__.py:1630
 #, python-brace-format
 msgid ""
 "A new version of the client is available: {version}. Please upgrade to the "
 "latest version to get the new features and bug fixes."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1632
+#: ../../uaclient/messages/__init__.py:1637
 #, python-brace-format
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1637
+#: ../../uaclient/messages/__init__.py:1642
 #, python-brace-format
 msgid "{title} does not support being disabled with --purge"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1643
+#: ../../uaclient/messages/__init__.py:1648
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1650
+#: ../../uaclient/messages/__init__.py:1655
 #, python-brace-format
 msgid "Cannot disable {entitlement_name} with purge: no origin value defined"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1657
+#: ../../uaclient/messages/__init__.py:1662
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1662
+#: ../../uaclient/messages/__init__.py:1667
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1665
+#: ../../uaclient/messages/__init__.py:1670
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1670
+#: ../../uaclient/messages/__init__.py:1675
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1676
+#: ../../uaclient/messages/__init__.py:1681
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1680
+#: ../../uaclient/messages/__init__.py:1685
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1684
+#: ../../uaclient/messages/__init__.py:1689
 #, python-brace-format
 msgid "{title} does not have a suites directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1689
+#: ../../uaclient/messages/__init__.py:1694
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1697
+#: ../../uaclient/messages/__init__.py:1702
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1704
+#: ../../uaclient/messages/__init__.py:1709
 #, python-brace-format
 msgid ""
 "{title} is already enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1712
+#: ../../uaclient/messages/__init__.py:1717
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1718
+#: ../../uaclient/messages/__init__.py:1723
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1724
+#: ../../uaclient/messages/__init__.py:1726
 #, python-brace-format
-msgid ""
-"{title} is not available for kernel {kernel}.\n"
-"Minimum kernel version required: {min_kernel}."
+msgid "Auto-selected {variant_name} variant"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1732
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
-"Supported flavors are: {supported_kernels}."
+"Minimum kernel version required: {min_kernel}."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1740
 #, python-brace-format
+msgid ""
+"{title} is not available for kernel {kernel}.\n"
+"Supported flavors are: {supported_kernels}."
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1748
+#, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1747
+#: ../../uaclient/messages/__init__.py:1755
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1755
+#: ../../uaclient/messages/__init__.py:1763
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1762
+#: ../../uaclient/messages/__init__.py:1770
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1768
+#: ../../uaclient/messages/__init__.py:1776
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1778
+#: ../../uaclient/messages/__init__.py:1786
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1781
+#: ../../uaclient/messages/__init__.py:1789
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1785
+#: ../../uaclient/messages/__init__.py:1793
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1790
+#: ../../uaclient/messages/__init__.py:1798
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1798
+#: ../../uaclient/messages/__init__.py:1806
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1807
+#: ../../uaclient/messages/__init__.py:1815
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1815
+#: ../../uaclient/messages/__init__.py:1823
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1819
+#: ../../uaclient/messages/__init__.py:1827
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1824
+#: ../../uaclient/messages/__init__.py:1832
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "coverage."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1832
+#: ../../uaclient/messages/__init__.py:1840
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2890,7 +2902,7 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1841
+#: ../../uaclient/messages/__init__.py:1849
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not covered by livepatch.\n"
@@ -2899,79 +2911,79 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1851
+#: ../../uaclient/messages/__init__.py:1859
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1857
+#: ../../uaclient/messages/__init__.py:1865
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1866
+#: ../../uaclient/messages/__init__.py:1874
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1873
+#: ../../uaclient/messages/__init__.py:1881
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1879
+#: ../../uaclient/messages/__init__.py:1887
 msgid "Livepatch does not currently cover the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1883
+#: ../../uaclient/messages/__init__.py:1891
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1887
+#: ../../uaclient/messages/__init__.py:1895
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1892
+#: ../../uaclient/messages/__init__.py:1900
 msgid "ROS packages assume ESM updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1897
+#: ../../uaclient/messages/__init__.py:1905
 msgid "ROS bug-fix updates assume ROS security fix updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1903
+#: ../../uaclient/messages/__init__.py:1911
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1907
+#: ../../uaclient/messages/__init__.py:1915
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1911
+#: ../../uaclient/messages/__init__.py:1919
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1915
+#: ../../uaclient/messages/__init__.py:1923
 msgid "unattended-upgrades package is not installed"
 msgstr "O pacote unattended-upgrades não está instalado"
 
-#: ../../uaclient/messages/__init__.py:1921
+#: ../../uaclient/messages/__init__.py:1929
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1930
+#: ../../uaclient/messages/__init__.py:1938
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1937
+#: ../../uaclient/messages/__init__.py:1945
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2981,28 +2993,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1956
+#: ../../uaclient/messages/__init__.py:1964
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1962
+#: ../../uaclient/messages/__init__.py:1970
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1992
+#: ../../uaclient/messages/__init__.py:2000
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1997
+#: ../../uaclient/messages/__init__.py:2005
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2003
+#: ../../uaclient/messages/__init__.py:2011
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -3010,107 +3022,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2013
+#: ../../uaclient/messages/__init__.py:2021
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2020
+#: ../../uaclient/messages/__init__.py:2028
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2025
+#: ../../uaclient/messages/__init__.py:2033
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2029
+#: ../../uaclient/messages/__init__.py:2037
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2033
+#: ../../uaclient/messages/__init__.py:2041
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2038
+#: ../../uaclient/messages/__init__.py:2046
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2043
+#: ../../uaclient/messages/__init__.py:2051
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2048
+#: ../../uaclient/messages/__init__.py:2056
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2054
+#: ../../uaclient/messages/__init__.py:2062
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2060
+#: ../../uaclient/messages/__init__.py:2068
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2064
+#: ../../uaclient/messages/__init__.py:2072
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2070
+#: ../../uaclient/messages/__init__.py:2078
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2078
+#: ../../uaclient/messages/__init__.py:2086
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2084
+#: ../../uaclient/messages/__init__.py:2092
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2093
+#: ../../uaclient/messages/__init__.py:2101
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2100
+#: ../../uaclient/messages/__init__.py:2108
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2107
+#: ../../uaclient/messages/__init__.py:2115
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2112
+#: ../../uaclient/messages/__init__.py:2120
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2118
+#: ../../uaclient/messages/__init__.py:2126
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3118,7 +3130,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2128
+#: ../../uaclient/messages/__init__.py:2136
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3126,7 +3138,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2138
+#: ../../uaclient/messages/__init__.py:2146
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -3134,41 +3146,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2148
+#: ../../uaclient/messages/__init__.py:2156
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2155
+#: ../../uaclient/messages/__init__.py:2163
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2161
+#: ../../uaclient/messages/__init__.py:2169
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2167
+#: ../../uaclient/messages/__init__.py:2175
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2172
+#: ../../uaclient/messages/__init__.py:2180
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2178
+#: ../../uaclient/messages/__init__.py:2186
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2186
+#: ../../uaclient/messages/__init__.py:2194
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2195
+#: ../../uaclient/messages/__init__.py:2203
 #, python-brace-format
 msgid ""
 "Cannot {{operation}} services when unattached - nothing to do.\n"
@@ -3177,74 +3189,74 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2212
+#: ../../uaclient/messages/__init__.py:2220
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2217
+#: ../../uaclient/messages/__init__.py:2225
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2222
+#: ../../uaclient/messages/__init__.py:2230
 #, python-brace-format
 msgid "failed to enable {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2227
+#: ../../uaclient/messages/__init__.py:2235
 #, python-brace-format
 msgid "failed to disable {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2233
+#: ../../uaclient/messages/__init__.py:2241
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2241
+#: ../../uaclient/messages/__init__.py:2249
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2249
+#: ../../uaclient/messages/__init__.py:2257
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2256
+#: ../../uaclient/messages/__init__.py:2264
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2263
+#: ../../uaclient/messages/__init__.py:2271
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2272
+#: ../../uaclient/messages/__init__.py:2280
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
-msgstr ""
-
-#: ../../uaclient/messages/__init__.py:2278
-#, python-brace-format
-msgid ""
-"Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:2286
 #, python-brace-format
 msgid ""
-"Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
+"Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:2294
+#, python-brace-format
+msgid ""
+"Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:2302
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2303
+#: ../../uaclient/messages/__init__.py:2311
 #, python-brace-format
 msgid ""
 "Failed to identify this image as a valid Ubuntu Pro image.\n"
@@ -3252,14 +3264,14 @@ msgid ""
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2313
+#: ../../uaclient/messages/__init__.py:2321
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2320
+#: ../../uaclient/messages/__init__.py:2328
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -3267,16 +3279,16 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2330
+#: ../../uaclient/messages/__init__.py:2338
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2337
+#: ../../uaclient/messages/__init__.py:2345
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2345
+#: ../../uaclient/messages/__init__.py:2353
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
@@ -3285,7 +3297,7 @@ msgstr ""
 "Suporte para auto-attach não está disponível para esta imagem\n"
 "Veja {url}"
 
-#: ../../uaclient/messages/__init__.py:2354
+#: ../../uaclient/messages/__init__.py:2362
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
@@ -3294,18 +3306,18 @@ msgstr ""
 "Suporte para auto-attach não está disponível para {{cloud_type}}\n"
 "Veja: {url}"
 
-#: ../../uaclient/messages/__init__.py:2362
+#: ../../uaclient/messages/__init__.py:2370
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2368
+#: ../../uaclient/messages/__init__.py:2376
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2376
+#: ../../uaclient/messages/__init__.py:2384
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -3316,7 +3328,7 @@ msgstr ""
 "o campo VERSION não tem a informação de versão: {version}\n"
 "e o campo VERSION_CODENAME não está presente"
 
-#: ../../uaclient/messages/__init__.py:2386
+#: ../../uaclient/messages/__init__.py:2394
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -3330,12 +3342,12 @@ msgstr ""
 "\n"
 "$ sudo rm {lock_file_path}"
 
-#: ../../uaclient/messages/__init__.py:2395
+#: ../../uaclient/messages/__init__.py:2403
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr "{source} retornou um json inválido: {out}"
 
-#: ../../uaclient/messages/__init__.py:2401
+#: ../../uaclient/messages/__init__.py:2409
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
@@ -3344,7 +3356,7 @@ msgstr ""
 "Valor inválido para {path_to_value} em /etc/ubuntu-advantage/uaclient.conf."
 "Esperava {expected_value}, mas {value} foi encontrado."
 
-#: ../../uaclient/messages/__init__.py:2410
+#: ../../uaclient/messages/__init__.py:2418
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
@@ -3352,17 +3364,17 @@ msgstr ""
 "Não foi possível associar {key} a {value}: <value> precisa ser um inteiro "
 "positivo."
 
-#: ../../uaclient/messages/__init__.py:2417
+#: ../../uaclient/messages/__init__.py:2425
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr "url inválida no arquivo de configuração. {key}: {value}"
 
-#: ../../uaclient/messages/__init__.py:2422
+#: ../../uaclient/messages/__init__.py:2430
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr "Não foi possível encontrar o arquivo yaml: {filepath}"
 
-#: ../../uaclient/messages/__init__.py:2428
+#: ../../uaclient/messages/__init__.py:2436
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
@@ -3373,27 +3385,27 @@ msgstr ""
 "pro de apt ao mesmo tempo não é suportado.\n"
 "Cancelando o processo de configuração.\n"
 
-#: ../../uaclient/messages/__init__.py:2438
+#: ../../uaclient/messages/__init__.py:2446
 msgid "Can't load the distro-info database."
 msgstr "Não foi possível carregar o banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2443
+#: ../../uaclient/messages/__init__.py:2451
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 "Não foi possível encontrar a série {series} na banco de dados do distro-info."
 
-#: ../../uaclient/messages/__init__.py:2448
+#: ../../uaclient/messages/__init__.py:2456
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr "Erro: não é possível usar {option1} junto com {option2}"
 
-#: ../../uaclient/messages/__init__.py:2452
+#: ../../uaclient/messages/__init__.py:2460
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr "Ajuda não disponível para '{name}'"
 
-#: ../../uaclient/messages/__init__.py:2458
+#: ../../uaclient/messages/__init__.py:2466
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
@@ -3402,39 +3414,39 @@ msgstr ""
 "Erro: problema de segurnça \"{issue}\" não foi reconhecido.\n"
 "Use: \"pro fix CVE-yyyy-nnnn\" ou \"pro fix USN-nnnn\""
 
-#: ../../uaclient/messages/__init__.py:2464
+#: ../../uaclient/messages/__init__.py:2472
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr "{arg} precisa ser um de: {choices}"
 
-#: ../../uaclient/messages/__init__.py:2469
+#: ../../uaclient/messages/__init__.py:2477
 #, python-brace-format
 msgid "Empty value provided for {arg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2474
+#: ../../uaclient/messages/__init__.py:2482
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr "Esperava {expected} mas encontrou: {actual}"
 
-#: ../../uaclient/messages/__init__.py:2478
+#: ../../uaclient/messages/__init__.py:2486
 msgid "Unable to process uaclient.conf"
 msgstr "Falha ao processar uaclient.conf"
 
-#: ../../uaclient/messages/__init__.py:2483
+#: ../../uaclient/messages/__init__.py:2491
 msgid "Unable to refresh your subscription"
 msgstr "Falha ao atualizar sua assinatura"
 
-#: ../../uaclient/messages/__init__.py:2488
+#: ../../uaclient/messages/__init__.py:2496
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 "Falha ao atualizar as mensagens de APT e MOTD relacioandas ao Ubuntu Pro"
 
-#: ../../uaclient/messages/__init__.py:2494
+#: ../../uaclient/messages/__init__.py:2502
 msgid "json formatted response requires --assume-yes flag."
 msgstr "resposta formatada em json necessita do paramêtro --assume-yes"
 
-#: ../../uaclient/messages/__init__.py:2502
+#: ../../uaclient/messages/__init__.py:2510
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
@@ -3444,54 +3456,54 @@ msgstr ""
 "Ao invés disso, inclua o token no arquivo de attach-config.\n"
 "    "
 
-#: ../../uaclient/messages/__init__.py:2511
+#: ../../uaclient/messages/__init__.py:2519
 msgid "Cannot provide both --args and --data at the same time"
 msgstr "Não é possível usar --args e --data ao mesmo tempo"
 
-#: ../../uaclient/messages/__init__.py:2516
+#: ../../uaclient/messages/__init__.py:2524
 msgid "Operation cancelled by user"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2522
+#: ../../uaclient/messages/__init__.py:2530
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr "Falha ao executar: {lock_request}.\n"
 
-#: ../../uaclient/messages/__init__.py:2531
+#: ../../uaclient/messages/__init__.py:2539
 msgid "This command must be run as root (try using sudo)."
 msgstr "Esse comando precisa ser executado como root (tente usando sudo)."
 
-#: ../../uaclient/messages/__init__.py:2536
+#: ../../uaclient/messages/__init__.py:2544
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr "Metadados para {issue} não são válidos. Erro: {error_msg}."
 
-#: ../../uaclient/messages/__init__.py:2543
+#: ../../uaclient/messages/__init__.py:2551
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr "Erro: {issue_id} não encontrada."
 
-#: ../../uaclient/messages/__init__.py:2547
+#: ../../uaclient/messages/__init__.py:2555
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr "chave GPG '{keyfile}' não foi encontrada"
 
-#: ../../uaclient/messages/__init__.py:2552
+#: ../../uaclient/messages/__init__.py:2560
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr "'{endpoint}' não é um endpoint válido"
 
-#: ../../uaclient/messages/__init__.py:2557
+#: ../../uaclient/messages/__init__.py:2565
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr "'{arg}' está faltando para endpoint {endpoint}"
 
-#: ../../uaclient/messages/__init__.py:2562
+#: ../../uaclient/messages/__init__.py:2570
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr "{endpoint} não aceita paramêtros"
 
-#: ../../uaclient/messages/__init__.py:2567
+#: ../../uaclient/messages/__init__.py:2575
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
@@ -3500,32 +3512,32 @@ msgstr ""
 "Error ao analisar paramêtro data para API json:\n"
 "{data}"
 
-#: ../../uaclient/messages/__init__.py:2572
+#: ../../uaclient/messages/__init__.py:2580
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr "'{arg}' não está formatado como 'chave=valor'"
 
-#: ../../uaclient/messages/__init__.py:2577
+#: ../../uaclient/messages/__init__.py:2585
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr "Não foi possível determinar a versão: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2582
+#: ../../uaclient/messages/__init__.py:2590
 msgid "features.disable_auto_attach set in config"
 msgstr "features.disable_auto_attach definida na configuração"
 
-#: ../../uaclient/messages/__init__.py:2587
+#: ../../uaclient/messages/__init__.py:2595
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 "Não foi possível determinar o status do unattended-upgrades: {error_msg}"
 
-#: ../../uaclient/messages/__init__.py:2593
+#: ../../uaclient/messages/__init__.py:2601
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr "Esperava valor com tipo {expected_type}, mas recebeu tipo {got_type}"
 
-#: ../../uaclient/messages/__init__.py:2599
+#: ../../uaclient/messages/__init__.py:2607
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
@@ -3534,7 +3546,7 @@ msgstr ""
 "Valor com tipo incorreto na posição {index}:\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2605
+#: ../../uaclient/messages/__init__.py:2613
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
@@ -3543,19 +3555,19 @@ msgstr ""
 "Valor com tipo incorreto para o campo \"{key}\":\n"
 "{nested_msg}"
 
-#: ../../uaclient/messages/__init__.py:2612
+#: ../../uaclient/messages/__init__.py:2620
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""
 "Valor fornecido não está presente nos valores permitidos de {enum_class}: "
 "{values}"
 
-#: ../../uaclient/messages/__init__.py:2623
+#: ../../uaclient/messages/__init__.py:2631
 #, python-brace-format
 msgid "Error updating ESM services cache: {error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2629
+#: ../../uaclient/messages/__init__.py:2637
 #, python-brace-format
 msgid ""
 "There is a problem with the resource directives provided by {url}\n"
@@ -3565,20 +3577,20 @@ msgid ""
 "These directives need to be unique for every entitlement."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2638
+#: ../../uaclient/messages/__init__.py:2646
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2644
+#: ../../uaclient/messages/__init__.py:2652
 msgid ""
 "You must use the pro command to purge a service that has installed a kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2651
+#: ../../uaclient/messages/__init__.py:2659
 msgid "The operation is not supported"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2661
+#: ../../uaclient/messages/__init__.py:2669
 #, python-brace-format
 msgid "Invalid URL: {url}"
 msgstr ""

--- a/debian/po/ubuntu-pro.pot
+++ b/debian/po/ubuntu-pro.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-06 15:29-0400\n"
+"POT-Creation-Date: 2024-06-10 14:00-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -666,18 +666,25 @@ msgstr ""
 msgid "Configuring APT access to {service}"
 msgstr ""
 
+#: ../../uaclient/messages/__init__.py:345
+#, python-brace-format
+msgid ""
+"No variant specified. To specify a variant, use the variant option.\n"
+"Auto-selecting {variant} variant. Proceed? (y/N) "
+msgstr ""
+
 #. DISABLE
-#: ../../uaclient/messages/__init__.py:346
+#: ../../uaclient/messages/__init__.py:351
 #, python-brace-format
 msgid "Removing APT access to {title}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:347
+#: ../../uaclient/messages/__init__.py:352
 #, python-brace-format
 msgid "Could not disable {title}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:349
+#: ../../uaclient/messages/__init__.py:354
 #, python-brace-format
 msgid ""
 "{dependent_service} depends on {service_being_disabled}.\n"
@@ -685,55 +692,55 @@ msgid ""
 "(y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:355
+#: ../../uaclient/messages/__init__.py:360
 #, python-brace-format
 msgid "Disabling dependent service: {required_service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:358
+#: ../../uaclient/messages/__init__.py:363
 #, python-brace-format
 msgid "Removing apt source file: {filename}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:360
+#: ../../uaclient/messages/__init__.py:365
 #, python-brace-format
 msgid "Removing apt preferences file: {filename}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:363
+#: ../../uaclient/messages/__init__.py:368
 #, python-brace-format
 msgid "Uninstalling all packages installed from {title}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:368
+#: ../../uaclient/messages/__init__.py:373
 msgid "(The --purge flag is still experimental - use with caution)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:371
+#: ../../uaclient/messages/__init__.py:376
 #, python-brace-format
 msgid "Purging the {service} packages would uninstall the following kernel(s):"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:374
+#: ../../uaclient/messages/__init__.py:379
 #, python-brace-format
 msgid "{kernel_version} is the current running kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:377
+#: ../../uaclient/messages/__init__.py:382
 msgid ""
 "No other valid Ubuntu kernel was found in the system.\n"
 "Removing the package would potentially make the system unbootable.\n"
 "Aborting.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:384
+#: ../../uaclient/messages/__init__.py:389
 msgid ""
 "If you cannot guarantee that other kernels in this system are bootable and\n"
 "working properly, *do not proceed*. You may end up with an unbootable "
 "system.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:393
+#: ../../uaclient/messages/__init__.py:398
 #, python-brace-format
 msgid ""
 "Failed to automatically attach to an Ubuntu Pro subscription {num_attempts} "
@@ -743,7 +750,7 @@ msgid ""
 "You can try manually with `sudo pro auto-attach`."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:401
+#: ../../uaclient/messages/__init__.py:406
 #, python-brace-format
 msgid ""
 "Failed to automatically attach to an Ubuntu Pro subscription {num_attempts} "
@@ -754,183 +761,183 @@ msgid ""
 "You can try manually with `sudo pro auto-attach`."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:409
+#: ../../uaclient/messages/__init__.py:414
 #, python-brace-format
 msgid ""
 "Canonical servers did not recognize this machine as Ubuntu Pro: \"{detail}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:413
+#: ../../uaclient/messages/__init__.py:418
 msgid "Canonical servers did not recognize this image as Ubuntu Pro"
-msgstr ""
-
-#: ../../uaclient/messages/__init__.py:415
-#, python-brace-format
-msgid "the pro lock was held by pid {pid}"
-msgstr ""
-
-#: ../../uaclient/messages/__init__.py:417
-#, python-brace-format
-msgid "an error from Canonical servers: \"{error_msg}\""
-msgstr ""
-
-#: ../../uaclient/messages/__init__.py:419
-msgid "a connectivity error"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:420
 #, python-brace-format
-msgid "an error while reaching {url}"
+msgid "the pro lock was held by pid {pid}"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:422
+#, python-brace-format
+msgid "an error from Canonical servers: \"{error_msg}\""
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:424
+msgid "a connectivity error"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:425
+#, python-brace-format
+msgid "an error while reaching {url}"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:429
 #, python-brace-format
 msgid "Due to contract refresh, '{service}' is now disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:427
+#: ../../uaclient/messages/__init__.py:432
 #, python-brace-format
 msgid ""
 "Unable to disable '{service}' as recommended during contract refresh. "
 "Service is still active. See `pro status`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:432
+#: ../../uaclient/messages/__init__.py:437
 #, python-brace-format
 msgid "Updating '{service}' on changed directives."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:435
+#: ../../uaclient/messages/__init__.py:440
 #, python-brace-format
 msgid "Updating '{service}' apt sources list on changed directives."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:438
+#: ../../uaclient/messages/__init__.py:443
 #, python-brace-format
 msgid "Installing packages on changed directives: {packages}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:448
+#: ../../uaclient/messages/__init__.py:453
 #, python-brace-format
 msgid "Choose: [S]ubscribe at {url} [A]ttach existing token [C]ancel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:452
+#: ../../uaclient/messages/__init__.py:457
 #, python-brace-format
 msgid "Choose: [E]nable {service} [C]ancel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:456
+#: ../../uaclient/messages/__init__.py:461
 #, python-brace-format
 msgid "Choose: [R]enew your subscription (at {url}) [C]ancel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:459
+#: ../../uaclient/messages/__init__.py:464
 #, python-brace-format
 msgid "A fix is available in {fix_stream}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:460
+#: ../../uaclient/messages/__init__.py:465
 msgid "The update is not yet installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:462
+#: ../../uaclient/messages/__init__.py:467
 msgid ""
 "The update is not installed because this system is not attached to a\n"
 "subscription.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:468
+#: ../../uaclient/messages/__init__.py:473
 msgid ""
 "The update is not installed because this system is attached to an\n"
 "expired subscription.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:474
+#: ../../uaclient/messages/__init__.py:479
 #, python-brace-format
 msgid ""
 "The update is not installed because this system does not have\n"
 "{service} enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:479
+#: ../../uaclient/messages/__init__.py:484
 msgid "The update is already installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:481
+#: ../../uaclient/messages/__init__.py:486
 #, python-brace-format
 msgid ""
 "For easiest security on {title}, use Ubuntu Pro instances.\n"
 "Learn more at {cloud_specific_url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:486
+#: ../../uaclient/messages/__init__.py:491
 msgid "requested"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:487
+#: ../../uaclient/messages/__init__.py:492
 msgid "related"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:488
+#: ../../uaclient/messages/__init__.py:493
 #, python-brace-format
 msgid " {issue} is resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:490
+#: ../../uaclient/messages/__init__.py:495
 #, python-brace-format
 msgid " {issue} [{context}] is resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:492
+#: ../../uaclient/messages/__init__.py:497
 #, python-brace-format
 msgid " {issue} is not resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:494
+#: ../../uaclient/messages/__init__.py:499
 #, python-brace-format
 msgid " {issue} [{context}] is not resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:497
+#: ../../uaclient/messages/__init__.py:502
 #, python-brace-format
 msgid " {issue} does not affect your system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:500
+#: ../../uaclient/messages/__init__.py:505
 #, python-brace-format
 msgid " {issue} [{context}] does not affect your system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:504
+#: ../../uaclient/messages/__init__.py:509
 #, python-brace-format
 msgid "{num_pkgs} package is still affected: {pkgs}"
 msgid_plural "{num_pkgs} packages are still affected: {pkgs}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:511
+#: ../../uaclient/messages/__init__.py:516
 #, python-brace-format
 msgid "{count} affected source package is installed: {pkgs}"
 msgid_plural "{count} affected source packages are installed: {pkgs}"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:517
+#: ../../uaclient/messages/__init__.py:522
 msgid "No affected source packages are installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:519
+#: ../../uaclient/messages/__init__.py:524
 #, python-brace-format
 msgid "{issue} is resolved."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:521
+#: ../../uaclient/messages/__init__.py:526
 #, python-brace-format
 msgid " {issue} is resolved by livepatch patch version: {version}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:524
+#: ../../uaclient/messages/__init__.py:529
 #, python-brace-format
 msgid ""
 "{bold}Ubuntu Pro service: {{service}} is not enabled.\n"
@@ -940,7 +947,7 @@ msgid ""
 "{{{{ pro enable {{service}} }}}}{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:531
+#: ../../uaclient/messages/__init__.py:536
 #, python-brace-format
 msgid ""
 "{bold}The machine is not attached to an Ubuntu Pro subscription.\n"
@@ -949,7 +956,7 @@ msgid ""
 "{{ pro attach }}{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:538
+#: ../../uaclient/messages/__init__.py:543
 #, python-brace-format
 msgid ""
 "{bold}The machine has an expired subscription.\n"
@@ -959,104 +966,104 @@ msgid ""
 "{{ pro attach }}{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:546
+#: ../../uaclient/messages/__init__.py:551
 #, python-brace-format
 msgid ""
 "{bold}WARNING: The option --dry-run is being used.\n"
 "No packages will be installed when running this command.{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:551
+#: ../../uaclient/messages/__init__.py:556
 #, python-brace-format
 msgid ""
 "Error: Ubuntu Pro service: {service} is not enabled.\n"
 "Without it, we cannot fix the system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:556
+#: ../../uaclient/messages/__init__.py:561
 #, python-brace-format
 msgid ""
 "Error: The current Ubuntu Pro subscription is not entitled to: {service}.\n"
 "Without it, we cannot fix the system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:561
+#: ../../uaclient/messages/__init__.py:566
 #, python-brace-format
 msgid "{service} is required for upgrade."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:565
+#: ../../uaclient/messages/__init__.py:570
 #, python-brace-format
 msgid "{service} is required for upgrade, but current subscription is expired."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:569
+#: ../../uaclient/messages/__init__.py:574
 #, python-brace-format
 msgid "{service} is required for upgrade, but it is not enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:573
+#: ../../uaclient/messages/__init__.py:578
 msgid "APT failed to install the package.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:578
+#: ../../uaclient/messages/__init__.py:583
 msgid "Sorry, no fix is available yet."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:582
+#: ../../uaclient/messages/__init__.py:587
 msgid "Ubuntu security engineers are investigating this issue."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:586
+#: ../../uaclient/messages/__init__.py:591
 msgid "A fix is coming soon. Try again tomorrow."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:590
+#: ../../uaclient/messages/__init__.py:595
 msgid "Sorry, no fix is available."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:594
+#: ../../uaclient/messages/__init__.py:599
 msgid "Source package does not exist on this release."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:598
+#: ../../uaclient/messages/__init__.py:603
 msgid "Source package is not affected on this release."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:602
+#: ../../uaclient/messages/__init__.py:607
 #, python-brace-format
 msgid "UNKNOWN: {status}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:606
+#: ../../uaclient/messages/__init__.py:611
 msgid "Associated CVEs:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:607
+#: ../../uaclient/messages/__init__.py:612
 msgid "Found Launchpad bugs:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:609
+#: ../../uaclient/messages/__init__.py:614
 #, python-brace-format
 msgid "Fixing requested {issue_id}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:613
+#: ../../uaclient/messages/__init__.py:618
 msgid "Fixing related USNs:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:617
+#: ../../uaclient/messages/__init__.py:622
 #, python-brace-format
 msgid ""
 "Found related USNs:\n"
 "- {related_usns}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:621
+#: ../../uaclient/messages/__init__.py:626
 msgid "Summary:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:625
+#: ../../uaclient/messages/__init__.py:630
 #, python-brace-format
 msgid ""
 "Even though a related USN failed to be fixed, note\n"
@@ -1067,149 +1074,149 @@ msgid ""
 "{url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:634
+#: ../../uaclient/messages/__init__.py:639
 msgid "Ubuntu standard updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:635
-#: ../../uaclient/messages/__init__.py:1243
+#: ../../uaclient/messages/__init__.py:640
+#: ../../uaclient/messages/__init__.py:1248
 msgid "Ubuntu Pro: ESM Infra"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:636
-#: ../../uaclient/messages/__init__.py:1229
+#: ../../uaclient/messages/__init__.py:641
+#: ../../uaclient/messages/__init__.py:1234
 msgid "Ubuntu Pro: ESM Apps"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:639
+#: ../../uaclient/messages/__init__.py:644
 msgid ""
 "Package fixes cannot be installed.\n"
 "To install them, run this command as root (try using sudo)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:645
+#: ../../uaclient/messages/__init__.py:650
 #, python-brace-format
 msgid "Enter your token (from {url}) to attach this system:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:649
+#: ../../uaclient/messages/__init__.py:654
 msgid "Enter your new token to renew Ubuntu Pro subscription on this system:"
 msgstr ""
 
 #. ##############################################################################
 #. SECURITYSTATUS SUBCOMMAND                              #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:659
+#: ../../uaclient/messages/__init__.py:664
 #, python-brace-format
 msgid "{count} packages installed:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:662
+#: ../../uaclient/messages/__init__.py:667
 #, python-brace-format
 msgid "{offset}{count} package from Ubuntu {repository} repository"
 msgid_plural "{offset}{count} packages from Ubuntu {repository} repository"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:669
+#: ../../uaclient/messages/__init__.py:674
 #, python-brace-format
 msgid "{offset}{count} package from a third party"
 msgid_plural "{offset}{count} packages from third parties"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:676
+#: ../../uaclient/messages/__init__.py:681
 #, python-brace-format
 msgid "{offset}{count} package no longer available for download"
 msgid_plural "{offset}{count} packages no longer available for download"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:683
+#: ../../uaclient/messages/__init__.py:688
 msgid ""
 "To get more information about the packages, run\n"
 "    pro security-status --help\n"
 "for a list of available options."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:690
+#: ../../uaclient/messages/__init__.py:695
 msgid ""
 " Make sure to run\n"
 "    sudo apt update\n"
 "to get the latest package information from apt."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:696
+#: ../../uaclient/messages/__init__.py:701
 #, python-brace-format
 msgid "The system apt information was updated {days} day(s) ago."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:700
+#: ../../uaclient/messages/__init__.py:705
 msgid "The system apt cache may be outdated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:704
+#: ../../uaclient/messages/__init__.py:709
 #, python-brace-format
 msgid "Main/Restricted packages receive updates until {date}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:707
+#: ../../uaclient/messages/__init__.py:712
 #, python-brace-format
 msgid ""
 "This machine is receiving security patching for Ubuntu Main/Restricted\n"
 "repository until {date}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:713
+#: ../../uaclient/messages/__init__.py:718
 msgid "This machine is attached to an Ubuntu Pro subscription."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:716
+#: ../../uaclient/messages/__init__.py:721
 msgid "This machine is NOT attached to an Ubuntu Pro subscription."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:720
+#: ../../uaclient/messages/__init__.py:725
 msgid ""
 "Packages from third parties are not provided by the official Ubuntu\n"
 "archive, for example packages from Personal Package Archives in Launchpad."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:725
+#: ../../uaclient/messages/__init__.py:730
 msgid ""
 "Packages that are not available for download may be left over from a\n"
 "previous release of Ubuntu, may have been installed directly from a\n"
 ".deb file, or are from a source which has been disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:732
+#: ../../uaclient/messages/__init__.py:737
 msgid ""
 "This machine is NOT receiving security patches because the LTS period has "
 "ended\n"
 "and esm-infra is not enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:738
+#: ../../uaclient/messages/__init__.py:743
 #, python-brace-format
 msgid ""
 "Ubuntu Pro with '{service}' enabled provides security updates for\n"
 "{repository} packages until {year}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:744
+#: ../../uaclient/messages/__init__.py:749
 #, python-brace-format
 msgid "There is {updates} pending security update."
 msgid_plural "There are {updates} pending security updates."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:751
+#: ../../uaclient/messages/__init__.py:756
 #, python-brace-format
 msgid ""
 "{repository} packages are receiving security updates from\n"
 "Ubuntu Pro with '{service}' enabled until {year}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:757
+#: ../../uaclient/messages/__init__.py:762
 #, python-brace-format
 msgid ""
 "You have received {updates} security\n"
@@ -1220,19 +1227,19 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../../uaclient/messages/__init__.py:767
+#: ../../uaclient/messages/__init__.py:772
 #, python-brace-format
 msgid "Enable {service} with: pro enable {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:769
+#: ../../uaclient/messages/__init__.py:774
 #, python-brace-format
 msgid ""
 "Try Ubuntu Pro with a free personal subscription on up to 5 machines.\n"
 "Learn more at {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:776
+#: ../../uaclient/messages/__init__.py:781
 #, python-brace-format
 msgid ""
 "For example, run:\n"
@@ -1240,161 +1247,161 @@ msgid ""
 "to learn more about that package."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:783
+#: ../../uaclient/messages/__init__.py:788
 msgid "You have no packages installed from a third party."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:786
+#: ../../uaclient/messages/__init__.py:791
 msgid "You have no packages installed that are no longer available."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:789
+#: ../../uaclient/messages/__init__.py:794
 msgid "Ubuntu Pro is not available for non-LTS releases."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:792
+#: ../../uaclient/messages/__init__.py:797
 #, python-brace-format
 msgid "Run 'pro help {service}' to learn more"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:795
+#: ../../uaclient/messages/__init__.py:800
 #, python-brace-format
 msgid "Installed packages with an available {service} update:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:798
+#: ../../uaclient/messages/__init__.py:803
 #, python-brace-format
 msgid "Installed packages with an {service} update applied:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:800
+#: ../../uaclient/messages/__init__.py:805
 #, python-brace-format
 msgid "Installed packages covered by {service}:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:802
+#: ../../uaclient/messages/__init__.py:807
 #, python-brace-format
 msgid "Further installed packages covered by {service}:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:804
+#: ../../uaclient/messages/__init__.py:809
 msgid "Packages:"
 msgstr ""
 
 #. ##############################################################################
 #. STATUS SUBCOMMAND                                 #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:812
+#: ../../uaclient/messages/__init__.py:817
 msgid "SERVICE"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:813
+#: ../../uaclient/messages/__init__.py:818
 msgid "AVAILABLE"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:814
+#: ../../uaclient/messages/__init__.py:819
 msgid "ENTITLED"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:815
+#: ../../uaclient/messages/__init__.py:820
 msgid "AUTO_ENABLED"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:816
+#: ../../uaclient/messages/__init__.py:821
 msgid "STATUS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:817
+#: ../../uaclient/messages/__init__.py:822
 msgid "DESCRIPTION"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:818
+#: ../../uaclient/messages/__init__.py:823
 msgid "NOTICES"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:819
+#: ../../uaclient/messages/__init__.py:824
 msgid "FEATURES"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:823
+#: ../../uaclient/messages/__init__.py:828
 msgid "enabled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:824
+#: ../../uaclient/messages/__init__.py:829
 msgid "disabled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:825
+#: ../../uaclient/messages/__init__.py:830
 msgid "n/a"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:827
+#: ../../uaclient/messages/__init__.py:832
 msgid "warning"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:828
+#: ../../uaclient/messages/__init__.py:833
 msgid "essential"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:829
+#: ../../uaclient/messages/__init__.py:834
 msgid "standard"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:830
+#: ../../uaclient/messages/__init__.py:835
 msgid "advanced"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:832
+#: ../../uaclient/messages/__init__.py:837
 msgid "Unknown/Expired"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:835
+#: ../../uaclient/messages/__init__.py:840
 #, python-brace-format
 msgid "Enable services with: {command}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:837
+#: ../../uaclient/messages/__init__.py:842
 msgid "Account"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:838
+#: ../../uaclient/messages/__init__.py:843
 msgid "Subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:839
+#: ../../uaclient/messages/__init__.py:844
 msgid "Valid until"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:840
+#: ../../uaclient/messages/__init__.py:845
 msgid "Technical support level"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:842
+#: ../../uaclient/messages/__init__.py:847
 msgid "This token is not valid."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:843
+#: ../../uaclient/messages/__init__.py:848
 msgid "No Ubuntu Pro operations are running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:846
+#: ../../uaclient/messages/__init__.py:851
 msgid "No Ubuntu Pro services are available to this system."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:849
+#: ../../uaclient/messages/__init__.py:854
 msgid "For a list of all Ubuntu Pro services, run 'pro status --all'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:851
+#: ../../uaclient/messages/__init__.py:856
 msgid " * Service has variants"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:853
+#: ../../uaclient/messages/__init__.py:858
 msgid ""
 "For a list of all Ubuntu Pro services and variants, run 'pro status --all'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:858
+#: ../../uaclient/messages/__init__.py:863
 msgid ""
 "A change has been detected in your contract.\n"
 "Please run `sudo pro refresh`."
@@ -1405,113 +1412,113 @@ msgstr ""
 #. ##############################################################################
 #. This encompasses help text for subcommands, flags, and arguments for the CLI
 #. Also, any generic strings about the CLI itself go here.
-#: ../../uaclient/messages/__init__.py:871
+#: ../../uaclient/messages/__init__.py:876
 msgid "Try 'pro --help' for more information."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:873
+#: ../../uaclient/messages/__init__.py:878
 #, python-brace-format
 msgid "Use {name} {command} --help for more information about a command."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:876
+#: ../../uaclient/messages/__init__.py:881
 msgid "Use pro help <service> to get more details about each service"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:879
+#: ../../uaclient/messages/__init__.py:884
 msgid "Variants:"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:880
+#: ../../uaclient/messages/__init__.py:885
 msgid "Arguments"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:881
+#: ../../uaclient/messages/__init__.py:886
 msgid "Flags"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:882
+#: ../../uaclient/messages/__init__.py:887
 msgid "Available Commands"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:884
+#: ../../uaclient/messages/__init__.py:889
 #, python-brace-format
 msgid "output in the specified format (default: {default})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:887
+#: ../../uaclient/messages/__init__.py:892
 #, python-brace-format
 msgid "do not prompt for confirmation before performing the {command}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:890
-#: ../../uaclient/messages/__init__.py:1124
+#: ../../uaclient/messages/__init__.py:895
+#: ../../uaclient/messages/__init__.py:1129
 msgid "Calls the Client API endpoints."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:891
+#: ../../uaclient/messages/__init__.py:896
 msgid "API endpoint to call"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:893
+#: ../../uaclient/messages/__init__.py:898
 msgid ""
 "For endpoints that support progress updates, show each progress update on a "
 "new line in JSON format"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:897
+#: ../../uaclient/messages/__init__.py:902
 msgid "Options to pass to the API endpoint, formatted as key=value"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:899
+#: ../../uaclient/messages/__init__.py:904
 msgid "arguments in JSON format to the API endpoint"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:902
+#: ../../uaclient/messages/__init__.py:907
 msgid "Automatically attach on an Ubuntu Pro cloud instance."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:906
+#: ../../uaclient/messages/__init__.py:911
 msgid "Collect logs and relevant system information into a tarball."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:909
+#: ../../uaclient/messages/__init__.py:914
 msgid "tarball where the logs will be stored. (Defaults to ./pro_logs.tar.gz)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:912
+#: ../../uaclient/messages/__init__.py:917
 msgid "Show customizable configuration settings"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:914
+#: ../../uaclient/messages/__init__.py:919
 msgid "Optional key or key(s) to show configuration settings."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:917
+#: ../../uaclient/messages/__init__.py:922
 msgid "Set and apply Ubuntu Pro configuration settings"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:920
+#: ../../uaclient/messages/__init__.py:925
 #, python-brace-format
 msgid ""
 "key=value pair to configure for Ubuntu Pro services. Key must be one of: "
 "{options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:923
+#: ../../uaclient/messages/__init__.py:928
 msgid "Unset Ubuntu Pro configuration setting"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:925
+#: ../../uaclient/messages/__init__.py:930
 #, python-brace-format
 msgid "configuration key to unset from Ubuntu Pro services. One of: {options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:927
+#: ../../uaclient/messages/__init__.py:932
 msgid "Manage Ubuntu Pro configuration"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:930
+#: ../../uaclient/messages/__init__.py:935
 #, python-brace-format
 msgid ""
 "Attach this machine to an Ubuntu Pro subscription with a token obtained "
@@ -1523,48 +1530,48 @@ msgid ""
 "a web browser."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:938
+#: ../../uaclient/messages/__init__.py:943
 msgid "token obtained for Ubuntu Pro authentication"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:940
+#: ../../uaclient/messages/__init__.py:945
 msgid "do not enable any recommended services automatically"
-msgstr ""
-
-#: ../../uaclient/messages/__init__.py:943
-msgid ""
-"use the provided attach config file instead of passing the token on the cli"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:948
 msgid ""
+"use the provided attach config file instead of passing the token on the cli"
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:953
+msgid ""
 "Inspect and resolve CVEs and USNs (Ubuntu Security Notices) on this machine."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:952
+#: ../../uaclient/messages/__init__.py:957
 msgid ""
 "Security vulnerability ID to inspect and resolve on this system. Format: CVE-"
 "yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-dd"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:956
+#: ../../uaclient/messages/__init__.py:961
 msgid ""
 "If used, fix will not actually run but will display everything that will "
 "happen on the machine during the command."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:961
+#: ../../uaclient/messages/__init__.py:966
 msgid ""
 "If used, when fixing a USN, the command will not try to also fix related "
 "USNs to the target USN."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:966
+#: ../../uaclient/messages/__init__.py:971
 msgid ""
 "WARNING: Failed to update ESM cache - package availability may be inaccurate"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:970
+#: ../../uaclient/messages/__init__.py:975
 #, python-brace-format
 msgid ""
 "{bold}WARNING: Unable to update ESM cache when running as non-root,\n"
@@ -1572,7 +1579,7 @@ msgid ""
 "{end_bold}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:976
+#: ../../uaclient/messages/__init__.py:981
 msgid ""
 "Show security updates for packages in the system, including all\n"
 "available Expanded Security Maintenance (ESM) related content.\n"
@@ -1592,23 +1599,23 @@ msgid ""
 "complete status on Ubuntu Pro services, run 'pro status'.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:996
+#: ../../uaclient/messages/__init__.py:1001
 msgid "List and present information about third-party packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:999
+#: ../../uaclient/messages/__init__.py:1004
 msgid "List and present information about unavailable packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1002
+#: ../../uaclient/messages/__init__.py:1007
 msgid "List and present information about esm-infra packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1005
+#: ../../uaclient/messages/__init__.py:1010
 msgid "List and present information about esm-apps packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1009
+#: ../../uaclient/messages/__init__.py:1014
 msgid ""
 "Refresh three distinct Ubuntu Pro related artifacts in the system:\n"
 "\n"
@@ -1621,72 +1628,72 @@ msgid ""
 "is specified, all targets are refreshed.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1021
+#: ../../uaclient/messages/__init__.py:1026
 msgid "Target to refresh."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1024
+#: ../../uaclient/messages/__init__.py:1029
 msgid "Detach this machine from an Ubuntu Pro subscription."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1028
+#: ../../uaclient/messages/__init__.py:1033
 msgid "Provide detailed information about Ubuntu Pro services."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1031
+#: ../../uaclient/messages/__init__.py:1036
 #, python-brace-format
 msgid "a service to view help output for. One of: {options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1033
+#: ../../uaclient/messages/__init__.py:1038
 msgid "Include beta services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1035
+#: ../../uaclient/messages/__init__.py:1040
 msgid "Enable an Ubuntu Pro service."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1037
+#: ../../uaclient/messages/__init__.py:1042
 #, python-brace-format
 msgid "the name(s) of the Ubuntu Pro services to enable. One of: {options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1040
+#: ../../uaclient/messages/__init__.py:1045
 msgid ""
 "do not auto-install packages. Valid for cc-eal, cis and realtime-kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1043
+#: ../../uaclient/messages/__init__.py:1048
 msgid "allow beta service to be enabled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1045
+#: ../../uaclient/messages/__init__.py:1050
 msgid "The name of the variant to use when enabling the service"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1048
+#: ../../uaclient/messages/__init__.py:1053
 msgid "Disable an Ubuntu Pro service."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1050
+#: ../../uaclient/messages/__init__.py:1055
 #, python-brace-format
 msgid "the name(s) of the Ubuntu Pro services to disable. One of: {options}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1053
+#: ../../uaclient/messages/__init__.py:1058
 msgid ""
 "disable the service and remove/downgrade related packages (experimental)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1057
+#: ../../uaclient/messages/__init__.py:1062
 msgid "Output system related information related to Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1059
+#: ../../uaclient/messages/__init__.py:1064
 msgid "does the system need to be rebooted"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1061
+#: ../../uaclient/messages/__init__.py:1066
 msgid ""
 "Report the current reboot-required status for the machine.\n"
 "\n"
@@ -1702,7 +1709,7 @@ msgid ""
 "  nearest maintenance window.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1078
+#: ../../uaclient/messages/__init__.py:1083
 msgid ""
 "Report current status of Ubuntu Pro services on system.\n"
 "\n"
@@ -1738,80 +1745,80 @@ msgid ""
 "listed in the output.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1113
+#: ../../uaclient/messages/__init__.py:1118
 msgid "Block waiting on pro to complete"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1115
+#: ../../uaclient/messages/__init__.py:1120
 msgid "simulate the output status using a provided token"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1117
+#: ../../uaclient/messages/__init__.py:1122
 msgid "Include unavailable and beta services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1119
+#: ../../uaclient/messages/__init__.py:1124
 msgid "show all debug log messages to console"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1120
+#: ../../uaclient/messages/__init__.py:1125
 #, python-brace-format
 msgid "show version of {name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1122
+#: ../../uaclient/messages/__init__.py:1127
 msgid "attach this machine to an Ubuntu Pro subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1125
+#: ../../uaclient/messages/__init__.py:1130
 msgid "automatically attach on supported platforms"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1126
+#: ../../uaclient/messages/__init__.py:1131
 msgid "collect Pro logs and debug information"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1127
+#: ../../uaclient/messages/__init__.py:1132
 msgid "manage Ubuntu Pro configuration on this machine"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1129
+#: ../../uaclient/messages/__init__.py:1134
 msgid "remove this machine from an Ubuntu Pro subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1132
+#: ../../uaclient/messages/__init__.py:1137
 msgid "disable a specific Ubuntu Pro service on this machine"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1135
+#: ../../uaclient/messages/__init__.py:1140
 msgid "enable a specific Ubuntu Pro service on this machine"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1138
+#: ../../uaclient/messages/__init__.py:1143
 msgid "check for and mitigate the impact of a CVE/USN on this system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1141
+#: ../../uaclient/messages/__init__.py:1146
 msgid "list available security updates for the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1144
+#: ../../uaclient/messages/__init__.py:1149
 msgid "show detailed information about Ubuntu Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1146
+#: ../../uaclient/messages/__init__.py:1151
 msgid "refresh Ubuntu Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1147
+#: ../../uaclient/messages/__init__.py:1152
 msgid "current status of all Ubuntu Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1148
+#: ../../uaclient/messages/__init__.py:1153
 msgid "show system information related to Pro services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1151
+#: ../../uaclient/messages/__init__.py:1156
 #, python-brace-format
 msgid ""
 "WARNING: this output is intended to be human readable, and subject to "
@@ -1823,15 +1830,15 @@ msgstr ""
 #. ##############################################################################
 #. SERVICE-SPECIFIC MESSAGES                            #
 #. ##############################################################################
-#: ../../uaclient/messages/__init__.py:1164
+#: ../../uaclient/messages/__init__.py:1169
 msgid "Anbox Cloud"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1165
+#: ../../uaclient/messages/__init__.py:1170
 msgid "Scalable Android in the cloud"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1167
+#: ../../uaclient/messages/__init__.py:1172
 #, python-brace-format
 msgid ""
 "Anbox Cloud lets you stream mobile apps securely, at any scale, to any "
@@ -1849,7 +1856,7 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1178
+#: ../../uaclient/messages/__init__.py:1183
 #, python-brace-format
 msgid ""
 "To finish setting up the Anbox Cloud Appliance, run:\n"
@@ -1861,15 +1868,15 @@ msgid ""
 "For more information, see {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1189
+#: ../../uaclient/messages/__init__.py:1194
 msgid "CC EAL2"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1190
+#: ../../uaclient/messages/__init__.py:1195
 msgid "Common Criteria EAL2 Provisioning Packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1192
+#: ../../uaclient/messages/__init__.py:1197
 msgid ""
 "Common Criteria is an Information Technology Security Evaluation standard\n"
 "(ISO/IEC IS 15408) for computer security certification. Ubuntu 16.04 has "
@@ -1879,29 +1886,29 @@ msgid ""
 "on Intel x86_64, IBM Power8 and IBM Z hardware platforms."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1199
+#: ../../uaclient/messages/__init__.py:1204
 msgid ""
 "(This will download more than 500MB of packages, so may take some time.)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1203
+#: ../../uaclient/messages/__init__.py:1208
 #, python-brace-format
 msgid "Please follow instructions in {filename} to configure EAL2"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1206
+#: ../../uaclient/messages/__init__.py:1211
 msgid "CIS Audit"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1207
+#: ../../uaclient/messages/__init__.py:1212
 msgid "Ubuntu Security Guide"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1208
+#: ../../uaclient/messages/__init__.py:1213
 msgid "Security compliance and audit tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1210
+#: ../../uaclient/messages/__init__.py:1215
 #, python-brace-format
 msgid ""
 "Ubuntu Security Guide is a tool for hardening and auditing and allows for\n"
@@ -1911,17 +1918,17 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1216
+#: ../../uaclient/messages/__init__.py:1221
 #, python-brace-format
 msgid "Visit {url} to learn how to use CIS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1219
+#: ../../uaclient/messages/__init__.py:1224
 #, python-brace-format
 msgid "Visit {url} for the next steps"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1223
+#: ../../uaclient/messages/__init__.py:1228
 #, python-brace-format
 msgid ""
 "From Ubuntu 20.04 onward 'pro enable cis' has been\n"
@@ -1929,11 +1936,11 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1231
+#: ../../uaclient/messages/__init__.py:1236
 msgid "Expanded Security Maintenance for Applications"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1234
+#: ../../uaclient/messages/__init__.py:1239
 #, python-brace-format
 msgid ""
 "Expanded Security Maintenance for Applications is enabled by default on\n"
@@ -1945,11 +1952,11 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1245
+#: ../../uaclient/messages/__init__.py:1250
 msgid "Expanded Security Maintenance for Infrastructure"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1248
+#: ../../uaclient/messages/__init__.py:1253
 #, python-brace-format
 msgid ""
 "Expanded Security Maintenance for Infrastructure provides access to a "
@@ -1962,15 +1969,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1257
+#: ../../uaclient/messages/__init__.py:1262
 msgid "FIPS"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1258
+#: ../../uaclient/messages/__init__.py:1263
 msgid "NIST-certified FIPS crypto packages"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1260
+#: ../../uaclient/messages/__init__.py:1265
 #, python-brace-format
 msgid ""
 "Installs FIPS 140 crypto packages for FedRAMP, FISMA and compliance use "
@@ -1981,18 +1988,18 @@ msgid ""
 "choose \"fips-updates\" for maximum security. Find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1267
+#: ../../uaclient/messages/__init__.py:1272
 msgid "Could not determine cloud, defaulting to generic FIPS package."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1270
+#: ../../uaclient/messages/__init__.py:1275
 #, python-brace-format
 msgid ""
 "FIPS kernel is running in a disabled state.\n"
 "  To manually remove fips kernel: {url}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1276
+#: ../../uaclient/messages/__init__.py:1281
 msgid ""
 "Warning: FIPS kernel is not optimized for your specific cloud.\n"
 "To fix it, run the following commands:\n"
@@ -2003,20 +2010,20 @@ msgid ""
 "    4. sudo reboot\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1288
+#: ../../uaclient/messages/__init__.py:1293
 msgid ""
 "This will install the FIPS packages. The Livepatch service will be "
 "unavailable.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1297
+#: ../../uaclient/messages/__init__.py:1302
 msgid ""
 "This will install the FIPS packages including security updates.\n"
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1306
+#: ../../uaclient/messages/__init__.py:1311
 #, python-brace-format
 msgid ""
 "Warning: Enabling {title} in a container.\n"
@@ -2026,14 +2033,14 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1318
+#: ../../uaclient/messages/__init__.py:1323
 #, python-brace-format
 msgid ""
 "This will disable the {title} entitlement but the {title} packages will "
 "remain installed.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1325
+#: ../../uaclient/messages/__init__.py:1330
 #, python-brace-format
 msgid ""
 "This will downgrade the kernel from {current_version} to {new_version}.\n"
@@ -2043,49 +2050,49 @@ msgid ""
 "proceeding.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1332
+#: ../../uaclient/messages/__init__.py:1337
 msgid "FIPS support requires system reboot to complete configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1334
-#: ../../uaclient/messages/__init__.py:1774
+#: ../../uaclient/messages/__init__.py:1339
+#: ../../uaclient/messages/__init__.py:1782
 msgid "Reboot to FIPS kernel required"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1336
+#: ../../uaclient/messages/__init__.py:1341
 msgid "This FIPS install is out of date, run: sudo pro enable fips"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1339
+#: ../../uaclient/messages/__init__.py:1344
 msgid "Disabling FIPS requires system reboot to complete operation."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1342
+#: ../../uaclient/messages/__init__.py:1347
 #, python-brace-format
 msgid "{service} {pkg} package could not be installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1345
+#: ../../uaclient/messages/__init__.py:1350
 msgid ""
 "Please run `apt upgrade` to ensure all FIPS packages are updated to the "
 "correct\n"
 "version.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1352
+#: ../../uaclient/messages/__init__.py:1357
 #, python-brace-format
 msgid "Failure occurred while upgrading packages to {service} versions."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1358
+#: ../../uaclient/messages/__init__.py:1363
 msgid "FIPS Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1360
+#: ../../uaclient/messages/__init__.py:1365
 msgid "FIPS compliant crypto packages with stable security updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1363
+#: ../../uaclient/messages/__init__.py:1368
 #, python-brace-format
 msgid ""
 "fips-updates installs FIPS 140 crypto packages including all security "
@@ -2094,21 +2101,21 @@ msgid ""
 "You can find out more at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1369
+#: ../../uaclient/messages/__init__.py:1374
 msgid "FIPS Preview"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1371
+#: ../../uaclient/messages/__init__.py:1376
 msgid "Preview of FIPS crypto packages undergoing certification with NIST"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1374
+#: ../../uaclient/messages/__init__.py:1379
 msgid ""
 "Installs FIPS crypto packages that are under certification with NIST,\n"
 "for FedRAMP, FISMA and compliance use cases."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1379
+#: ../../uaclient/messages/__init__.py:1384
 msgid ""
 "This will install crypto packages that have been submitted to NIST for "
 "review\n"
@@ -2120,15 +2127,15 @@ msgid ""
 "Warning: This action can take some time and cannot be undone.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1390
+#: ../../uaclient/messages/__init__.py:1395
 msgid "Landscape"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1392
+#: ../../uaclient/messages/__init__.py:1397
 msgid "Management and administration tool for Ubuntu"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1395
+#: ../../uaclient/messages/__init__.py:1400
 #, python-brace-format
 msgid ""
 "Landscape Client can be installed on this machine and enrolled in "
@@ -2141,22 +2148,22 @@ msgid ""
 "more. Find out more about Landscape at {home_url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1408
+#: ../../uaclient/messages/__init__.py:1413
 msgid ""
 "/etc/landscape/client.conf contains your landscape-client configuration.\n"
 "To re-enable Landscape with the same configuration, run:\n"
 "    sudo pro enable landscape --assume-yes\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1415
+#: ../../uaclient/messages/__init__.py:1420
 msgid "Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1416
+#: ../../uaclient/messages/__init__.py:1421
 msgid "Canonical Livepatch service"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1418
+#: ../../uaclient/messages/__init__.py:1423
 #, python-brace-format
 msgid ""
 "Livepatch provides selected high and critical kernel CVE fixes and other\n"
@@ -2171,50 +2178,50 @@ msgid ""
 "service at {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1427
+#: ../../uaclient/messages/__init__.py:1432
 msgid "Current kernel is not covered by livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1430
+#: ../../uaclient/messages/__init__.py:1435
 #, python-brace-format
 msgid "Kernels covered by livepatch are listed here: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1433
+#: ../../uaclient/messages/__init__.py:1438
 #, python-brace-format
 msgid "Unable to configure livepatch: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1435
+#: ../../uaclient/messages/__init__.py:1440
 msgid "Unable to enable Livepatch: "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1437
+#: ../../uaclient/messages/__init__.py:1442
 msgid "Disabling Livepatch prior to re-attach with new token"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1440
+#: ../../uaclient/messages/__init__.py:1445
 msgid "Livepatch coverage requires a system reboot across LTS upgrade."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1442
+#: ../../uaclient/messages/__init__.py:1447
 msgid "Installing Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1443
+#: ../../uaclient/messages/__init__.py:1448
 msgid "Setting up Livepatch"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1445
-#: ../../uaclient/messages/__init__.py:1458
+#: ../../uaclient/messages/__init__.py:1450
+#: ../../uaclient/messages/__init__.py:1463
 msgid "Real-time kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1447
+#: ../../uaclient/messages/__init__.py:1452
 msgid "Ubuntu kernel with PREEMPT_RT patches integrated"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1450
+#: ../../uaclient/messages/__init__.py:1455
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated. "
 "It\n"
@@ -2227,35 +2234,35 @@ msgid ""
 "Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1460
+#: ../../uaclient/messages/__init__.py:1465
 msgid "Generic version of the RT kernel (default)"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1462
+#: ../../uaclient/messages/__init__.py:1467
 msgid "Real-time NVIDIA Tegra Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1464
+#: ../../uaclient/messages/__init__.py:1469
 msgid "RT kernel optimized for NVIDIA Tegra platform"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1466
+#: ../../uaclient/messages/__init__.py:1471
 msgid "Raspberry Pi Real-time for Pi5/Pi4"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1468
+#: ../../uaclient/messages/__init__.py:1473
 msgid "24.04 Real-time kernel optimised for Raspberry Pi"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1470
+#: ../../uaclient/messages/__init__.py:1475
 msgid "Real-time Intel IOTG Kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1472
+#: ../../uaclient/messages/__init__.py:1477
 msgid "RT kernel optimized for Intel IOTG platform"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1475
+#: ../../uaclient/messages/__init__.py:1480
 #, python-brace-format
 msgid ""
 "The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches "
@@ -2268,7 +2275,7 @@ msgid ""
 "Do you want to continue? [ default = Yes ]: (Y/n) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1486
+#: ../../uaclient/messages/__init__.py:1491
 msgid ""
 "This will remove the boot order preference for the Real-time kernel and\n"
 "disable updates to the Real-time kernel.\n"
@@ -2285,15 +2292,15 @@ msgid ""
 "Are you sure? (y/N) "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1502
+#: ../../uaclient/messages/__init__.py:1507
 msgid "ROS ESM Security Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1503
+#: ../../uaclient/messages/__init__.py:1508
 msgid "Security Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1505
+#: ../../uaclient/messages/__init__.py:1510
 #, python-brace-format
 msgid ""
 "ros provides access to a private PPA which includes security-related "
@@ -2306,15 +2313,15 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1514
+#: ../../uaclient/messages/__init__.py:1519
 msgid "ROS ESM All Updates"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1516
+#: ../../uaclient/messages/__init__.py:1521
 msgid "All Updates for the Robot Operating System"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1519
+#: ../../uaclient/messages/__init__.py:1524
 #, python-brace-format
 msgid ""
 "ros-updates provides access to a private PPA that includes non-security-"
@@ -2327,7 +2334,7 @@ msgid ""
 "{url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1590
+#: ../../uaclient/messages/__init__.py:1595
 #, python-brace-format
 msgid ""
 "An unexpected error occurred: {error_msg}\n"
@@ -2335,7 +2342,7 @@ msgid ""
 "If you think this is a bug, please run: ubuntu-bug ubuntu-advantage-tools"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1600
+#: ../../uaclient/messages/__init__.py:1605
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2343,7 +2350,7 @@ msgid ""
 "Please install \"ca-certificates\" and try again."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1610
+#: ../../uaclient/messages/__init__.py:1615
 #, python-brace-format
 msgid ""
 "Failed to access URL: {url}\n"
@@ -2351,202 +2358,207 @@ msgid ""
 "Please check your openssl configuration."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1619
+#: ../../uaclient/messages/__init__.py:1624
 #, python-brace-format
 msgid "Ignoring unknown argument '{arg}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1625
+#: ../../uaclient/messages/__init__.py:1630
 #, python-brace-format
 msgid ""
 "A new version of the client is available: {version}. Please upgrade to the "
 "latest version to get the new features and bug fixes."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1632
+#: ../../uaclient/messages/__init__.py:1637
 #, python-brace-format
 msgid "{title} does not support being enabled with --access-only"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1637
+#: ../../uaclient/messages/__init__.py:1642
 #, python-brace-format
 msgid "{title} does not support being disabled with --purge"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1643
+#: ../../uaclient/messages/__init__.py:1648
 #, python-brace-format
 msgid "Cannot disable dependent service: {required_service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1650
+#: ../../uaclient/messages/__init__.py:1655
 #, python-brace-format
 msgid "Cannot disable {entitlement_name} with purge: no origin value defined"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1657
+#: ../../uaclient/messages/__init__.py:1662
 #, python-brace-format
 msgid "Cannot enable required service: {service}{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1662
+#: ../../uaclient/messages/__init__.py:1667
 #, python-brace-format
 msgid "Cannot install {title} on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1665
+#: ../../uaclient/messages/__init__.py:1670
 #, python-brace-format
 msgid "{title} is not configured"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1670
+#: ../../uaclient/messages/__init__.py:1675
 #, python-brace-format
 msgid ""
 "The {service} service is not enabled because the {package} package is\n"
 "not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1676
+#: ../../uaclient/messages/__init__.py:1681
 #, python-brace-format
 msgid "{title} is active"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1680
+#: ../../uaclient/messages/__init__.py:1685
 #, python-brace-format
 msgid "{title} does not have an aptURL directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1684
+#: ../../uaclient/messages/__init__.py:1689
 #, python-brace-format
 msgid "{title} does not have a suites directive"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1689
+#: ../../uaclient/messages/__init__.py:1694
 #, python-brace-format
 msgid ""
 "{title} is not currently enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1697
+#: ../../uaclient/messages/__init__.py:1702
 #, python-brace-format
 msgid ""
 "Disabling {title} with pro is not supported.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1704
+#: ../../uaclient/messages/__init__.py:1709
 #, python-brace-format
 msgid ""
 "{title} is already enabled - nothing to do.\n"
 "See: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1712
+#: ../../uaclient/messages/__init__.py:1717
 #, python-brace-format
 msgid ""
 "This subscription is not entitled to {{title}}\n"
 "View your subscription at: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1718
+#: ../../uaclient/messages/__init__.py:1723
 #, python-brace-format
 msgid "{title} is not entitled"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1724
+#: ../../uaclient/messages/__init__.py:1726
 #, python-brace-format
-msgid ""
-"{title} is not available for kernel {kernel}.\n"
-"Minimum kernel version required: {min_kernel}."
+msgid "Auto-selected {variant_name} variant"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1732
 #, python-brace-format
 msgid ""
 "{title} is not available for kernel {kernel}.\n"
-"Supported flavors are: {supported_kernels}."
+"Minimum kernel version required: {min_kernel}."
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:1740
 #, python-brace-format
+msgid ""
+"{title} is not available for kernel {kernel}.\n"
+"Supported flavors are: {supported_kernels}."
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:1748
+#, python-brace-format
 msgid "{title} is not available for Ubuntu {series}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1747
+#: ../../uaclient/messages/__init__.py:1755
 #, python-brace-format
 msgid ""
 "{title} is not available for platform {arch}.\n"
 "Supported platforms are: {supported_arches}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1755
+#: ../../uaclient/messages/__init__.py:1763
 #, python-brace-format
 msgid ""
 "{title} is not available for CPU vendor {vendor}.\n"
 "Supported CPU vendors are: {supported_vendors}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1762
+#: ../../uaclient/messages/__init__.py:1770
 msgid "no entitlement affordances checked"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1768
+#: ../../uaclient/messages/__init__.py:1776
 #, python-brace-format
 msgid ""
 "Ubuntu {{series}} does not provide {{cloud}} optimized FIPS kernel\n"
 "For help see: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1778
+#: ../../uaclient/messages/__init__.py:1786
 #, python-brace-format
 msgid "Cannot enable {fips} when {fips_updates} is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1781
+#: ../../uaclient/messages/__init__.py:1789
 #, python-brace-format
 msgid "{file_name} is not set to 1"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1785
+#: ../../uaclient/messages/__init__.py:1793
 #, python-brace-format
 msgid "Cannot enable {fips} because {fips_updates} was once enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1790
+#: ../../uaclient/messages/__init__.py:1798
 msgid ""
 "FIPS cannot be enabled if FIPS Updates has ever been enabled because FIPS "
 "Updates installs security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1798
+#: ../../uaclient/messages/__init__.py:1806
 msgid ""
 "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs "
 "security patches that aren't officially certified."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1807
+#: ../../uaclient/messages/__init__.py:1815
 msgid ""
 "Livepatch cannot be enabled while running the official FIPS certified "
 "kernel. If you would like a FIPS compliant kernel with additional bug fixes "
 "and security updates, you can use the FIPS Updates service with Livepatch."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1815
+#: ../../uaclient/messages/__init__.py:1823
 msgid "canonical-livepatch snap is not installed."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1819
+#: ../../uaclient/messages/__init__.py:1827
 msgid "Cannot enable Livepatch when FIPS is enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1824
+#: ../../uaclient/messages/__init__.py:1832
 msgid ""
 "The running kernel has reached the end of its active livepatch window.\n"
 "Please upgrade the kernel with apt and reboot for continued livepatch "
 "coverage."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1832
+#: ../../uaclient/messages/__init__.py:1840
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) has reached the end of its "
@@ -2556,7 +2568,7 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1841
+#: ../../uaclient/messages/__init__.py:1849
 #, python-brace-format
 msgid ""
 "The current kernel ({{version}}, {{arch}}) is not covered by livepatch.\n"
@@ -2565,79 +2577,79 @@ msgid ""
 "this warning."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1851
+#: ../../uaclient/messages/__init__.py:1859
 msgid "canonical-livepatch status didn't finish successfully"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1857
+#: ../../uaclient/messages/__init__.py:1865
 #, python-brace-format
 msgid ""
 "Error running canonical-livepatch status:\n"
 "{livepatch_error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1866
+#: ../../uaclient/messages/__init__.py:1874
 msgid ""
 "Realtime and FIPS require different kernels, so you cannot enable both at "
 "the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1873
+#: ../../uaclient/messages/__init__.py:1881
 msgid ""
 "Realtime and FIPS Updates require different kernels, so you cannot enable "
 "both at the same time."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1879
+#: ../../uaclient/messages/__init__.py:1887
 msgid "Livepatch does not currently cover the Real-time kernel."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1883
+#: ../../uaclient/messages/__init__.py:1891
 #, python-brace-format
 msgid "{service} cannot be enabled together with {variant}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1887
+#: ../../uaclient/messages/__init__.py:1895
 msgid "Cannot install Real-time kernel on a container."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1892
+#: ../../uaclient/messages/__init__.py:1900
 msgid "ROS packages assume ESM updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1897
+#: ../../uaclient/messages/__init__.py:1905
 msgid "ROS bug-fix updates assume ROS security fix updates are enabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1903
+#: ../../uaclient/messages/__init__.py:1911
 msgid "apt-daily.timer jobs are not running"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1907
+#: ../../uaclient/messages/__init__.py:1915
 #, python-brace-format
 msgid "{cfg_name} is empty"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1911
+#: ../../uaclient/messages/__init__.py:1919
 #, python-brace-format
 msgid "{cfg_name} is turned off"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1915
+#: ../../uaclient/messages/__init__.py:1923
 msgid "unattended-upgrades package is not installed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1921
+#: ../../uaclient/messages/__init__.py:1929
 msgid ""
 "Landscape is installed and configured but not registered.\n"
 "Run `sudo landscape-config` to register, or run `sudo pro disable landscape`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1930
+#: ../../uaclient/messages/__init__.py:1938
 msgid "landscape-client is either not installed or installed but disabled."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1937
+#: ../../uaclient/messages/__init__.py:1945
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue_id}\" is not recognized.\n"
@@ -2647,28 +2659,28 @@ msgid ""
 "USNs should follow the pattern USN-nnnn."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1956
+#: ../../uaclient/messages/__init__.py:1964
 msgid "Another process is running APT."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1962
+#: ../../uaclient/messages/__init__.py:1970
 #, python-brace-format
 msgid ""
 "APT update failed to read APT config for the following:\n"
 "{failed_repos}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1992
+#: ../../uaclient/messages/__init__.py:2000
 #, python-brace-format
 msgid "Invalid APT credentials provided for {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:1997
+#: ../../uaclient/messages/__init__.py:2005
 #, python-brace-format
 msgid "Timeout trying to access APT repository at {repo}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2003
+#: ../../uaclient/messages/__init__.py:2011
 #, python-brace-format
 msgid ""
 "Unexpected APT error.\n"
@@ -2676,107 +2688,107 @@ msgid ""
 "See /var/log/ubuntu-advantage.log"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2013
+#: ../../uaclient/messages/__init__.py:2021
 #, python-brace-format
 msgid ""
 "Cannot validate credentials for APT repo. Timeout after {seconds} seconds "
 "trying to reach {repo}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2020
+#: ../../uaclient/messages/__init__.py:2028
 #, python-brace-format
 msgid "snap {snap} is not installed or doesn't exist"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2025
+#: ../../uaclient/messages/__init__.py:2033
 #, python-brace-format
 msgid ""
 "Unexpected SNAPD API error\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2029
+#: ../../uaclient/messages/__init__.py:2037
 msgid "Could not reach the SNAPD API"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2033
+#: ../../uaclient/messages/__init__.py:2041
 msgid "Failed to install snapd on the system"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2038
+#: ../../uaclient/messages/__init__.py:2046
 #, python-brace-format
 msgid "Unable to install Livepatch client: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2043
+#: ../../uaclient/messages/__init__.py:2051
 #, python-brace-format
 msgid "\"{proxy}\" is not working. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2048
+#: ../../uaclient/messages/__init__.py:2056
 #, python-brace-format
 msgid "\"{proxy}\" is not a valid url. Not setting as proxy."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2054
+#: ../../uaclient/messages/__init__.py:2062
 msgid ""
 "To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt "
 "install python3-pycurl`"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2060
+#: ../../uaclient/messages/__init__.py:2068
 #, python-brace-format
 msgid "PycURL Error: {e}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2064
+#: ../../uaclient/messages/__init__.py:2072
 msgid "Proxy authentication failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2070
+#: ../../uaclient/messages/__init__.py:2078
 #, python-brace-format
 msgid ""
 "Failed to connect to {url}\n"
 "{cause_error}\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2078
+#: ../../uaclient/messages/__init__.py:2086
 #, python-brace-format
 msgid "Error connecting to {url}: {code} {body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2084
+#: ../../uaclient/messages/__init__.py:2092
 #, python-brace-format
 msgid ""
 "Cannot {operation} unknown service '{invalid_service}'.\n"
 "{service_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2093
+#: ../../uaclient/messages/__init__.py:2101
 #, python-brace-format
 msgid ""
 "This machine is already attached to '{account_name}'\n"
 "To use a different subscription first run: sudo pro detach."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2100
+#: ../../uaclient/messages/__init__.py:2108
 #, python-brace-format
 msgid "Failed to attach machine. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2107
+#: ../../uaclient/messages/__init__.py:2115
 #, python-brace-format
 msgid ""
 "Error while reading {config_name}:\n"
 "{error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2112
+#: ../../uaclient/messages/__init__.py:2120
 #, python-brace-format
 msgid "Invalid token. See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2118
+#: ../../uaclient/messages/__init__.py:2126
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2784,7 +2796,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2128
+#: ../../uaclient/messages/__init__.py:2136
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2792,7 +2804,7 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2138
+#: ../../uaclient/messages/__init__.py:2146
 #, python-brace-format
 msgid ""
 "Attach denied:\n"
@@ -2800,41 +2812,41 @@ msgid ""
 "Visit {url} to manage contract tokens."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2148
+#: ../../uaclient/messages/__init__.py:2156
 #, python-brace-format
 msgid "Expired token or contract. To obtain a new token visit: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2155
+#: ../../uaclient/messages/__init__.py:2163
 msgid "The magic attach token is already activated."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2161
+#: ../../uaclient/messages/__init__.py:2169
 msgid "The magic attach token is invalid, has expired or never existed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2167
+#: ../../uaclient/messages/__init__.py:2175
 msgid "Service unavailable, please try again later."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2172
+#: ../../uaclient/messages/__init__.py:2180
 #, python-brace-format
 msgid "This attach flow does not support {param} with value: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2178
+#: ../../uaclient/messages/__init__.py:2186
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptURL directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2186
+#: ../../uaclient/messages/__init__.py:2194
 #, python-brace-format
 msgid ""
 "This machine is not attached to an Ubuntu Pro subscription.\n"
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2195
+#: ../../uaclient/messages/__init__.py:2203
 #, python-brace-format
 msgid ""
 "Cannot {{operation}} services when unattached - nothing to do.\n"
@@ -2843,74 +2855,74 @@ msgid ""
 "See {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2212
+#: ../../uaclient/messages/__init__.py:2220
 #, python-brace-format
 msgid "could not find entitlement named \"{entitlement_name}\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2217
+#: ../../uaclient/messages/__init__.py:2225
 msgid "failed to enable some services"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2222
+#: ../../uaclient/messages/__init__.py:2230
 #, python-brace-format
 msgid "failed to enable {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2227
+#: ../../uaclient/messages/__init__.py:2235
 #, python-brace-format
 msgid "failed to disable {service}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2233
+#: ../../uaclient/messages/__init__.py:2241
 msgid "Failed to enable default services, check: sudo pro status"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2241
+#: ../../uaclient/messages/__init__.py:2249
 msgid "Something went wrong during the attach process. Check the logs."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2249
+#: ../../uaclient/messages/__init__.py:2257
 #, python-brace-format
 msgid "Ubuntu Pro server provided no aptKey directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2256
+#: ../../uaclient/messages/__init__.py:2264
 #, python-brace-format
 msgid "Ubuntu Pro server provided no suites directive for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2263
+#: ../../uaclient/messages/__init__.py:2271
 #, python-brace-format
 msgid ""
 "Cannot setup apt pin. Empty apt repo origin value for {entitlement_name}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2272
+#: ../../uaclient/messages/__init__.py:2280
 #, python-brace-format
 msgid "Could not determine contract delta service type {orig} {new}"
-msgstr ""
-
-#: ../../uaclient/messages/__init__.py:2278
-#, python-brace-format
-msgid ""
-"Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:2286
 #, python-brace-format
 msgid ""
-"Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
+"Cannot enable {service_being_enabled} when {required_service} is disabled.\n"
 msgstr ""
 
 #: ../../uaclient/messages/__init__.py:2294
+#, python-brace-format
+msgid ""
+"Cannot enable {service_being_enabled} when {incompatible_service} is enabled."
+msgstr ""
+
+#: ../../uaclient/messages/__init__.py:2302
 #, python-brace-format
 msgid ""
 "Cannot disable {service_being_disabled} when {dependent_service} is "
 "enabled.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2303
+#: ../../uaclient/messages/__init__.py:2311
 #, python-brace-format
 msgid ""
 "Failed to identify this image as a valid Ubuntu Pro image.\n"
@@ -2918,14 +2930,14 @@ msgid ""
 "{error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2313
+#: ../../uaclient/messages/__init__.py:2321
 #, python-brace-format
 msgid ""
 "An error occurred while talking the the cloud metadata service: {code} - "
 "{body}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2320
+#: ../../uaclient/messages/__init__.py:2328
 #, python-brace-format
 msgid ""
 "Failed to attach machine\n"
@@ -2933,41 +2945,41 @@ msgid ""
 "For more information, see {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2330
+#: ../../uaclient/messages/__init__.py:2338
 #, python-brace-format
 msgid "No valid AWS IMDS endpoint discovered at addresses: {addresses}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2337
+#: ../../uaclient/messages/__init__.py:2345
 msgid "Unable to determine cloud platform."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2345
+#: ../../uaclient/messages/__init__.py:2353
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on this image\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2354
+#: ../../uaclient/messages/__init__.py:2362
 #, python-brace-format
 msgid ""
 "Auto-attach image support is not available on {{cloud_type}}\n"
 "See: {url}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2362
+#: ../../uaclient/messages/__init__.py:2370
 #, python-brace-format
 msgid "{file_name} is not valid {file_format}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2368
+#: ../../uaclient/messages/__init__.py:2376
 #, python-brace-format
 msgid ""
 "Could not parse /etc/os-release VERSION: {orig_ver} (modified to {mod_ver})"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2376
+#: ../../uaclient/messages/__init__.py:2384
 #, python-brace-format
 msgid ""
 "Could not extract series information from /etc/os-release.\n"
@@ -2975,7 +2987,7 @@ msgid ""
 "and the VERSION_CODENAME information is not present"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2386
+#: ../../uaclient/messages/__init__.py:2394
 #, python-brace-format
 msgid ""
 "There is a corrupted lock file in the system. To continue, please remove it\n"
@@ -2984,208 +2996,208 @@ msgid ""
 "$ sudo rm {lock_file_path}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2395
+#: ../../uaclient/messages/__init__.py:2403
 #, python-brace-format
 msgid "{source} returned invalid json: {out}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2401
+#: ../../uaclient/messages/__init__.py:2409
 #, python-brace-format
 msgid ""
 "Invalid value for {path_to_value} in /etc/ubuntu-advantage/uaclient.conf. "
 "Expected {expected_value}, found {value}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2410
+#: ../../uaclient/messages/__init__.py:2418
 #, python-brace-format
 msgid ""
 "Cannot set {key} to {value}: <value> for interval must be a positive integer."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2417
+#: ../../uaclient/messages/__init__.py:2425
 #, python-brace-format
 msgid "Invalid url in config. {key}: {value}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2422
+#: ../../uaclient/messages/__init__.py:2430
 #, python-brace-format
 msgid "Could not find yaml file: {filepath}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2428
+#: ../../uaclient/messages/__init__.py:2436
 msgid ""
 "Error: Setting global apt proxy and pro scoped apt proxy\n"
 "at the same time is unsupported.\n"
 "Cancelling config process operation.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2438
+#: ../../uaclient/messages/__init__.py:2446
 msgid "Can't load the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2443
+#: ../../uaclient/messages/__init__.py:2451
 #, python-brace-format
 msgid "Can't find series {series} in the distro-info database."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2448
+#: ../../uaclient/messages/__init__.py:2456
 #, python-brace-format
 msgid "Error: Cannot use {option1} together with {option2}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2452
+#: ../../uaclient/messages/__init__.py:2460
 #, python-brace-format
 msgid "No help available for '{name}'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2458
+#: ../../uaclient/messages/__init__.py:2466
 #, python-brace-format
 msgid ""
 "Error: issue \"{issue}\" is not recognized.\n"
 "Usage: \"pro fix CVE-yyyy-nnnn\" or \"pro fix USN-nnnn\""
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2464
+#: ../../uaclient/messages/__init__.py:2472
 #, python-brace-format
 msgid "{arg} must be one of: {choices}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2469
+#: ../../uaclient/messages/__init__.py:2477
 #, python-brace-format
 msgid "Empty value provided for {arg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2474
+#: ../../uaclient/messages/__init__.py:2482
 #, python-brace-format
 msgid "Expected {expected} but found: {actual}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2478
+#: ../../uaclient/messages/__init__.py:2486
 msgid "Unable to process uaclient.conf"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2483
+#: ../../uaclient/messages/__init__.py:2491
 msgid "Unable to refresh your subscription"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2488
+#: ../../uaclient/messages/__init__.py:2496
 msgid "Unable to update Ubuntu Pro related APT and MOTD messages."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2494
+#: ../../uaclient/messages/__init__.py:2502
 msgid "json formatted response requires --assume-yes flag."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2502
+#: ../../uaclient/messages/__init__.py:2510
 msgid ""
 "Do not pass the TOKEN arg if you are using --attach-config.\n"
 "Include the token in the attach-config file instead.\n"
 "    "
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2511
+#: ../../uaclient/messages/__init__.py:2519
 msgid "Cannot provide both --args and --data at the same time"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2516
+#: ../../uaclient/messages/__init__.py:2524
 msgid "Operation cancelled by user"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2522
+#: ../../uaclient/messages/__init__.py:2530
 #, python-brace-format
 msgid "Unable to perform: {lock_request}.\n"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2531
+#: ../../uaclient/messages/__init__.py:2539
 msgid "This command must be run as root (try using sudo)."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2536
+#: ../../uaclient/messages/__init__.py:2544
 #, python-brace-format
 msgid "Metadata for {issue} is invalid. Error: {error_msg}."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2543
+#: ../../uaclient/messages/__init__.py:2551
 #, python-brace-format
 msgid "Error: {issue_id} not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2547
+#: ../../uaclient/messages/__init__.py:2555
 #, python-brace-format
 msgid "GPG key '{keyfile}' not found."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2552
+#: ../../uaclient/messages/__init__.py:2560
 #, python-brace-format
 msgid "'{endpoint}' is not a valid endpoint"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2557
+#: ../../uaclient/messages/__init__.py:2565
 #, python-brace-format
 msgid "Missing argument '{arg}' for endpoint {endpoint}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2562
+#: ../../uaclient/messages/__init__.py:2570
 #, python-brace-format
 msgid "{endpoint} accepts no arguments"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2567
+#: ../../uaclient/messages/__init__.py:2575
 #, python-brace-format
 msgid ""
 "Error parsing API json data parameter:\n"
 "{data}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2572
+#: ../../uaclient/messages/__init__.py:2580
 #, python-brace-format
 msgid "'{arg}' is not formatted as 'key=value'"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2577
+#: ../../uaclient/messages/__init__.py:2585
 #, python-brace-format
 msgid "Unable to determine version: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2582
+#: ../../uaclient/messages/__init__.py:2590
 msgid "features.disable_auto_attach set in config"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2587
+#: ../../uaclient/messages/__init__.py:2595
 #, python-brace-format
 msgid "Unable to determine unattended-upgrades status: {error_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2593
+#: ../../uaclient/messages/__init__.py:2601
 #, python-brace-format
 msgid "Expected value with type {expected_type} but got type: {got_type}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2599
+#: ../../uaclient/messages/__init__.py:2607
 #, python-brace-format
 msgid ""
 "Got value with incorrect type at index {index}:\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2605
+#: ../../uaclient/messages/__init__.py:2613
 #, python-brace-format
 msgid ""
 "Got value with incorrect type for field \"{key}\":\n"
 "{nested_msg}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2612
+#: ../../uaclient/messages/__init__.py:2620
 #, python-brace-format
 msgid "Value provided was not found in {enum_class}'s allowed: value: {values}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2623
+#: ../../uaclient/messages/__init__.py:2631
 #, python-brace-format
 msgid "Error updating ESM services cache: {error}"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2629
+#: ../../uaclient/messages/__init__.py:2637
 #, python-brace-format
 msgid ""
 "There is a problem with the resource directives provided by {url}\n"
@@ -3195,20 +3207,20 @@ msgid ""
 "These directives need to be unique for every entitlement."
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2638
+#: ../../uaclient/messages/__init__.py:2646
 msgid "landscape-config command failed"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2644
+#: ../../uaclient/messages/__init__.py:2652
 msgid ""
 "You must use the pro command to purge a service that has installed a kernel"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2651
+#: ../../uaclient/messages/__init__.py:2659
 msgid "The operation is not supported"
 msgstr ""
 
-#: ../../uaclient/messages/__init__.py:2661
+#: ../../uaclient/messages/__init__.py:2669
 #, python-brace-format
 msgid "Invalid URL: {url}"
 msgstr ""

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -51,11 +51,12 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
       This command must be run as root (try using sudo).
       """
-    When I run `pro enable realtime-kernel` `with sudo` and stdin `y`
+    When I run `pro enable realtime-kernel` `with sudo` and stdin `y\ny`
     Then stdout matches regexp:
       """
       One moment, checking your subscription first
-      The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated.
+      No variant specified. To specify a variant, use the variant option.
+      Auto-selecting .*generic.* variant. Proceed\? \(y/N\) The Real-time kernel is an Ubuntu kernel with PREEMPT_RT patches integrated.
 
       .*This will change your kernel. To revert to your original kernel, you will need
       to make the change manually..*
@@ -129,14 +130,15 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
       realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
       ├ generic        yes +enabled   +Generic version of the RT kernel \(default\)
-      └ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+      ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+      └ raspi          yes +n/a      +24.04 Real-time kernel optimised for Raspberry Pi
       """
     When I run `pro api u.pro.status.enabled_services.v1` as non-root
     Then stdout matches regexp:
       """
       {"_schema_version": "v1", "data": {"attributes": {"enabled_services": \[{"name": "realtime-kernel", "variant_enabled": true, "variant_name": "generic"}\]}, "meta": {"environment_vars": \[\]}, "type": "EnabledServices"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
       """
-    When I run `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `y\ny\n`
+    When I run `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `y\ny\ny`
     Then stdout contains substring:
       """
       Real-time Intel IOTG Kernel cannot be enabled with Real-time kernel.
@@ -152,7 +154,8 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
       realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
       ├ generic        yes +disabled   +Generic version of the RT kernel \(default\)
-      └ intel-iotg     yes +enabled  +RT kernel optimized for Intel IOTG platform
+      ├ intel-iotg     yes +enabled  +RT kernel optimized for Intel IOTG platform
+      └ raspi          yes +n/a      +24.04 Real-time kernel optimised for Raspberry Pi
       """
     When I run `pro api u.pro.status.enabled_services.v1` as non-root
     Then stdout matches regexp:
@@ -165,21 +168,23 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
       intel
       """
-    When I run `pro enable realtime-kernel --variant generic` `with sudo` and stdin `y\ny\n`
+    When I run `pro enable realtime-kernel --variant generic` `with sudo` and stdin `y\ny\ny`
     And I run `pro status --all` as non-root
     Then stdout matches regexp:
       """
       realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
       ├ generic        yes +enabled   +Generic version of the RT kernel \(default\)
-      └ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+      ├ intel-iotg     yes +disabled  +RT kernel optimized for Intel IOTG platform
+      └ raspi          yes +n/a      +24.04 Real-time kernel optimised for Raspberry Pi
       """
-    When I run `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `y\ny\n`
+    When I run `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `y\ny\ny`
     And I run `pro status --all` as non-root
     Then stdout matches regexp:
       """
       realtime-kernel  yes +enabled   +Ubuntu kernel with PREEMPT_RT patches integrated
       ├ generic        yes +disabled   +Generic version of the RT kernel \(default\)
-      └ intel-iotg     yes +enabled  +RT kernel optimized for Intel IOTG platform
+      ├ intel-iotg     yes +enabled  +RT kernel optimized for Intel IOTG platform
+      └ raspi          yes +n/a      +24.04 Real-time kernel optimised for Raspberry Pi
       """
     When I verify that running `pro enable realtime-kernel` `with sudo` exits `1`
     Then stdout contains substring:
@@ -207,6 +212,11 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
                       - nvidia-prime
                 - selector:
                     variant: raspi
+                  affordances:
+                    series:
+                      - jammy
+                    architectures:
+                      - amd64
                   directives:
                     additionalPackages:
                       - raspi-config

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -116,14 +116,6 @@ def given_a_machine(
             context, "python3-coverage", machine_name=machine_name
         )
 
-    # trigger GH: #3137
-    when_i_run_command(
-        context,
-        "touch /var/lib/dpkg/arch",
-        "with sudo",
-        machine_name=machine_name,
-    )
-
     if cleanup:
 
         def cleanup_instance():
@@ -242,6 +234,13 @@ def given_a_sut_machine(context, series, machine_type):
         given_a_machine(context, series, machine_type=machine_type)
         _update_distro_info_data(context)
         when_i_install_uat(context)
+
+    # trigger GH: #3137 on all machines
+    when_i_run_command(
+        context,
+        "touch /var/lib/dpkg/arch",
+        "with sudo",
+    )
 
     logging.info(
         "--- instance ip: {}".format(context.machines[SUT].instance.ip)

--- a/uaclient/api/u/pro/services/enable/v1.py
+++ b/uaclient/api/u/pro/services/enable/v1.py
@@ -127,7 +127,20 @@ def _enable(
         raise exceptions.NotSupported()
 
     enabled_services_before = _enabled_services_names(cfg)
-    if options.service in enabled_services_before:
+
+    already_enabled = next(
+        (
+            s
+            for s in _enabled_services(cfg).enabled_services
+            if s.name == options.service
+            and (
+                not options.variant
+                or (s.variant_enabled and s.variant_name == options.variant)
+            )
+        ),
+        None,
+    )
+    if already_enabled:
         # nothing to do
         return EnableResult(
             enabled=[],

--- a/uaclient/cli/enable.py
+++ b/uaclient/cli/enable.py
@@ -236,8 +236,8 @@ def _enable_one_service(
             for s in enabled_services
             if s.name == real_name
             and (
-                (s.variant_enabled and s.variant_name == variant)
-                or (not s.variant_enabled and not variant)
+                not variant
+                or (s.variant_enabled and s.variant_name == variant)
             )
         ),
         None,

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -262,6 +262,27 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 return variant
         return None
 
+    def variant_auto_select(self) -> bool:
+        """
+        Only implemented on variant classes.
+        Returns True if this variant should be auto-selected.
+        """
+        return False
+
+    @property
+    def default_variant(self):
+        """
+        Cannot actually set the return type because
+        https://github.com/python/typing/issues/266
+        affects xenial.
+
+        :rtype: Optional[Type["UAEntitlement"]]
+        """
+        variants = list(self.variants.values())
+        if variants:
+            return variants[0]
+        return None
+
     # Any custom messages to emit to the console or callables which are
     # handled at pre_enable, pre_disable, pre_install or post_enable stages
     @property

--- a/uaclient/entitlements/tests/test_realtime.py
+++ b/uaclient/entitlements/tests/test_realtime.py
@@ -3,10 +3,41 @@ import pytest
 
 from uaclient import messages
 from uaclient.entitlements.entitlement_status import ApplicabilityStatus
-from uaclient.entitlements.realtime import IntelIotgRealtime
+from uaclient.entitlements.realtime import (
+    IntelIotgRealtime,
+    RaspberryPiRealtime,
+)
 from uaclient.system import CpuInfo
 
-RT_PATH = "uaclient.entitlements.realtime.RealtimeKernelEntitlement."
+M_PATH = "uaclient.entitlements.realtime."
+
+
+class TestRaspiVariant:
+    @pytest.mark.parametrize(
+        [
+            "load_file_side_effect",
+            "expected_result",
+        ],
+        [
+            (["Raspberry Pi 5 Model B Rev 1.0"], True),
+            (["Raspberry Pi 4 Model B Rev 1.1"], True),
+            (["Raspberry Pi 3 Model B Plus Rev 1.3"], False),
+            ([FileNotFoundError()], False),
+        ],
+    )
+    @mock.patch(M_PATH + "system.load_file")
+    def test_variant_auto_select(
+        self,
+        m_load_file,
+        load_file_side_effect,
+        expected_result,
+        FakeConfig,
+    ):
+        m_load_file.side_effect = load_file_side_effect
+        assert (
+            expected_result
+            == RaspberryPiRealtime(FakeConfig()).variant_auto_select()
+        )
 
 
 class TestIntelIOTGVariannt:

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1722,6 +1722,9 @@ View your subscription at: {url}"""
 SERVICE_NOT_ENTITLED = FormattedNamedMessage(
     "service-not-entitled", t.gettext("{title} is not entitled")
 )
+AUTO_SELECTED_VARIANT_WARNING = FormattedNamedMessage(
+    "auto-selected-variant", t.gettext("Auto-selected {variant_name} variant")
+)
 
 INAPPLICABLE_KERNEL_VER = FormattedNamedMessage(
     "inapplicable-kernel-version",

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -341,6 +341,11 @@ ENABLE_REBOOT_REQUIRED_TMPL = t.gettext(
 A reboot is required to complete {operation}."""
 )
 CONFIGURING_APT_ACCESS = t.gettext("Configuring APT access to {service}")
+AUTO_SELECTING_VARIANT = t.gettext(
+    """\
+No variant specified. To specify a variant, use the variant option.
+Auto-selecting {variant} variant. Proceed? (y/N) """
+)
 
 # DISABLE
 REMOVING_APT_CONFIGURATION = t.gettext("Removing APT access to {title}")


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This helps users get the right realtime-kernel when running on a raspberry pi. It also informs users of what variant will be installed when it is auto-selected.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Ideally test on a rpi3/4/5 and test that auto-selection works as expected (select raspi on 4/5 and generic everwhere else)
Or you can trick the rpi5 detection on a multipass vm with something like this:
```
./tools/test-in-multipass.sh noble

# now in vm
pro attach --no-auto-enable

cat > /usr/local/bin/dpkg << EOF
#!/usr/bin/bash
echo arm64
EOF
chmod +x /usr/local/bin/dpkg

sed -i 's/(proc_file_path)/("\/home\/ubuntu\/fake")/' /usr/lib/python3/dist-packages/uaclient/entitlements/realtime.py
echo "Raspberry Pi 5 Model B Rev 1.0" > /home/ubuntu/fake
```

Then `pro enable realtime-kernel` and ensure that the raspi variant is auto-selected.

Also test that raspi is not selected if the proc file is mocked but the arch is not arm64.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
