### PR TITLE
chore: run reformat-gherkin

### DIFF
--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -245,12 +245,12 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
       """
 
     Examples: ubuntu release
-      | release | machine_type   |
-      | xenial  | aws.generic    |
-      | bionic  | aws.generic    |
-      | focal   | aws.generic    |
-      | jammy   | aws.generic    |
-      | noble   | aws.generic    |
+      | release | machine_type |
+      | xenial  | aws.generic  |
+      | bionic  | aws.generic  |
+      | focal   | aws.generic  |
+      | jammy   | aws.generic  |
+      | noble   | aws.generic  |
 
   Scenario Outline: Auto-attach no-op when cloud-init has ubuntu_advantage on userdata
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we ended up merging a change which makes the formatter complain and it is annoying now


## Test Steps
`tox -e reformat-gherkin`

---

- [ ] *(un)check this to re-run the checklist action*