### PR TITLE
docs: rename pro package name

### DIFF
--- a/dev-docs/references/architecture.md
+++ b/dev-docs/references/architecture.md
@@ -4,11 +4,11 @@ Ubuntu Pro Client is a python3-based command line
 utility. It provides a CLI to attach, detach, enable,
 disable and check status of support related services.
 
-The package `ubuntu-advantage-tools` also provides a C++ APT hook which helps
+The package `ubuntu-pro-client` also provides a C++ APT hook which helps
 advertise ESM service and available packages in MOTD and during various apt
 commands.
 
-The `ubuntu-advantage-pro` package delivers auto-attach functionality via a
+The `ubuntu-pro-auto-attach` package delivers auto-attach functionality via a
 systemd service for various cloud platforms.
 
 By default, Ubuntu machines are deployed in an unattached state. A machine can

--- a/docs/explanations.rst
+++ b/docs/explanations.rst
@@ -38,7 +38,7 @@ Public Cloud Ubuntu Pro
 =======================
 
 Here we talk about Ubuntu Pro images for AWS, Azure and GCP, and the related
-tooling: the ``ubuntu-advantage-pro`` package.
+tooling: the ``ubuntu-pro-auto-attach`` package.
 
 ..  toctree::
     :maxdepth: 1

--- a/docs/explanations/what_is_the_ubuntu_advantage_pro_package.rst
+++ b/docs/explanations/what_is_the_ubuntu_advantage_pro_package.rst
@@ -1,9 +1,9 @@
-What is the ``ubuntu-advantage-pro`` package?
-*********************************************
+What is the ``ubuntu-pro-auto-attach`` package?
+************************************************
 
-The ``ubuntu-advantage-pro`` package is used by
+The ``ubuntu-pro-auto-attach`` package is used by
 :ref:`Public Cloud Ubuntu Pro <expl-about-pro-cpc>` machines to automate the
 process of attaching a machine on boot.
 
-Therefore, the only thing that ``ubuntu-advantage-pro`` does is ship a
+Therefore, the only thing that ``ubuntu-pro-auto-attach`` does is ship a
 ``systemd`` unit that runs an auto-attach command on first boot.


### PR DESCRIPTION
## Why is this needed?
rename the package from ubuntu-advantage-pro to ubuntu-pro-auto-attach, and ubuntu-advantage-tools to ubuntu-pro-client, as those are the new package names

- [ ] *(un)check this to re-run the checklist action*