### PR TITLE
d/rules: test for version mismatch

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -30,6 +30,10 @@ override_dh_auto_build:
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
+	# fail early if version.py wasn't updated to match d/changelog's version
+	# only take into account the actual upstream version, discarding ubuntu and
+	# backport suffixes
+	python3 tools/check-versions-are-consistent.py
 # Hooks will only be delivered on LTS instances
 ifeq (LTS,$(findstring LTS,$(VERSION)))
 	make -C apt-hook test

--- a/tools/check-versions-are-consistent.py
+++ b/tools/check-versions-are-consistent.py
@@ -14,7 +14,17 @@ changelog_version = (
 )
 
 # remove tilde and suffix of changelog_version if present
-base_changelog_version = changelog_version.split("~")[0]
+# typical version strings:
+# GH: 32.3ubuntu1~1.gbp761c11~noble1 -> 32.3
+# backports: 32.3~22.04 -> 32.3
+# ppa test builds: 32.3~22.04~ppa1 -> 32.3
+# devel: 1:1+devel -> 1:1+devel
+#
+m = re.match(r"((\d+:\d+\+devel)|\d+(\.\d+)?)", changelog_version)
+if m:
+    base_changelog_version = m.group()
+else:
+    base_changelog_version = None
 
 if python_version != base_changelog_version:
     print(


### PR DESCRIPTION
Fixes: #3154

## Why is this needed?
This prevents package builders and uploaders from forgetting to also update the __VERSION__ in uaclient/version.py if a new upstream version is created. Since this is a native package in ubuntu, every single upload will be a new upstream version as well.

## Test Steps
Change version in d/changelog to something different from uaclient/version.py's __VERSION__, and build the package. The build should fail.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] Changes here need to be documented, and this was done in: <!-- Insert PR number here if the box is checked (ex. #1234) -->

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [x] Yes
 - [ ] No