### PR TITLE
tests: fix upgrade_lts_contract tests

### DIFF
--- a/uaclient/tests/test_upgrade_lts_contract.py
+++ b/uaclient/tests/test_upgrade_lts_contract.py
@@ -80,9 +80,11 @@ class TestUpgradeLTSContract:
         capsys,
         caplog_text,
         FakeConfig,
+        fake_machine_token_file,
     ):
         m_is_attached.return_value = mock.MagicMock(is_attached=True)
         m_get_release_info.return_value = mock.MagicMock(series="focal")
+        fake_machine_token_file.attached = True
 
         m_subp.side_effect = [
             ("apt     146195 root", ""),

--- a/uaclient/upgrade_lts_contract.py
+++ b/uaclient/upgrade_lts_contract.py
@@ -30,7 +30,7 @@ import time
 from uaclient import contract, defaults, messages, system, util
 from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UAConfig
-from uaclient.files.machine_token import get_machine_token_file
+from uaclient.files import machine_token
 
 # We consider the past release for LTSs to be the last LTS,
 # because we don't have any services available on non-LTS.
@@ -60,7 +60,7 @@ def process_contract_delta_after_apt_lock(cfg: UAConfig) -> None:
         print(messages.RELEASE_UPGRADE_APT_LOCK_HELD_WILL_WAIT)
 
     current_release = system.get_release_info().series
-    machine_token_file = get_machine_token_file(cfg)
+    machine_token_file = machine_token.get_machine_token_file(cfg)
 
     past_release = current_codename_to_past_codename.get(current_release)
     if past_release is None:


### PR DESCRIPTION
## Why is this needed?
We are not mocking the machine token file for one
of our upgrade_lts_contract tests. That means that when unattached, this test will fail. We are now correctly mocking it.

## Test Steps
Check that the affected test pass when running on an unattached machine

---

- [ ] *(un)check this to re-run the checklist action*