### PR TITLE
fix: update endpoint for fetching USNs

### DIFF
--- a/uaclient/api/tests/test_api_u_pro_security_fix.py
+++ b/uaclient/api/tests/test_api_u_pro_security_fix.py
@@ -36,7 +36,7 @@ SAMPLE_GET_CVES_QUERY_PARAMS = {
 }
 
 SAMPLE_GET_NOTICES_QUERY_PARAMS = {
-    "details": "cve",
+    "cves": "cve",
     "release": "vq",
     "limit": 1,
     "offset": 2,
@@ -635,7 +635,7 @@ class TestUASecurityClient:
         "m_kwargs,expected_error, extra_security_params",
         (
             ({}, None, None),
-            ({"details": "cve"}, None, None),
+            ({"cves": "cve"}, None, None),
             (SAMPLE_GET_NOTICES_QUERY_PARAMS, None, {"test": "blah"}),
             ({"invalidparam": "vv"}, TypeError, None),
         ),
@@ -690,11 +690,11 @@ class TestUASecurityClient:
                 mock.call(API_V1_NOTICES, query_params=m_kwargs)
             ] == request_url.call_args_list
 
-    @pytest.mark.parametrize("details", (("cve1"), (None)))
-    def test_get_notices_filter_usns_when_setting_details_param(
-        self, request_url, details, FakeConfig
+    @pytest.mark.parametrize("cves", (("cve1"), (None)))
+    def test_get_notices_filter_usns_when_setting_cves_param(
+        self, request_url, cves, FakeConfig
     ):
-        """Test if details are used to filter the returned USNs."""
+        """Test if cves are used to filter the returned USNs."""
         cfg = FakeConfig()
         client = UASecurityClient(cfg)
         request_url.return_value = http.HTTPResponse(
@@ -710,9 +710,9 @@ class TestUASecurityClient:
             },
             json_list=[],
         )
-        usns = client.get_notices(details=details)
+        usns = client.get_notices(cves=cves)
 
-        if details:
+        if cves:
             assert len(usns) == 1
             assert usns[0].id == "USN-1"
         else:

--- a/uaclient/api/u/pro/security/fix/_common/__init__.py
+++ b/uaclient/api/u/pro/security/fix/_common/__init__.py
@@ -145,7 +145,7 @@ class UASecurityClient(serviceclient.UAServiceClient):
 
     def get_notices(
         self,
-        details: Optional[str] = None,
+        cves: Optional[str] = None,
         release: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
@@ -156,7 +156,7 @@ class UASecurityClient(serviceclient.UAServiceClient):
         @return: Sorted list of USN instances based on the the JSON response.
         """
         query_params = {
-            "details": details,
+            "cves": cves,
             "release": release,
             "limit": limit,
             "offset": offset,
@@ -172,7 +172,7 @@ class UASecurityClient(serviceclient.UAServiceClient):
             [
                 USN(client=self, response=usn_md)
                 for usn_md in response.json_dict.get("notices", [])
-                if (details is None or details in usn_md.get("cves_ids", []))
+                if (cves is None or cves in usn_md.get("cves_ids", []))
                 and usn_md.get("id", "").startswith("USN-")
             ],
             key=lambda x: x.id,

--- a/uaclient/api/u/pro/security/fix/_common/plan/v1.py
+++ b/uaclient/api/u/pro/security/fix/_common/plan/v1.py
@@ -742,7 +742,7 @@ def _get_cve_data(
 ) -> Tuple[CVE, List[USN]]:
     try:
         cve = client.get_cve(cve_id=issue_id)
-        usns = client.get_notices(details=issue_id)
+        usns = client.get_notices(cves=issue_id)
     except exceptions.SecurityAPIError as e:
         if e.code == 404:
             raise exceptions.SecurityIssueNotFound(issue_id=issue_id)


### PR DESCRIPTION
## Why is this needed?
Use cves parameter instead of details to fetch USNs from the security endpoint

## Test Steps
Check that the fix integration tests are now working as expected

---

- [ ] *(un)check this to re-run the checklist action*