### PR TITLE
Reorganise how-to navigation

### DIFF
--- a/docs/howtoguides.rst
+++ b/docs/howtoguides.rst
@@ -10,73 +10,74 @@ can be applied to a wider range of situations.
 They will help you to achieve a particular end result, but may require you to
 understand and adapt the steps to fit your specific requirements.
 
-How to use ``pro`` commands
-===========================
+Attach a machine to a subscription
+==================================
 
-``pro attach``
---------------
+.. include:: howtoguides/attach_index.rst
+   :start-line: 3
+   :end-before: .. TOC
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   
+   Attach... <howtoguides/attach_index>
+
+Enable services
+===============
+
+.. include:: howtoguides/enable_index.rst
+   :start-line: 3
+   :end-before: .. TOC
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+      
+   Enable... <howtoguides/enable_index>
+
+Fix vulnerabilities
+===================
+
+.. include:: howtoguides/fix_index.rst
+   :start-line: 3
+   :end-before: .. TOC
+   
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   Fix vulnerabilities... <howtoguides/fix_index>
+
+Use the Pro Client
+==================
+
+.. include:: howtoguides/configure_index.rst
+   :start-line: 3
+   :end-before: .. TOC
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   Use the Client... <howtoguides/configure_index>
+
+Proxies
+=======
 
 .. toctree::
    :maxdepth: 1
 
-   Attach a machine to a subscription <howtoguides/get_token_and_attach>
-   Attach via a configuration file <howtoguides/how_to_attach_with_config_file>
+   Configure a proxy <howtoguides/configure_proxies>
+   Configure TLS-in-TLS proxy <howtoguides/configure_tls_in_tls_proxy>
 
-``pro collect-logs``
---------------------
+How to collect logs
+===================
 
 .. toctree::
    :maxdepth: 1
    
    Collect data logs for bug reporting <howtoguides/how_to_collect_logs>
-
-``pro config``
---------------
-
-.. toctree::
-   :maxdepth: 2
-   
-   Configure... <howtoguides/configure_index>
-
-``pro enable``
---------------
-
-.. toctree::
-   :maxdepth: 2
-      
-   Enable... <howtoguides/enable_index>
-
-``pro refresh``
----------------
-
-.. toctree::
-   :maxdepth: 1
-
-   Update MOTD and APT messages <howtoguides/update_motd_messages>
-
-``pro status``
---------------
-
-.. toctree::
-   :maxdepth: 1
-
-   Simulate the `attach` operation <howtoguides/how_to_simulate_attach>
-
-``pro version``
----------------
-
-.. toctree::
-   :maxdepth: 1
-
-   Check Ubuntu Pro Client version <howtoguides/check_pro_version>
-
-Fixing CVEs and USNs
-====================
-
-.. toctree::
-   :maxdepth: 2
-
-   Resolving CVEs and USNs... <howtoguides/fix_index>
 
 Corrupted lock files
 ====================
@@ -102,11 +103,3 @@ Ubuntu Pro Client for Clouds
 
    Create a customised Cloud Ubuntu Pro image <howtoguides/create_pro_golden_image>
    Cloud Ubuntu Pro images with FIPS updates <howtoguides/create_a_fips_updates_pro_cloud_image>
-
-APT integration
-===============
-
-.. toctree::
-   :maxdepth: 1
-
-    How to use custom APT configuration <howtoguides/use_custom_apt_config>

--- a/docs/howtoguides/attach_index.rst
+++ b/docs/howtoguides/attach_index.rst
@@ -1,0 +1,19 @@
+Attach a machine to a subscription
+**********************************
+
+* :ref:`How to attach <attach>` shows you how to perform the attach process
+* :ref:`How to simulate the attach operation <simulate-attach>` to check a
+  specific token to see what will happen if you attach to it (before
+  attaching anything), you can see:
+* :ref:`How to attach with a config file <attach-with-config>` to pass a
+  specific token to your machine using a configuration file.
+
+.. TOC
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   How to attach <how_to_attach>
+   How to simulate attaching <how_to_simulate_attach>
+   How to attach with a configuration file <how_to_attach_with_config_file>

--- a/docs/howtoguides/attach_index.rst
+++ b/docs/howtoguides/attach_index.rst
@@ -1,10 +1,10 @@
 Attach a machine to a subscription
 **********************************
 
