### PR TITLE
Bring back disable notice for FIPS

### DIFF
--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -461,6 +461,16 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
         return False
 
+    def _perform_disable(self, progress: api.ProgressWrapper) -> bool:
+        if super()._perform_disable(progress):
+            if self._check_for_reboot():
+                notices.add(
+                    Notice.FIPS_DISABLE_REBOOT_REQUIRED,
+                )
+            return True
+
+        return False
+
     def unhold_packages(self, package_names):
         cmd = ["apt-mark", "showholds"]
         holds = apt.run_apt_command(


### PR DESCRIPTION
## Why is this needed?
During disable, we create a notice that states that a reboot is necessary after the operation. We are now bringing that notice back, since it is still valid for FIPS

## Test Steps
Run the `Attached enable of FIPS in an ubuntu lxd vm` test for xenial and verify the test is now passing as expected


---

- [ ] *(un)check this to re-run the checklist action*