### PR TITLE
Apparmor apt news package selector 3193

### DIFF
--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -43,7 +43,16 @@ profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   /run/ubuntu-advantage/ rw,
   /run/ubuntu-advantage/* rw,
 
-  /tmp/** r,
+  # LP: #2072489
+  # the apt-news package selector needs access to packaging information
+  # this is a good candidate for a child profile
+  owner /tmp/** rw,
+  /etc/machine-id r,
+  /etc/dpkg/** r,
+  /{,usr/}bin/dpkg mrix,
+  /var/lib/apt/** r,
+  /var/lib/dpkg/** r,
+  /var/cache/apt/** rw,
 
   owner @{PROC}/@{pid}/fd/ r,
   @{PROC}/@{pid}/status r,

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -720,7 +720,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout
       """
@@ -747,7 +749,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout
       """
@@ -779,7 +783,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout:
       """
@@ -810,7 +816,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout:
       """
@@ -837,7 +845,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout:
       """
@@ -871,7 +881,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then I will see the following on stdout:
       """
@@ -901,7 +913,9 @@ Feature: APT Messages
       """
     And I apt install `<package>=<installed_version>`
     And I run `apt-mark hold <package>` with sudo
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then stdout contains substring:
       """
@@ -927,7 +941,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then stdout contains substring:
       """
@@ -955,7 +971,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then stdout contains substring:
       """
@@ -985,7 +1003,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then stdout contains substring:
       """
@@ -1014,7 +1034,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    And I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    And I run `systemctl start apt-news.service` with sudo
+    And I wait `5` seconds
     And I apt upgrade
     Then I will see the following on stdout:
       """
@@ -1045,7 +1067,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    And I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    And I run `systemctl start apt-news.service` with sudo
+    And I wait `5` seconds
     And I apt upgrade
     Then I will see the following on stdout:
       """

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -864,7 +864,7 @@ Feature: Security status command behavior
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # Get the system up to date
     When I apt update
-    And I apt upgrade
+    And I apt upgrade including phased updates
     # Install older versions of packages which have alternatives in -updates and -security
     # This will mess up a little with the system but all should be fine for the test purpose
     And I apt install `<pkg_in_updates> <pkg_in_security>`

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -107,6 +107,13 @@ def given_a_machine(
             machine_name=machine_name,
         )
 
+    when_i_run_command(
+        context,
+        "systemctl mask apt-news.service",
+        "with sudo",
+        machine_name=machine_name,
+    )
+
     # make sure the machine has up-to-date apt data
     when_i_apt_update(context, machine_name=machine_name)
 
@@ -115,6 +122,13 @@ def given_a_machine(
         when_i_apt_install(
             context, "python3-coverage", machine_name=machine_name
         )
+
+    when_i_run_command(
+        context,
+        "systemctl unmask apt-news.service",
+        "with sudo",
+        machine_name=machine_name,
+    )
 
     if cleanup:
 
@@ -232,8 +246,19 @@ def given_a_sut_machine(context, series, machine_type):
         )
     else:
         given_a_machine(context, series, machine_type=machine_type)
+        when_i_run_command(
+            context,
+            "systemctl mask apt-news.service",
+            "with sudo",
+        )
         _update_distro_info_data(context)
         when_i_install_uat(context)
+
+        when_i_run_command(
+            context,
+            "systemctl unmask apt-news.service",
+            "with sudo",
+        )
 
     # trigger GH: #3137 on all machines
     when_i_run_command(


### PR DESCRIPTION
## Why is this needed?
The apt-news service has grown a package selector, and therefore it needs access to the packages information on the system.
This feature is not new, but was used for the first time recently due to an [openssh security update](https://ubuntu.com/security/notices/USN-6887-1) .

LP: #2072489
Fixes: #3193

## Test Steps
As of this writing, the apt news json is still out there and will trigger the issue, but that may not be the case in the future. Right now, just running `apt-get update` on a system should show the apparmor DENIED messages in the logs.

The behave test created for this scenario happened to not be using the systemd service file for apt-news, which means that code ran unconfined by apparmor, which is why this wasn't caught in tests before. The test will be changed in a follow-up PR.

- [x] *(un)check this to re-run the checklist action*