### PR TITLE
test: update packages on security status test

### DIFF
--- a/features/security_status.feature
+++ b/features/security_status.feature
@@ -960,6 +960,6 @@ Feature: Security status command behavior
       """
 
     Examples: ubuntu release
-      | release | machine_type  | pkg_in_updates          | pkg_in_security      |
-      | xenial  | lxd-container | base-files=9.4ubuntu4   | wget=1.17.1-1ubuntu1 |
-      | noble   | lxd-container | xxd=2:9.1.0016-1ubuntu7 | less=590-2ubuntu2    |
+      | release | machine_type  | pkg_in_updates               | pkg_in_security      |
+      | xenial  | lxd-container | base-files=9.4ubuntu4        | wget=1.17.1-1ubuntu1 |
+      | noble   | lxd-container | xz-utils=5.6.1+really5.4.5-1 | less=590-2ubuntu2    |


### PR DESCRIPTION
For the Noble securitu-status test, we need one package with an upgrade from security and another for updates. The past packages now both have candidates on the security pocket. We are now updating the package to have that distinction again

This is a cherry pick to main for verification.