### PR TITLE
Add arm64 tag to integration tests

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -136,6 +136,7 @@ Feature: Pro is expected version
       | noble    | lxd-container |
       | oracular | lxd-container |
 
+  @arm64
   Scenario Outline: Check for newer versions of the client in an ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # Make sure we have a fresh, just rebooted, environment

--- a/features/api/api.feature
+++ b/features/api/api.feature
@@ -1,5 +1,6 @@
 Feature: Client behaviour for the API endpoints
 
+  @arm64
   Scenario Outline: all API endpoints can be imported individually
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `python3 -c "from uaclient.api.u.pro.attach.auto.configure_retry_service.v1 import configure_retry_service"` as non-root
@@ -34,6 +35,7 @@ Feature: Client behaviour for the API endpoints
       | noble    | lxd-container |
       | oracular | lxd-container |
 
+  @arm64
   Scenario Outline: API invalid endpoint or args
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I verify that running `pro api invalid.endpoint` `with sudo` exits `1`
@@ -83,6 +85,7 @@ Feature: Client behaviour for the API endpoints
       | noble    | lxd-container |
       | oracular | lxd-container |
 
+  @arm64
   Scenario Outline: Basic endpoints
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `pro api u.pro.version.v1` with sudo
@@ -175,7 +178,7 @@ Feature: Client behaviour for the API endpoints
       | noble    | lxd-container |
       | oracular | lxd-container |
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: u.pro.status.is_attached.v1
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `pro api u.pro.status.is_attached.v1` with sudo

--- a/features/api/detach.feature
+++ b/features/api/detach.feature
@@ -1,6 +1,6 @@
 Feature: Detach API endpoint
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: Detach API endpoint on an attached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I verify that running `pro api u.pro.detach.v1` `as non-root` exits `1`

--- a/features/api/disable.feature
+++ b/features/api/disable.feature
@@ -1,5 +1,6 @@
 Feature: u.pro.services.disable
 
+  @arm64
   Scenario Outline: u.pro.services.disable.v1 container services
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I apt update

--- a/features/api/enable.feature
+++ b/features/api/enable.feature
@@ -1,5 +1,6 @@
 Feature: u.pro.services.enable
 
+  @arm64
   Scenario Outline: u.pro.services.enable.v1 container services
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I apt update

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -1,6 +1,6 @@
 Feature: APT Messages
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: APT JSON Hook prints package counts correctly on xenial
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo

--- a/features/cc_eal.feature
+++ b/features/cc_eal.feature
@@ -1,6 +1,7 @@
 @uses.config.contract_token
 Feature: Enable cc-eal on Ubuntu
 
+  @arm64
   Scenario Outline: Attached enable Common Criteria service in an ubuntu lxd container
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo
@@ -28,6 +29,7 @@ Feature: Enable cc-eal on Ubuntu
       | bionic  | lxd-container |
       | bionic  | wsl           |
 
+  @arm64
   Scenario Outline: Enable cc-eal with --access-only
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo

--- a/features/cli/attach.feature
+++ b/features/cli/attach.feature
@@ -36,7 +36,6 @@ Feature: CLI attach command
   # Examples: ubuntu release
   # | release  | machine_type  | landscape | status_string                                                           |
   # | oracular | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
-
   Scenario Outline: Attach command with attach config
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # simplest happy path
@@ -306,6 +305,7 @@ Feature: CLI attach command
       | focal   | lxd-container |
       | jammy   | lxd-container |
 
+  @arm64
   Scenario Outline: Attach command failure on invalid token
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I verify that running `pro attach INVALID_TOKEN` `with sudo` exits `1`

--- a/features/cli/auto_attach.feature
+++ b/features/cli/auto_attach.feature
@@ -36,6 +36,7 @@ Feature: CLI auto-attach command
       | noble    | lxd-container |
       | oracular | lxd-container |
 
+  @arm64
   Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # Validate systemd unit/timer syntax

--- a/features/cli/collect_logs.feature
+++ b/features/cli/collect_logs.feature
@@ -1,5 +1,6 @@
 Feature: CLI collect-logs command
 
+  @arm64
   Scenario Outline: Run collect-logs on an unattached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `python3 /usr/lib/ubuntu-advantage/timer.py` with sudo
@@ -47,7 +48,7 @@ Feature: CLI collect-logs command
       | noble    | lxd-container |
       | oracular | lxd-container |
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: Run collect-logs on an attached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo

--- a/features/cli/config.feature
+++ b/features/cli/config.feature
@@ -1,6 +1,7 @@
 Feature: CLI config command
 
   # earliest, latest lts[, latest stable]
+  @arm64
   Scenario Outline: old ua_config in uaclient.conf is still supported
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `pro config show` with sudo

