### PR TITLE
typing: add no_implicit_optional lint lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ line_length = 79
 [tool.mypy]
 check_untyped_defs = "true"
 explicit_package_bases = "true"
+no_implicit_optional = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -8,13 +8,13 @@ from uaclient import config, event_logger
 def machine_token(
     entitlement_type: str,
     *,
-    affordances: Dict[str, Any] = None,
-    directives: Dict[str, Any] = None,
-    overrides: List[Dict[str, Any]] = None,
+    affordances: Optional[Dict[str, Any]] = None,
+    directives: Optional[Dict[str, Any]] = None,
+    overrides: Optional[List[Dict[str, Any]]] = None,
     entitled: bool = True,
-    obligations: Dict[str, Any] = None,
-    suites: List[str] = None,
-    additional_packages: List[str] = None
+    obligations: Optional[Dict[str, Any]] = None,
+    suites: Optional[List[str]] = None,
+    additional_packages: Optional[List[str]] = None
 ) -> Dict[str, Any]:
     return {
         "resourceTokens": [
@@ -46,13 +46,13 @@ def machine_token(
 def machine_access(
     entitlement_type: str,
     *,
-    affordances: Dict[str, Any] = None,
-    directives: Dict[str, Any] = None,
-    overrides: List[Dict[str, Any]] = None,
+    affordances: Optional[Dict[str, Any]] = None,
+    directives: Optional[Dict[str, Any]] = None,
+    overrides: Optional[List[Dict[str, Any]]] = None,
     entitled: bool = True,
-    obligations: Dict[str, Any] = None,
-    suites: List[str] = None,
-    additional_packages: List[str] = None
+    obligations: Optional[Dict[str, Any]] = None,
+    suites: Optional[List[str]] = None,
+    additional_packages: Optional[List[str]] = None
 ) -> Dict[str, Any]:
     if affordances is None:
         affordances = {}
@@ -96,16 +96,16 @@ def entitlement_factory(tmpdir, FakeConfig, fake_machine_token_file):
     def factory_func(
         cls,
         *,
-        affordances: Dict[str, Any] = None,
-        directives: Dict[str, Any] = None,
-        obligations: Dict[str, Any] = None,
-        overrides: List[Dict[str, Any]] = None,
+        affordances: Optional[Dict[str, Any]] = None,
+        directives: Optional[Dict[str, Any]] = None,
+        obligations: Optional[Dict[str, Any]] = None,
+        overrides: Optional[List[Dict[str, Any]]] = None,
         entitled: bool = True,
         called_name: str = "",
         access_only: bool = False,
         purge: bool = False,
-        suites: List[str] = None,
-        additional_packages: List[str] = None,
+        suites: Optional[List[str]] = None,
+        additional_packages: Optional[List[str]] = None,
         cfg: Optional[config.UAConfig] = None,
         cfg_extension: Optional[Dict[str, Any]] = None,
         cfg_features: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because it enforces a newer and better default for a lint check.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
typing: add no_implicit_optional lint

Explicit optional types are preferred and the default in mypy >= 0.980[1].

Add the config to check for this and fix any instance of the lint error.

References:
[1] https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_optional
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [ ] *(un)check this to re-run the checklist action*