### PR TITLE
tests: don't install ubuntu-advantage-tools on Noble

### DIFF
--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -73,7 +73,6 @@ Feature: Enable anbox on Ubuntu
       """
       https://archive.anbox-cloud.io/stable <release>/main amd64 Packages
       """
-    And I check that snap `amc` is not installed
     And I check that snap `lxd` is not installed
     And I check that snap `anbox-cloud-appliance` is not installed
     And I verify that files exist matching `/var/lib/ubuntu-advantage/private/anbox-cloud-credentials`
@@ -86,7 +85,6 @@ Feature: Enable anbox on Ubuntu
     Then stdout contains substring:
       """
       Installing required snaps
-      Installing required snap: amc
       Installing required snap: anbox-cloud-appliance
       Installing required snap: lxd
       Configuring APT access to Anbox Cloud
@@ -106,7 +104,6 @@ Feature: Enable anbox on Ubuntu
       """
       https://archive.anbox-cloud.io/stable <release>/main amd64 Packages
       """
-    And I check that snap `amc` is installed
     And I check that snap `lxd` is installed
     And I check that snap `anbox-cloud-appliance` is installed
     And I verify that files exist matching `/var/lib/ubuntu-advantage/private/anbox-cloud-credentials`

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -84,7 +84,7 @@ def when_i_install_uat(context, machine_name=SUT):
             instance.push_file(deb_path, instance_tmp_path)
             to_install.append(instance_tmp_path)
         if is_pro:
-            for deb_name, deb_path in debs.cloud_pro_image_debs(series):
+            for deb_name, deb_path in debs.cloud_pro_image_debs():
                 instance_tmp_path = "/tmp/behave_{}.deb".format(deb_name)
                 instance.push_file(deb_path, instance_tmp_path)
                 to_install.append(instance_tmp_path)
@@ -151,7 +151,7 @@ def when_i_have_the_debs_under_test(context, series, dest):
             sbuild_output_to_terminal=context.pro_config.sbuild_output_to_terminal,  # noqa: E501
         )
 
-        for deb_name, deb_path in debs.all_debs():
+        for deb_name, deb_path in debs.all_debs(series):
             context.machines[SUT].instance.push_file(
                 deb_path, "{}/{}.deb".format(dest, deb_name)
             )
@@ -239,7 +239,7 @@ def create_local_ppa(context, release):
         release,
         sbuild_output_to_terminal=context.pro_config.sbuild_output_to_terminal,
     )
-    for deb_name, deb_path in debs.all_debs():
+    for deb_name, deb_path in debs.all_debs(release):
         deb_destination = "/tmp/{}.deb".format(deb_name)
         context.machines["ppa"].instance.push_file(deb_path, deb_destination)
         when_i_run_command(

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -79,12 +79,12 @@ def when_i_install_uat(context, machine_name=SUT):
         debs = get_debs_for_series(context.pro_config.debs_path, series)
         logging.info("using debs: {}".format(debs))
         to_install = []
-        for deb_name, deb_path in debs.non_cloud_pro_image_debs():
+        for deb_name, deb_path in debs.non_cloud_pro_image_debs(series):
             instance_tmp_path = "/tmp/behave_{}.deb".format(deb_name)
             instance.push_file(deb_path, instance_tmp_path)
             to_install.append(instance_tmp_path)
         if is_pro:
-            for deb_name, deb_path in debs.cloud_pro_image_debs():
+            for deb_name, deb_path in debs.cloud_pro_image_debs(series):
                 instance_tmp_path = "/tmp/behave_{}.deb".format(deb_name)
                 instance.push_file(deb_path, instance_tmp_path)
                 to_install.append(instance_tmp_path)
@@ -97,7 +97,7 @@ def when_i_install_uat(context, machine_name=SUT):
             sbuild_output_to_terminal=context.pro_config.sbuild_output_to_terminal,  # noqa: E501
         )
         to_install = []
-        for deb_name, deb_path in debs.non_cloud_pro_image_debs():
+        for deb_name, deb_path in debs.non_cloud_pro_image_debs(series):
             instance_tmp_path = "/tmp/behave_{}.deb".format(deb_name)
             instance.push_file(deb_path, instance_tmp_path)
             to_install.append(instance_tmp_path)
@@ -110,11 +110,19 @@ def when_i_install_uat(context, machine_name=SUT):
             context, " ".join(to_install), machine_name=machine_name
         )
     else:
-        when_i_apt_install(
-            context,
-            "ubuntu-pro-client ubuntu-advantage-tools",
-            machine_name=machine_name,
-        )
+        if series in ("xenial", "bionic", "focal", "jammy"):
+            when_i_apt_install(
+                context,
+                "ubuntu-pro-client ubuntu-advantage-tools",
+                machine_name=machine_name,
+            )
+        else:
+            when_i_apt_install(
+                context,
+                "ubuntu-pro-client",
+                machine_name=machine_name,
+            )
+
         if is_pro:
             when_i_apt_install(
                 context,

--- a/features/util.py
+++ b/features/util.py
@@ -74,8 +74,10 @@ class ProDebPaths:
             ("ubuntu-advantage-pro", self.ubuntu_advantage_pro),
         ]
 
-    def all_debs(self) -> List[Tuple[str, str]]:
-        return self.non_cloud_pro_image_debs() + self.cloud_pro_image_debs()
+    def all_debs(self, series: str) -> List[Tuple[str, str]]:
+        return (
+            self.non_cloud_pro_image_debs(series) + self.cloud_pro_image_debs()
+        )
 
 
 class InstallationSource(Enum):

--- a/features/util.py
+++ b/features/util.py
@@ -52,12 +52,18 @@ class ProDebPaths:
     ubuntu_advantage_tools: str
     ubuntu_advantage_pro: str
 
-    def non_cloud_pro_image_debs(self) -> List[Tuple[str, str]]:
-        return [
-            ("ubuntu-pro-client", self.ubuntu_pro_client),
-            ("ubuntu-advantage-tools", self.ubuntu_advantage_tools),
-            ("ubuntu-pro-client-l10n", self.ubuntu_pro_client_l10n),
-        ]
+    def non_cloud_pro_image_debs(self, series: str) -> List[Tuple[str, str]]:
+        if series in ("xenial", "bionic", "focal", "jammy"):
+            return [
+                ("ubuntu-pro-client", self.ubuntu_pro_client),
+                ("ubuntu-advantage-tools", self.ubuntu_advantage_tools),
+                ("ubuntu-pro-client-l10n", self.ubuntu_pro_client_l10n),
+            ]
+        else:
+            return [
+                ("ubuntu-pro-client", self.ubuntu_pro_client),
+                ("ubuntu-pro-client-l10n", self.ubuntu_pro_client_l10n),
+            ]
 
     def cloud_pro_image_debs(self) -> List[Tuple[str, str]]:
         return [


### PR DESCRIPTION
## Why is this needed?
On Noble, the ubuntu-advantage-tools package is not installed by default, that means that once we install the package in our tests, all of the previous migrations would run. This was causing some issue on our Pro cloud integration tests. We configure those tests to disable the auto_attach feature on startup. However, one of the migrations was overriding our config file momentarily, allowing our daemon to run and attach the machine. Since we want to avoid that behavior, we are now masking the daemon before the package install and unmasking it just after the operation

## Test Steps
Run the GCP Pro Noble tests and double check they are working now

---

- [x] *(un)check this to re-run the checklist action*