### PR TITLE
cli: add custom help to the main 'pro' parser

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -7,29 +7,36 @@ Feature: Pro Client help text
       """
       usage: pro [-h] [--debug] [--version] <command> ...
 
+      Quick start commands:
+
+        status           current status of all Ubuntu Pro services
+        attach           attach this machine to an Ubuntu Pro subscription
+        enable           enable a specific Ubuntu Pro service on this machine
+        system           show system information related to Pro services
+        security-status  list available security updates for the system
+
+      Security-related commands:
+
+        fix              check for and mitigate the impact of a CVE/USN on this system
+
+      Troubleshooting-related commands:
+
+        collect-logs     collect Pro logs and debug information
+
+      Other commands:
+
+        api              Calls the Client API endpoints.
+        auto-attach      automatically attach on supported platforms
+        config           manage Ubuntu Pro configuration on this machine
+        detach           remove this machine from an Ubuntu Pro subscription
+        disable          disable a specific Ubuntu Pro service on this machine
+        refresh          refresh Ubuntu Pro services
+
       Flags:
-        -h, --help       show this help message and exit
+
+        -h, --help       Displays help on pro and command line options
         --debug          show all debug log messages to console
         --version        show version of pro
-
-      Available Commands:
-        <command>
-          api            Calls the Client API endpoints.
-          attach         attach this machine to an Ubuntu Pro subscription
-          auto-attach    automatically attach on supported platforms
-          collect-logs   collect Pro logs and debug information
-          config         manage Ubuntu Pro configuration on this machine
-          detach         remove this machine from an Ubuntu Pro subscription
-          disable        disable a specific Ubuntu Pro service on this machine
-          enable         enable a specific Ubuntu Pro service on this machine
-          fix            check for and mitigate the impact of a CVE/USN on this
-                         system
-          help           show detailed information about Ubuntu Pro services
-          refresh        refresh Ubuntu Pro services
-          security-status
-                         list available security updates for the system
-          status         current status of all Ubuntu Pro services
-          system         show system information related to Pro services
 
       Use pro <command> --help for more information about a command.
       """

