### PR TITLE
apidocs: include network requirements per api endpoint

### DIFF
--- a/tools/apidocgen.py
+++ b/tools/apidocgen.py
@@ -27,6 +27,7 @@ ENDPOINT_TEMPLATE = """\
 {description}
 
 - Introduced in Ubuntu Pro Client Version: ``{introduced_in}~``
+- Requires network access: {requires_network}
 
 Arguments:
 
@@ -200,6 +201,7 @@ def print_endpoint_docs(endpoint_name):
         "underline": "=" * len(endpoint_name),
         "description": textwrap.dedent(module.endpoint.fn.__doc__).strip(),
         "introduced_in": module._doc.get("introduced_in"),
+        "requires_network": "Yes" if module._doc["requires_network"] else "No",
         "args_section": args_section,
         "example_python": textwrap.indent(
             module._doc.get("example_python").strip(),
@@ -259,4 +261,10 @@ if __name__ == "__main__":
             print(f"- `{e}`_")
         print()
         for e in VALID_ENDPOINTS:
-            print_endpoint_docs(e)
+            try:
+                print_endpoint_docs(e)
+            except Exception:
+                msg = f"Failed generating docs for {e}"
+                print(msg)
+                print("^" * len(msg))
+                raise

--- a/uaclient/api/u/apt_news/current_news/v1.py
+++ b/uaclient/api/u/apt_news/current_news/v1.py
@@ -47,6 +47,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "29",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.apt_news.current_news.v1 import current_news
 

--- a/uaclient/api/u/pro/attach/auto/configure_retry_service/v1.py
+++ b/uaclient/api/u/pro/attach/auto/configure_retry_service/v1.py
@@ -58,6 +58,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.12",
+    "requires_network": False,
     "extra_args_content": """
 .. note::
 

