### PR TITLE
cli: add custom help to the main 'pro' parser

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -7,29 +7,36 @@ Feature: Pro Client help text
       """
       usage: pro [-h] [--debug] [--version] <command> ...
 
+      Quick start commands:
+
+        status           current status of all Ubuntu Pro services
+        attach           attach this machine to an Ubuntu Pro subscription
+        enable           enable a specific Ubuntu Pro service on this machine
+        system           show system information related to Pro services
+        security-status  list available security updates for the system
+
+      Security-related commands:
+
+        fix              check for and mitigate the impact of a CVE/USN on this system
+
+      Troubleshooting-related commands:
+
+        collect-logs     collect Pro logs and debug information
+
+      Other commands:
+
+        api              Calls the Client API endpoints.
+        auto-attach      automatically attach on supported platforms
+        config           manage Ubuntu Pro configuration on this machine
+        detach           remove this machine from an Ubuntu Pro subscription
+        disable          disable a specific Ubuntu Pro service on this machine
+        refresh          refresh Ubuntu Pro services
+
       Flags:
-        -h, --help       show this help message and exit
+
+        -h, --help       Displays help on pro and command line options
         --debug          show all debug log messages to console
         --version        show version of pro
-
-      Available Commands:
-        <command>
-          api            Calls the Client API endpoints.
-          attach         attach this machine to an Ubuntu Pro subscription
-          auto-attach    automatically attach on supported platforms
-          collect-logs   collect Pro logs and debug information
-          config         manage Ubuntu Pro configuration on this machine
-          detach         remove this machine from an Ubuntu Pro subscription
-          disable        disable a specific Ubuntu Pro service on this machine
-          enable         enable a specific Ubuntu Pro service on this machine
-          fix            check for and mitigate the impact of a CVE/USN on this
-                         system
-          help           show detailed information about Ubuntu Pro services
-          refresh        refresh Ubuntu Pro services
-          security-status
-                         list available security updates for the system
-          status         current status of all Ubuntu Pro services
-          system         show system information related to Pro services
 
       Use pro <command> --help for more information about a command.
       """

