### PR TITLE
api: Do not consider unattended-upgrade disabled when any config is 

### DIFF
--- a/uaclient/api/tests/test_api_u_unattended_upgrades_status_v1.py
+++ b/uaclient/api/tests/test_api_u_unattended_upgrades_status_v1.py
@@ -45,23 +45,51 @@ class TestIsUnattendedUpgradesRunning:
             (False, {}, False, UNATTENDED_UPGRADES_SYSTEMD_JOB_DISABLED),
             (
                 True,
-                {"test": []},
+                {
+                    "APT::Periodic::Enable": "1",
+                    "APT::Periodic::Update-Package-Lists": "1",
+                    "APT::Periodic::Unattended-Upgrade": "1",
+                    "Unattended-Upgrade::Allowed-Origins": [],
+                },
                 False,
                 UNATTENDED_UPGRADES_CFG_LIST_VALUE_EMPTY.format(
-                    cfg_name="test"
+                    cfg_name="Unattended-Upgrade::Allowed-Origins"
                 ),
             ),
             (
                 True,
-                {"test": ["foo"], "test2": "0"},
+                {
+                    "APT::Periodic::Enable": "0",
+                    "APT::Periodic::Update-Package-Lists": "0",
+                    "APT::Periodic::Unattended-Upgrade": "0",
+                    "Unattended-Upgrade::Allowed-Origins": ["foo"],
+                },
                 False,
                 UNATTENDED_UPGRADES_CFG_VALUE_TURNED_OFF.format(
-                    cfg_name="test2"
+                    cfg_name="APT::Periodic::Enable"
                 ),
             ),
             (
                 True,
-                {"test": ["foo"], "test2": "1"},
+                {
+                    "APT::Periodic::Enable": "1",
+                    "APT::Periodic::Update-Package-Lists": "0",
+                    "APT::Periodic::Unattended-Upgrade": "1",
+                    "Unattended-Upgrade::Allowed-Origins": ["foo"],
+                },
+                False,
+                UNATTENDED_UPGRADES_CFG_VALUE_TURNED_OFF.format(
+                    cfg_name="APT::Periodic::Update-Package-Lists"
+                ),
+            ),
+            (
+                True,
+                {
+                    "APT::Periodic::Enable": "1",
+                    "APT::Periodic::Update-Package-Lists": "1",
+                    "APT::Periodic::Unattended-Upgrade": "1",
+                    "Unattended-Upgrade::Allowed-Origins": ["foo"],
+                },
                 True,
                 None,
             ),

--- a/uaclient/api/u/unattended_upgrades/status/v1.py
+++ b/uaclient/api/u/unattended_upgrades/status/v1.py
@@ -160,7 +160,8 @@ def _is_unattended_upgrades_running(
     if not systemd_apt_timer_enabled:
         return (False, messages.UNATTENDED_UPGRADES_SYSTEMD_JOB_DISABLED)
 
-    for key, value in unattended_upgrades_cfg.items():
+    for key in UNATTENDED_UPGRADES_CONFIG_KEYS:
+        value = unattended_upgrades_cfg.get(key)
         if not value:
             return (
                 False,


### PR DESCRIPTION
## Why is this needed?

There are many configs in the 'Unattended-Upgrade::' prefix which can be disabled while still keeping the main functionality enabled. For example:
 - Unattended-Upgrade::OnlyOnACPower "0" Allows upgrades even on battery power
 - Unattended-Upgrade::Skip-Updates-On-Metered-Connections "0" Allows upgrades even on metered connections

 ... and many more.

You may `grep Unattended-Upgrade:: /usr/bin/unattended-upgrade` for a list of keys that may make sense to disable while keeping unattended-upgrades enabled.

## Test Steps
`echo 'Unattended-Upgrade::OnlyOnACPower "0";' | sudo tee /etc/apt/apt.conf.d/99test`
`pro api u.unattended_upgrades.status.v1 | python3 -m json.tool`

without this change it reports:
```
            "unattended_upgrades_disabled_reason": {
                "code": "unattended-upgrades-cfg-value-turned-off",
                "msg": "Unattended-Upgrade::OnlyOnACPower is turned off"
            },
```

---

- [ ] *(un)check this to re-run the checklist action*