### PR TITLE
api: Do not crash when a Unattended-Upgrade config is missing

### DIFF
--- a/uaclient/api/tests/test_api_u_unattended_upgrades_status_v1.py
+++ b/uaclient/api/tests/test_api_u_unattended_upgrades_status_v1.py
@@ -86,6 +86,19 @@ class TestIsUnattendedUpgradesRunning:
                 True,
                 {
                     "APT::Periodic::Enable": "1",
+                    "APT::Periodic::Update-Package-Lists": None,
+                    "APT::Periodic::Unattended-Upgrade": "1",
+                    "Unattended-Upgrade::Allowed-Origins": ["foo"],
+                },
+                False,
+                UNATTENDED_UPGRADES_CFG_VALUE_TURNED_OFF.format(
+                    cfg_name="APT::Periodic::Update-Package-Lists"
+                ),
+            ),
+            (
+                True,
+                {
+                    "APT::Periodic::Enable": "1",
                     "APT::Periodic::Update-Package-Lists": "1",
                     "APT::Periodic::Unattended-Upgrade": "1",
                     "Unattended-Upgrade::Allowed-Origins": ["foo"],

--- a/uaclient/api/u/unattended_upgrades/status/v1.py
+++ b/uaclient/api/u/unattended_upgrades/status/v1.py
@@ -162,14 +162,14 @@ def _is_unattended_upgrades_running(
 
     for key in UNATTENDED_UPGRADES_CONFIG_KEYS:
         value = unattended_upgrades_cfg.get(key)
-        if not value:
+        if isinstance(value, list) and not value:
             return (
                 False,
                 messages.UNATTENDED_UPGRADES_CFG_LIST_VALUE_EMPTY.format(
                     cfg_name=key
                 ),
             )
-        if isinstance(value, str) and value == "0":
+        if value == "0" or not value:
             return (
                 False,
                 messages.UNATTENDED_UPGRADES_CFG_VALUE_TURNED_OFF.format(
@@ -236,6 +236,11 @@ def _status(cfg: UAConfig) -> UnattendedUpgradesStatusResult:
     # will not be present in APT
     unattended_upgrades_cfg["APT::Periodic::Enable"] = (
         unattended_upgrades_cfg["APT::Periodic::Enable"] or "1"
+    )
+
+    # This should be a list, even if the key is missing.
+    unattended_upgrades_cfg["Unattended-Upgrade::Allowed-Origins"] = (
+        unattended_upgrades_cfg["Unattended-Upgrade::Allowed-Origins"] or []
     )
 
     (

--- a/uaclient/api/u/unattended_upgrades/status/v1.py
+++ b/uaclient/api/u/unattended_upgrades/status/v1.py
@@ -261,13 +261,15 @@ def _status(cfg: UAConfig) -> UnattendedUpgradesStatusResult:
         == "1",
         package_lists_refresh_frequency_days=int(
             unattended_upgrades_cfg.get(  # type: ignore
-                "APT::Periodic::Update-Package-Lists", 0
+                "APT::Periodic::Update-Package-Lists"
             )
+            or 0
         ),
         unattended_upgrades_frequency_days=int(
             unattended_upgrades_cfg.get(  # type: ignore
-                "APT::Periodic::Unattended-Upgrade", 0
+                "APT::Periodic::Unattended-Upgrade"
             )
+            or 0
         ),
         unattended_upgrades_allowed_origins=list(
             unattended_upgrades_cfg.get("Unattended-Upgrade::Allowed-Origins")


### PR DESCRIPTION
## Why is this needed?

The keys in UNATTENDED_UPGRADES_CONFIG_KEYS are considered to be mandatory in order to report unattended-upgrades as enabled.

When parsing the config files, get_apt_config_values will set missing keys to None rather than not populating the dict. Thus unattended_upgrades_cfg.get(key, fallback) for a missing key returns None rather than the fallback. Finally `int(None)` fails.

## Test Steps
```
sudo sed -i "/APT::Periodic::Unattended-Upgrade/s/^/#/" /etc/apt/apt.conf.d/20auto-upgrades
pro api u.unattended_upgrades.status.v1
```
should not fail.


---

- [ ] *(un)check this to re-run the checklist action*