### PR TITLE
d/control: breaks old python3-minimal on noble

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,7 +53,7 @@ Depends: ${misc:Depends},
          python3-pkg-resources,
          ${extra:Depends}
 Recommends: ubuntu-pro-client-l10n
-Breaks: ubuntu-advantage-tools (<<31~)
+Breaks: ubuntu-advantage-tools (<<31~), ${misc:Breaks}
 Replaces: ubuntu-advantage-tools (<<31~)
 # IMPORTANT: ubuntu-pro-client does not "Provide" ubuntu-advantage-tools
 # At the time of the rename, existing releases with ubuntu-advantage-tools

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,8 @@ include /etc/os-release
 
 # see https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/1840091/comments/3
 
+MISC_BREAKS=""
+
 # Bionic and Xenial each have older versions of distro-info that don't support
 # the flag --supported-esm. Those versions are 0.18 and 0.14build1,
 # respectively. So we set specific distro-info requirements for bionic and later
@@ -18,6 +20,10 @@ APT_PKG_DEPS=apt (>= 1.2.32), apt-transport-https (>= 1.2.32), apt-utils (>= 1.2
 DISTRO_INFO_DEPS=distro-info (>= 0.14ubuntu0.2),
 else ifeq (${VERSION_ID},"18.04")
 APT_PKG_DEPS=apt (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11),
+else ifeq (${VERSION_ID},"24.04")
+# Noble python3-minimal has a bug that can break upgrades on systems with non-utf-translations
+# https://bugs.launchpad.net/ubuntu/+source/python3-defaults/+bug/2075337
+MISC_BREAKS=python3-minimal (<< 3.12.3-0ubuntu2~)
 endif
 
 %:
@@ -44,6 +50,7 @@ endif
 
 override_dh_gencontrol:
 	echo "extra:Depends=$(APT_PKG_DEPS) $(DISTRO_INFO_DEPS)" >> debian/ubuntu-pro-client.substvars
+	echo "misc:Breaks=$(MISC_BREAKS)" >> debian/ubuntu-pro-client.substvars
 	dh_gencontrol
 
 override_dh_systemd_enable:


### PR DESCRIPTION
## Why is this needed?

This forces the fix for LP#2075337 to be applied when upgrading to ubuntu-pro-client only on noble.

LP: #2075337


<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because...

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Test that the `debian/control` file for noble has the extra `Breaks` and builds for other releases don't

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [ ] *(un)check this to re-run the checklist action*