-* :ref:`How to attach <attach>` shows you how to perform the attach process
+* :ref:`How to attach <attach>` shows you how to perform the attach process.
 * :ref:`How to simulate the attach operation <simulate-attach>` to check a
   specific token to see what will happen if you attach to it (before
-  attaching anything), you can see:
+  attaching anything).
 * :ref:`How to attach with a config file <attach-with-config>` to pass a
   specific token to your machine using a configuration file.
 

--- a/docs/howtoguides/check_pro_version.rst
+++ b/docs/howtoguides/check_pro_version.rst
@@ -1,3 +1,5 @@
+.. _check_pro_version:
+
 How to check your Ubuntu Pro Client version
 *******************************************
 

--- a/docs/howtoguides/configure_index.rst
+++ b/docs/howtoguides/configure_index.rst
@@ -1,10 +1,20 @@
-How to configure...
-*******************
+Use the Pro Client
+******************
+
+* :ref:`Check Ubuntu Pro Client version <check_pro_version>`
+* :ref:`Display APT News <disable_enable_apt_news>`
+* :ref:`Configure a timer job <configuring_timer_jobs>`
+* :ref:`Update MOTD and APT messages <update_motd_apt>`
+* :ref:`How to use custom APT configuration <custom_apt_config>`
+
+.. TOC
 
 .. toctree::
-   :maxdepth: 1
-   
-   Displaying APT News <disable_enable_apt_news.rst>
-   A proxy <configure_proxies.rst>
-   A TLS-in-TLS proxy <configure_tls_in_tls_proxy.rst>
-   A timer job <configuring_timer_jobs.rst>
+   :titlesonly:
+   :hidden:
+
+   Check Ubuntu Pro Client version <check_pro_version>
+   Display APT News <disable_enable_apt_news>
+   Configure a timer job <configuring_timer_jobs>
+   Update MOTD and APT messages <update_motd_messages>
+   How to use custom APT configuration <use_custom_apt_config>

--- a/docs/howtoguides/configure_tls_in_tls_proxy.rst
+++ b/docs/howtoguides/configure_tls_in_tls_proxy.rst
@@ -1,3 +1,5 @@
+.. _tls_in_tls:
+
 How to configure a TLS-in-TLS proxy
 ***********************************
 
@@ -73,7 +75,7 @@ Success!
 
 Now with the TLS-in-TLS proxy configured, you can
 :ref:`configure any other proxies you need <configure-proxies>` and then use
-your Ubuntu Pro token to :ref:`attach your machine <get_token_and_attach>`.
+your Ubuntu Pro token to :ref:`attach your machine <attach>`.
 
 .. LINKS:
 .. _PEM: https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail

--- a/docs/howtoguides/configuring_timer_jobs.rst
+++ b/docs/howtoguides/configuring_timer_jobs.rst
@@ -1,3 +1,5 @@
+.. _configuring_timer_jobs:
+
 How to configure a timer job
 ****************************
 

--- a/docs/howtoguides/create_a_fips_updates_pro_cloud_image.rst
+++ b/docs/howtoguides/create_a_fips_updates_pro_cloud_image.rst
@@ -1,3 +1,5 @@
+.. _create_a_fips_updates_pro_cloud_image:
+
 How to customise a cloud Ubuntu Pro image with FIPS updates
 ***********************************************************
 

--- a/docs/howtoguides/create_pro_golden_image.rst
+++ b/docs/howtoguides/create_pro_golden_image.rst
@@ -1,3 +1,5 @@
+.. _create_pro_golden_image:
+
 How to create a customised Cloud Ubuntu Pro image
 *************************************************
 

--- a/docs/howtoguides/disable_enable_apt_news.rst
+++ b/docs/howtoguides/disable_enable_apt_news.rst
@@ -1,3 +1,5 @@
+.. _disable_enable_apt_news:
+
 How to disable or re-enable APT News
 ************************************
 

--- a/docs/howtoguides/enable-disable/check-status.txt
+++ b/docs/howtoguides/enable-disable/check-status.txt
@@ -1,7 +1,7 @@
 Check the status of the services
 ================================
 
-After you have :ref:`attached your subscription <get_token_and_attach>` and
+After you have :ref:`attached your subscription <attach>` and
 updated the ``ubuntu-advantage-tools`` package, you can check which services
 are enabled by running the following command:
 

