### PR TITLE
tests: change how to disable network on airgapped

### DIFF
--- a/features/steps/network.py
+++ b/features/steps/network.py
@@ -18,62 +18,14 @@ def block_access_to_address(context, website):
 def disable_internet_connection(context, machine_name=SUT):
     when_i_run_command(
         context,
-        "ufw default deny incoming",
+        "ip route del default",
         "with sudo",
         machine_name=machine_name,
     )
+
     when_i_run_command(
         context,
-        "ufw default deny outgoing",
-        "with sudo",
-        machine_name=machine_name,
-    )
-    when_i_run_command(
-        context,
-        "ufw allow from 10.0.0.0/8",
-        "with sudo",
-        machine_name=machine_name,
-    )
-    when_i_run_command(
-        context,
-        "ufw allow from 172.16.0.0/12",
-        "with sudo",
-        machine_name=machine_name,
-    )
-    when_i_run_command(
-        context,
-        "ufw allow from 192.168.0.0/16",
-        "with sudo",
-        machine_name=machine_name,
-    )
-    when_i_run_command(
-        context,
-        "ufw allow out to 10.0.0.0/8",
-        "with sudo",
-        machine_name=machine_name,
-    )
-    when_i_run_command(
-        context,
-        "ufw allow out to 172.16.0.0/12",
-        "with sudo",
-        machine_name=machine_name,
-    )
-    when_i_run_command(
-        context,
-        "ufw allow out to 192.168.0.0/16",
-        "with sudo",
-        machine_name=machine_name,
-    )
-    when_i_run_command(
-        context, "ufw allow ssh", "with sudo", machine_name=machine_name
-    )
-    # We expect DNS to be working, but don't really want to set a server up...
-    when_i_run_command(
-        context, "ufw allow out 53", "with sudo", machine_name=machine_name
-    )
-    when_i_run_command(
-        context,
-        "ufw --force enable",
+        "sed -i '$ a precedence ::ffff:0:0/96  100' /etc/gai.conf",
         "with sudo",
         machine_name=machine_name,
     )


### PR DESCRIPTION
## Why is this needed?
Change how we disable the network connection on the airgapped container, since the ufw approach was occasionally hanging in CI

## Test Steps
Check that the airgapped container cannot reach the network and check that the airgapped tests keep working and no longer hangs on CI

- [ ] *(un)check this to re-run the checklist action*