--- a/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/full_auto_attach/v1.py
@@ -161,6 +161,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.11",
+    "requires_network": True,
     "extra_args_content": """
 .. note::
 

--- a/uaclient/api/u/pro/attach/auto/should_auto_attach/v1.py
+++ b/uaclient/api/u/pro/attach/auto/should_auto_attach/v1.py
@@ -50,6 +50,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.11",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.pro.attach.auto.should_auto_attach.v1 import should_auto_attach
 

--- a/uaclient/api/u/pro/attach/magic/initiate/v1.py
+++ b/uaclient/api/u/pro/attach/magic/initiate/v1.py
@@ -86,6 +86,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.11",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.attach.magic.initiate.v1 import initiate
 

--- a/uaclient/api/u/pro/attach/magic/revoke/v1.py
+++ b/uaclient/api/u/pro/attach/magic/revoke/v1.py
@@ -48,6 +48,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.11",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.attach.magic.revoke.v1 import MagicAttachRevokeOptions, revoke
 

--- a/uaclient/api/u/pro/attach/magic/wait/v1.py
+++ b/uaclient/api/u/pro/attach/magic/wait/v1.py
@@ -155,6 +155,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.11",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.attach.magic.wait.v1 import MagicAttachWaitOptions, wait
 

--- a/uaclient/api/u/pro/attach/token/full_token_attach/v1.py
+++ b/uaclient/api/u/pro/attach/token/full_token_attach/v1.py
@@ -155,6 +155,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "32",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.attach.token.full_token_attach.v1 import full_token_attach, FullTokenAttachOptions
 

--- a/uaclient/api/u/pro/detach/v1.py
+++ b/uaclient/api/u/pro/detach/v1.py
@@ -139,6 +139,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "32",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.detach.v1 import detach
 

--- a/uaclient/api/u/pro/packages/summary/v1.py
+++ b/uaclient/api/u/pro/packages/summary/v1.py
@@ -123,6 +123,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.12",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.pro.packages.summary.v1 import summary
 

--- a/uaclient/api/u/pro/packages/updates/v1.py
+++ b/uaclient/api/u/pro/packages/updates/v1.py
@@ -177,6 +177,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.12",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.pro.packages.updates.v1 import updates
 

--- a/uaclient/api/u/pro/security/fix/cve/execute/v1.py
+++ b/uaclient/api/u/pro/security/fix/cve/execute/v1.py
@@ -104,6 +104,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "30",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.security.fix.cve.execute.v1 import execute, CVEFixExecuteOptions
 

--- a/uaclient/api/u/pro/security/fix/cve/plan/v1.py
+++ b/uaclient/api/u/pro/security/fix/cve/plan/v1.py
@@ -105,6 +105,7 @@ endpoint = APIEndpoint(
 )
 _doc = {
     "introduced_in": "29",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.security.fix.cve.plan.v1 import plan, CVEFixPlanOptions
 

--- a/uaclient/api/u/pro/security/fix/usn/execute/v1.py
+++ b/uaclient/api/u/pro/security/fix/usn/execute/v1.py
@@ -144,6 +144,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "30",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.security.fix.usn.execute.v1 import execute, USNFixExecuteOptions
 

--- a/uaclient/api/u/pro/security/fix/usn/plan/v1.py
+++ b/uaclient/api/u/pro/security/fix/usn/plan/v1.py
@@ -108,6 +108,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "29",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.security.fix.usn.plan.v1 import plan, USNFixPlanOptions
 

--- a/uaclient/api/u/pro/security/status/livepatch_cves/v1.py
+++ b/uaclient/api/u/pro/security/status/livepatch_cves/v1.py
@@ -65,6 +65,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.12",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.pro.security.status.livepatch_cves.v1 import livepatch_cves
 

--- a/uaclient/api/u/pro/security/status/reboot_required/v1.py
+++ b/uaclient/api/u/pro/security/status/reboot_required/v1.py
@@ -222,6 +222,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.12",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.pro.security.status.reboot_required.v1 import reboot_required
 

--- a/uaclient/api/u/pro/services/dependencies/v1.py
+++ b/uaclient/api/u/pro/services/dependencies/v1.py
@@ -153,6 +153,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "32",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.pro.services.dependencies.v1 import dependencies
 result = dependencies()

--- a/uaclient/api/u/pro/services/disable/v1.py
+++ b/uaclient/api/u/pro/services/disable/v1.py
@@ -147,6 +147,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "32",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.services.disable.v1 import disable, DisableOptions
 result = disable(DisableOptions(service="usg"))

--- a/uaclient/api/u/pro/services/enable/v1.py
+++ b/uaclient/api/u/pro/services/enable/v1.py
@@ -288,6 +288,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "32",
+    "requires_network": True,
     "example_python": """
 from uaclient.api.u.pro.services.enable.v1 import enable, EnableOptions
 result = enable(EnableOptions(service="usg"))

--- a/uaclient/api/u/pro/status/enabled_services/v1.py
+++ b/uaclient/api/u/pro/status/enabled_services/v1.py
@@ -117,6 +117,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "28",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.pro.status.enabled_services.v1 import enabled_services
 

--- a/uaclient/api/u/pro/status/is_attached/v1.py
+++ b/uaclient/api/u/pro/status/is_attached/v1.py
@@ -135,6 +135,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "28",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.pro.status.is_attached.v1 import is_attached
 

--- a/uaclient/api/u/pro/version/v1.py
+++ b/uaclient/api/u/pro/version/v1.py
@@ -48,6 +48,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.11",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.pro.version.v1 import version
 

--- a/uaclient/api/u/security/package_manifest/v1.py
+++ b/uaclient/api/u/security/package_manifest/v1.py
@@ -61,6 +61,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.12",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.security.package_manifest.v1 import package_manifest
 

--- a/uaclient/api/u/unattended_upgrades/status/v1.py
+++ b/uaclient/api/u/unattended_upgrades/status/v1.py
@@ -292,6 +292,7 @@ endpoint = APIEndpoint(
 
 _doc = {
     "introduced_in": "27.14",
+    "requires_network": False,
     "example_python": """
 from uaclient.api.u.unattended_upgrades.status.v1 import status
 


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This adds network requirements to the api doc metadata and renders it using `apidocgen.py`.

Results in #3223

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Regenerate the api docs and double check the new network information for each endpoint.
<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*