### PR TITLE
Ignore corrupt jobs-state.json file

### DIFF
--- a/lib/timer.py
+++ b/lib/timer.py
@@ -8,7 +8,10 @@ from typing import Callable, Optional
 
 from uaclient import http, log
 from uaclient.config import UAConfig
-from uaclient.exceptions import InvalidFileFormatError
+from uaclient.exceptions import (
+    InvalidFileEncodingError,
+    InvalidFileFormatError,
+)
 from uaclient.files import machine_token
 from uaclient.files.state_files import (
     AllTimerJobsState,
@@ -150,11 +153,11 @@ def run_jobs(cfg: UAConfig, current_time: datetime):
     state introspection for jobs which have not yet run.
     """
     jobs_status_obj = None
-    # If the file format is wrong we remove it, and after the jobs are
-    # executed it will be recreated with the proper data.
+    # If the file format or encoding is wrong we remove it.
+    # After the jobs are executed it will be recreated with the proper data.
     try:
         jobs_status_obj = timer_jobs_state_file.read()
-    except InvalidFileFormatError:
+    except (InvalidFileEncodingError, InvalidFileFormatError):
         try:
             timer_jobs_state_file.delete()
         except (OSError, PermissionError) as exception:

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -494,6 +494,10 @@ class InvalidFileFormatError(UbuntuProError):
     _formatted_msg = messages.E_INVALID_FILE_FORMAT
 
 
+class InvalidFileEncodingError(UbuntuProError):
+    _formatted_msg = messages.E_INVALID_FILE_ENCODING
+
+
 class ParsingErrorOnOSReleaseFile(UbuntuProError):
     _formatted_msg = messages.E_ERROR_PARSING_VERSION_OS_RELEASE
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -2404,6 +2404,11 @@ E_INVALID_FILE_FORMAT = FormattedNamedMessage(
     msg=t.gettext("{file_name} is not valid {file_format}"),
 )
 
+E_INVALID_FILE_ENCODING = FormattedNamedMessage(
+    name="invalid-file-encoding",
+    msg=t.gettext("{file_name} is not encoded as {file_encoding}"),
+)
+
 E_ERROR_PARSING_VERSION_OS_RELEASE = FormattedNamedMessage(
     "error-parsing-version-os-release",
     t.gettext(

--- a/uaclient/system.py
+++ b/uaclient/system.py
@@ -530,12 +530,17 @@ def is_exe(path: str) -> bool:
     return os.path.isfile(path) and os.access(path, os.X_OK)
 
 
-def load_file(filename: str, decode: bool = True) -> str:
+def load_file(filename: str) -> str:
     """Read filename and decode content."""
     with open(filename, "rb") as stream:
         LOG.debug("Reading file: %s", filename)
         content = stream.read()
-    return content.decode("utf-8")
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError:
+        raise exceptions.InvalidFileEncodingError(
+            file_name=filename, file_encoding="utf-8"
+        )
 
 
 def create_file(filename: str, mode: int = 0o644) -> None:


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we now ignore invalid jobs-state.json files if they are corrupted and cannot be decoded, avoiding the oops which stopped phasing on noble (see LP bug)

LP: #2078737

## Test Steps
Unit tests cover behavior
for the functionality:
- insert some weird characters in your jobs-state.json file
- `systemctl start ua-timer.service`
- see it degrade
- apply this patch
- repeat
- see it happy


---

- [x] *(un)check this to re-run the checklist action*