--- a/docs/howtoguides/enable_index.rst
+++ b/docs/howtoguides/enable_index.rst
@@ -1,15 +1,31 @@
-How to enable...
-****************
+Enable services
+***************
+
+Find out how to enable, disable or check the status of the following services
+with the Pro Client.
+
+* :ref:`Anbox Cloud <manage-anbox>`
+* :ref:`CC EAL <manage-cc>`
+* :ref:`CIS or USG <manage-cis>`
+* :ref:`ESM-Infra and ESM-Apps <manage-esm>`
+* :ref:`ESM-Infra Legacy on Trusty <enable_trusty>`
+* :ref:`FIPS <manage-fips>`
+* :ref:`Landscape <manage-landscape>`
+* :ref:`Livepatch <manage-livepatch>`
+* :ref:`Real-Time Ubuntu <manage-realtime>`
+
+.. TOC
 
 .. toctree::
-   :maxdepth: 1
+   :titlesonly:
+   :hidden:
       
-   Anbox Cloud <enable_anbox>
-   CC EAL <enable_cc>
-   CIS <enable_cis>
-   ESM-Infra and ESM-Apps <enable_esm_infra>
-   ESM-Infra Legacy on Trusty <trusty_legacy_support>
-   FIPS <enable_fips>
-   Landscape <enable_landscape>
-   Livepatch <enable_livepatch>
-   Real-Time Ubuntu <enable_realtime_kernel>
+   Anbox Cloud <enable_anbox.rst>
+   CC EAL <enable_cc.rst>
+   CIS or USG <enable_cis.rst>
+   ESM-Infra and ESM-Apps <enable_esm_infra.rst>
+   ESM-Infra Legacy on Trusty <trusty_legacy_support.rst>
+   FIPS <enable_fips.rst>
+   Landscape <enable_landscape.rst>
+   Livepatch <enable_livepatch.rst>
+   Real-Time Ubuntu <enable_realtime_kernel.rst>

--- a/docs/howtoguides/enable_realtime_kernel.rst
+++ b/docs/howtoguides/enable_realtime_kernel.rst
@@ -4,8 +4,8 @@ How to enable Real-time Ubuntu
 ******************************
 
 `Real-time Ubuntu <realtime_>`_ is supported on specific Ubuntu releases. To
- find out more about the supported Ubuntu versions and what kernel variants
- are available, refer to `the supported releases page <rt_releases_>`_.
+find out more about the supported Ubuntu versions and what kernel variants
+are available, refer to `the supported releases page <rt_releases_>`_.
 
 Attach your subscription
 ========================
@@ -19,8 +19,7 @@ running the following command:
     sudo pro attach
 
 And follow the instructions in your terminal window. For a more complete guide
-to the attach process, refer to our
-:ref:`how to attach <get_token_and_attach>` guide.
+to the attach process, refer to our :ref:`how to attach <attach>` guide.
 
 .. Make sure Pro is up to date
 .. include:: ./enable-disable/update-pro.txt

--- a/docs/howtoguides/fix_index.rst
+++ b/docs/howtoguides/fix_index.rst
@@ -1,11 +1,20 @@
-Resolving CVEs and USNs...
-**************************
+Fix vulnerabilities
+*******************
+
+* :ref:`Is my system affected by this specific CVE? <pro-fix-check-cve>`
+* :ref:`Resolve a single CVE or USN? <pro-fix-resolve-cve>`
+* :ref:`How to know what the fix command would change <pro-fix-dry-run>`
+* :ref:`Skip fixing related USNs <pro-fix-skip-related>`
+* :ref:`Better visualise results when fixing multiple CVEs <how_to_better_visualise_fixing_multiple_cves>`
+
+.. TOC
 
 .. toctree::
-   :maxdepth: 1
+   :titlesonly:
+   :hidden:
 
    Is my system affected by this specific CVE? <fix_how_to_know_if_system_affected_by_cve>
-   How do I resolve a single CVE or USN? <fix_how_to_resolve_given_cve>
-   How to know what the `fix` command would change? <fix_how_to_know_what_the_fix_command_would_change>
+   Resolve a single CVE or USN <fix_how_to_resolve_given_cve>
+   Discover what the `fix` command would change <fix_how_to_know_what_the_fix_command_would_change>
    Skip fixing related USNs <fix_how_to_not_fix_related_usns>
    Better visualise results when fixing multiple CVEs <fix_how_to_better_visualise_fixing_multiple_cves>

