### PR TITLE
Update livepatch network requirements

### DIFF
--- a/docs/references/network_requirements.rst
+++ b/docs/references/network_requirements.rst
@@ -58,6 +58,7 @@ Necessary endpoints for ``snap``
 Necessary endpoints for ``livepatch``:
 
 - ``livepatch.canonical.com:443``
+- ``livepatch-files.canonical.com:443``
 
 Fix
 ===


### PR DESCRIPTION
Livepatch requires access to `livepatch-files.canonical.com` to download patches ([upstream docs](https://ubuntu.com/security/livepatch/docs/livepatch_on_prem/reference/firewall)).

---

- [ ] *(un)check this to re-run the checklist action*