### PR TITLE
Adjustments and tweaks to the help text

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -288,7 +288,7 @@ Feature: Pro Client help text
     When I run `pro system --help` as non-root
     Then I will see the following on stdout
       """
-      usage: pro system [-h]  ...
+      usage: pro system [-h] {reboot-required} ...
 
       Output system related information related to Pro services
 
@@ -296,7 +296,7 @@ Feature: Pro Client help text
         -h, --help       show this help message and exit
 
       Available Commands:
-        
+        {reboot-required}
           reboot-required
                          does the system need to be rebooted
       """
@@ -324,7 +324,7 @@ Feature: Pro Client help text
     When I run `pro config --help` as non-root
     Then I will see the following on stdout
       """
-      usage: pro config [-h]  ...
+      usage: pro config [-h] {show,set,unset} ...
 
       Manage Ubuntu Pro configuration
 
@@ -332,7 +332,7 @@ Feature: Pro Client help text
         -h, --help  show this help message and exit
 
       Available Commands:
-        
+        {show,set,unset}
           show      Show customizable configuration settings
           set       Set and apply Ubuntu Pro configuration settings
           unset     Unset Ubuntu Pro configuration setting

--- a/features/help.feature
+++ b/features/help.feature
@@ -5,7 +5,7 @@ Feature: Pro Client help text
     When I run `pro collect-logs --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro collect-logs \[flags\]
+      usage: pro collect-logs \[-h\] \[-o OUTPUT\]
 
       Collect logs and relevant system information into a tarball.
 
@@ -18,7 +18,8 @@ Feature: Pro Client help text
     When I run `pro api --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro api \[flags\]
+      usage: pro api \[-h\] \[--show-progress\] \[--args \[OPTIONS ...\]\] \[--data DATA\]
+                     endpoint
 
       Calls the Client API endpoints.
 
@@ -36,7 +37,8 @@ Feature: Pro Client help text
     When I run `pro disable --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro disable \[flags\]
+      usage: pro disable \[-h\] \[--assume-yes\] \[--format \{cli,json\}\] \[--purge\]
+                         service \[service ...\]
 
       Disable an Ubuntu Pro service.
 
@@ -57,7 +59,9 @@ Feature: Pro Client help text
     When I run `pro enable --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro enable \[flags\]
+      usage: pro enable \[-h\] \[--assume-yes\] \[--access-only\] \[--beta\]
+                        \[--format \{cli,json\}\] \[--variant VARIANT\]
+                        service \[service ...\]
 
       Enable an Ubuntu Pro service.
 
@@ -81,7 +85,9 @@ Feature: Pro Client help text
     When I run `pro attach --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro attach \[flags\]
+      usage: pro attach \[-h\] \[--no-auto-enable\] \[--attach-config ATTACH_CONFIG\]
+                        \[--format \{cli,json\}\]
+                        \[token\]
 
       Attach this machine to an Ubuntu Pro subscription with a token obtained from:
       https://ubuntu.com/pro/dashboard
@@ -104,7 +110,7 @@ Feature: Pro Client help text
     When I run `pro auto-attach --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro auto-attach \[flags\]
+      usage: pro auto-attach \[-h\]
 
       Automatically attach on an Ubuntu Pro cloud instance.
 
@@ -114,7 +120,7 @@ Feature: Pro Client help text
     When I run `pro detach --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro detach \[flags\]
+      usage: pro detach \[-h\] \[--assume-yes\] \[--format \{cli,json\}\]
 
       Detach this machine from an Ubuntu Pro subscription.
 
@@ -127,7 +133,8 @@ Feature: Pro Client help text
     When I run `pro security-status --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro security-status \[flags\]
+      usage: pro security-status \[-h\] \[--format \{json,yaml,text\}\]
+                                 \[--thirdparty \| --unavailable \| --esm-infra \| --esm-apps\]
 
       Show security updates for packages in the system, including all
       available Expanded Security Maintenance \(ESM\) related content.
@@ -160,7 +167,7 @@ Feature: Pro Client help text
     When I run `pro fix --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro fix \[flags\]
+      usage: pro fix \[-h\] \[--dry-run\] \[--no-related\] security_issue
 
       Inspect and resolve CVEs and USNs \(Ubuntu Security Notices\) on this machine.
 
@@ -180,7 +187,8 @@ Feature: Pro Client help text
     When I run `pro status --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro status \[flags\]
+      usage: pro status \[-h\] \[--wait\] \[--format \{tabular,json,yaml\}\]
+                        \[--simulate-with-token TOKEN\] \[--all\]
 
       Report current status of Ubuntu Pro services on system.
 
@@ -227,7 +235,7 @@ Feature: Pro Client help text
     When I run `pro refresh --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro refresh \[flags\]
+      usage: pro refresh \[-h\] \[\{contract,config,messages\}\]
 
       Refresh three distinct Ubuntu Pro related artifacts in the system:
 
@@ -249,7 +257,7 @@ Feature: Pro Client help text
     When I run `pro system --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro system \[flags\]
+      usage: pro system \[-h\]  ...
 
       Output system related information related to Pro services
 
@@ -264,7 +272,7 @@ Feature: Pro Client help text
     When I run `pro system reboot-required --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro reboot-required \[flags\]
+      usage: pro system reboot-required \[-h\]
 
       Report the current reboot-required status for the machine.
 
@@ -282,7 +290,7 @@ Feature: Pro Client help text
     When I run `pro config --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro config \[flags\]
+      usage: pro config \[-h\]  ...
 
       Manage Ubuntu Pro configuration
 
@@ -298,7 +306,7 @@ Feature: Pro Client help text
     When I run `pro config show --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro show \[flags\]
+      usage: pro config show \[-h\] \[key\]
 
       Show customizable configuration settings
 
@@ -308,7 +316,7 @@ Feature: Pro Client help text
     When I run `pro config set --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro set \[flags\]
+      usage: pro config set \[-h\] key_value_pair
 
       Set and apply Ubuntu Pro configuration settings
 
@@ -326,7 +334,7 @@ Feature: Pro Client help text
     When I run `pro config unset --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro unset \[flags\]
+      usage: pro config unset \[-h\] key
 
       Unset Ubuntu Pro configuration setting
 

--- a/features/help.feature
+++ b/features/help.feature
@@ -5,7 +5,7 @@ Feature: Pro Client help text
     When I run `pro --help` as non-root
     Then I will see the following on stdout
       """
