### PR TITLE
test: update packages on security status test

### DIFF
--- a/features/cli/security_status.feature
+++ b/features/cli/security_status.feature
@@ -964,6 +964,6 @@ Feature: CLI security-status command
       """
 
     Examples: ubuntu release
-      | release | machine_type  | pkg_in_updates          | pkg_in_security      |
-      | xenial  | lxd-container | base-files=9.4ubuntu4   | wget=1.17.1-1ubuntu1 |
-      | noble   | lxd-container | xxd=2:9.1.0016-1ubuntu7 | less=590-2ubuntu2    |
+      | release | machine_type  | pkg_in_updates               | pkg_in_security      |
+      | xenial  | lxd-container | base-files=9.4ubuntu4        | wget=1.17.1-1ubuntu1 |
+      | noble   | lxd-container | xz-utils=5.6.1+really5.4.5-1 | less=590-2ubuntu2    |


### PR DESCRIPTION
## Why is this needed?
For the Noble securitu-status test, we need one package with an upgrade from security and another for updates. The past packages now both have candidates on the security pocket. We are now updating the package to have that distinction again


## Test Steps
Run the modified integration test to see that it works


---

- [ ] *(un)check this to re-run the checklist action*