### PR TITLE
debian: add more scenarios to dep8 tests

### DIFF
--- a/debian/tests/usage
+++ b/debian/tests/usage
@@ -2,5 +2,11 @@
 
 set -ex
 
-ua --help | grep --silent services
-ua version
+pro --help | grep --silent services
+pro version
+
+# These calls are used to ensure that the
+# way we interact with APT is still working
+# if python3-apt receives an upgrade
+pro api u.pro.packages.summary.v1
+pro api u.pro.packages.updates.v1


### PR DESCRIPTION
## Why is this needed?
We are now calling two API endpoints on the dep8 tests. Those endpoints don't trigger any network call and their main use is to verify if any python3-apt change would change the way we interact with that library, as those API endpoints heavily rely on apt functionality.

This is being documented on: #3231 

## Test Steps
1. Build the package
2. Use the .dsc file to run this command:

```bash
autopkgtest --no-built-binaries --apt-upgrade --setup-commands setup-testbed --shell-fail ubuntu-advantage-tools_1+devel.dsc -- lxd ubuntu-daily:<RELEASE>
```

3. Check that this passes and that the API endpoints appears in the logs 

---

- [ ] *(un)check this to re-run the checklist action*