-      usage: pro [-h] [--debug] [--version]  ...
+      usage: pro [-h] [--debug] [--version] <command> ...
 
     Flags:
       -h, --help       show this help message and exit
@@ -13,7 +13,7 @@ Feature: Pro Client help text
       --version        show version of pro
 
       Available Commands:
-        
+        <command>
           api            Calls the Client API endpoints.
           attach         attach this machine to an Ubuntu Pro subscription
           auto-attach    automatically attach on supported platforms

--- a/features/help.feature
+++ b/features/help.feature
@@ -3,53 +3,53 @@ Feature: Pro Client help text
   Scenario Outline: Help text for the Pro Client commands
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `pro --help` as non-root
-    Then stdout matches regexp:
-    """
-    usage: pro \[-h\] \[--debug\] \[--version\]  ...
+    Then I will see the following on stdout
+      """
+      usage: pro [-h] [--debug] [--version]  ...
 
     Flags:
       -h, --help       show this help message and exit
       --debug          show all debug log messages to console
       --version        show version of pro
 
-    Available Commands:
-     *
-        api            Calls the Client API endpoints.
-        attach         attach this machine to an Ubuntu Pro subscription
-        auto-attach    automatically attach on supported platforms
-        collect-logs   collect Pro logs and debug information
-        config         manage Ubuntu Pro configuration on this machine
-        detach         remove this machine from an Ubuntu Pro subscription
-        disable        disable a specific Ubuntu Pro service on this machine
-        enable         enable a specific Ubuntu Pro service on this machine
-        fix            check for and mitigate the impact of a CVE/USN on this
-                       system
-        help           show detailed information about Ubuntu Pro services
-        refresh        refresh Ubuntu Pro services
-        security-status
-                       list available security updates for the system
-        status         current status of all Ubuntu Pro services
-        system         show system information related to Pro services
+      Available Commands:
+        
+          api            Calls the Client API endpoints.
+          attach         attach this machine to an Ubuntu Pro subscription
+          auto-attach    automatically attach on supported platforms
+          collect-logs   collect Pro logs and debug information
+          config         manage Ubuntu Pro configuration on this machine
+          detach         remove this machine from an Ubuntu Pro subscription
+          disable        disable a specific Ubuntu Pro service on this machine
+          enable         enable a specific Ubuntu Pro service on this machine
+          fix            check for and mitigate the impact of a CVE/USN on this
+                         system
+          help           show detailed information about Ubuntu Pro services
+          refresh        refresh Ubuntu Pro services
+          security-status
+                         list available security updates for the system
+          status         current status of all Ubuntu Pro services
+          system         show system information related to Pro services
 
-    Use pro \<command\> --help for more information about a command.
-    """
-    When I run `pro collect-logs --help` as non-root
-    Then stdout matches regexp:
+      Use pro <command> --help for more information about a command.
       """
