### PR TITLE
api: update cache for vulnerabilities

### DIFF
--- a/uaclient/api/tests/test_api_u_pro_security_vulnerabilities_common_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_security_vulnerabilities_common_v1.py
@@ -223,7 +223,7 @@ class TestVulnerabilityParser:
         assert (
             parser.get_vulnerabilities_for_installed_pkgs(
                 vulnerabilities_data, installed_pkgs_by_source
-            )
+            ).vulnerabilities
             == expected_result
         )
 

--- a/uaclient/api/tests/test_api_u_pro_security_vulnerabilities_cve_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_security_vulnerabilities_cve_v1.py
@@ -12,6 +12,7 @@ from uaclient.api.u.pro.security.vulnerabilities.cve.v1 import (
 )
 
 M_PATH = "uaclient.api.u.pro.security.vulnerabilities.cve.v1."
+M_VULN_COMMON_PATH = "uaclient.api.u.pro.security.vulnerabilities._common.v1."
 
 VULNEBILITIES_DATA = {
     "published_at": "2024-06-24T13:19:16",
@@ -260,19 +261,26 @@ class TestCVEVulnerabilities:
             ),
         ),
     )
+    @mock.patch(
+        M_VULN_COMMON_PATH + "VulnerabilityResultCache.save_result_cache"
+    )
     @mock.patch(M_PATH + "get_apt_cache_datetime")
-    @mock.patch(M_PATH + "VulnerabilityData.get")
-    @mock.patch(M_PATH + "SourcePackages.get")
+    @mock.patch(M_VULN_COMMON_PATH + "VulnerabilityData.get")
+    @mock.patch(M_VULN_COMMON_PATH + "VulnerabilityData.is_cache_valid")
+    @mock.patch(M_VULN_COMMON_PATH + "SourcePackages.get")
     def test_parse_data(
         self,
         m_get_source_pkgs,
+        m_vulnerability_data_is_cache_valid,
         m_vulnerability_data_get,
         m_get_apt_cache_datetime,
+        _m_vulnerability_result_save_cache,
         vulnerabilities_data,
         installed_pkgs_by_source,
         cve_options,
         expected_result,
     ):
+        m_vulnerability_data_is_cache_valid.return_value = (False, None)
         m_get_source_pkgs.return_value = installed_pkgs_by_source
         m_vulnerability_data_get.return_value = vulnerabilities_data
         m_get_apt_cache_datetime.return_value = datetime.datetime(

--- a/uaclient/api/tests/test_api_u_pro_security_vulnerabilities_usn_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_security_vulnerabilities_usn_v1.py
@@ -12,6 +12,7 @@ from uaclient.api.u.pro.security.vulnerabilities.usn.v1 import (
 )
 
 M_PATH = "uaclient.api.u.pro.security.vulnerabilities.usn.v1."
+M_VULN_COMMON_PATH = "uaclient.api.u.pro.security.vulnerabilities._common.v1."
 
 VULNEBILITIES_DATA = {
     "published_at": "2024-06-24T13:19:16",
@@ -308,19 +309,26 @@ class TestUSNVulnerabilities:
             ),
         ),
     )
+    @mock.patch(
+        M_VULN_COMMON_PATH + "VulnerabilityResultCache.save_result_cache"
+    )
     @mock.patch(M_PATH + "get_apt_cache_datetime")
-    @mock.patch(M_PATH + "VulnerabilityData.get")
-    @mock.patch(M_PATH + "SourcePackages.get")
+    @mock.patch(M_VULN_COMMON_PATH + "VulnerabilityData.get")
+    @mock.patch(M_VULN_COMMON_PATH + "VulnerabilityData.is_cache_valid")
+    @mock.patch(M_VULN_COMMON_PATH + "SourcePackages.get")
     def test_parse_data(
         self,
         m_get_source_pkgs,
+        m_vulnerability_data_is_cache_valid,
         m_vulnerability_data_get,
         m_get_apt_cache_datetime,
+        _m_vulnerability_result_save_cache,
         vulnerabilities_data,
         installed_pkgs_by_source,
         usn_options,
         expected_result,
     ):
