### PR TITLE
tests: give jammy->noble upgrade its own test

### DIFF
--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -133,7 +133,6 @@ Feature: APT Messages
       | release | machine_type  | version |
       | xenial  | lxd-container | 16      |
       | bionic  | lxd-container | 18      |
-      | bionic  | wsl           | 18      |
 
   @uses.config.contract_token
   Scenario Outline: APT Hook advertises esm-apps on upgrade

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -286,3 +286,13 @@ def given_a_sut_machine_with_user_data(context, series, machine_type):
 @when("I reboot the machine")
 def when_i_reboot_the_machine(context, machine_name=SUT):
     context.machines[machine_name].instance.restart(wait=True)
+
+
+@when("I update the series in the machine test metadata to `{series}`")
+def when_i_update_series(context, series, machine_name=SUT):
+    context.machines[machine_name] = MachineTuple(
+        series=series,
+        machine_type=context.machines[machine_name].machine_type,
+        cloud=context.machines[machine_name].cloud,
+        instance=context.machines[machine_name].instance,
+    )

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -90,8 +90,8 @@ Feature: Timer for regular background jobs while attached
       | release  | machine_type  |
       | xenial   | lxd-container |
       | bionic   | lxd-container |
-      | bionic   | wsl           |
       | focal    | lxd-container |
+      | focal    | wsl           |
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -45,12 +45,73 @@ Feature: Upgrade between releases when uaclient is attached
       """
 
     Examples: ubuntu release
-      | release | machine_type  | next_release | prompt | devel_release   | service1  | service1_status | service2 | service2_status | before_cmd     |
-      | xenial  | lxd-container | bionic       | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-      | bionic  | lxd-container | focal        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-      | bionic  | lxd-container | focal        | lts    |                 | usg       | enabled         | usg      | enabled         | pro enable cis |
-      | focal   | lxd-container | jammy        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-      | jammy   | lxd-container | noble        | lts    | --devel-release | esm-infra | enabled         | esm-apps | enabled         | true           |
+      | release | machine_type  | next_release | prompt | devel_release | service1  | service1_status | service2 | service2_status | before_cmd     |
+      | xenial  | lxd-container | bionic       | lts    |               | esm-infra | enabled         | esm-apps | enabled         | true           |
+      | bionic  | lxd-container | focal        | lts    |               | esm-infra | enabled         | esm-apps | enabled         | true           |
+      | bionic  | lxd-container | focal        | lts    |               | usg       | enabled         | usg      | enabled         | pro enable cis |
+      | focal   | lxd-container | jammy        | lts    |               | esm-infra | enabled         | esm-apps | enabled         | true           |
+
+  # This test is unideal.
+  # do-release-upgrade started disabling proposed on upgrade, which prevents us from testing the upgrade from
+  # jammy-proposed to noble-proposed of pro-client. Ideally we'd have a way to leave -proposed enabled during the upgrade.
+  # Since there is no feature of do-release-upgrade to leave -proposed enabled, this test does the release upgrade,
+  # then re-enables proposed and then installs pro-client from -proposed.
+  # This is unideal, because the jammy-proposed pro-client will still be installed until the extra steps to re-enable
+  # -proposed and upgrade from there. The jammy-proposed release-upgrades.d script will run, and the jammy-proposed
+  # apparmor profiles will remain installed. The apparmor profiles are particularly problematic, because the noble
+  # profiles require extra rules. That is why this test needs to mask the apparmored systemd units during the upgrade of
+  # pro-client after the release upgrade.
+  @slow @upgrade
+  Scenario Outline: Attached upgrade jammy to noble
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I attach `contract_token` with sudo
+    # Local PPAs are prepared and served only when testing with local debs
+    And I prepare the local PPAs to upgrade from `<release>` to `<next_release>`
+    And I run `DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade --assume-yes` with sudo
+    # Some packages upgrade may require a reboot
+    And I reboot the machine
+    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
+      """
+      [Sources]
+      AllowThirdParty=yes
+      """
+    And I run `sed -i 's/Prompt=lts/Prompt=<prompt>/' /etc/update-manager/release-upgrades` with sudo
+    And I run `do-release-upgrade <devel_release> --frontend DistUpgradeViewNonInteractive` `with sudo` and stdin `y\n`
+    When I run `systemctl mask apt-news.service` with sudo
+    When I run `systemctl mask esm-cache.service` with sudo
+    And I update the series in the machine test metadata to `<next_release>`
+    And I install ubuntu-advantage-tools
+    When I run `systemctl unmask esm-cache.service` with sudo
+    When I run `systemctl unmask apt-news.service` with sudo
+    And I reboot the machine
+    And I run `lsb_release -cs` as non-root
+    Then I will see the following on stdout:
+      """
+      <next_release>
+      """
+    And I verify that running `egrep "<release>|disabled" /etc/apt/sources.list.d/*` `as non-root` exits `2`
+    And I will see the following on stdout:
+      """
+      """
+    When I run `pro refresh` with sudo
+    And I run `pro status --all` with sudo
+    Then stdout matches regexp:
+      """
+      <service1> +yes +<service1_status>
+      """
+    Then stdout matches regexp:
+      """
+      <service2> +yes +<service2_status>
+      """
+    When I run `pro detach --assume-yes` with sudo
+    Then stdout matches regexp:
+      """
+      This machine is now detached.
+      """
+
+    Examples: ubuntu release
+      | release | machine_type  | next_release | prompt | devel_release   | service1  | service1_status | service2 | service2_status |
+      | jammy   | lxd-container | noble        | lts    | --devel-release | esm-infra | enabled         | esm-apps | enabled         |
 
   @slow @upgrade
   Scenario Outline: Attached FIPS upgrade across LTS releases

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
     behave
     jsonschema
     jq
-    pycloudlib==1!6.5.0
+    pycloudlib==1!9.2.0
     PyHamcrest
     requests
     toml==0.10


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because...

jammy -> noble needs special treatment now that do-release-upgrade disables -proposed. We need a special step to ensure that the package is actually upgraded to the noble version. We also need to mask the apparmored services so that they don't cause denials during the upgrade to the noble version.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the new test
<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*