### PR TITLE
Cherry pick apparmor fix

### DIFF
--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -43,7 +43,16 @@ profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   /run/ubuntu-advantage/ rw,
   /run/ubuntu-advantage/* rw,
 
-  /tmp/** r,
+  # LP: #2072489
+  # the apt-news package selector needs access to packaging information
+  # this is a good candidate for a child profile
+  owner /tmp/** rw,
+  /etc/machine-id r,
+  /etc/dpkg/** r,
+  /{,usr/}bin/dpkg mrix,
+  /var/lib/apt/** r,
+  /var/lib/dpkg/** r,
+  /var/cache/apt/** rw,
 
   owner @{PROC}/@{pid}/fd/ r,
   @{PROC}/@{pid}/status r,

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -720,7 +720,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout
       """
@@ -747,7 +749,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout
       """
@@ -779,7 +783,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout:
       """
@@ -810,7 +816,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout:
       """
@@ -837,7 +845,9 @@ Feature: APT Messages
         ]
       }
       """
-    When I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     When I apt upgrade
     Then I will see the following on stdout:
       """
@@ -871,7 +881,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then I will see the following on stdout:
       """
@@ -901,7 +913,9 @@ Feature: APT Messages
       """
     And I apt install `<package>=<installed_version>`
     And I run `apt-mark hold <package>` with sudo
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then stdout contains substring:
       """
@@ -927,7 +941,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then stdout contains substring:
       """
@@ -955,7 +971,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then stdout contains substring:
       """
@@ -985,7 +1003,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    When I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    When I run `systemctl start apt-news.service` with sudo
+    When I wait `5` seconds
     And I apt upgrade
     Then stdout contains substring:
       """
@@ -1014,7 +1034,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    And I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    And I run `systemctl start apt-news.service` with sudo
+    And I wait `5` seconds
     And I apt upgrade
     Then I will see the following on stdout:
       """
@@ -1045,7 +1067,9 @@ Feature: APT Messages
         ]
       }
       """
-    And I run `pro refresh messages` with sudo
+    And I run `rm -rf /var/lib/apt/periodic/update-success-stamp` with sudo
+    And I run `systemctl start apt-news.service` with sudo
+    And I wait `5` seconds
     And I apt upgrade
     Then I will see the following on stdout:
       """

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -859,3 +859,106 @@ Feature: Security status command behavior
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
+
+  Scenario Outline: Pass custom APT configuration to the Client for updates information
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    # Get the system up to date
+    When I apt update
+    And I apt upgrade including phased updates
+    # Install older versions of packages which have alternatives in -updates and -security
+    # This will mess up a little with the system but all should be fine for the test purpose
+    And I apt install `<pkg_in_updates> <pkg_in_security>`
+    And I apt update
+    Then stdout contains substring:
+      """
+      2 packages can be upgraded
+      """
+    When I run `apt list --upgradable` with sudo
+    Then stdout contains substring:
+      """
+      <release>-updates
+      """
+    And stdout contains substring:
+      """
+      <release>-security
+      """
+    When I run `pro api u.pro.packages.updates.v1` with sudo
+    Then stdout contains substring:
+      """
+      "num_standard_security_updates": 1
+      """
+    And stdout contains substring:
+      """
+      "num_standard_updates": 1
+      """
+    # Create custom configuration (lists file) for APT
+    When I create the file `/tmp/custom.list` with the following:
+      """
+      deb http://security.ubuntu.com/ubuntu <release>-security main restricted universe multiverse
+      """
+    And I create the file `/tmp/custom.conf` with the following:
+      """
+      Dir::Etc::Sourcelist "/tmp/custom.list";
+      Dir::Etc::Sourceparts "nonexisting";
+      """
+    # Pass the config using the environment
+    And I run `APT_CONFIG=/tmp/custom.conf pro api u.pro.packages.updates.v1` with sudo
+    Then stdout contains substring:
+      """
+      "num_standard_security_updates": 1
+      """
+    And stdout contains substring:
+      """
+      "num_standard_updates": 0
+      """
+    When I run `APT_CONFIG=/tmp/custom.conf apt list --upgradable` with sudo
+    Then stdout does not contain substring:
+      """
+      <release>-updates
+      """
+    And stdout contains substring:
+      """
+      <release>-security
+      """
+    When I run `APT_CONFIG=/tmp/custom.conf apt update` with sudo
+    Then stdout contains substring:
+      """
+      1 package can be upgraded
+      """
+    # Update the APT lists again after the past customized update
+    When I apt update
+    # Pass the config in a proper APT config file
+    And I create the file `/etc/apt/apt.conf.d/50-custom` with the following:
+      """
+      Dir::Etc::Sourcelist "/tmp/custom.list";
+      Dir::Etc::Sourceparts "nonexisting";
+      """
+    # Check it works the same
+    And I run `pro api u.pro.packages.updates.v1` with sudo
+    Then stdout contains substring:
+      """
+      "num_standard_security_updates": 1
+      """
+    And stdout contains substring:
+      """
+      "num_standard_updates": 0
+      """
+    When I run `apt list --upgradable` with sudo
+    Then stdout does not contain substring:
+      """
+      <release>-updates
+      """
+    And stdout contains substring:
+      """
+      <release>-security
+      """
+    When I apt update
+    Then stdout contains substring:
+      """
+      1 package can be upgraded
+      """
+
+    Examples: ubuntu release
+      | release | machine_type  | pkg_in_updates          | pkg_in_security      |
+      | xenial  | lxd-container | base-files=9.4ubuntu4   | wget=1.17.1-1ubuntu1 |
+      | noble   | lxd-container | xxd=2:9.1.0016-1ubuntu7 | less=590-2ubuntu2    |

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -107,6 +107,13 @@ def given_a_machine(
             machine_name=machine_name,
         )
 
+    when_i_run_command(
+        context,
+        "systemctl mask apt-news.service",
+        "with sudo",
+        machine_name=machine_name,
+    )
+
     # make sure the machine has up-to-date apt data
     when_i_apt_update(context, machine_name=machine_name)
 
@@ -115,6 +122,13 @@ def given_a_machine(
         when_i_apt_install(
             context, "python3-coverage", machine_name=machine_name
         )
+
+    when_i_run_command(
+        context,
+        "systemctl unmask apt-news.service",
+        "with sudo",
+        machine_name=machine_name,
+    )
 
     if cleanup:
 
@@ -232,8 +246,19 @@ def given_a_sut_machine(context, series, machine_type):
         )
     else:
         given_a_machine(context, series, machine_type=machine_type)
+        when_i_run_command(
+            context,
+            "systemctl mask apt-news.service",
+            "with sudo",
+        )
         _update_distro_info_data(context)
         when_i_install_uat(context)
+
+        when_i_run_command(
+            context,
+            "systemctl unmask apt-news.service",
+            "with sudo",
+        )
 
     # trigger GH: #3137 on all machines
     when_i_run_command(


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because...

Cherry picks the apparmor fix to next-v34

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [ ] *(un)check this to re-run the checklist action*