### PR TITLE
tests: fix APT messages test for xenial

### DIFF
--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -73,8 +73,8 @@ Feature: APT Messages
       """
 
     Examples: ubuntu release
-      | release | machine_type  | standard-pkg         | infra-pkg                                            | apps-pkg     |
-      | xenial  | lxd-container | wget=1.17.1-1ubuntu1 | curl=7.47.0-1ubuntu2 libcurl3-gnutls=7.47.0-1ubuntu2 | hello=2.10-1 |
+      | release | machine_type  | standard-pkg              | infra-pkg                                            | apps-pkg     |
+      | xenial  | lxd-container | apparmor=2.10.95-0ubuntu2 | curl=7.47.0-1ubuntu2 libcurl3-gnutls=7.47.0-1ubuntu2 | hello=2.10-1 |
 
   @uses.config.contract_token
   Scenario Outline: APT Hook advertises esm-infra on upgrade


### PR DESCRIPTION
## Why is this needed?
The standard package we use to test the APT messages now have an esm-infra counterpart. We are now using another package that doesn't have an esm-infra version

## Test Steps
Check that the modified Xenial APT test is now working as expected

- [ ] *(un)check this to re-run the checklist action*