--- a/docs/howtoguides/get_rid_of_corrupt_lock.rst
+++ b/docs/howtoguides/get_rid_of_corrupt_lock.rst
@@ -1,3 +1,5 @@
+.. _fix_corrupt_lock:
+
 How to get rid of a corrupt lock
 ********************************
 

--- a/docs/howtoguides/how_to_attach.rst
+++ b/docs/howtoguides/how_to_attach.rst
@@ -1,4 +1,4 @@
-.. _get_token_and_attach:
+.. _attach:
 
 How to attach a machine to your Ubuntu Pro subscription
 *******************************************************

--- a/docs/howtoguides/how_to_attach_with_config_file.rst
+++ b/docs/howtoguides/how_to_attach_with_config_file.rst
@@ -3,7 +3,7 @@
 How to attach with a configuration file
 ***************************************
 
-To attach with a configuration file, you must run ``pro attach`` with the
+To attach with a configuration file, you can run ``pro attach`` with the
 ``--attach-config`` flag, passing the path of the configuration file you intend
 to use.
 

--- a/docs/howtoguides/how_to_collect_logs.rst
+++ b/docs/howtoguides/how_to_collect_logs.rst
@@ -1,3 +1,5 @@
+.. _collect_logs:
+
 How to collect Ubuntu Pro Client logs
 *************************************
 

--- a/docs/howtoguides/how_to_simulate_attach.rst
+++ b/docs/howtoguides/how_to_simulate_attach.rst
@@ -1,9 +1,33 @@
+.. _simulate-attach:
+
 How to simulate the ``attach`` operation
 ****************************************
 
 If you are unsure what the state of your machine will be after running
 ``attach`` with a specific token, you can simulate running the ``attach``
-operation by running:
+operation.
+
+Get an Ubuntu Pro token
+=======================
+
+You first need to retrieve the Ubuntu Pro token you want to test from the
+`Ubuntu Pro portal <Pro_>`_. Log in with your "Single Sign On" credentials,
+the same credentials you use for https://login.ubuntu.com.
+
+After you have logged in you can go to the
+`Ubuntu Pro Dashboard <Pro_dashboard_>`_ associated with your user account. It
+will show you all subscriptions currently available to you and for each
+associated token.
+
+Note that even without buying anything you can always obtain a free personal
+token that way, which provides you with access to several of the Ubuntu Pro
+services.
+
+Simulate the attach process
+===========================
+
+Once you have your token, you can run the following command (replacing
+`YOUR_TOKEN` with the token you retrieved from the dashboard):
 
 .. code-block:: bash
 
@@ -31,3 +55,19 @@ automatically enabled when running an ``attach`` operation.
 
     If you want more information about the **AVAILABLE** and **ENTITLED**
     columns, please refer to :ref:`this explanation <pro-status-output>`.
+
+If there are services that will be auto-enabled that you don't want to enable,
+or you only want to enable specific services, you may want to run ``attach``
+:ref:`using a config file <attach-with-config>` instead of the usual attach
+process. Otherwise, you can run:
+
+.. code-block:: bash
+
+    $ sudo pro attach --no-auto-enable
+
+This will prevent the auto-enabling of any services while attaching a
+particular machine.
+
+.. LINKS
+
+.. include:: ../links.txt

--- a/docs/howtoguides/update_motd_messages.rst
+++ b/docs/howtoguides/update_motd_messages.rst
@@ -1,3 +1,5 @@
+.. _update_motd_apt:
+
 How to update MOTD and APT messages
 ***********************************
 

--- a/docs/howtoguides/use_custom_apt_config.rst
+++ b/docs/howtoguides/use_custom_apt_config.rst
@@ -1,3 +1,5 @@
+.. _custom_apt_config:
+
 How to use custom APT configuration
 ***********************************
 


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because...the LHS navigation menu in the docs needed to be reorganised. 

## Please Squash this PR with this commit message

```
doc: organise how-to navigation

- Add extra drop-downs to gather grouped pages
- Add anchors to pages that had none
- Other housekeeping
```
