### PR TITLE
system: use correct spelling of UTF-8

### DIFF
--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -284,3 +284,4 @@ Feature: Pro supports multiple languages
       | xenial  | lxd-container |
       | jammy   | lxd-container |
       | mantic  | lxd-container |
+      | noble   | lxd-container |

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -635,7 +635,7 @@ def _subp(
         stdout = subprocess.PIPE
         stderr = subprocess.PIPE
         # Set LANG to avoid non-utf8 when we pipe the handlers
-        set_lang = {"LANG": "C.UTF8", "LC_ALL": "C.UTF8"}
+        set_lang = {"LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"}
 
     if override_env_vars is None:
         override_env_vars = {}

--- a/uaclient/tests/test_system.py
+++ b/uaclient/tests/test_system.py
@@ -1275,24 +1275,24 @@ class TestSubp:
             "expected_env_arg",
         ],
         (
-            (None, {}, {"LANG": "C.UTF8", "LC_ALL": "C.UTF8"}),
+            (None, {}, {"LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"}),
             (
                 None,
                 {"test": "val"},
-                {"test": "val", "LANG": "C.UTF8", "LC_ALL": "C.UTF8"},
+                {"test": "val", "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"},
             ),
             (
                 {},
                 {"test": "val"},
-                {"test": "val", "LANG": "C.UTF8", "LC_ALL": "C.UTF8"},
+                {"test": "val", "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"},
             ),
             (
                 {"set": "new"},
                 {"test": "val"},
                 {
                     "test": "val",
-                    "LANG": "C.UTF8",
-                    "LC_ALL": "C.UTF8",
+                    "LANG": "C.UTF-8",
+                    "LC_ALL": "C.UTF-8",
                     "set": "new",
                 },
             ),
@@ -1300,8 +1300,8 @@ class TestSubp:
                 {"set": "new", "test": "newval"},
                 {"test": "val"},
                 {
-                    "LANG": "C.UTF8",
-                    "LC_ALL": "C.UTF8",
+                    "LANG": "C.UTF-8",
+                    "LC_ALL": "C.UTF-8",
                     "test": "newval",
                     "set": "new",
                 },


### PR DESCRIPTION
## Why is this needed?

UTF8 on locale names works but is not the correct way of specifying it. The correct spelling that is officially supported is UTF-8.

## Test Steps

utf8 behave test should still pass


---

- [ ] *(un)check this to re-run the checklist action*