### PR TITLE
lintian: adjust overrides for oracular

### DIFF
--- a/debian/ubuntu-advantage-tools.lintian-overrides
+++ b/debian/ubuntu-advantage-tools.lintian-overrides
@@ -10,5 +10,5 @@ ubuntu-advantage-tools: python3-script-but-no-python3-dep
 ubuntu-advantage-tools: possibly-insecure-handling-of-tmp-files-in-maintainer-script /tmp [postinst:61]
 
 # systemctl is the only way to do these calls, and we do the required check before calling it
-ubuntu-advantage-tools: maintainer-script-calls-systemctl [postinst:260]
-ubuntu-advantage-tools: maintainer-script-calls-systemctl [postinst:263]
+ubuntu-advantage-tools: maintainer-script-calls-systemctl [postinst:261]
+ubuntu-advantage-tools: maintainer-script-calls-systemctl [postinst:264]

--- a/debian/ubuntu-pro-client.lintian-overrides
+++ b/debian/ubuntu-pro-client.lintian-overrides
@@ -1,6 +1,3 @@
-# Ubuntu doesn't support sysv init.d
-ubuntu-pro-client: package-supports-alternative-init-but-no-init.d-script
-
 # We have made the decision of delivering those files
 ubuntu-pro-client: package-installs-apt-preferences
 


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
lintian was erroring on oracular builds + had mismatched warning overrides. This fixes that.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
build and run lintian for oracular
<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*