### PR TITLE
detach: fix issue when removing auth file

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -186,6 +186,7 @@ Feature: Command behaviour when attached to an Ubuntu Pro subscription
       This machine is now detached.
       """
     And the machine is unattached
+    And I verify that no files exist matching `/etc/apt/auth.conf.d/90ubuntu-advantage`
     And I ensure apt update runs without errors
     When I attach `contract_token` with sudo
     Then I verify that running `pro enable foobar --format json` `as non-root` exits `1`

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -701,6 +701,8 @@ class RepoEntitlement(base.UAEntitlement):
         if not repo_url:
             raise exceptions.MissingAptURLDirective(entitlement_name=self.name)
 
+        repo_url = self.repo_url_tmpl.format(repo_url)
+
         progress.progress(
             messages.REMOVING_APT_CONFIGURATION.format(title=self.title)
         )

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -998,12 +998,12 @@ class TestRemoveAptConfig:
         entitlement.remove_apt_config(mock.MagicMock())
 
         assert [
-            mock.call("http://REPOTEST", "xenial")
+            mock.call("http://REPOTEST/ubuntu", "xenial")
         ] == m_remove_apt_list_files.call_args_list
         assert [
             mock.call(
                 "/etc/apt/sources.list.d/ubuntu-repotest.list",
-                "http://REPOTEST",
+                "http://REPOTEST/ubuntu",
                 "test.gpg",
             )
         ] == m_remove_auth_apt_repo.call_args_list


### PR DESCRIPTION
## Why is this needed?
To verify if we need to remove an entry from `/etc/apt/auth.conf.d/90ubuntu-advantage`, we check
if a service url is in that file, if it is, we remove the line corresponding to the service. However, we are using the wrong service url to make that check, since it is missing the `/ubuntu suffix. We are now fixing that issue, allowing detach to remove the appropriate lines and delete the file if needed

## Test Steps
Verify that the modified integration test is working as expected


---

- [ ] *(un)check this to re-run the checklist action*