--- a/features/cli/enable.feature
+++ b/features/cli/enable.feature
@@ -26,6 +26,7 @@ Feature: CLI enable command
       | jammy   | lxd-container |
       | noble   | lxd-container |
 
+  @arm64
   Scenario Outline: Empty series affordance means no series, null means all series
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo and options `--no-auto-enable`

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -1,5 +1,6 @@
 Feature: Pro Client help text
 
+  @arm64
   Scenario Outline: Help text for the Pro Client commands
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `pro --help` as non-root
@@ -441,6 +442,7 @@ Feature: Pro Client help text
       | noble    | lxd-container | enabled      |
       | oracular | lxd-container | n/a          |
 
+  @arm64
   Scenario Outline: Help command on an unattached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `pro help esm-infra` as non-root

--- a/features/cli/magic_attach.feature
+++ b/features/cli/magic_attach.feature
@@ -1,5 +1,6 @@
 Feature: CLI magic attach flow
 
+  @arm64
   Scenario Outline: Attach using the magic attach flow
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I create the file `/tmp/response-overlay.json` with the following:

--- a/features/cli/security_status.feature
+++ b/features/cli/security_status.feature
@@ -1,6 +1,6 @@
 Feature: CLI security-status command
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: Run security status with JSON/YAML format
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I apt update
@@ -108,7 +108,7 @@ Feature: CLI security-status command
       \s*  patched: true
       """
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario: Run security status in an Ubuntu machine
     Given a `xenial` `lxd-container` machine with ubuntu-advantage-tools installed
     When I install third-party / unknown packages in the machine

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -77,7 +77,7 @@ Feature: CLI status command
       | noble    | lxd-container |
       | oracular | lxd-container |
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: Non-root status can see in-progress operations
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo
@@ -285,7 +285,7 @@ Feature: CLI status command
       | jammy   | azure.pro    |
       | jammy   | gcp.pro      |
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: Attached status in a ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo
@@ -429,7 +429,7 @@ Feature: CLI status command
       | release | machine_type  |
       | jammy   | lxd-container |
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: Attached status in the latest LTS ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo
@@ -475,6 +475,7 @@ Feature: CLI status command
       | release | machine_type  |
       | noble   | lxd-container |
 
+  @arm64
   Scenario Outline: Unattached status in a ubuntu machine - formatted
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `pro status --format json` as non-root
@@ -529,6 +530,7 @@ Feature: CLI status command
       | noble    | lxd-container |
       | oracular | lxd-container |
 
+  @arm64
   Scenario Outline: Unattached status in a ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I verify root and non-root `pro status` calls have the same output

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -1,6 +1,6 @@
 Feature: Pro Upgrade Daemon only runs in environments where necessary
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: cloud-id-shim service is not installed on anything other than xenial
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     Then I verify that running `systemctl status ubuntu-advantage-cloud-id-shim.service` `with sudo` exits `4`
@@ -17,7 +17,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | noble    | lxd-container |
       | oracular | lxd-container |
 
-  @uses.config.contract_token
+  @uses.config.contract_token @arm64
   Scenario Outline: cloud-id-shim should run in postinst and on boot
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # verify installing pro created the cloud-id file

--- a/features/reboot_cmds.feature
+++ b/features/reboot_cmds.feature
@@ -1,4 +1,4 @@
-@uses.config.contract_token
+@uses.config.contract_token @arm64
 Feature: Reboot Commands
 
   Scenario Outline: reboot-cmds removes fips package holds and updates packages

--- a/features/subscription_attach_restrictions.feature
+++ b/features/subscription_attach_restrictions.feature
@@ -1,6 +1,7 @@
 @uses.config.contract_token
 Feature: One time pro subscription related tests
 
+  @arm64
   Scenario Outline: Attach fail if subscription is restricted to release
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I create the file `/tmp/response-overlay.json` with the following:
@@ -46,6 +47,7 @@ Feature: One time pro subscription related tests
       | jammy   | lxd-container | focal      | 20.04 LTS   | Focal Fossa         |
       | noble   | lxd-container | jammy      | 22.04 LTS   | Jammy Jellyfish     |
 
+  @arm64
   Scenario Outline: Check notice visible when attached with onlySeries present
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I create the file `/tmp/response-overlay.json` with the following:

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -2,6 +2,7 @@
 Feature: Timer for regular background jobs while attached
 
   # earlies, latest lts, devel
+  @arm64
   Scenario Outline: Timer is stopped when detached, started when attached
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     Then I verify the `ua-timer` systemd timer is disabled


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
@arm64 tag added to basic tests for running weekly on new arm64 jenkins job


---

- [ ] *(un)check this to re-run the checklist action*