+        m_vulnerability_data_is_cache_valid.return_value = (False, None)
         m_get_source_pkgs.return_value = installed_pkgs_by_source
         m_vulnerability_data_get.return_value = vulnerabilities_data
         m_get_apt_cache_datetime.return_value = datetime.datetime(

--- a/uaclient/api/u/pro/security/vulnerabilities/_common/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/_common/v1.py
@@ -1,10 +1,10 @@
 import abc
+import datetime
 import enum
 import json
 import os
 import re
-from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 from urllib.parse import urljoin
 
 from uaclient import apt, exceptions, http, system, util
@@ -13,12 +13,19 @@ from uaclient.api.u.pro.security.fix._common import (
 )
 from uaclient.api.u.pro.status.enabled_services.v1 import _enabled_services
 from uaclient.config import UAConfig
-from uaclient.data_types import DataObject, Field, StringDataValue
+from uaclient.data_types import (
+    DataObject,
+    Field,
+    FloatDataValue,
+    StringDataValue,
+)
 from uaclient.defaults import (
     VULNERABILITY_CACHE_PATH,
     VULNERABILITY_DATA_CACHE,
     VULNERABILITY_DATA_TMPL,
+    VULNERABILITY_DPKG_STATUS_DATE_CACHE,
     VULNERABILITY_PUBLISH_DATE_CACHE,
+    VULNERABILITY_RESULT_CACHE,
 )
 from uaclient.entitlements.fips import FIPSEntitlement, FIPSUpdatesEntitlement
 from uaclient.files.data_types import DataObjectFile
@@ -30,6 +37,13 @@ class VulnerabilityCacheDate(DataObject):
 
     def __init__(self, cache_date):
         self.cache_date = cache_date
+
+
+class VulnerabilityDpkgCacheDate(DataObject):
+    fields = [Field("dpkg_status_date", FloatDataValue)]
+
+    def __init__(self, dpkg_status_date: float):
+        self.dpkg_status_date = dpkg_status_date
 
 
 @enum.unique
@@ -50,25 +64,28 @@ class VulnerabilityData:
         cfg: UAConfig,
         data_file: Optional[str] = None,
         series: Optional[str] = None,
+        update_data: bool = True,
     ):
         self.cfg = cfg
         self.data_file = data_file
-        self.series = series
+        self.series = series or system.get_release_info().series
+        self.update_data = update_data
+        self._last_published_date = None  # type: Optional[str]
 
-    def _get_cache_data_path(self, series: str):
+    def _get_cache_data_path(self):
         return os.path.join(
-            VULNERABILITY_CACHE_PATH, series, VULNERABILITY_DATA_CACHE
+            VULNERABILITY_CACHE_PATH, self.series, VULNERABILITY_DATA_CACHE
         )
 
-    def _get_cache_published_date_path(self, series: str):
+    def _get_cache_published_date_path(self):
         return os.path.join(
-            VULNERABILITY_CACHE_PATH, series, VULNERABILITY_PUBLISH_DATE_CACHE
+            VULNERABILITY_CACHE_PATH,
+            self.series,
+            VULNERABILITY_PUBLISH_DATE_CACHE,
         )
 
-    def _save_cache_data(self, series: str, json_data: Dict[str, Any]):
-        system.write_file(
-            self._get_cache_data_path(series), json.dumps(json_data)
-        )
+    def _save_cache_data(self, json_data: Dict[str, Any]):
+        system.write_file(self._get_cache_data_path(), json.dumps(json_data))
 
     def _save_cache_publish_date(
         self, cache_date_file: DataObjectFile, published_date: str
@@ -79,78 +96,121 @@ class VulnerabilityData:
 
     def _parse_published_date(self, published_date: str):
         format_str = "%a, %d %b %Y %H:%M:%S %Z"
-        return datetime.strptime(published_date, format_str)
+        return datetime.datetime.strptime(published_date, format_str)
 
-    def _get_published_date(self, data_url):
-        resp = http.readurl(url=data_url, method="HEAD")
-        return resp.headers["last-modified"]
+    def _get_published_date(self):
+        if not self._last_published_date:
+            resp = http.readurl(url=self._get_data_url(), method="HEAD")
+            self._last_published_date = resp.headers["last-modified"]
+
+        return self._last_published_date
+
+    def is_cache_valid(self) -> Tuple[bool, Optional[datetime.datetime]]:
+        if self.data_file:
+            return (False, None)
+
+        last_published_date = self._get_published_date()
+        cache_date_file = self._get_cache_file()
+
+        return self._is_cache_valid(last_published_date, cache_date_file)
+
+    def cache_exists(self):
+        cache_date_file = self._get_cache_file()
+        return cache_date_file.read() is not None
 
     def _is_cache_valid(
         self,
-        series: str,
         last_published_date: str,
         cache_date_file: DataObjectFile,
-    ) -> bool:
+    ) -> Tuple[bool, Optional[datetime.datetime]]:
+        """
+        Return if the vulnerability data cache is valid.
+        By valid it means if the data is the latest available
+        version of the vulnerability data.
+
+        If we detect that a cache exists, but it is not the latest
+        version, we will return also by how much time the cache is
+        outdated.
+        """
         last_published_datetime = self._parse_published_date(
             last_published_date
         )
 
         cache_date_obj = cache_date_file.read()
         if not cache_date_obj:
-            return False
+            return (False, None)
 
         cache_published_datetime = self._parse_published_date(
             cache_date_obj.cache_date
         )
 
-        return cache_published_datetime >= last_published_datetime
+        return (
+            cache_published_datetime >= last_published_datetime,
+            last_published_datetime - cache_published_datetime,
+        )
 
-    def _get_cache_data(self, series: str):
-        return json.loads(system.load_file(self._get_cache_data_path(series)))
+    def _get_cache_data(self):
+        return json.loads(system.load_file(self._get_cache_data_path()))
 
-    def _get_data_url(self, series):
-        data_name = series
+    def _get_data_url(self):
+        data_name = self.series
 
         enabled_services_names = [
             s.name for s in _enabled_services(self.cfg).enabled_services
         ]
         if FIPSEntitlement.name in enabled_services_names:
-            data_name = "fips_{}".format(series)
+            data_name = "fips_{}".format(self.series)
         elif FIPSUpdatesEntitlement.name in enabled_services_names:
-            data_name = "fips-updates_{}".format(series)
+            data_name = "fips-updates_{}".format(self.series)
 
         data_file = VULNERABILITY_DATA_TMPL.format(series=data_name)
         return urljoin(self.cfg.vulnerability_data_url_prefix, data_file)
+
+    def _get_cache_file(self):
+        return DataObjectFile(
+            data_object_cls=VulnerabilityCacheDate,
+            ua_file=UAFile(
+                name=VULNERABILITY_PUBLISH_DATE_CACHE,
+                directory=os.path.join(VULNERABILITY_CACHE_PATH, self.series),
+                private=False,
+            ),
+        )
+
+    def get_published_date(self):
+        vulnerability_json_data = self.get()
+        return vulnerability_json_data["published_at"]
 
     def get(self):
         if self.data_file:
             return json.loads(system.load_file(self.data_file))
 
-        series = self.series or system.get_release_info().series
-        data_url = self._get_data_url(series)
+        if not self.update_data and self.cache_exists():
+            return self._get_cache_data()
 
-        last_published_date = self._get_published_date(data_url)
+        last_published_date = self._get_published_date()
+        cache_date_file = self._get_cache_file()
 
