### PR TITLE
Better secret cleanup instructions in docker docs

### DIFF
--- a/docs/howtoguides/enable_in_dockerfile.rst
+++ b/docs/howtoguides/enable_in_dockerfile.rst
@@ -116,14 +116,15 @@ inline comments explaining each line:
       # services, we can clean up.
       ###########################################################################
       #
-      # This purges ubuntu-pro-client, including all Ubuntu Pro related
-      # secrets from the system.
+      # This detaches and purges ubuntu-pro-client, including all Ubuntu Pro
+      # related secrets from the system.
       ###########################################################################
       # IMPORTANT: As written here, this command assumes your container does not
       # need ca-certificates so it is purged as well.
       # If your container needs ca-certificates, then do not purge it from the
       # system here.
       ###########################################################################
+      && pro detach --assume-yes
       && apt-get purge --auto-remove -y ubuntu-pro-client ca-certificates \
       #
       # Finally, we clean up the apt lists which should not be needed anymore

--- a/docs/howtoguides/enable_in_dockerfile.rst
+++ b/docs/howtoguides/enable_in_dockerfile.rst
@@ -19,16 +19,16 @@ check the version you are running with the following command:
 
     pro version
 
-If you're on a version lower than 27.7, you can update it by running: 
+If you're on a version lower than 27.7, you can update it by running:
 
 .. code-block:: bash
 
-    sudo apt update && sudo apt install ubuntu-advantage-tools
+    sudo apt update && sudo apt install ubuntu-pro-client
 
 Create an Ubuntu Pro Attach Config file
 =======================================
 
-.. attention:: 
+.. attention::
 
    The Ubuntu Pro Attach Config file will contain your Ubuntu Pro Contract
    token and should be treated as a secret file.
@@ -86,9 +86,9 @@ inline comments explaining each line:
       # the next step
       apt-get update \
       #
-      # Here we install `pro` (ubuntu-advantage-tools) as well as ca-certificates,
+      # Here we install `pro` (ubuntu-pro-client) as well as ca-certificates,
       # which is required to talk to the Ubuntu Pro authentication server securely.
-      && apt-get install --no-install-recommends -y ubuntu-advantage-tools ca-certificates \
+      && apt-get install --no-install-recommends -y ubuntu-pro-client ca-certificates \
       #
       # With pro installed, we attach using our attach config file from the
       # previous step
@@ -116,7 +116,7 @@ inline comments explaining each line:
       # services, we can clean up.
       ###########################################################################
       #
-      # This purges ubuntu-advantage-tools, including all Ubuntu Pro related
+      # This purges ubuntu-pro-client, including all Ubuntu Pro related
       # secrets from the system.
       ###########################################################################
       # IMPORTANT: As written here, this command assumes your container does not
@@ -124,7 +124,7 @@ inline comments explaining each line:
       # If your container needs ca-certificates, then do not purge it from the
       # system here.
       ###########################################################################
-      && apt-get purge --auto-remove -y ubuntu-advantage-tools ca-certificates \
+      && apt-get purge --auto-remove -y ubuntu-pro-client ca-certificates \
       #
       # Finally, we clean up the apt lists which should not be needed anymore
       # because any `apt-get install`s should have happened above. Cleaning these

--- a/docs/tutorials/create_a_fips_docker_image.rst
+++ b/docs/tutorials/create_a_fips_docker_image.rst
@@ -4,9 +4,9 @@ Create an Ubuntu FIPS Docker image
 **********************************
 
 .. note::
-    
+
     This tutorial requires at least Ubuntu Pro Client version 27.7 -- to check
-    which version of the Pro Client you are using, run ``pro version``. 
+    which version of the Pro Client you are using, run ``pro version``.
 
 Acquire your Ubuntu Pro token
 =============================
@@ -71,7 +71,7 @@ command:
     touch Dockerfile
 
 This file will later enable FIPS in the container, upgrade all the packages,
-and install the FIPS version of ``openssl``. 
+and install the FIPS version of ``openssl``.
 
 Edit the file and add the following contents:
 
@@ -81,11 +81,11 @@ Edit the file and add the following contents:
 
     RUN --mount=type=secret,id=pro-attach-config \
         apt-get update \
-        && apt-get install --no-install-recommends -y ubuntu-advantage-tools ca-certificates \
+        && apt-get install --no-install-recommends -y ubuntu-pro-client ca-certificates \
         && pro attach --attach-config /run/secrets/pro-attach-config \
         && apt-get upgrade -y \
         && apt-get install -y openssl libssl1.1 libssl1.1-hmac libgcrypt20 libgcrypt20-hmac strongswan strongswan-hmac openssh-client openssh-server \
-        && apt-get purge --auto-remove -y ubuntu-advantage-tools ca-certificates \
+        && apt-get purge --auto-remove -y ubuntu-pro-client ca-certificates \
         && rm -rf /var/lib/apt/lists/*
 
 .. hint::

--- a/docs/tutorials/create_a_fips_docker_image.rst
+++ b/docs/tutorials/create_a_fips_docker_image.rst
@@ -85,6 +85,7 @@ Edit the file and add the following contents:
         && pro attach --attach-config /run/secrets/pro-attach-config \
         && apt-get upgrade -y \
         && apt-get install -y openssl libssl1.1 libssl1.1-hmac libgcrypt20 libgcrypt20-hmac strongswan strongswan-hmac openssh-client openssh-server \
+        && pro detach --assume-yes
         && apt-get purge --auto-remove -y ubuntu-pro-client ca-certificates \
         && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
purging ubuntu-advantage-tools with autoremove only "removes" ubuntu-pro-client which doesn't remove secrets.
This is an unexpected consequence of the package rename.
Also start recommending to detach to be safe.