--- a/features/help.feature
+++ b/features/help.feature
@@ -242,7 +242,7 @@ Feature: Pro Client help text
         entitles use of this service. Possible values are: yes or no
       * STATUS: whether the service is enabled on this machine. Possible
         values are: enabled, disabled, n/a (if your contract entitles
-        you to the service, but it isn't available for this machine) or — (if
+        you to the service, but it isn't available for this machine) or - (if
         you aren't entitled to this service)
       * DESCRIPTION: a brief description of the service
 

--- a/uaclient/cli/api.py
+++ b/uaclient/cli/api.py
@@ -51,6 +51,7 @@ api_command = ProCommand(
     help=messages.CLI_ROOT_API,
     description=messages.CLI_API_DESC,
     action=action_api,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/attach.py
+++ b/uaclient/cli/attach.py
@@ -141,6 +141,8 @@ attach_command = ProCommand(
     description=messages.CLI_ATTACH_DESC,
     action=action_attach,
     preserve_description=True,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=2,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/auto_attach.py
+++ b/uaclient/cli/auto_attach.py
@@ -30,4 +30,5 @@ auto_attach_command = ProCommand(
     help=messages.CLI_ROOT_AUTO_ATTACH,
     description=messages.CLI_AUTO_ATTACH_DESC,
     action=action_auto_attach,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
 )

--- a/uaclient/cli/collect_logs.py
+++ b/uaclient/cli/collect_logs.py
@@ -29,6 +29,7 @@ collect_logs_command = ProCommand(
     help=messages.CLI_ROOT_COLLECT_LOGS,
     description=messages.CLI_COLLECT_LOGS_DESC,
     action=action_collect_logs,
+    help_category=messages.CLI_HELP_HEADER_TROUBLESHOOT,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/commands.py
+++ b/uaclient/cli/commands.py
@@ -79,6 +79,8 @@ class ProCommand:
         preserve_description: bool = False,
         argument_groups: Iterable[ProArgumentGroup] = (),
         subcommands: Iterable["ProCommand"] = (),
+        help_category: Optional[str] = None,
+        help_position: int = 0,
     ):
         self.name = name
         self.help = help
@@ -87,6 +89,8 @@ class ProCommand:
         self.preserve_description = preserve_description
         self.argument_groups = argument_groups
         self.subcommands = subcommands
+        self.help_category = help_category
+        self.help_position = help_position
 
     def register(self, subparsers: argparse._SubParsersAction):
         self.parser = subparsers.add_parser(
@@ -96,6 +100,14 @@ class ProCommand:
         )
         if self.preserve_description:
             self.parser.formatter_class = argparse.RawDescriptionHelpFormatter
+
+        if self.help_category:
+            self.parser.add_help_entry(
+                category=self.help_category,
+                name=self.name,
+                help_string=self.help,
+                position=self.help_position,
+            )
 
         for argument_group in self.argument_groups:
             argument_group.register(self.parser)

--- a/uaclient/cli/config.py
+++ b/uaclient/cli/config.py
@@ -293,5 +293,6 @@ config_command = ProCommand(
     help=messages.CLI_ROOT_CONFIG,
     description=messages.CLI_CONFIG_DESC,
     action=action_config,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     subcommands=[show_subcommand, set_subcommand, unset_subcommand],
 )

--- a/uaclient/cli/detach.py
+++ b/uaclient/cli/detach.py
@@ -92,6 +92,7 @@ detach_command = ProCommand(
     help=messages.CLI_ROOT_DETACH,
     description=messages.CLI_DETACH_DESC,
     action=action_detach,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/disable.py
+++ b/uaclient/cli/disable.py
@@ -294,6 +294,7 @@ disable_command = ProCommand(
     help=messages.CLI_ROOT_DISABLE,
     description=messages.CLI_DISABLE_DESC,
     action=action_disable,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/enable.py
+++ b/uaclient/cli/enable.py
@@ -511,6 +511,8 @@ enable_command = ProCommand(
     help=messages.CLI_ROOT_ENABLE,
     description=messages.CLI_ENABLE_DESC,
     action=action_enable,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=3,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/fix.py
+++ b/uaclient/cli/fix.py
@@ -915,6 +915,7 @@ fix_command = ProCommand(
     help=messages.CLI_ROOT_FIX,
     description=messages.CLI_FIX_DESC,
     action=action_fix,
+    help_category=messages.CLI_HELP_HEADER_SECURITY,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/refresh.py
+++ b/uaclient/cli/refresh.py
@@ -63,6 +63,7 @@ refresh_command = ProCommand(
     description=messages.CLI_REFRESH_DESC,
     action=action_refresh,
     preserve_description=True,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/security_status.py
+++ b/uaclient/cli/security_status.py
@@ -46,6 +46,8 @@ security_status_command = ProCommand(
     description=messages.CLI_SS_DESC,
     preserve_description=True,
     action=action_security_status,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=5,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/status.py
+++ b/uaclient/cli/status.py
@@ -41,6 +41,8 @@ status_command = ProCommand(
     description=messages.CLI_STATUS_DESC,
     action=action_status,
     preserve_description=True,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=1,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/system.py
+++ b/uaclient/cli/system.py
@@ -33,5 +33,7 @@ system_command = ProCommand(
     help=messages.CLI_ROOT_SYSTEM,
     description=messages.CLI_SYSTEM_DESC,
     action=action_system,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=4,
     subcommands=[reboot_required_subcommand],
 )

--- a/uaclient/cli/tests/test_cli_commands.py
+++ b/uaclient/cli/tests/test_cli_commands.py
@@ -87,6 +87,28 @@ class TestProCommand:
             mock.call(inner_subparsers)
         ] == example_subcommand2.register.call_args_list
 
+    def has_help_entry(self):
+        mock_subparsers = mock.MagicMock()
+
+        example_command = ProCommand(
+            "example",
+            help="help",
+            description="description",
+            help_category="help_cat",
+            help_position=6,
+        )
+
+        example_command.register(mock_subparsers)
+
+        assert [
+            mock.call(
+                category="help_cat",
+                name="example",
+                help_string="help",
+                position=6,
+            )
+        ] == example_command.parser.add_help_entry.call_args_list
+
 
 class TestProArgument:
     def test_argument_register(self):

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1109,7 +1109,7 @@ The attached status output has four columns:
   entitles use of this service. Possible values are: yes or no
 * STATUS: whether the service is enabled on this machine. Possible
   values are: enabled, disabled, n/a (if your contract entitles
-  you to the service, but it isn't available for this machine) or — (if
+  you to the service, but it isn't available for this machine) or - (if
   you aren't entitled to this service)
 * DESCRIPTION: a brief description of the service
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -886,6 +886,16 @@ CLI_HELP_EPILOG = t.gettext(
     "Use {name} {command} --help for more information about a command."
 )
 
+CLI_HELP_FLAG_DESC = t.gettext(
+    "Displays help on {name} and command line options"
+)
+
+CLI_HELP_HEADER_QUICK_START = t.gettext("Quick start commands")
+CLI_HELP_HEADER_SECURITY = t.gettext("Security-related commands")
+CLI_HELP_HEADER_TROUBLESHOOT = t.gettext("Troubleshooting-related commands")
+CLI_HELP_HEADER_OTHER = t.gettext("Other commands")
+
+
 CLI_HELP_VARIANTS_HEADER = t.gettext("Variants:")
 CLI_FLAGS = t.gettext("Flags")
 CLI_AVAILABLE_COMMANDS = t.gettext("Available Commands")


### PR DESCRIPTION
## Why is this needed?

This PR solves all of our problems because it implements the `help` structure defined for the new UX.

For all other commands we rely on argparse defaults, but for the main --help entry we want to present the available commands in a customized way.

Some commands will have their own categories, and some will not even appear in help.

## Test Steps
Run help.
There is an integration test to cover the whole thing.

---

- [ ] *(un)check this to re-run the checklist action*