-        cache_date_file = DataObjectFile(
-            data_object_cls=VulnerabilityCacheDate,
-            ua_file=UAFile(
-                name=VULNERABILITY_PUBLISH_DATE_CACHE,
-                directory=os.path.join(VULNERABILITY_CACHE_PATH, series),
-            ),
+        cache_valid, _ = self._is_cache_valid(
+            last_published_date, cache_date_file
         )
 
-        if self._is_cache_valid(series, last_published_date, cache_date_file):
-            return self._get_cache_data(series)
+        if cache_valid:
+            return self._get_cache_data()
 
-        json_data = json.loads(
-            http.download_xz_file_from_url(data_url).decode("utf-8")
-        )
+        if self.update_data or not self.cache_exists():
+            json_data = json.loads(
+                http.download_xz_file_from_url(self._get_data_url()).decode(
+                    "utf-8"
+                )
+            )
 
-        if util.we_are_currently_root():
-            self._save_cache_data(series, json_data)
-            self._save_cache_publish_date(cache_date_file, last_published_date)
+            if util.we_are_currently_root():
+                self._save_cache_data(json_data)
+                self._save_cache_publish_date(
+                    cache_date_file, last_published_date
+                )
 
-        return json_data
+            return json_data
 
 
 def _get_source_package_from_vulnerabilities_data(
@@ -258,11 +318,22 @@ def _get_vulnerability_fix_status(
     return vulnerability_status
 
 
+VulnerabilityParserResult = NamedTuple(
+    "VulnerabilityParserResult",
+    [
+        ("vulnerability_data_published_at", Optional[datetime.datetime]),
+        ("vulnerabilities", Dict[str, Any]),
+    ],
+)
+
+
 class VulnerabilityParser(metaclass=abc.ABCMeta):
     vulnerability_type = None  # type: str
 
     @abc.abstractmethod
-    def get_package_vulnerabilities(self, affected_pkg: Dict[str, Any]):
+    def get_package_vulnerabilities(
+        self, affected_pkg: Dict[str, Any]
+    ) -> Dict[str, Any]:
         pass
 
     def _add_new_vulnerability(
@@ -518,4 +589,120 @@ class VulnerabilityParser(metaclass=abc.ABCMeta):
                         vuln_pkg_status=vuln_pkg_status,
                     )
 
-        return vulnerabilities
+        return VulnerabilityParserResult(
+            vulnerability_data_published_at=vulnerabilities_data.get(
+                "published_at"
+            ),
+            vulnerabilities=vulnerabilities,
+        )
+
+
+class VulnerabilityResultCache:
+
+    def __init__(self, series, vulnerability_type):
+        self.series = series or system.get_release_info().series
+        self.vulnerability_type = vulnerability_type
+        self.dpkg_status_cache = DataObjectFile(
+            data_object_cls=VulnerabilityDpkgCacheDate,
+            ua_file=UAFile(
+                name=VULNERABILITY_DPKG_STATUS_DATE_CACHE,
+                directory=VULNERABILITY_CACHE_PATH,
+                private=False,
+            ),
+        )
+
+    def _get_result_cache_path(self):
+        return os.path.join(
+            VULNERABILITY_CACHE_PATH,
+            self.series,
+            self.vulnerability_type,
+            VULNERABILITY_RESULT_CACHE,
+        )
+
+    def save_result_cache(self, vulnerability_data: Dict[str, Any]):
+        if util.we_are_currently_root():
+            latest_dpkg_status_time = apt.get_dpkg_status_time() or 0
+            self.dpkg_status_cache.write(
+                VulnerabilityDpkgCacheDate(
+                    dpkg_status_date=latest_dpkg_status_time
+                )
+            )
+            system.write_file(
+                self._get_result_cache_path(),
+                json.dumps(vulnerability_data),
+            )
+
+    def _has_apt_state_changed(self):
+        latest_dpkg_status_time = apt.get_dpkg_status_time() or 0
+        dpkg_status_cache_obj = self.dpkg_status_cache.read()
+        if not dpkg_status_cache_obj:
+            return True
+
+        return latest_dpkg_status_time > dpkg_status_cache_obj.dpkg_status_date
+
+    def _cache_result_exists(self):
+        return os.path.exists(self._get_result_cache_path())
+
+    def _is_cache_result_valid(self):
+        if not self._cache_result_exists():
+            return False
+
+        if self._has_apt_state_changed():
+            return False
+
+        return True
+
+    def is_cache_valid(self):
+        return self._is_cache_result_valid()
+
+    def get_result_cache(self):
+        return json.loads(system.load_file(self._get_result_cache_path()))
+
+
+def get_vulnerabilities(
+    parser: VulnerabilityParser,
+    cfg: UAConfig,
+    update_json_data: bool,
+    series: Optional[str],
+    data_file: Optional[str],
+    manifest_file: Optional[str],
+):
+    vulnerabilities_data = VulnerabilityData(
+        cfg=cfg,
+        data_file=data_file,
+        series=series,
+        update_data=update_json_data,
+    )
+    vulnerabilities_result = VulnerabilityResultCache(
+        series=series,
+        vulnerability_type=parser.vulnerability_type,
+    )
+
+    if not manifest_file:
+        is_cache_valid, _ = vulnerabilities_data.is_cache_valid()
+        if is_cache_valid:
+            if vulnerabilities_result.is_cache_valid():
+                return VulnerabilityParserResult(
+                    vulnerability_data_published_at=vulnerabilities_data.get_published_date(),  # noqa
+                    vulnerabilities=vulnerabilities_result.get_result_cache(),
+                )
+
+    vulnerabilities_json_data = vulnerabilities_data.get()
+    installed_pkgs_by_source = SourcePackages(
+        vulnerabilities_data=vulnerabilities_json_data,
+        manifest_file=manifest_file,
+    ).get()
+
+    vulnerabilities_parser_result = (
+        parser.get_vulnerabilities_for_installed_pkgs(
+            vulnerabilities_data=vulnerabilities_json_data,
+            installed_pkgs_by_source=installed_pkgs_by_source,
+        )
+    )
+
+    if not manifest_file and not data_file:
+        vulnerabilities_result.save_result_cache(
+            vulnerabilities_parser_result.vulnerabilities
+        )
+
+    return vulnerabilities_parser_result

--- a/uaclient/api/u/pro/security/vulnerabilities/cve/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/cve/v1.py
@@ -6,11 +6,10 @@ from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
 from uaclient.api.exceptions import InvalidOptionCombination
 from uaclient.api.u.pro.security.vulnerabilities._common.v1 import (
-    SourcePackages,
-    VulnerabilityData,
     VulnerabilityParser,
     VulnerabilityStatus,
     _get_vulnerability_fix_status,
+    get_vulnerabilities,
 )
 from uaclient.apt import get_apt_cache_datetime
 from uaclient.config import UAConfig
@@ -60,6 +59,15 @@ class CVEVulnerabilitiesOptions(DataObject):
                 "vulnerabilities data for the given series."
             ),
         ),
+        Field(
+            "update",
+            BoolDataValue,
+            False,
+            doc=(
+                "If the vulnerability data should automatically "
+                "be updated when running the command (default=True)"
+            ),
+        ),
     ]
 
     def __init__(
@@ -69,13 +77,15 @@ class CVEVulnerabilitiesOptions(DataObject):
         unfixable: Optional[bool] = False,
         data_file: Optional[str] = None,
         manifest_file: Optional[str] = None,
-        series: Optional[str] = None
+        series: Optional[str] = None,
+        update: bool = True
     ):
         self.all = all
         self.unfixable = unfixable
         self.data_file = data_file
         self.manifest_file = manifest_file
         self.series = series
