### PR TITLE
docs: update daemon documentation

### DIFF
--- a/docs/explanations/what_is_the_daemon.rst
+++ b/docs/explanations/what_is_the_daemon.rst
@@ -1,9 +1,38 @@
-What is the Pro upgrade daemon?
+What is the Pro daemon?
 *******************************
 
-Ubuntu Pro Client sets up a daemon on supported platforms (currently GCP
-only) to detect if an Ubuntu Pro license has been purchased for the machine.
+Ubuntu Pro Client sets up a daemon for two types of machines:
+
+* Azure and GCP generic cloud images
+* Cloud Pro images
+
+For the first type of images, the daemon is responsible
+for detecting if an Ubuntu Pro license has been purchased for the machine.
 If a Pro license is detected, then the machine is automatically attached.
+
+For the Pro cloud images, the daemon is responsible for retrying the auto-attach
+operation if it fails on first boot. When that happens, users will be notified in
+MOTD or when they run `pro status` with a message like:
+
+.. code-block:: text
+
+   Failed to automatically attach to an Ubuntu Pro subscription 1 time
+   The failure was due to: ERROR_MSG
+   The next attempt is scheduled for RETRY_DATE
+   You can try manually with `sudo pro auto-attach`.
+
+The "retry auto-attach" operation will keep retrying for a **month**. If at the end, we cannot attach
+to the machine, we display the following message to the user:
+
+.. code-block:: text
+
+   Failed to automatically attach to an Ubuntu Pro subscription NUM times.
+   The most recent failure was due to: ERROR_MSG
+   Try re-launching the instance or report this issue by running `ubuntu-bug ubutu-advantage-tools`
+   You can try manually with `sudo pro auto-attach`.
+
+Disabling the daemon
+---------------------
 
 If you are not interested in Ubuntu Pro services and don't want your machine to
 be automatically attached to your subscription, you can safely stop and disable


### PR DESCRIPTION
## Why is this needed?
Update the daemon documentation to state that it now also runs on Azure while also explaining the retry auto-attach mechanism the daemon is now running.

Fixes: #2922

- [ ] *(un)check this to re-run the checklist action*