### PR TITLE
chore: use python-apt version from noble-updates in tox

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -13,4 +13,4 @@ pytest-cov
 # two releases have the same python_version.
 git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/jammy-updates ; python_version == '3.10'
 # need to keep an aye to bump this when python-apt is in noble-updates
-git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/noble ; python_version == '3.12'
+git+https://git.launchpad.net/ubuntu/+source/python-apt@ubuntu/noble-updates ; python_version == '3.12'


### PR DESCRIPTION


## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because we want the latest compatible python3-apt in tests.

## Test Steps
`tox` on Noble


---

- [ ] *(un)check this to re-run the checklist action*