-      usage: pro collect-logs \[-h\] \[-o OUTPUT\]
+    When I run `pro collect-logs --help` as non-root
+    Then I will see the following on stdout
+      """
+      usage: pro collect-logs [-h] [-o OUTPUT]
 
       Collect logs and relevant system information into a tarball.
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help            show this help message and exit
         -o OUTPUT, --output OUTPUT
-                              tarball where the logs will be stored. \(Defaults to
-                              ./pro_logs.tar.gz\)
+                              tarball where the logs will be stored. (Defaults to
+                              ./pro_logs.tar.gz)
       """
     When I run `pro api --help` as non-root
     Then stdout matches regexp:
       """
-      usage: pro api \[-h\] \[--show-progress\] \[--args \[OPTIONS ...\]\] \[--data DATA\]
+      usage: pro api \[-h\] \[--show-progress\] \[--args \[OPTIONS .*\]\](.|\n)*\[--data DATA\](.|\n)*
                      endpoint
 
       Calls the Client API endpoints.
@@ -57,7 +57,7 @@ Feature: Pro Client help text
       positional arguments:
         endpoint              API endpoint to call
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help            show this help message and exit
         --show-progress       For endpoints that support progress updates, show each(.|\n)*
                               progress update on a new line in JSON format
@@ -66,59 +66,59 @@ Feature: Pro Client help text
         --data DATA           arguments in JSON format to the API endpoint
       """
     When I run `pro disable --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro disable \[-h\] \[--assume-yes\] \[--format \{cli,json\}\] \[--purge\]
-                         service \[service ...\]
+      usage: pro disable [-h] [--assume-yes] [--format {cli,json}] [--purge]
+                         service [service ...]
 
       Disable an Ubuntu Pro service.
 
       positional arguments:
-        service              the name\(s\) of the Ubuntu Pro services to disable. One
+        service              the name(s) of the Ubuntu Pro services to disable. One
                              of: anbox-cloud, cc-eal, cis, esm-apps, esm-infra,
                              fips, fips-preview, fips-updates, landscape, livepatch,
                              realtime-kernel, ros, ros-updates
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help           show this help message and exit
         --assume-yes         do not prompt for confirmation before performing the
                              disable
-        --format \{cli,json\}  output in the specified format \(default: cli\)
+        --format {cli,json}  output in the specified format (default: cli)
         --purge              disable the service and remove/downgrade related
-                             packages \(experimental\)
+                             packages (experimental)
       """
     When I run `pro enable --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro enable \[-h\] \[--assume-yes\] \[--access-only\] \[--beta\]
-                        \[--format \{cli,json\}\] \[--variant VARIANT\]
-                        service \[service ...\]
+      usage: pro enable [-h] [--assume-yes] [--access-only] [--beta]
+                        [--format {cli,json}] [--variant VARIANT]
+                        service [service ...]
 
       Enable an Ubuntu Pro service.
 
       positional arguments:
-        service              the name\(s\) of the Ubuntu Pro services to enable. One
+        service              the name(s) of the Ubuntu Pro services to enable. One
                              of: anbox-cloud, cc-eal, cis, esm-apps, esm-infra,
                              fips, fips-preview, fips-updates, landscape, livepatch,
                              realtime-kernel, ros, ros-updates
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help           show this help message and exit
         --assume-yes         do not prompt for confirmation before performing the
                              enable
         --access-only        do not auto-install packages. Valid for cc-eal, cis and
                              realtime-kernel.
         --beta               allow beta service to be enabled
-        --format \{cli,json\}  output in the specified format \(default: cli\)
+        --format {cli,json}  output in the specified format (default: cli)
         --variant VARIANT    The name of the variant to use when enabling the
                              service
       """
     When I run `pro attach --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro attach \[-h\] \[--no-auto-enable\] \[--attach-config ATTACH_CONFIG\]
-                        \[--format \{cli,json\}\]
-                        \[token\]
+      usage: pro attach [-h] [--no-auto-enable] [--attach-config ATTACH_CONFIG]
+                        [--format {cli,json}]
+                        [token]
 
       Attach this machine to an Ubuntu Pro subscription with a token obtained from:
       https://ubuntu.com/pro/dashboard
@@ -130,64 +130,64 @@ Feature: Pro Client help text
       positional arguments:
         token                 token obtained for Ubuntu Pro authentication
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help            show this help message and exit
         --no-auto-enable      do not enable any recommended services automatically
         --attach-config ATTACH_CONFIG
                               use the provided attach config file instead of passing
                               the token on the cli
-        --format \{cli,json\}   output in the specified format \(default: cli\)
+        --format {cli,json}   output in the specified format (default: cli)
       """
     When I run `pro auto-attach --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro auto-attach \[-h\]
+      usage: pro auto-attach [-h]
 
       Automatically attach on an Ubuntu Pro cloud instance.
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help  show this help message and exit
       """
     When I run `pro detach --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro detach \[-h\] \[--assume-yes\] \[--format \{cli,json\}\]
+      usage: pro detach [-h] [--assume-yes] [--format {cli,json}]
 
       Detach this machine from an Ubuntu Pro subscription.
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help           show this help message and exit
         --assume-yes         do not prompt for confirmation before performing the
                              detach
