### PR TITLE
tests: handle when syslog file do not exist

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -529,6 +529,12 @@ def _get_relevant_apparmor_logs(context):
                     "Unable to pull syslog. Skipping apparmor log check."
                 )
                 return None
+            except FileNotFoundError:
+                logging.warning(
+                    "syslog file doesn't exist. Skipping apparmor log check."
+                )
+                return None
+
             with open(syslog_dest, "r") as syslog_fd:
                 syslog_messages = syslog_fd.readlines()
             apparmor_denied = [


### PR DESCRIPTION
## Why is this needed?
When collecting apparmor logs, we pull the /var/log/syslog file from the system under test. However, if the file doesn't exist, we shouldn't block the whole test, but instead alert about that

## Test Steps
Check that we can run WSL tests again


---

- [x] *(un)check this to re-run the checklist action*