--- a/features/help.feature
+++ b/features/help.feature
@@ -242,7 +242,7 @@ Feature: Pro Client help text
         entitles use of this service. Possible values are: yes or no
       * STATUS: whether the service is enabled on this machine. Possible
         values are: enabled, disabled, n/a (if your contract entitles
-        you to the service, but it isn't available for this machine) or — (if
+        you to the service, but it isn't available for this machine) or - (if
         you aren't entitled to this service)
       * DESCRIPTION: a brief description of the service
 

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -1,10 +1,7 @@
 """Client to manage Ubuntu Pro services on a machine."""
 
-import argparse
 import logging
 import sys
-from collections import OrderedDict
-from typing import List, NamedTuple  # noqa: F401
 
 from uaclient import (
     apt,
@@ -28,6 +25,7 @@ from uaclient.cli.disable import disable_command
 from uaclient.cli.enable import enable_command
 from uaclient.cli.fix import fix_command
 from uaclient.cli.help import help_command
+from uaclient.cli.parser import ProArgumentParser
 from uaclient.cli.refresh import refresh_command
 from uaclient.cli.security_status import security_status_command
 from uaclient.cli.status import status_command
@@ -56,64 +54,6 @@ COMMANDS = [
     status_command,
     system_command,
 ]
-
-HelpEntry = NamedTuple(
-    "HelpEntry", [("position", int), ("name", str), ("help_string", str)]
-)
-
-
-class ProArgumentParser(argparse.ArgumentParser):
-    help_entries = OrderedDict(
-        [
-            (messages.CLI_HELP_HEADER_QUICK_START, []),
-            (messages.CLI_HELP_HEADER_SECURITY, []),
-            (messages.CLI_HELP_HEADER_TROUBLESHOOT, []),
-            (messages.CLI_HELP_HEADER_OTHER, []),
-            (messages.CLI_FLAGS, []),
-        ]
-    )  # type: OrderedDict[str, List[HelpEntry]]
-
-    @classmethod
-    def add_help_entry(
-        cls, category: str, name: str, help_string: str, position: int = 0
-    ):
-        cls.help_entries[category].append(
-            HelpEntry(position=position, name=name, help_string=help_string)
-        )
-
-    def __init__(self, *args, use_main_help: bool = True, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.use_main_help = use_main_help
-
-    def print_help_for_command(self, command: str):
-        args_list = command.split()
-        args_list.append("--help")
-        try:
-            self.parse_args(args_list)
-        # We want help for any specific command,
-        # but without exiting right after
-        except SystemExit:
-            pass
-
-    def format_help(self):
-        if self.use_main_help:
-            return super().format_help()
-        help_output = self.format_usage()
-
-        for category, items in self.help_entries.items():
-            help_output += "\n"
-            help_output += "{}:".format(category)
-            help_output += "\n"
-            for item in sorted(items, key=lambda item: item.position):
-                help_output += "\n"
-                help_output += "  {:<17}{}".format(item.name, item.help_string)
-            help_output += "\n"
-        if self.epilog:
-            help_output += "\n"
-            help_output += self.epilog
-            help_output += "\n"
-
-        return help_output
 
 
 def get_parser():

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -25,7 +25,7 @@ from uaclient.cli.disable import disable_command
 from uaclient.cli.enable import enable_command
 from uaclient.cli.fix import fix_command
 from uaclient.cli.help import help_command
-from uaclient.cli.parser import ProArgumentParser
+from uaclient.cli.parser import HelpCategory, ProArgumentParser
 from uaclient.cli.refresh import refresh_command
 from uaclient.cli.security_status import security_status_command
 from uaclient.cli.status import status_command
@@ -63,7 +63,7 @@ def get_parser():
         epilog=messages.CLI_HELP_EPILOG.format(name=NAME, command="<command>"),
     )
     parser.add_help_entry(
-        messages.CLI_FLAGS,
+        HelpCategory.FLAGS,
         "-h, --help",
         messages.CLI_HELP_FLAG_DESC.format(name=NAME),
     )
@@ -72,7 +72,7 @@ def get_parser():
         "--debug", action="store_true", help=messages.CLI_ROOT_DEBUG
     )
     parser.add_help_entry(
-        messages.CLI_FLAGS, "--debug", messages.CLI_ROOT_DEBUG
+        HelpCategory.FLAGS, "--debug", messages.CLI_ROOT_DEBUG
     )
 
     parser.add_argument(
@@ -82,7 +82,7 @@ def get_parser():
         help=messages.CLI_ROOT_VERSION.format(name=NAME),
     )
     parser.add_help_entry(
-        messages.CLI_FLAGS,
+        HelpCategory.FLAGS,
         "--version",
         messages.CLI_ROOT_VERSION.format(name=NAME),
     )

--- a/uaclient/cli/api.py
+++ b/uaclient/cli/api.py
@@ -51,6 +51,7 @@ api_command = ProCommand(
     help=messages.CLI_ROOT_API,
     description=messages.CLI_API_DESC,
     action=action_api,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/api.py
+++ b/uaclient/cli/api.py
@@ -7,6 +7,7 @@ from uaclient import exceptions, messages
 from uaclient.api import AbstractProgress
 from uaclient.api.api import call_api
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.parser import HelpCategory
 
 
 class CLIAPIProgress(AbstractProgress):
@@ -51,7 +52,7 @@ api_command = ProCommand(
     help=messages.CLI_ROOT_API,
     description=messages.CLI_API_DESC,
     action=action_api,
-    help_category=messages.CLI_HELP_HEADER_OTHER,
+    help_category=HelpCategory.OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/attach.py
+++ b/uaclient/cli/attach.py
@@ -20,6 +20,7 @@ from uaclient.api.u.pro.attach.magic.wait.v1 import (
 )
 from uaclient.cli import cli_util
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.parser import HelpCategory
 from uaclient.data_types import AttachActionsConfigFile, IncorrectTypeError
 from uaclient.entitlements import (
     create_enable_entitlements_not_found_error,
@@ -141,7 +142,7 @@ attach_command = ProCommand(
     description=messages.CLI_ATTACH_DESC,
     action=action_attach,
     preserve_description=True,
-    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_category=HelpCategory.QUICKSTART,
     help_position=2,
     argument_groups=[
         ProArgumentGroup(

--- a/uaclient/cli/attach.py
+++ b/uaclient/cli/attach.py
@@ -141,6 +141,8 @@ attach_command = ProCommand(
     description=messages.CLI_ATTACH_DESC,
     action=action_attach,
     preserve_description=True,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=2,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/auto_attach.py
+++ b/uaclient/cli/auto_attach.py
@@ -30,4 +30,5 @@ auto_attach_command = ProCommand(
     help=messages.CLI_ROOT_AUTO_ATTACH,
     description=messages.CLI_AUTO_ATTACH_DESC,
     action=action_auto_attach,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
 )

--- a/uaclient/cli/auto_attach.py
+++ b/uaclient/cli/auto_attach.py
@@ -5,6 +5,7 @@ from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
 )
 from uaclient.cli import cli_util
 from uaclient.cli.commands import ProCommand
+from uaclient.cli.parser import HelpCategory
 
 event = event_logger.get_event_logger()
 
@@ -30,5 +31,5 @@ auto_attach_command = ProCommand(
     help=messages.CLI_ROOT_AUTO_ATTACH,
     description=messages.CLI_AUTO_ATTACH_DESC,
     action=action_auto_attach,
-    help_category=messages.CLI_HELP_HEADER_OTHER,
+    help_category=HelpCategory.OTHER,
 )

--- a/uaclient/cli/collect_logs.py
+++ b/uaclient/cli/collect_logs.py
@@ -29,6 +29,7 @@ collect_logs_command = ProCommand(
     help=messages.CLI_ROOT_COLLECT_LOGS,
     description=messages.CLI_COLLECT_LOGS_DESC,
     action=action_collect_logs,
+    help_category=messages.CLI_HELP_HEADER_TROUBLESHOOT,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/collect_logs.py
+++ b/uaclient/cli/collect_logs.py
@@ -5,6 +5,7 @@ import tempfile
 from uaclient import messages
 from uaclient.actions import collect_logs
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.parser import HelpCategory
 from uaclient.util import replace_top_level_logger_name
 
 PRO_COLLECT_LOGS_FILE = "pro_logs.tar.gz"
@@ -29,7 +30,7 @@ collect_logs_command = ProCommand(
     help=messages.CLI_ROOT_COLLECT_LOGS,
     description=messages.CLI_COLLECT_LOGS_DESC,
     action=action_collect_logs,
-    help_category=messages.CLI_HELP_HEADER_TROUBLESHOOT,
+    help_category=HelpCategory.TROUBLESHOOT,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/commands.py
+++ b/uaclient/cli/commands.py
@@ -79,6 +79,8 @@ class ProCommand:
         preserve_description: bool = False,
         argument_groups: Iterable[ProArgumentGroup] = (),
         subcommands: Iterable["ProCommand"] = (),
+        help_category: Optional[str] = None,
+        help_position: int = 0,
     ):
         self.name = name
         self.help = help
@@ -87,6 +89,8 @@ class ProCommand:
         self.preserve_description = preserve_description
         self.argument_groups = argument_groups
         self.subcommands = subcommands
+        self.help_category = help_category
+        self.help_position = help_position
 
     def register(self, subparsers: argparse._SubParsersAction):
         self.parser = subparsers.add_parser(
@@ -96,6 +100,14 @@ class ProCommand:
         )
         if self.preserve_description:
             self.parser.formatter_class = argparse.RawDescriptionHelpFormatter
+
+        if self.help_category:
+            self.parser.add_help_entry(
+                category=self.help_category,
+                name=self.name,
+                help_string=self.help,
+                position=self.help_position,
+            )
 
         for argument_group in self.argument_groups:
             argument_group.register(self.parser)

--- a/uaclient/cli/commands.py
+++ b/uaclient/cli/commands.py
@@ -2,6 +2,7 @@ import argparse
 from typing import Callable, Iterable, Optional, Union
 
 from uaclient import messages
+from uaclient.cli.parser import HelpCategory
 
 
 class ProArgument:
@@ -79,7 +80,7 @@ class ProCommand:
         preserve_description: bool = False,
         argument_groups: Iterable[ProArgumentGroup] = (),
         subcommands: Iterable["ProCommand"] = (),
-        help_category: Optional[str] = None,
+        help_category: Optional[HelpCategory] = None,
         help_position: int = 0,
     ):
         self.name = name

--- a/uaclient/cli/config.py
+++ b/uaclient/cli/config.py
@@ -293,5 +293,6 @@ config_command = ProCommand(
     help=messages.CLI_ROOT_CONFIG,
     description=messages.CLI_CONFIG_DESC,
     action=action_config,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     subcommands=[show_subcommand, set_subcommand, unset_subcommand],
 )

--- a/uaclient/cli/config.py
+++ b/uaclient/cli/config.py
@@ -10,6 +10,7 @@ from uaclient import (
 from uaclient.apt import AptProxyScope
 from uaclient.cli import cli_util
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.parser import HelpCategory
 from uaclient.entitlements.entitlement_status import ApplicationStatus
 from uaclient.files import state_files
 from uaclient.livepatch import (
@@ -293,6 +294,6 @@ config_command = ProCommand(
     help=messages.CLI_ROOT_CONFIG,
     description=messages.CLI_CONFIG_DESC,
     action=action_config,
-    help_category=messages.CLI_HELP_HEADER_OTHER,
+    help_category=HelpCategory.OTHER,
     subcommands=[show_subcommand, set_subcommand, unset_subcommand],
 )

--- a/uaclient/cli/detach.py
+++ b/uaclient/cli/detach.py
@@ -92,6 +92,7 @@ detach_command = ProCommand(
     help=messages.CLI_ROOT_DETACH,
     description=messages.CLI_DETACH_DESC,
     action=action_detach,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/detach.py
+++ b/uaclient/cli/detach.py
@@ -11,6 +11,7 @@ from uaclient import (
 from uaclient.cli import cli_util
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
 from uaclient.cli.disable import perform_disable
+from uaclient.cli.parser import HelpCategory
 from uaclient.files import machine_token, state_files
 from uaclient.timer.update_messaging import update_motd_messages
 
@@ -92,7 +93,7 @@ detach_command = ProCommand(
     help=messages.CLI_ROOT_DETACH,
     description=messages.CLI_DETACH_DESC,
     action=action_detach,
-    help_category=messages.CLI_HELP_HEADER_OTHER,
+    help_category=HelpCategory.OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/disable.py
+++ b/uaclient/cli/disable.py
@@ -21,6 +21,7 @@ from uaclient.api.u.pro.services.dependencies.v1 import (
 from uaclient.api.u.pro.status.enabled_services.v1 import _enabled_services
 from uaclient.cli import cli_util
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.parser import HelpCategory
 from uaclient.entitlements.entitlement_status import CanDisableFailure
 
 event = event_logger.get_event_logger()
@@ -294,7 +295,7 @@ disable_command = ProCommand(
     help=messages.CLI_ROOT_DISABLE,
     description=messages.CLI_DISABLE_DESC,
     action=action_disable,
-    help_category=messages.CLI_HELP_HEADER_OTHER,
+    help_category=HelpCategory.OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/disable.py
+++ b/uaclient/cli/disable.py
@@ -294,6 +294,7 @@ disable_command = ProCommand(
     help=messages.CLI_ROOT_DISABLE,
     description=messages.CLI_DISABLE_DESC,
     action=action_disable,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/enable.py
+++ b/uaclient/cli/enable.py
@@ -30,6 +30,7 @@ from uaclient.api.u.pro.status.enabled_services.v1 import (
 from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.cli import cli_util
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.parser import HelpCategory
 
 LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
 
@@ -511,7 +512,7 @@ enable_command = ProCommand(
     help=messages.CLI_ROOT_ENABLE,
     description=messages.CLI_ENABLE_DESC,
     action=action_enable,
-    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_category=HelpCategory.QUICKSTART,
     help_position=3,
     argument_groups=[
         ProArgumentGroup(

--- a/uaclient/cli/enable.py
+++ b/uaclient/cli/enable.py
@@ -511,6 +511,8 @@ enable_command = ProCommand(
     help=messages.CLI_ROOT_ENABLE,
     description=messages.CLI_ENABLE_DESC,
     action=action_enable,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=3,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/fix.py
+++ b/uaclient/cli/fix.py
@@ -59,6 +59,7 @@ from uaclient.api.u.pro.status.is_attached.v1 import (
 )
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
 from uaclient.cli.detach import action_detach
+from uaclient.cli.parser import HelpCategory
 from uaclient.clouds.identity import (
     CLOUD_TYPE_TO_TITLE,
     PRO_CLOUD_URLS,
@@ -915,7 +916,7 @@ fix_command = ProCommand(
     help=messages.CLI_ROOT_FIX,
     description=messages.CLI_FIX_DESC,
     action=action_fix,
-    help_category=messages.CLI_HELP_HEADER_SECURITY,
+    help_category=HelpCategory.SECURITY,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/fix.py
+++ b/uaclient/cli/fix.py
@@ -915,6 +915,7 @@ fix_command = ProCommand(
     help=messages.CLI_ROOT_FIX,
     description=messages.CLI_FIX_DESC,
     action=action_fix,
+    help_category=messages.CLI_HELP_HEADER_SECURITY,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/parser.py
+++ b/uaclient/cli/parser.py
@@ -11,14 +11,26 @@ HelpEntry = NamedTuple(
 
 
 class HelpCategory(Enum):
-    QUICKSTART = messages.CLI_HELP_HEADER_QUICK_START
-    SECURITY = messages.CLI_HELP_HEADER_SECURITY
-    TROUBLESHOOT = messages.CLI_HELP_HEADER_TROUBLESHOOT
-    OTHER = messages.CLI_HELP_HEADER_OTHER
-    FLAGS = messages.CLI_FLAGS
+
+    class _Value:
+        def __init__(self, code: str, msg: str):
+            self.code = code
+            self.msg = msg
+
+    QUICKSTART = _Value("quickstart", messages.CLI_HELP_HEADER_QUICK_START)
+    SECURITY = _Value("security", messages.CLI_HELP_HEADER_SECURITY)
+    TROUBLESHOOT = _Value(
+        "troubleshoot", messages.CLI_HELP_HEADER_TROUBLESHOOT
+    )
+    OTHER = _Value("other", messages.CLI_HELP_HEADER_OTHER)
+    FLAGS = _Value("flags", messages.CLI_FLAGS)
 
     def __str__(self):
-        return str(self.value)
+        return self.value.code
+
+    @property
+    def header(self):
+        return self.value.msg
 
 
 class ProArgumentParser(argparse.ArgumentParser):
@@ -65,7 +77,7 @@ class ProArgumentParser(argparse.ArgumentParser):
 
         for category, items in self.help_entries.items():
             help_output += "\n"
-            help_output += "{}:".format(category)
+            help_output += "{}:".format(category.header)
             help_output += "\n"
             for item in sorted(items, key=lambda item: item.position):
                 help_output += "\n"

--- a/uaclient/cli/parser.py
+++ b/uaclient/cli/parser.py
@@ -1,5 +1,6 @@
 import argparse
 from collections import OrderedDict
+from enum import Enum
 from typing import List, NamedTuple  # noqa: F401
 
 from uaclient import messages
@@ -9,20 +10,35 @@ HelpEntry = NamedTuple(
 )
 
 
+class HelpCategory(Enum):
+    QUICKSTART = messages.CLI_HELP_HEADER_QUICK_START
+    SECURITY = messages.CLI_HELP_HEADER_SECURITY
+    TROUBLESHOOT = messages.CLI_HELP_HEADER_TROUBLESHOOT
+    OTHER = messages.CLI_HELP_HEADER_OTHER
+    FLAGS = messages.CLI_FLAGS
+
+    def __str__(self):
+        return str(self.value)
+
+
 class ProArgumentParser(argparse.ArgumentParser):
     help_entries = OrderedDict(
         [
-            (messages.CLI_HELP_HEADER_QUICK_START, []),
-            (messages.CLI_HELP_HEADER_SECURITY, []),
-            (messages.CLI_HELP_HEADER_TROUBLESHOOT, []),
-            (messages.CLI_HELP_HEADER_OTHER, []),
-            (messages.CLI_FLAGS, []),
+            (HelpCategory.QUICKSTART, []),
+            (HelpCategory.SECURITY, []),
+            (HelpCategory.TROUBLESHOOT, []),
+            (HelpCategory.OTHER, []),
+            (HelpCategory.FLAGS, []),
         ]
-    )  # type: OrderedDict[str, List[HelpEntry]]
+    )  # type: OrderedDict[HelpCategory, List[HelpEntry]]
 
     @classmethod
     def add_help_entry(
-        cls, category: str, name: str, help_string: str, position: int = 0
+        cls,
+        category: HelpCategory,
+        name: str,
+        help_string: str,
+        position: int = 0,
     ):
         cls.help_entries[category].append(
             HelpEntry(position=position, name=name, help_string=help_string)

--- a/uaclient/cli/parser.py
+++ b/uaclient/cli/parser.py
@@ -1,0 +1,63 @@
+import argparse
+from collections import OrderedDict
+from typing import List, NamedTuple  # noqa: F401
+
+from uaclient import messages
+
+HelpEntry = NamedTuple(
+    "HelpEntry", [("position", int), ("name", str), ("help_string", str)]
+)
+
+
+class ProArgumentParser(argparse.ArgumentParser):
+    help_entries = OrderedDict(
+        [
+            (messages.CLI_HELP_HEADER_QUICK_START, []),
+            (messages.CLI_HELP_HEADER_SECURITY, []),
+            (messages.CLI_HELP_HEADER_TROUBLESHOOT, []),
+            (messages.CLI_HELP_HEADER_OTHER, []),
+            (messages.CLI_FLAGS, []),
+        ]
+    )  # type: OrderedDict[str, List[HelpEntry]]
+
+    @classmethod
+    def add_help_entry(
+        cls, category: str, name: str, help_string: str, position: int = 0
+    ):
+        cls.help_entries[category].append(
+            HelpEntry(position=position, name=name, help_string=help_string)
+        )
+
+    def __init__(self, *args, use_main_help: bool = True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.use_main_help = use_main_help
+
+    def print_help_for_command(self, command: str):
+        args_list = command.split()
+        args_list.append("--help")
+        try:
+            self.parse_args(args_list)
+        # We want help for any specific command,
+        # but without exiting right after
+        except SystemExit:
+            pass
+
+    def format_help(self):
+        if self.use_main_help:
+            return super().format_help()
+        help_output = self.format_usage()
+
+        for category, items in self.help_entries.items():
+            help_output += "\n"
+            help_output += "{}:".format(category)
+            help_output += "\n"
+            for item in sorted(items, key=lambda item: item.position):
+                help_output += "\n"
+                help_output += "  {:<17}{}".format(item.name, item.help_string)
+            help_output += "\n"
+        if self.epilog:
+            help_output += "\n"
+            help_output += self.epilog
+            help_output += "\n"
+
+        return help_output

--- a/uaclient/cli/refresh.py
+++ b/uaclient/cli/refresh.py
@@ -3,6 +3,7 @@ import logging
 from uaclient import apt_news, config, contract, exceptions, messages, util
 from uaclient.cli import cli_util
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.parser import HelpCategory
 from uaclient.timer.update_messaging import refresh_motd, update_motd_messages
 
 LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
@@ -63,7 +64,7 @@ refresh_command = ProCommand(
     description=messages.CLI_REFRESH_DESC,
     action=action_refresh,
     preserve_description=True,
-    help_category=messages.CLI_HELP_HEADER_OTHER,
+    help_category=HelpCategory.OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/refresh.py
+++ b/uaclient/cli/refresh.py
@@ -63,6 +63,7 @@ refresh_command = ProCommand(
     description=messages.CLI_REFRESH_DESC,
     action=action_refresh,
     preserve_description=True,
+    help_category=messages.CLI_HELP_HEADER_OTHER,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/security_status.py
+++ b/uaclient/cli/security_status.py
@@ -46,6 +46,8 @@ security_status_command = ProCommand(
     description=messages.CLI_SS_DESC,
     preserve_description=True,
     action=action_security_status,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=5,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/security_status.py
+++ b/uaclient/cli/security_status.py
@@ -7,6 +7,7 @@ from uaclient.cli.commands import (
     ProArgumentMutuallyExclusiveGroup,
     ProCommand,
 )
+from uaclient.cli.parser import HelpCategory
 from uaclient.yaml import safe_dump
 
 
@@ -46,7 +47,7 @@ security_status_command = ProCommand(
     description=messages.CLI_SS_DESC,
     preserve_description=True,
     action=action_security_status,
-    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_category=HelpCategory.QUICKSTART,
     help_position=5,
     argument_groups=[
         ProArgumentGroup(

--- a/uaclient/cli/status.py
+++ b/uaclient/cli/status.py
@@ -41,6 +41,8 @@ status_command = ProCommand(
     description=messages.CLI_STATUS_DESC,
     action=action_status,
     preserve_description=True,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=1,
     argument_groups=[
         ProArgumentGroup(
             arguments=[

--- a/uaclient/cli/status.py
+++ b/uaclient/cli/status.py
@@ -2,6 +2,7 @@ import time
 
 from uaclient import actions, config, event_logger, messages, status, util
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.parser import HelpCategory
 
 event = event_logger.get_event_logger()
 
@@ -41,7 +42,7 @@ status_command = ProCommand(
     description=messages.CLI_STATUS_DESC,
     action=action_status,
     preserve_description=True,
-    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_category=HelpCategory.QUICKSTART,
     help_position=1,
     argument_groups=[
         ProArgumentGroup(

--- a/uaclient/cli/system.py
+++ b/uaclient/cli/system.py
@@ -33,5 +33,7 @@ system_command = ProCommand(
     help=messages.CLI_ROOT_SYSTEM,
     description=messages.CLI_SYSTEM_DESC,
     action=action_system,
+    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_position=4,
     subcommands=[reboot_required_subcommand],
 )

--- a/uaclient/cli/system.py
+++ b/uaclient/cli/system.py
@@ -3,6 +3,7 @@ from uaclient.api.u.pro.security.status.reboot_required.v1 import (
     _reboot_required,
 )
 from uaclient.cli.commands import ProCommand
+from uaclient.cli.parser import HelpCategory
 
 event = event_logger.get_event_logger()
 
@@ -33,7 +34,7 @@ system_command = ProCommand(
     help=messages.CLI_ROOT_SYSTEM,
     description=messages.CLI_SYSTEM_DESC,
     action=action_system,
-    help_category=messages.CLI_HELP_HEADER_QUICK_START,
+    help_category=HelpCategory.QUICKSTART,
     help_position=4,
     subcommands=[reboot_required_subcommand],
 )

--- a/uaclient/cli/tests/test_cli_commands.py
+++ b/uaclient/cli/tests/test_cli_commands.py
@@ -87,6 +87,28 @@ class TestProCommand:
             mock.call(inner_subparsers)
         ] == example_subcommand2.register.call_args_list
 
+    def has_help_entry(self):
+        mock_subparsers = mock.MagicMock()
+
+        example_command = ProCommand(
+            "example",
+            help="help",
+            description="description",
+            help_category="help_cat",
+            help_position=6,
+        )
+
+        example_command.register(mock_subparsers)
+
+        assert [
+            mock.call(
+                category="help_cat",
+                name="example",
+                help_string="help",
+                position=6,
+            )
+        ] == example_command.parser.add_help_entry.call_args_list
+
 
 class TestProArgument:
     def test_argument_register(self):

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1109,7 +1109,7 @@ The attached status output has four columns:
   entitles use of this service. Possible values are: yes or no
 * STATUS: whether the service is enabled on this machine. Possible
   values are: enabled, disabled, n/a (if your contract entitles
-  you to the service, but it isn't available for this machine) or — (if
+  you to the service, but it isn't available for this machine) or - (if
   you aren't entitled to this service)
 * DESCRIPTION: a brief description of the service
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -886,6 +886,16 @@ CLI_HELP_EPILOG = t.gettext(
     "Use {name} {command} --help for more information about a command."
 )
 
+CLI_HELP_FLAG_DESC = t.gettext(
+    "Displays help on {name} and command line options"
+)
+
+CLI_HELP_HEADER_QUICK_START = t.gettext("Quick start commands")
+CLI_HELP_HEADER_SECURITY = t.gettext("Security-related commands")
+CLI_HELP_HEADER_TROUBLESHOOT = t.gettext("Troubleshooting-related commands")
+CLI_HELP_HEADER_OTHER = t.gettext("Other commands")
+
+
 CLI_HELP_VARIANTS_HEADER = t.gettext("Variants:")
 CLI_FLAGS = t.gettext("Flags")
 CLI_AVAILABLE_COMMANDS = t.gettext("Available Commands")


### PR DESCRIPTION
## Why is this needed?

This PR solves all of our problems because it implements the `help` structure defined for the new UX.

For all other commands we rely on argparse defaults, but for the main --help entry we want to present the available commands in a customized way.

Some commands will have their own categories, and some will not even appear in help.

This is the same as #3240.

## Test Steps
Run help.
There is an integration test to cover the whole thing.

---

- [x] *(un)check this to re-run the checklist action*