### PR TITLE
Remove Mantic from the codebase+tests

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        release: ['xenial', 'bionic', 'focal', 'jammy', 'mantic', 'noble']
+        release: ['xenial', 'bionic', 'focal', 'jammy', 'noble']
     steps:
       - name: Prepare build tools
         env:
@@ -70,7 +70,7 @@ jobs:
       # as much information as possible from them.
       fail-fast: false
       matrix:
-        release: ['bionic', 'focal', 'jammy', 'mantic', 'noble']
+        release: ['bionic', 'focal', 'jammy', 'noble']
         platform: ['lxd-container']
         host_os: ['ubuntu-22.04']
         include:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 [![Released Bionic Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/bionic?label=Bionic&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/bionic/+source/ubuntu-advantage-tools)
 [![Released Focal Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/focal?label=Focal&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/focal/+source/ubuntu-advantage-tools)
 [![Released Jammy Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/jammy?label=Jammy&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/jammy/+source/ubuntu-advantage-tools)
-[![Released Mantic Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/mantic?label=Mantic&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/mantic/+source/ubuntu-advantage-tools)
 [![Released Noble Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/noble?label=Noble&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/noble/+source/ubuntu-advantage-tools)
 [![Released Oracular Version](https://img.shields.io/ubuntu/v/ubuntu-advantage-tools/oracular?label=Oracular&logo=ubuntu&logoColor=white)](https://launchpad.net/ubuntu/oracular/+source/ubuntu-advantage-tools)
 

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -23,73 +23,65 @@ Feature: Pro is expected version
       """
 
     Examples: version
-      | release | machine_type   |
-      | xenial  | lxd-container  |
-      | xenial  | lxd-vm         |
-      | xenial  | aws.generic    |
-      | xenial  | aws.pro        |
-      | xenial  | aws.pro-fips   |
-      | xenial  | azure.generic  |
-      | xenial  | azure.pro      |
-      | xenial  | azure.pro-fips |
-      | xenial  | gcp.generic    |
-      | xenial  | gcp.pro        |
-      | xenial  | gcp.pro-fips   |
-      | bionic  | lxd-container  |
-      | bionic  | lxd-vm         |
-      | bionic  | aws.generic    |
-      | bionic  | aws.pro        |
-      | bionic  | aws.pro-fips   |
-      | bionic  | azure.generic  |
-      | bionic  | azure.pro      |
-      | bionic  | azure.pro-fips |
-      | bionic  | gcp.generic    |
-      | bionic  | gcp.pro        |
-      | bionic  | gcp.pro-fips   |
-      | focal   | lxd-container  |
-      | focal   | lxd-vm         |
-      | focal   | aws.generic    |
-      | focal   | aws.pro        |
-      | focal   | aws.pro-fips   |
-      | focal   | azure.generic  |
-      | focal   | azure.pro      |
-      | focal   | azure.pro-fips |
-      | focal   | gcp.generic    |
-      | focal   | gcp.pro        |
-      | focal   | gcp.pro-fips   |
-      | jammy   | lxd-container  |
-      | jammy   | lxd-vm         |
-      | jammy   | aws.generic    |
-      | jammy   | aws.pro        |
-      | jammy   | aws.pro-fips   |
-      | jammy   | azure.generic  |
-      | jammy   | azure.pro      |
-      | jammy   | azure.pro-fips |
-      | jammy   | gcp.generic    |
-      | jammy   | gcp.pro        |
-      | jammy   | gcp.pro-fips   |
-      | mantic  | lxd-container  |
-      | mantic  | lxd-vm         |
-      | mantic  | aws.generic    |
-      | mantic  | aws.pro        |
-      | mantic  | aws.pro-fips   |
-      | mantic  | azure.generic  |
-      | mantic  | azure.pro      |
-      | mantic  | azure.pro-fips |
-      | mantic  | gcp.generic    |
-      | mantic  | gcp.pro        |
-      | mantic  | gcp.pro-fips   |
-      | noble   | lxd-container  |
-      | noble   | lxd-vm         |
-      | noble   | aws.generic    |
-      | noble   | aws.pro        |
-      | noble   | aws.pro-fips   |
-      | noble   | azure.generic  |
-      | noble   | azure.pro      |
-      | noble   | azure.pro-fips |
-      | noble   | gcp.generic    |
-      | noble   | gcp.pro        |
-      | noble   | gcp.pro-fips   |
+      | release  | machine_type   |
+      | xenial   | lxd-container  |
+      | xenial   | lxd-vm         |
+      | xenial   | aws.generic    |
+      | xenial   | aws.pro        |
+      | xenial   | aws.pro-fips   |
+      | xenial   | azure.generic  |
+      | xenial   | azure.pro      |
+      | xenial   | azure.pro-fips |
+      | xenial   | gcp.generic    |
+      | xenial   | gcp.pro        |
+      | xenial   | gcp.pro-fips   |
+      | bionic   | lxd-container  |
+      | bionic   | lxd-vm         |
+      | bionic   | aws.generic    |
+      | bionic   | aws.pro        |
+      | bionic   | aws.pro-fips   |
+      | bionic   | azure.generic  |
+      | bionic   | azure.pro      |
+      | bionic   | azure.pro-fips |
+      | bionic   | gcp.generic    |
+      | bionic   | gcp.pro        |
+      | bionic   | gcp.pro-fips   |
+      | focal    | lxd-container  |
+      | focal    | lxd-vm         |
+      | focal    | aws.generic    |
+      | focal    | aws.pro        |
+      | focal    | aws.pro-fips   |
+      | focal    | azure.generic  |
+      | focal    | azure.pro      |
+      | focal    | azure.pro-fips |
+      | focal    | gcp.generic    |
+      | focal    | gcp.pro        |
+      | focal    | gcp.pro-fips   |
+      | jammy    | lxd-container  |
+      | jammy    | lxd-vm         |
+      | jammy    | aws.generic    |
+      | jammy    | aws.pro        |
+      | jammy    | aws.pro-fips   |
+      | jammy    | azure.generic  |
+      | jammy    | azure.pro      |
+      | jammy    | azure.pro-fips |
+      | jammy    | gcp.generic    |
+      | jammy    | gcp.pro        |
+      | jammy    | gcp.pro-fips   |
+      | noble    | lxd-container  |
+      | noble    | lxd-vm         |
+      | noble    | aws.generic    |
+      | noble    | aws.pro        |
+      | noble    | aws.pro-fips   |
+      | noble    | azure.generic  |
+      | noble    | azure.pro      |
+      | noble    | azure.pro-fips |
+      | noble    | gcp.generic    |
+      | noble    | gcp.pro        |
+      | noble    | gcp.pro-fips   |
+      # no oracular on clouds yet - add it when those are available
+      | oracular | lxd-container  |
+      | oracular | lxd-vm         |
 
   @uses.config.check_version @upgrade
   Scenario Outline: Check pro version
@@ -114,13 +106,13 @@ Feature: Pro is expected version
       """
 
     Examples: version
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: Attached show version in a ubuntu machine
@@ -136,13 +128,13 @@ Feature: Pro is expected version
     Then I will see the uaclient version on stdout
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Check for newer versions of the client in an ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -218,10 +210,10 @@ Feature: Pro is expected version
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/api/api.feature
+++ b/features/api/api.feature
@@ -26,13 +26,13 @@ Feature: Client behaviour for the API endpoints
     When I run `python3 -c "from uaclient.api.u.pro.detach.v1 import detach"` as non-root
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: API invalid endpoint or args
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -75,13 +75,13 @@ Feature: Client behaviour for the API endpoints
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Basic endpoints
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -167,13 +167,13 @@ Feature: Client behaviour for the API endpoints
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: u.pro.status.is_attached.v1
@@ -279,10 +279,10 @@ Feature: Client behaviour for the API endpoints
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/api/enable.feature
+++ b/features/api/enable.feature
@@ -166,8 +166,9 @@ Feature: u.pro.services.enable
       """
 
     Examples:
-      | release | machine_type  |
-      | mantic  | lxd-container |
+      | release  | machine_type  |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: u.pro.services.enable.v1 vm services
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/api/fix_plan.feature
+++ b/features/api/fix_plan.feature
@@ -3011,5 +3011,5 @@ Feature: Fix plan API endpoints
       """
 
     Examples: ubuntu release details
-      | release | machine_type |
-      | mantic  | lxd-vm       |
+      | release  | machine_type |
+      | oracular | lxd-vm       |

--- a/features/api/packages.feature
+++ b/features/api/packages.feature
@@ -54,4 +54,5 @@ Feature: Package related API endpoints
       | focal   | wsl           | libcurl4        | 7.68.0-1ubuntu2  | standard-security |
       | jammy   | lxd-container | libcurl4        | 7.81.0-1         | standard-security |
       | jammy   | wsl           | libcurl4        | 7.81.0-1         | standard-security |
-      | mantic  | lxd-container | libcurl4        | 8.2.1-1ubuntu3   | standard-security |
+
+# TODO: add noble/oracular?

--- a/features/api/services_dependencies.feature
+++ b/features/api/services_dependencies.feature
@@ -365,9 +365,10 @@ Feature: u.pro.services.dependencies
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/api/unattended_upgrades.feature
+++ b/features/api/unattended_upgrades.feature
@@ -247,10 +247,10 @@ Feature: api.u.unattended_upgrades.status.v1
       """
 
     Examples: ubuntu release
-      | release | machine_type  | extra_field                                  |
-      | xenial  | lxd-container |                                              |
-      | bionic  | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "false" |
-      | focal   | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
-      | jammy   | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
-      | mantic  | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
-      | noble   | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
+      | release  | machine_type  | extra_field                                  |
+      | xenial   | lxd-container |                                              |
+      | bionic   | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "false" |
+      | focal    | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
+      | jammy    | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
+      | noble    | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
+      | oracular | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |

--- a/features/autocomplete.feature
+++ b/features/autocomplete.feature
@@ -56,10 +56,10 @@ Feature: Pro autocomplete commands
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
+      | release  | machine_type  |
       # | xenial  | lxd-container | Can't rely on Xenial because of bash sorting things weirdly
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/cc_eal.feature
+++ b/features/cc_eal.feature
@@ -64,7 +64,8 @@ Feature: Enable cc-eal on Ubuntu
       """
 
     Examples: ubuntu release
-      | release | machine_type  | version   | full_name       |
-      | focal   | lxd-container | 20.04 LTS | Focal Fossa     |
-      | jammy   | lxd-container | 22.04 LTS | Jammy Jellyfish |
-      | mantic  | lxd-container | 23.10     | Mantic Minotaur |
+      | release  | machine_type  | version   | full_name       |
+      | focal    | lxd-container | 20.04 LTS | Focal Fossa     |
+      | jammy    | lxd-container | 22.04 LTS | Jammy Jellyfish |
+      | noble    | lxd-container | 24.04 LTS | Noble Numbat    |
+      | oracular | lxd-container | 24.10     | Oracular Oriole |

--- a/features/cli/attach.feature
+++ b/features/cli/attach.feature
@@ -1,41 +1,41 @@
 @uses.config.contract_token
 Feature: CLI attach command
 
-  Scenario Outline: Attached command in a non-lts ubuntu machine
-    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-    When I attach `contract_token` with sudo
-    And I run `pro status` as non-root
-    Then stdout matches regexp:
-      """
-      <status_string>
-      """
-    And stdout matches regexp:
-      """
-      For a list of all Ubuntu Pro services, run 'pro status --all'
-      """
-    When I run `pro status --all` as non-root
-    Then stdout matches regexp:
-      """
-      SERVICE       +ENTITLED +STATUS   +DESCRIPTION
-      anbox-cloud   +yes      +n/a      +.*
-      cc-eal        +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
-      cis           +yes      +n/a      +Security compliance and audit tools
-      esm-apps      +yes      +n/a      +Expanded Security Maintenance for Applications
-      esm-infra     +yes      +n/a      +Expanded Security Maintenance for Infrastructure
-      fips          +yes      +n/a      +NIST-certified FIPS crypto packages
-      fips-preview  +yes      +n/a      +.*
-      fips-updates  +yes      +n/a      +FIPS compliant crypto packages with stable security updates
-      landscape     +yes      +<landscape>      +Management and administration tool for Ubuntu
-      livepatch     +yes      +n/a      +Canonical Livepatch service
-      """
-    And stdout does not match regexp:
-      """
-      For a list of all Ubuntu Pro services, run 'pro status --all'
-      """
-
-    Examples: ubuntu release
-      | release | machine_type  | landscape | status_string                                                           |
-      | mantic  | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
+  # To be uncommented when Oracular backend definitions are done (at least for landscape)
+  # Scenario Outline: Attached command in a non-lts ubuntu machine
+  # Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+  # When I attach `contract_token` with sudo
+  # And I run `pro status` as non-root
+  # Then stdout matches regexp:
+  # """
+  # <status_string>
+  # """
+  # And stdout matches regexp:
+  # """
+  # For a list of all Ubuntu Pro services, run 'pro status --all'
+  # """
+  # When I run `pro status --all` as non-root
+  # Then stdout matches regexp:
+  # """
+  # SERVICE       +ENTITLED +STATUS   +DESCRIPTION
+  # anbox-cloud   +yes      +n/a      +.*
+  # cc-eal        +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
+  # cis           +yes      +n/a      +Security compliance and audit tools
+  # esm-apps      +yes      +n/a      +Expanded Security Maintenance for Applications
+  # esm-infra     +yes      +n/a      +Expanded Security Maintenance for Infrastructure
+  # fips          +yes      +n/a      +NIST-certified FIPS crypto packages
+  # fips-preview  +yes      +n/a      +.*
+  # fips-updates  +yes      +n/a      +FIPS compliant crypto packages with stable security updates
+  # landscape     +yes      +<landscape>      +Management and administration tool for Ubuntu
+  # livepatch     +yes      +n/a      +Canonical Livepatch service
+  # """
+  # And stdout does not match regexp:
+  # """
+  # For a list of all Ubuntu Pro services, run 'pro status --all'
+  # """
+  # Examples: ubuntu release
+  # | release  | machine_type  | landscape | status_string                                                           |
+  # | oracular | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
 
   Scenario Outline: Attach command with attach config
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -341,13 +341,13 @@ Feature: CLI attach command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   @uses.config.contract_token_staging_expired
   Scenario Outline: Attach command failure on expired token
@@ -387,13 +387,13 @@ Feature: CLI attach command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Attach operation on a lxd vm
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/auto_attach.feature
+++ b/features/cli/auto_attach.feature
@@ -28,13 +28,13 @@ Feature: CLI auto-attach command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -57,10 +57,10 @@ Feature: CLI auto-attach command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/cli/collect_logs.feature
+++ b/features/cli/collect_logs.feature
@@ -39,13 +39,13 @@ Feature: CLI collect-logs command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: Run collect-logs on an attached machine

--- a/features/cli/config.feature
+++ b/features/cli/config.feature
@@ -47,8 +47,8 @@ Feature: CLI config command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/cli/detach.feature
+++ b/features/cli/detach.feature
@@ -159,13 +159,13 @@ Feature: CLI detach command
       """
 
     Examples: pro commands
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | bionic  | wsl           |
-      | focal   | lxd-container |
-      | focal   | wsl           |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | jammy   | wsl           |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | bionic   | wsl           |
+      | focal    | lxd-container |
+      | focal    | wsl           |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | jammy    | wsl           |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/cli/disable.feature
+++ b/features/cli/disable.feature
@@ -470,13 +470,13 @@ Feature: CLI disable command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | bionic  | wsl           |
-      | focal   | lxd-container |
-      | focal   | wsl           |
-      | jammy   | lxd-container |
-      | jammy   | wsl           |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | bionic   | wsl           |
+      | focal    | lxd-container |
+      | focal    | wsl           |
+      | jammy    | lxd-container |
+      | jammy    | wsl           |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/cli/enable.feature
+++ b/features/cli/enable.feature
@@ -619,13 +619,13 @@ Feature: CLI enable command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | bionic  | wsl           |
-      | focal   | lxd-container |
-      | focal   | wsl           |
-      | jammy   | lxd-container |
-      | jammy   | wsl           |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | bionic   | wsl           |
+      | focal    | lxd-container |
+      | focal    | wsl           |
+      | jammy    | lxd-container |
+      | jammy    | wsl           |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -433,13 +433,13 @@ Feature: Pro Client help text
       """
 
     Examples: ubuntu release
-      | release | machine_type  | infra-status |
-      | bionic  | lxd-container | enabled      |
-      | xenial  | lxd-container | enabled      |
-      | focal   | lxd-container | enabled      |
-      | jammy   | lxd-container | enabled      |
-      | mantic  | lxd-container | n/a          |
-      | noble   | lxd-container | enabled      |
+      | release  | machine_type  | infra-status |
+      | bionic   | lxd-container | enabled      |
+      | xenial   | lxd-container | enabled      |
+      | focal    | lxd-container | enabled      |
+      | jammy    | lxd-container | enabled      |
+      | noble    | lxd-container | enabled      |
+      | oracular | lxd-container | n/a          |
 
   Scenario Outline: Help command on an unattached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -478,13 +478,13 @@ Feature: Pro Client help text
       """
 
     Examples: ubuntu release
-      | release | machine_type  | infra-available |
-      | xenial  | lxd-container | yes             |
-      | bionic  | lxd-container | yes             |
-      | bionic  | wsl           | yes             |
-      | focal   | lxd-container | yes             |
-      | focal   | wsl           | yes             |
-      | jammy   | lxd-container | yes             |
-      | jammy   | wsl           | yes             |
-      | mantic  | lxd-container | no              |
-      | noble   | lxd-container | yes             |
+      | release  | machine_type  | infra-available |
+      | xenial   | lxd-container | yes             |
+      | bionic   | lxd-container | yes             |
+      | bionic   | wsl           | yes             |
+      | focal    | lxd-container | yes             |
+      | focal    | wsl           | yes             |
+      | jammy    | lxd-container | yes             |
+      | jammy    | wsl           | yes             |
+      | noble    | lxd-container | yes             |
+      | oracular | lxd-container | no              |

--- a/features/cli/refresh.feature
+++ b/features/cli/refresh.feature
@@ -36,16 +36,16 @@ Feature: CLI refresh command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | bionic  | wsl           |
-      | focal   | lxd-container |
-      | focal   | wsl           |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | jammy   | wsl           |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | bionic   | wsl           |
+      | focal    | lxd-container |
+      | focal    | wsl           |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | jammy    | wsl           |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -62,13 +62,13 @@ Feature: CLI refresh command
       """
 
     Examples: pro commands
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | bionic  | wsl           |
-      | focal   | lxd-container |
-      | focal   | wsl           |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | jammy   | wsl           |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | bionic   | wsl           |
+      | focal    | lxd-container |
+      | focal    | wsl           |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | jammy    | wsl           |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/cli/security_status.feature
+++ b/features/cli/security_status.feature
@@ -772,8 +772,8 @@ Feature: CLI security-status command
       | focal   | wsl           |
 
   # Latest released non-LTS
-  Scenario: Run security status in an Ubuntu machine
-    Given a `mantic` `lxd-container` machine with ubuntu-advantage-tools installed
+  Scenario Outline: Run security status in an Ubuntu machine
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I install third-party / unknown packages in the machine
     # Ansible is in esm-apps
     And I apt install `ansible`
@@ -791,7 +791,7 @@ Feature: CLI security-status command
           pro security-status --help
       for a list of available options\.
 
-      Main/Restricted packages receive updates until 7/2024\.
+      Main/Restricted packages receive updates until 7/2025\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
@@ -802,7 +802,7 @@ Feature: CLI security-status command
       \d+ packages installed:
        +\d+ packages from Ubuntu Main/Restricted repository
 
-      Main/Restricted packages receive updates until 7/2024\.
+      Main/Restricted packages receive updates until 7/2025\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
@@ -833,7 +833,7 @@ Feature: CLI security-status command
           sudo apt update
       to get the latest package information from apt\.
 
-      Main/Restricted packages receive updates until 7/2024\.
+      Main/Restricted packages receive updates until 7/2025\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
@@ -855,10 +855,14 @@ Feature: CLI security-status command
           sudo apt update
       to get the latest package information from apt\.
 
-      Main/Restricted packages receive updates until 7/2024\.
+      Main/Restricted packages receive updates until 7/2025\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
+
+    Examples: ubuntu release
+      | release  | machine_type  |
+      | oracular | lxd-container |
 
   Scenario Outline: Pass custom APT configuration to the Client for updates information
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -69,13 +69,13 @@ Feature: CLI status command
     And I verify that `/var/lib/ubuntu-advantage/status.json` is owned by `root:root` with permission `644`
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: Non-root status can see in-progress operations
@@ -521,13 +521,13 @@ Feature: CLI status command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Unattached status in a ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -1190,12 +1190,13 @@ Feature: CLI status command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Warn users not to redirect/pipe human readable output
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -1283,10 +1284,10 @@ Feature: CLI status command
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -10,12 +10,12 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       """
 
     Examples: version
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: cloud-id-shim should run in postinst and on boot
@@ -270,29 +270,28 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | jammy   | azure.generic |
       | noble   | azure.generic |
 
-  @uses.config.contract_token
-  Scenario Outline: daemon does not start on gcp,azure generic non lts
-    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-    When I wait `1` seconds
-    When I run `journalctl -o cat -u ubuntu-advantage.service` with sudo
-    Then stdout contains substring:
-      """
-      daemon starting
-      """
-    Then stdout contains substring:
-      """
-      Not on LTS, shutting down
-      """
-    Then stdout contains substring:
-      """
-      daemon ending
-      """
-
-    Examples: version
-      | release | machine_type  |
-      | mantic  | azure.generic |
-      | mantic  | gcp.generic   |
-
+  # Not available yet - uncomment when oracular is in the clouds
+  # @uses.config.contract_token
+  # Scenario Outline: daemon does not start on gcp,azure generic non lts
+  # Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+  # When I wait `1` seconds
+  # When I run `journalctl -o cat -u ubuntu-advantage.service` with sudo
+  # Then stdout contains substring:
+  # """
+  # daemon starting
+  # """
+  # Then stdout contains substring:
+  # """
+  # Not on LTS, shutting down
+  # """
+  # Then stdout contains substring:
+  # """
+  # daemon ending
+  # """
+  # Examples: version
+  # | release  | machine_type  |
+  # | oracular | azure.generic |
+  # | oracular | gcp.generic   |
   @uses.config.contract_token
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -313,25 +312,25 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       """
 
     Examples: version
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | xenial  | lxd-vm        |
-      | xenial  | aws.generic   |
-      | bionic  | lxd-container |
-      | bionic  | lxd-vm        |
-      | bionic  | aws.generic   |
-      | focal   | lxd-container |
-      | focal   | lxd-vm        |
-      | focal   | aws.generic   |
-      | jammy   | lxd-container |
-      | jammy   | lxd-vm        |
-      | jammy   | aws.generic   |
-      | mantic  | lxd-container |
-      | mantic  | lxd-vm        |
-      | mantic  | aws.generic   |
-      | noble   | lxd-container |
-      | noble   | lxd-vm        |
-      | noble   | aws.generic   |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | xenial   | lxd-vm        |
+      | xenial   | aws.generic   |
+      | bionic   | lxd-container |
+      | bionic   | lxd-vm        |
+      | bionic   | aws.generic   |
+      | focal    | lxd-container |
+      | focal    | lxd-vm        |
+      | focal    | aws.generic   |
+      | jammy    | lxd-container |
+      | jammy    | lxd-vm        |
+      | jammy    | aws.generic   |
+      | noble    | lxd-container |
+      | noble    | lxd-vm        |
+      | noble    | aws.generic   |
+      # | oracular | aws.generic   | - not there yet
+      | oracular | lxd-container |
+      | oracular | lxd-vm        |
 
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/docker.feature
+++ b/features/docker.feature
@@ -65,13 +65,13 @@ Feature: Build docker images with pro services
     Then I verify that running `DOCKER_BUILDKIT=1 docker build . --no-cache --secret id=ua-attach-config,src=ua-attach-config.yaml -t ua-test` `with sudo` exits `1`
 
     Examples: ubuntu release
-      | release | machine_type | container_release | enable_services | test_package_name | test_package_version |
-      | mantic  | lxd-vm       | xenial            | [ esm-infra ]   | curl              | esm                  |
-      | mantic  | lxd-vm       | bionic            | [ fips ]        | openssl           | fips                 |
-      | mantic  | lxd-vm       | focal             | [ esm-apps ]    | hello             | esm                  |
-      | noble   | lxd-vm       | xenial            | [ esm-infra ]   | curl              | esm                  |
-      | noble   | lxd-vm       | bionic            | [ fips ]        | openssl           | fips                 |
-      | noble   | lxd-vm       | focal             | [ esm-apps ]    | hello             | esm                  |
+      | release  | machine_type | container_release | enable_services | test_package_name | test_package_version |
+      | noble    | lxd-vm       | xenial            | [ esm-infra ]   | curl              | esm                  |
+      | noble    | lxd-vm       | bionic            | [ fips ]        | openssl           | fips                 |
+      | noble    | lxd-vm       | focal             | [ esm-apps ]    | hello             | esm                  |
+      | oracular | lxd-vm       | xenial            | [ esm-infra ]   | curl              | esm                  |
+      | oracular | lxd-vm       | bionic            | [ fips ]        | openssl           | fips                 |
+      | oracular | lxd-vm       | focal             | [ esm-apps ]    | hello             | esm                  |
 
   Scenario Outline: Build pro docker images auto-attached instances - settings_overrides method
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -22,13 +22,13 @@ Feature: Ua fix command behaviour
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Fix command on an unattached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -62,8 +62,8 @@ Feature: Pro supports multiple languages
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | mantic  | lxd-container |
+      | release  | machine_type  |
+      | oracular | lxd-container |
 
   # Note: Translations do work on xenial, but our test environment triggers a bug in python that
   # causes it to think we're in an ascii-only environment
@@ -221,12 +221,13 @@ Feature: Pro supports multiple languages
     Then I will see the uaclient version on stdout
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: Pro client's commands run successfully in a non-utf8 locale
@@ -278,10 +279,10 @@ Feature: Pro supports multiple languages
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -6,13 +6,13 @@ Feature: Pro Install and Uninstall related tests
     Then I verify that running `dpkg-reconfigure <pkg_name>` `with sudo` exits `0`
 
     Examples: ubuntu release
-      | release | machine_type  | pkg_name               |
-      | xenial  | lxd-container | ubuntu-advantage-tools |
-      | bionic  | lxd-container | ubuntu-advantage-tools |
-      | focal   | lxd-container | ubuntu-advantage-tools |
-      | jammy   | lxd-container | ubuntu-advantage-tools |
-      | mantic  | lxd-container | ubuntu-advantage-tools |
-      | noble   | lxd-container | ubuntu-pro-client      |
+      | release  | machine_type  | pkg_name               |
+      | xenial   | lxd-container | ubuntu-advantage-tools |
+      | bionic   | lxd-container | ubuntu-advantage-tools |
+      | focal    | lxd-container | ubuntu-advantage-tools |
+      | jammy    | lxd-container | ubuntu-advantage-tools |
+      | noble    | lxd-container | ubuntu-pro-client      |
+      | oracular | lxd-container | ubuntu-pro-client      |
 
   @uses.config.contract_token
   Scenario Outline: Purge package after attaching it to a machine
@@ -122,13 +122,13 @@ Feature: Pro Install and Uninstall related tests
     Then I verify that `ubuntu-advantage-tools` is installed
 
     Examples: ubuntu release
-      | release | machine_type  | user_data_field  |
-      | xenial  | lxd-container | ubuntu-advantage |
-      | bionic  | lxd-container | ubuntu_advantage |
-      | focal   | lxd-container | ubuntu_advantage |
-      | jammy   | lxd-container | ubuntu_advantage |
-      | mantic  | lxd-container | ubuntu_advantage |
-      | noble   | lxd-container | ubuntu_pro       |
+      | release  | machine_type  | user_data_field  |
+      | xenial   | lxd-container | ubuntu-advantage |
+      | bionic   | lxd-container | ubuntu_advantage |
+      | focal    | lxd-container | ubuntu_advantage |
+      | jammy    | lxd-container | ubuntu_advantage |
+      | noble    | lxd-container | ubuntu_pro       |
+      | oracular | lxd-container | ubuntu_pro       |
 
   @uses.config.contract_token
   Scenario Outline: Create public machine token on postinst

--- a/features/landscape.feature
+++ b/features/landscape.feature
@@ -103,7 +103,7 @@ Feature: Enable landscape on Ubuntu
 
     Examples: ubuntu release
       | release | machine_type  |
-      | mantic  | lxd-container |
+      # | oracular | lxd-container | - not yet in the backend
       | noble   | lxd-container |
 
   Scenario Outline: Enable Landscape interactively
@@ -178,7 +178,7 @@ Feature: Enable landscape on Ubuntu
 
     Examples: ubuntu release
       | release | machine_type  |
-      | mantic  | lxd-container |
+      # | oracular | lxd-container | - not yet in the backend
       | noble   | lxd-container |
 
   Scenario Outline: Easily re-enable Landscape non-interactively after a disable
@@ -265,7 +265,7 @@ Feature: Enable landscape on Ubuntu
 
     Examples: ubuntu release
       | release | machine_type  |
-      | mantic  | lxd-container |
+      # | oracular | lxd-container | - not yet in the backend
       | noble   | lxd-container |
 
   Scenario Outline: Detaching/reattaching on an unsupported release does not affect landscape

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -191,8 +191,8 @@ Feature: Livepatch
       """
 
     Examples: ubuntu release
-      | release | machine_type | pretty_name             |
-      | mantic  | lxd-vm       | 23.10 (Mantic Minotaur) |
+      | release  | machine_type | pretty_name             |
+      | oracular | lxd-vm       | 24.10 (Oracular Oriole) |
 
   Scenario Outline: Livepatch is supported on interim HWE kernel
     # This test is intended to ensure that an interim HWE kernel has the correct support status

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -20,13 +20,13 @@ Feature: Logs in Json Array Formatter
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Non-root user and root user log files are different
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -53,13 +53,13 @@ Feature: Logs in Json Array Formatter
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Non-root user log files included in collect logs
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -79,13 +79,13 @@ Feature: Logs in Json Array Formatter
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: logrotate configuration works
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -128,9 +128,10 @@ Feature: Logs in Json Array Formatter
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -12,11 +12,11 @@ Feature: Timer for regular background jobs while attached
     Then I verify the `ua-timer` systemd timer is disabled
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Run timer script on an attached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -86,14 +86,14 @@ Feature: Timer for regular background jobs while attached
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | bionic  | wsl           |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | mantic  | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | bionic   | wsl           |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | oracular | lxd-container |
 
   Scenario Outline: Run timer script to validate machine activity endpoint
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -41,7 +41,7 @@ Feature: Upgrade between releases when uaclient is unattached
     And I verify that the folder `/var/lib/ubuntu-advantage/apt-esm` does not exist
     When I apt update
     And I run shell command `cat /var/lib/ubuntu-advantage/apt-esm/etc/apt/sources.list.d/ubuntu-esm-apps.sources || true` with sudo
-    Then if `<next_release>` not in `mantic or noble` and stdout matches regexp:
+    Then if `<next_release>` not in `noble` and stdout matches regexp:
       """
       Types: deb
       URIs: https://esm.ubuntu.com/apps/ubuntu

--- a/features/yaml.feature
+++ b/features/yaml.feature
@@ -30,7 +30,7 @@ Feature: YAML related interactions with Pro client
       esm-cache.service
       """
     When I apt install `python3-pip`
-    And I run `pip3 install pyyaml==3.10 <suffix>` with sudo
+    And I run `pip3 install pyyaml==3.10` with sudo
     And I run `ls /usr/local/lib/<python_version>/dist-packages/` with sudo
     Then stdout matches regexp:
       """
@@ -64,10 +64,5 @@ Feature: YAML related interactions with Pro client
       """
 
     Examples: ubuntu release
-      | release | machine_type  | python_version | suffix                  |
-      | jammy   | lxd-container | python3.10     |                         |
-      # mantic has a BIG error message explaining why this is a clear user error...
-      | mantic  | lxd-container | python3.11     | --break-system-packages |
-
-# noble doesn't even allow --break-system-packages to work
-# | noble   | lxd-container | python3.11     | --break-system-packages |
+      | release | machine_type  | python_version |
+      | jammy   | lxd-container | python3.10     |

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -12,6 +12,5 @@ pytest-cov
 # fixme: This may cause weird behavior in the future, or even break, if
 # two releases have the same python_version.
 git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/jammy-updates ; python_version == '3.10'
-git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/mantic ; python_version == '3.11'
 # need to keep an aye to bump this when python-apt is in noble-updates
 git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/noble ; python_version == '3.12'

--- a/tools/create-gh-release-branches.sh
+++ b/tools/create-gh-release-branches.sh
@@ -42,7 +42,6 @@ do
       bionic) version=${PRO_VERSION}~18.04;;
       focal) version=${PRO_VERSION}~20.04;;
       jammy) version=${PRO_VERSION}~22.04;;
-      mantic) version=${PRO_VERSION}~23.10;;
       noble) version=${PRO_VERSION}~24.04;;
   esac
   dch_cmd=(dch -m -v "${version}" -D "${release}" -b  "Backport $PRO_VERSION to $release (LP: #${SRU_BUG})")

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -60,7 +60,7 @@ APT_PROXY_CONF_FILE = "/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy"
 
 APT_UPDATE_SUCCESS_STAMP_PATH = "/var/lib/apt/periodic/update-success-stamp"
 
-SERIES_NOT_USING_DEB822 = ("xenial", "bionic", "focal", "jammy", "mantic")
+SERIES_NOT_USING_DEB822 = ("xenial", "bionic", "focal", "jammy")
 
 DEB822_REPO_FILE_CONTENT = """\
 # Written by ubuntu-pro-client

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -290,6 +290,13 @@ def get_apt_pkg_cache():
 
 def get_esm_apt_pkg_cache():
     try:
+        # If the rootdir folder doesn't contain any apt source info, the
+        # cache will be empty
+        # apt_pkg recently changed behvior: when the cache structure isn't
+        # present, instead of having an exception raised we only get a
+        # stderr warning. So we need to ensure all is there, our side.
+        _ensure_esm_cache_structure()
+
         # Take care to initialize the cache with only the
         # Acquire configuration preserved
         for key in apt_pkg.config.keys():
@@ -297,12 +304,10 @@ def get_esm_apt_pkg_cache():
                 apt_pkg.config.clear(key)
         apt_pkg.config.set("Dir", ESM_APT_ROOTDIR)
         apt_pkg.init()
-        # If the rootdir folder doesn't contain any apt source info, the
-        # cache will be empty
-        # If the structure in the rootdir folder does not exist or is
-        # incorrect, an exception will be raised
+
         return apt_pkg.Cache(None)
     except Exception:
+        # We don't mind if there is any exception while trying to get the cache
         # The empty dictionary will act as an empty cache
         return {}
 

--- a/uaclient/upgrade_lts_contract.py
+++ b/uaclient/upgrade_lts_contract.py
@@ -42,8 +42,8 @@ current_codename_to_past_codename = {
     "bionic": "xenial",
     "focal": "bionic",
     "jammy": "focal",
-    "mantic": "lunar",
     "noble": "jammy",
+    "oracular": "noble",
 }
 
 LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because mantic is EOL and we want to remove it. To cover the gap left behind, some tests got noble and some tests got oracular versions instead.

To sort out some tests, this
Fixes: #3132

## Test Steps
All about integration tests here - every new added noble/oracular test should pass.

---

- [ ] *(un)check this to re-run the checklist action*