### PR TITLE
tests: update Unattended-Upgrade::Allowed-Origins

### DIFF
--- a/features/api/unattended_upgrades.feature
+++ b/features/api/unattended_upgrades.feature
@@ -193,7 +193,7 @@ Feature: api.u.unattended_upgrades.status.v1
     When I run shell command `pro api u.unattended_upgrades.status.v1 | jq '.data.meta.raw_config.\"Unattended-Upgrade::Allowed-Origins\"'` as non-root
     Then I will see the following on stdout:
       """
-      null
+      []
       """
     When I run `/usr/lib/apt/apt.systemd.daily update` with sudo
     And I run `/usr/lib/apt/apt.systemd.daily install` with sudo


### PR DESCRIPTION
## Why is this needed?
We are now updating the expected value of `Unattended-Upgrade::Allowed-Origins` when that field is not present. We have recently changed the default value from null to an empty list and we are now reflecting that on the test

## Test Steps
Check that the modified integration test is working

---

- [ ] *(un)check this to re-run the checklist action*