+        self.update = update
 
 
 class CVEAffectedPackage(DataObject):
@@ -236,7 +246,9 @@ class CVEVulnerabilitiesResult(DataObject, AdditionalInfo):
 class CVEParser(VulnerabilityParser):
     vulnerability_type = "cves"
 
-    def get_package_vulnerabilities(self, affected_pkg: Dict[str, Any]):
+    def get_package_vulnerabilities(
+        self, affected_pkg: Dict[str, Any]
+    ) -> Dict[str, Any]:
         return affected_pkg.get(self.vulnerability_type, {})
 
 
@@ -258,20 +270,15 @@ def _vulnerabilities(
     if options.unfixable and options.all:
         raise InvalidOptionCombination(option1="unfixable", option2="all")
 
-    vulnerabilities_json_data = VulnerabilityData(
-        cfg=cfg, data_file=options.data_file, series=options.series
-    ).get()
-
-    installed_pkgs_by_source = SourcePackages(
-        vulnerabilities_data=vulnerabilities_json_data,
+    cve_vulnerabilities_result = get_vulnerabilities(
+        parser=CVEParser(),
+        cfg=cfg,
+        update_json_data=options.update,
+        series=options.series,
+        data_file=options.data_file,
         manifest_file=options.manifest_file,
-    ).get()
-
-    cve_parser = CVEParser()
-    cve_vulnerabilities = cve_parser.get_vulnerabilities_for_installed_pkgs(
-        vulnerabilities_data=vulnerabilities_json_data,
-        installed_pkgs_by_source=installed_pkgs_by_source,
     )
+    cve_vulnerabilities = cve_vulnerabilities_result.vulnerabilities
 
     if options.unfixable:
         block_fixable_cves = True
@@ -327,7 +334,7 @@ def _vulnerabilities(
     return CVEVulnerabilitiesResult(
         cves=cves,
         vulnerability_data_published_at=util.parse_rfc3339_date(
-            vulnerabilities_json_data["published_at"]
+            cve_vulnerabilities_result.vulnerability_data_published_at
         ),
         apt_updated_at=(
             get_apt_cache_datetime() if not options.manifest_file else None

--- a/uaclient/api/u/pro/security/vulnerabilities/usn/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/usn/v1.py
@@ -6,11 +6,10 @@ from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
 from uaclient.api.exceptions import InvalidOptionCombination
 from uaclient.api.u.pro.security.vulnerabilities._common.v1 import (
-    SourcePackages,
-    VulnerabilityData,
     VulnerabilityParser,
     VulnerabilityStatus,
     _get_vulnerability_fix_status,
+    get_vulnerabilities,
 )
 from uaclient.apt import get_apt_cache_datetime
 from uaclient.config import UAConfig
@@ -59,6 +58,15 @@ class USNVulnerabilitiesOptions(DataObject):
                 "vulnerabilities data for the given series."
             ),
         ),
+        Field(
+            "update",
+            BoolDataValue,
+            False,
+            doc=(
+                "If the vulnerability data should automatically "
+                "be updated when running the command (default=True)"
+            ),
+        ),
     ]
 
     def __init__(
@@ -68,13 +76,15 @@ class USNVulnerabilitiesOptions(DataObject):
         unfixable: Optional[bool] = False,
         data_file: Optional[str] = None,
         manifest_file: Optional[str] = None,
-        series: Optional[str] = None
+        series: Optional[str] = None,
+        update: bool = True
     ):
         self.all = all
         self.unfixable = unfixable
         self.data_file = data_file
         self.manifest_file = manifest_file
         self.series = series
+        self.update = update
 
 
 class USNAffectedPackage(DataObject):
@@ -235,20 +245,15 @@ def _vulnerabilities(
     if options.unfixable and options.all:
         raise InvalidOptionCombination(option1="unfixable", option2="all")
 
-    vulnerabilities_json_data = VulnerabilityData(
-        cfg=cfg, data_file=options.data_file, series=options.series
-    ).get()
-
-    installed_pkgs_by_source = SourcePackages(
-        vulnerabilities_data=vulnerabilities_json_data,
+    usn_vulnerabilities_result = get_vulnerabilities(
+        parser=USNParser(),
+        cfg=cfg,
+        update_json_data=options.update,
+        series=options.series,
+        data_file=options.data_file,
         manifest_file=options.manifest_file,
-    ).get()
-
-    usn_parser = USNParser()
-    usn_vulnerabilities = usn_parser.get_vulnerabilities_for_installed_pkgs(
-        vulnerabilities_data=vulnerabilities_json_data,
-        installed_pkgs_by_source=installed_pkgs_by_source,
     )
+    usn_vulnerabilities = usn_vulnerabilities_result.vulnerabilities
 
     if options.unfixable:
         block_fixable_usns = True
@@ -301,7 +306,7 @@ def _vulnerabilities(
     return USNVulnerabilitiesResult(
         usns=usns,
         vulnerability_data_published_at=util.parse_rfc3339_date(
-            vulnerabilities_json_data["published_at"]
+            usn_vulnerabilities_result.vulnerability_data_published_at
         ),
         apt_updated_at=(
             get_apt_cache_datetime() if not options.manifest_file else None

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -59,6 +59,7 @@ CA_CERTIFICATES_FILE = "/usr/sbin/update-ca-certificates"
 APT_PROXY_CONF_FILE = "/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy"
 
 APT_UPDATE_SUCCESS_STAMP_PATH = "/var/lib/apt/periodic/update-success-stamp"
+DPKG_STATUS_PATH = "/var/lib/dpkg/status"
 
 SERIES_NOT_USING_DEB822 = ("xenial", "bionic", "focal", "jammy")
 
@@ -847,6 +848,13 @@ def get_apt_cache_time() -> Optional[float]:
     if os.path.exists(APT_UPDATE_SUCCESS_STAMP_PATH):
         cache_time = os.stat(APT_UPDATE_SUCCESS_STAMP_PATH).st_mtime
     return cache_time
+
+
+def get_dpkg_status_time() -> Optional[float]:
+    status_time = None
+    if os.path.exists(DPKG_STATUS_PATH):
+        status_time = os.stat(DPKG_STATUS_PATH).st_mtime
+    return status_time
 
 
 def get_apt_cache_datetime() -> Optional[datetime.datetime]:

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -27,7 +27,9 @@ NOTICES_SUBDIR = "notices"
 PRIVATE_ESM_CACHE_SUBDIR = "apt-esm"
 VULNERABILITY_SUBDIR = "vulnerability-data"
 VULNERABILITY_DATA_CACHE = "vulnerability-cache.json"
+VULNERABILITY_RESULT_CACHE = "vulnerability-result.json"
 VULNERABILITY_PUBLISH_DATE_CACHE = "vulnerability-publish-date"
+VULNERABILITY_DPKG_STATUS_DATE_CACHE = "vulnerability-dpkg-status-date"
 
 DEFAULT_PRIVATE_MACHINE_TOKEN_PATH = os.path.join(
     DEFAULT_DATA_DIR, PRIVATE_SUBDIR, MACHINE_TOKEN_FILE


### PR DESCRIPTION
## Why is this needed?
We are now caching the vulnerability result as well. That means that if we detect that there is now new vulnerability JSON data to be used and no dpkg related changes on the system, we can simply reuse the old results.


## Test Steps
1. Verify that the vulnerabilities integration tests are still working 
2. Verify that the result cache is being produced
3. Verify when running two API commands in a row, the second one is way faster than the first
---

- [x] *(un)check this to re-run the checklist action*