### PR TITLE
tests: add --force flag to ufw enable

### DIFF
--- a/features/steps/network.py
+++ b/features/steps/network.py
@@ -73,8 +73,7 @@ def disable_internet_connection(context, machine_name=SUT):
     )
     when_i_run_command(
         context,
-        "ufw enable",
+        "ufw --force enable",
         "with sudo",
         machine_name=machine_name,
-        stdin="y\n",
     )


### PR DESCRIPTION
## Why is this needed?
Sometimes, the aigapped tests are hanging when we try to disable the internet on a given machine. We believe this is being caused by unhandled prompts on the ufw enable command. We are now adding the --force flag to prevent that

## Test Steps
Guarantee that airgapped tests are now unstuck on CI


---

- [ ] *(un)check this to re-run the checklist action*