-        --format \{cli,json\}  output in the specified format \(default: cli\)
+        --format {cli,json}  output in the specified format (default: cli)
       """
     When I run `pro security-status --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro security-status \[-h\] \[--format \{json,yaml,text\}\]
-                                 \[--thirdparty \| --unavailable \| --esm-infra \| --esm-apps\]
+      usage: pro security-status [-h] [--format {json,yaml,text}]
+                                 [--thirdparty | --unavailable | --esm-infra | --esm-apps]
 
       Show security updates for packages in the system, including all
-      available Expanded Security Maintenance \(ESM\) related content.
+      available Expanded Security Maintenance (ESM) related content.
 
       Shows counts of how many packages are supported for security updates
       in the system.
 
-      If called with --format json\|yaml it shows a summary of the
+      If called with --format json|yaml it shows a summary of the
       installed packages based on the origin:
       - main/restricted/universe/multiverse: packages from the Ubuntu archive
       - esm-infra/esm-apps: packages from the ESM archive
       - third-party: packages installed from non-Ubuntu sources
-      - unknown: packages which don't have an installation source \(like local
-        deb packages or packages for which the source was removed\)
+      - unknown: packages which don't have an installation source (like local
+        deb packages or packages for which the source was removed)
 
       The output contains basic information about Ubuntu Pro. For a
       complete status on Ubuntu Pro services, run 'pro status'.
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help            show this help message and exit
-        --format \{json,yaml,text\}
-                              output in the specified format \(default: text\)
+        --format {json,yaml,text}
+                              output in the specified format (default: text)
         --thirdparty          List and present information about third-party
                               packages
         --unavailable         List and present information about unavailable
@@ -196,18 +196,18 @@ Feature: Pro Client help text
         --esm-apps            List and present information about esm-apps packages
       """
     When I run `pro fix --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro fix \[-h\] \[--dry-run\] \[--no-related\] security_issue
+      usage: pro fix [-h] [--dry-run] [--no-related] security_issue
 
-      Inspect and resolve CVEs and USNs \(Ubuntu Security Notices\) on this machine.
+      Inspect and resolve CVEs and USNs (Ubuntu Security Notices) on this machine.
 
       positional arguments:
         security_issue  Security vulnerability ID to inspect and resolve on this
                         system. Format: CVE-yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-
                         dd
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help      show this help message and exit
         --dry-run       If used, fix will not actually run but will display
                         everything that will happen on the machine during the
@@ -216,10 +216,10 @@ Feature: Pro Client help text
                         fix related USNs to the target USN.
       """
     When I run `pro status --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro status \[-h\] \[--wait\] \[--format \{tabular,json,yaml\}\]
-                        \[--simulate-with-token TOKEN\] \[--all\]
+      usage: pro status [-h] [--wait] [--format {tabular,json,yaml}]
+                        [--simulate-with-token TOKEN] [--all]
 
       Report current status of Ubuntu Pro services on system.
 
@@ -230,20 +230,20 @@ Feature: Pro Client help text
 
       The attached status output has four columns:
 
-      \* SERVICE: name of the service
-      \* ENTITLED: whether the contract to which this machine is attached
+      * SERVICE: name of the service
+      * ENTITLED: whether the contract to which this machine is attached
         entitles use of this service. Possible values are: yes or no
