### PR TITLE
d/rules: check version consistency at build time

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -30,16 +30,16 @@ endif
 	dh $@ --with python3,bash-completion,systemd --buildsystem=pybuild
 
 override_dh_auto_build:
+	# fail early if version.py wasn't updated to match d/changelog's version
+	# only take into account the actual upstream version, discarding ubuntu and
+	# backport suffixes
+	python3 tools/check-versions-are-consistent.py
 	dh_auto_build
 	make -C apt-hook build
 	make -C debian/po build
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	# fail early if version.py wasn't updated to match d/changelog's version
-	# only take into account the actual upstream version, discarding ubuntu and
-	# backport suffixes
-	python3 tools/check-versions-are-consistent.py
 # Hooks will only be delivered on LTS instances
 ifeq (LTS,$(findstring LTS,$(VERSION)))
 	make -C apt-hook test


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This addresses v34 feedback described here: https://github.com/canonical/ubuntu-pro-client/pull/3247#discussion_r1710257188

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Make a temporary change to either the changelog version or version.py version and run
```
./tools/build.sh xenial
```

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [ ] *(un)check this to re-run the checklist action*