-      \* STATUS: whether the service is enabled on this machine. Possible
-        values are: enabled, disabled, n/a \(if your contract entitles
-        you to the service, but it isn't available for this machine\) or — \(if
-        you aren't entitled to this service\)
-      \* DESCRIPTION: a brief description of the service
+      * STATUS: whether the service is enabled on this machine. Possible
+        values are: enabled, disabled, n/a (if your contract entitles
+        you to the service, but it isn't available for this machine) or — (if
+        you aren't entitled to this service)
+      * DESCRIPTION: a brief description of the service
 
       The unattached status output instead has three columns. SERVICE
       and DESCRIPTION are the same as above, and there is the addition
       of:
 
-      \* AVAILABLE: whether this service would be available if this machine
+      * AVAILABLE: whether this service would be available if this machine
         were attached. The possible values are yes or no.
 
       If --simulate-with-token is used, then the output has five
@@ -254,100 +254,106 @@ Feature: Pro Client help text
       If the --all flag is set, beta and unavailable services are also
       listed in the output.
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help            show this help message and exit
         --wait                Block waiting on pro to complete
-        --format \{tabular,json,yaml\}
-                              output in the specified format \(default: tabular\)
+        --format {tabular,json,yaml}
+                              output in the specified format (default: tabular)
         --simulate-with-token TOKEN
                               simulate the output status using a provided token
         --all                 Include unavailable and beta services
       """
     When I run `pro refresh --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro refresh \[-h\] \[\{contract,config,messages\}\]
+      usage: pro refresh [-h] [{contract,config,messages}]
 
       Refresh three distinct Ubuntu Pro related artifacts in the system:
 
-      \* contract: Update contract details from the server.
-      \* config:   Reload the config file.
-      \* messages: Update APT and MOTD messages related to UA.
+      * contract: Update contract details from the server.
+      * config:   Reload the config file.
+      * messages: Update APT and MOTD messages related to UA.
 
       You can individually target any of the three specific actions,
       by passing the target name to the command.  If no `target`
       is specified, all targets are refreshed.
 
       positional arguments:
-        \{contract,config,messages\}
+        {contract,config,messages}
                               Target to refresh.
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help            show this help message and exit
       """
     When I run `pro system --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro system \[-h\]  ...
+      usage: pro system [-h]  ...
 
       Output system related information related to Pro services
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help       show this help message and exit
 
       Available Commands:
-       *
+        
           reboot-required
                          does the system need to be rebooted
       """
     When I run `pro system reboot-required --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro system reboot-required \[-h\]
+      usage: pro system reboot-required [-h]
 
       Report the current reboot-required status for the machine.
 
       This command will output one of the three following states
       for the machine regarding reboot:
 
-      \* no: The machine doesn't require a reboot
-      \* yes: The machine requires a reboot
-      \* yes-kernel-livepatches-applied: There are only kernel related
+      * no: The machine doesn't require a reboot
+      * yes: The machine requires a reboot
+      * yes-kernel-livepatches-applied: There are only kernel related
         packages that require a reboot, but Livepatch has already provided
         patches for the current running kernel. The machine still needs a
         reboot, but you can assess if the reboot can be performed in the
         nearest maintenance window.
+
+      <options_string>:
+        -h, --help  show this help message and exit
       """
     When I run `pro config --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro config \[-h\]  ...
+      usage: pro config [-h]  ...
 
       Manage Ubuntu Pro configuration
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help  show this help message and exit
 
       Available Commands:
-       *
+        
           show      Show customizable configuration settings
           set       Set and apply Ubuntu Pro configuration settings
           unset     Unset Ubuntu Pro configuration setting
       """
     When I run `pro config show --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro config show \[-h\] \[key\]
+      usage: pro config show [-h] [key]
 
       Show customizable configuration settings
 
       positional arguments:
-        key         Optional key or key\(s\) to show configuration settings.
+        key         Optional key or key(s) to show configuration settings.
+
+      <options_string>:
+        -h, --help  show this help message and exit
       """
     When I run `pro config set --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro config set \[-h\] key_value_pair
+      usage: pro config set [-h] key_value_pair
 
       Set and apply Ubuntu Pro configuration settings
 
@@ -359,13 +365,13 @@ Feature: Pro Client help text
                         update_messaging_timer, metering_timer, apt_news,
                         apt_news_url
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help      show this help message and exit
       """
     When I run `pro config unset --help` as non-root
-    Then stdout matches regexp:
+    Then I will see the following on stdout
       """
-      usage: pro config unset \[-h\] key
+      usage: pro config unset [-h] key
 
       Unset Ubuntu Pro configuration setting
 
@@ -376,14 +382,14 @@ Feature: Pro Client help text
                     global_apt_https_proxy, update_messaging_timer, metering_timer,
                     apt_news, apt_news_url
 
-      (optional arguments|options):
+      <options_string>:
         -h, --help  show this help message and exit
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | noble   | lxd-container |
+      | release | machine_type  | options_string     |
+      | xenial  | lxd-container | optional arguments |
+      | bionic  | lxd-container | optional arguments |
+      | focal   | lxd-container | optional arguments |
+      | jammy   | lxd-container | options            |
+      | noble   | lxd-container | options            |

--- a/features/help.feature
+++ b/features/help.feature
@@ -2,6 +2,37 @@ Feature: Pro Client help text
 
   Scenario Outline: Help text for the Pro Client commands
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I run `pro --help` as non-root
+    Then stdout matches regexp:
+    """
+    usage: pro \[-h\] \[--debug\] \[--version\]  ...
+
+    Flags:
+      -h, --help       show this help message and exit
+      --debug          show all debug log messages to console
+      --version        show version of pro
+
+    Available Commands:
+     *
+        api            Calls the Client API endpoints.
+        attach         attach this machine to an Ubuntu Pro subscription
+        auto-attach    automatically attach on supported platforms
+        collect-logs   collect Pro logs and debug information
+        config         manage Ubuntu Pro configuration on this machine
+        detach         remove this machine from an Ubuntu Pro subscription
+        disable        disable a specific Ubuntu Pro service on this machine
+        enable         enable a specific Ubuntu Pro service on this machine
+        fix            check for and mitigate the impact of a CVE/USN on this
+                       system
+        help           show detailed information about Ubuntu Pro services
+        refresh        refresh Ubuntu Pro services
+        security-status
+                       list available security updates for the system
+        status         current status of all Ubuntu Pro services
+        system         show system information related to Pro services
+
+    Use pro \<command\> --help for more information about a command.
+    """
     When I run `pro collect-logs --help` as non-root
     Then stdout matches regexp:
       """

--- a/features/help.feature
+++ b/features/help.feature
@@ -7,10 +7,10 @@ Feature: Pro Client help text
       """
       usage: pro [-h] [--debug] [--version] <command> ...
 
-    Flags:
-      -h, --help       show this help message and exit
-      --debug          show all debug log messages to console
-      --version        show version of pro
+      Flags:
+        -h, --help       show this help message and exit
+        --debug          show all debug log messages to console
+        --version        show version of pro
 
       Available Commands:
         <command>
@@ -293,12 +293,11 @@ Feature: Pro Client help text
       Output system related information related to Pro services
 
       <options_string>:
-        -h, --help       show this help message and exit
+        -h, --help         show this help message and exit
 
       Available Commands:
         {reboot-required}
-          reboot-required
-                         does the system need to be rebooted
+          reboot-required  does the system need to be rebooted
       """
     When I run `pro system reboot-required --help` as non-root
     Then I will see the following on stdout
@@ -329,13 +328,13 @@ Feature: Pro Client help text
       Manage Ubuntu Pro configuration
 
       <options_string>:
-        -h, --help  show this help message and exit
+        -h, --help        show this help message and exit
 
       Available Commands:
         {show,set,unset}
-          show      Show customizable configuration settings
-          set       Set and apply Ubuntu Pro configuration settings
-          unset     Unset Ubuntu Pro configuration setting
+          show            Show customizable configuration settings
+          set             Set and apply Ubuntu Pro configuration settings
+          unset           Unset Ubuntu Pro configuration setting
       """
     When I run `pro config show --help` as non-root
     Then I will see the following on stdout

--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -79,8 +79,9 @@ Feature: Security status command behavior
     When I verify that running `pro security-status --format unsupported` `as non-root` exits `2`
     Then I will see the following on stderr:
       """
-      usage: pro security-status [flags]
-      argument --format: invalid choice: 'unsupported' (choose from 'json', 'yaml', 'text')
+      usage: pro security-status [-h] [--format {json,yaml,text}]
+                                 [--thirdparty | --unavailable | --esm-infra | --esm-apps]
+      pro security-status: error: argument --format: invalid choice: 'unsupported' (choose from 'json', 'yaml', 'text')
       """
 
     Examples: ubuntu release
@@ -379,8 +380,9 @@ Feature: Security status command behavior
     When I verify that running `pro security-status --thirdparty --unavailable` `as non-root` exits `2`
     Then I will see the following on stderr
       """
-      usage: pro security-status [flags]
-      argument --unavailable: not allowed with argument --thirdparty
+      usage: pro security-status [-h] [--format {json,yaml,text}]
+                                 [--thirdparty | --unavailable | --esm-infra | --esm-apps]
+      pro security-status: error: argument --unavailable: not allowed with argument --thirdparty
       """
     When I run `rm /var/lib/apt/periodic/update-success-stamp` with sudo
     And I run `pro security-status` as non-root
@@ -695,8 +697,9 @@ Feature: Security status command behavior
     When I verify that running `pro security-status --thirdparty --unavailable` `as non-root` exits `2`
     Then I will see the following on stderr
       """
-      usage: pro security-status [flags]
-      argument --unavailable: not allowed with argument --thirdparty
+      usage: pro security-status [-h] [--format {json,yaml,text}]
+                                 [--thirdparty | --unavailable | --esm-infra | --esm-apps]
+      pro security-status: error: argument --unavailable: not allowed with argument --thirdparty
       """
     When I run `rm /var/lib/apt/periodic/update-success-stamp` with sudo
     And I run `pro security-status` as non-root

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -93,11 +93,11 @@ Feature: Command behaviour when unattached
       """
       No help available for 'invalid-service'
       """
-    When I verify that running `pro --wrong-flag` `with sudo` exits `2`
+    When I verify that running `pro --no-command` `with sudo` exits `2`
     Then I will see the following on stderr:
       """
-      usage: pro <command> [flags]
-      Try 'pro --help' for more information.
+      usage: pro [-h] [--debug] [--version] <command> ...
+      pro: error: the following arguments are required: <command>
       """
 
     Examples: ubuntu release

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -68,7 +68,7 @@ class ProArgumentParser(argparse.ArgumentParser):
             pass
 
 
-def get_parser(cfg: UAConfig):
+def get_parser():
     parser = ProArgumentParser(
         prog=NAME,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -247,7 +247,7 @@ def main(sys_argv=None):
     if not sys_argv:
         sys_argv = sys.argv
 
-    parser = get_parser(cfg=cfg)
+    parser = get_parser()
     cli_arguments = sys_argv[1:]
     if not cli_arguments:
         parser.print_help()

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -21,7 +21,6 @@ from uaclient.cli.attach import attach_command
 from uaclient.cli.auto_attach import auto_attach_command
 from uaclient.cli.collect_logs import collect_logs_command
 from uaclient.cli.config import config_command
-from uaclient.cli.constants import NAME, USAGE_TMPL
 from uaclient.cli.detach import detach_command
 from uaclient.cli.disable import disable_command
 from uaclient.cli.enable import enable_command
@@ -36,6 +35,8 @@ from uaclient.log import get_user_or_root_log_file_path
 
 event = event_logger.get_event_logger()
 LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
+
+NAME = "pro"
 
 COMMANDS = [
     api_command,
@@ -87,7 +88,6 @@ def get_parser(cfg: UAConfig):
     parser = ProArgumentParser(
         prog=NAME,
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        usage=USAGE_TMPL.format(name=NAME, command="<command>"),
         epilog=messages.CLI_HELP_EPILOG.format(name=NAME, command="<command>"),
     )
     parser.add_argument(

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -57,22 +57,6 @@ COMMANDS = [
 
 
 class ProArgumentParser(argparse.ArgumentParser):
-    def error(self, message):
-        self.print_usage(sys.stderr)
-        # In some cases (e.g. `pro --wrong-flag`) argparse errors out asking
-        # for required arguments, but the error message it gives us doesn't
-        # include any info about what required args it expects.
-        # In python versions prior to 3.9 there is no `exit_on_error` param
-        # to ArgumentParser, and as a result, there is no built-in way of
-        # catching the ArgumentError exception and handling it ourselves.
-        # Instead we just look for the buggy error message.
-        # Rather than try to fill in what arguments argparse was hoping for,
-        # we just suggest the user runs `--help` which should cover most
-        # use cases.
-        if message == "the following arguments are required: ":
-            message = messages.CLI_TRY_HELP
-        self.exit(2, message + "\n")
-
     def print_help_for_command(self, command: str):
         args_list = command.split()
         args_list.append("--help")
@@ -102,7 +86,9 @@ def get_parser(cfg: UAConfig):
     parser._optionals.title = messages.CLI_FLAGS
 
     subparsers = parser.add_subparsers(
-        title=messages.CLI_AVAILABLE_COMMANDS, dest="command", metavar=""
+        title=messages.CLI_AVAILABLE_COMMANDS,
+        dest="command",
+        metavar="<command>",
     )
     subparsers.required = True
 

--- a/uaclient/cli/commands.py
+++ b/uaclient/cli/commands.py
@@ -2,7 +2,6 @@ import argparse
 from typing import Callable, Iterable, Optional, Union
 
 from uaclient import messages
-from uaclient.cli.constants import NAME, USAGE_TMPL
 
 
 class ProArgument:
@@ -76,7 +75,6 @@ class ProCommand:
         name: str,
         help: str,
         description: str,
-        usage: Optional[str] = None,
         action: Callable = lambda *args, **kwargs: None,
         preserve_description: bool = False,
         argument_groups: Iterable[ProArgumentGroup] = (),
@@ -85,7 +83,6 @@ class ProCommand:
         self.name = name
         self.help = help
         self.description = description
-        self.usage = usage or USAGE_TMPL.format(name=NAME, command=name)
         self.action = action
         self.preserve_description = preserve_description
         self.argument_groups = argument_groups
@@ -96,7 +93,6 @@ class ProCommand:
             self.name,
             help=self.help,
             description=self.description,
-            usage=self.usage,
         )
         if self.preserve_description:
             self.parser.formatter_class = argparse.RawDescriptionHelpFormatter

--- a/uaclient/cli/commands.py
+++ b/uaclient/cli/commands.py
@@ -106,7 +106,6 @@ class ProCommand:
             subparsers = self.parser.add_subparsers(
                 title=messages.CLI_AVAILABLE_COMMANDS,
                 dest="command",
-                metavar="",
             )
             for command in self.subcommands:
                 command.register(subparsers)

--- a/uaclient/cli/config.py
+++ b/uaclient/cli/config.py
@@ -25,7 +25,7 @@ def action_config(args, *, cfg, **kwargs):
     # Avoiding a circular import
     from uaclient.cli import get_parser
 
-    get_parser(cfg).print_help_for_command("config")
+    get_parser().print_help_for_command("config")
     return 0
 
 
@@ -68,7 +68,7 @@ def action_config_set(args, *, cfg, **kwargs):
     """
     from uaclient.cli import get_parser
 
-    parser = get_parser(cfg=cfg)
+    parser = get_parser()
     try:
         set_key, set_value = args.key_value_pair.split("=")
     except ValueError:
@@ -193,7 +193,7 @@ def action_config_unset(args, *, cfg, **kwargs):
     from uaclient.cli import get_parser
 
     if args.key not in config.UA_CONFIGURABLE_KEYS:
-        parser = get_parser(cfg=cfg)
+        parser = get_parser()
         parser.print_help_for_command("config unset")
         raise exceptions.InvalidArgChoice(
             arg="<key>", choices=", ".join(config.UA_CONFIGURABLE_KEYS)

--- a/uaclient/cli/constants.py
+++ b/uaclient/cli/constants.py
@@ -1,8 +1,0 @@
-"""
-CLI related constants
-
-These are in their own file so they can be imported by differen CLI modules.
-"""
-
-NAME = "pro"
-USAGE_TMPL = "{name} {command} [flags]"

--- a/uaclient/cli/help.py
+++ b/uaclient/cli/help.py
@@ -11,7 +11,7 @@ def action_help(args, *, cfg, **kwargs):
         # Avoiding a circular import
         from uaclient.cli import get_parser
 
-        get_parser(cfg=cfg).print_help()
+        get_parser().print_help()
         return 0
 
     if not cfg:

--- a/uaclient/cli/system.py
+++ b/uaclient/cli/system.py
@@ -17,7 +17,7 @@ def action_system(args, *, cfg, **kwargs):
     # Avoiding a circular import
     from uaclient.cli import get_parser
 
-    get_parser(cfg).print_help_for_command("system")
+    get_parser().print_help_for_command("system")
 
 
 reboot_required_subcommand = ProCommand(

--- a/uaclient/cli/tests/test_cli_commands.py
+++ b/uaclient/cli/tests/test_cli_commands.py
@@ -39,7 +39,6 @@ class TestProCommand:
             "example",
             help="help",
             description="description",
-            usage="usage",
             argument_groups=[mock_argument_group1, mock_argument_group2],
         )
 
@@ -50,7 +49,6 @@ class TestProCommand:
                 "example",
                 help="help",
                 description="description",
-                usage="usage",
             )
         ] == mock_subparsers.add_parser.call_args_list
         assert (

--- a/uaclient/cli/tests/test_cli_config_show.py
+++ b/uaclient/cli/tests/test_cli_config_show.py
@@ -25,7 +25,7 @@ class TestMainConfigShow:
         out, err = capsys.readouterr()
         assert "" == out
         expected_logs = [
-            "usage: pro config [flags]",
+            "usage: pro config [-h]  ...",
             "argument : invalid choice: 'invalid' (choose from 'show', 'set',"
             " 'unset')",
         ]

--- a/uaclient/cli/tests/test_cli_config_show.py
+++ b/uaclient/cli/tests/test_cli_config_show.py
@@ -25,9 +25,9 @@ class TestMainConfigShow:
         out, err = capsys.readouterr()
         assert "" == out
         expected_logs = [
-            "usage: pro config [-h]  ...",
-            "argument : invalid choice: 'invalid' (choose from 'show', 'set',"
-            " 'unset')",
+            "usage: pro config [-h] {show,set,unset} ...",
+            "argument command: invalid choice: 'invalid' (choose from 'show',"
+            " 'set', 'unset')",
         ]
         for log in expected_logs:
             assert log in err

--- a/uaclient/cli/tests/test_cli_security_status.py
+++ b/uaclient/cli/tests/test_cli_security_status.py
@@ -85,8 +85,10 @@ class TestActionSecurityStatus:
                     main()
 
         _, err = capsys.readouterr()
-
-        assert "usage: pro security-status [flags]" in err
+        assert (
+            "usage: pro security-status [-h] [--format {json,yaml,text}]"
+            in err
+        )
         assert (
             "argument --format: invalid choice: 'unsupported'"
             " (choose from 'json', 'yaml', 'text')"

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -882,7 +882,6 @@ Please run `sudo pro refresh`."""
 # Also, any generic strings about the CLI itself go here.
 
 
-CLI_TRY_HELP = t.gettext("Try 'pro --help' for more information.")
 CLI_HELP_EPILOG = t.gettext(
     "Use {name} {command} --help for more information about a command."
 )

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -887,7 +887,6 @@ CLI_HELP_EPILOG = t.gettext(
 )
 
 CLI_HELP_VARIANTS_HEADER = t.gettext("Variants:")
-CLI_ARGS = t.gettext("Arguments")
 CLI_FLAGS = t.gettext("Flags")
 CLI_AVAILABLE_COMMANDS = t.gettext("Available Commands")
 CLI_FORMAT_DESC = t.gettext(


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it applies a set of unhacks to our argparse logic, tweaking the help text and preparing fo the new format.

## Test Steps
I changed unit and integration tests, but give it a go and check all help messages are good.
---

- [x] *(un)check this to re-run the checklist action*