### PR TITLE
cli: add vulnerability commands

### DIFF
--- a/features/api_vulnerabilities_cve.feature
+++ b/features/api_vulnerabilities_cve.feature
@@ -3,6 +3,20 @@ Feature: Client behaviour for CVE vulnerabilities API
   @uses.config.contract_token
   Scenario Outline: CVE vulnerabilities for xenial machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I verify that running `pro api u.pro.security.vulnerabilities.cve.v1 --args series=jammy` `as non-root` exits `1`
+    Then API errors field output is:
+      """
+      [
+        {
+          "code": "depedent-option",
+          "meta": {
+            "option1": "series",
+            "option2": "manifest_file"
+          },
+          "title": "Error: series depends on manifest_file to work properly."
+        }
+      ]
+      """
     When I attach `contract_token` with sudo
     # Check we can download and parse the JSON data
     And I run `pro api u.pro.security.vulnerabilities.cve.v1` as non-root

--- a/features/api_vulnerabilities_cve.feature
+++ b/features/api_vulnerabilities_cve.feature
@@ -8,7 +8,7 @@ Feature: Client behaviour for CVE vulnerabilities API
       """
       [
         {
-          "code": "depedent-option",
+          "code": "dependent-option",
           "meta": {
             "option1": "series",
             "option2": "manifest_file"

--- a/features/api_vulnerabilities_cve.feature
+++ b/features/api_vulnerabilities_cve.feature
@@ -20,8 +20,8 @@ Feature: Client behaviour for CVE vulnerabilities API
     When I attach `contract_token` with sudo
     # Check we can download and parse the JSON data
     And I run `pro api u.pro.security.vulnerabilities.cve.v1` as non-root
-    And I push static file `security_issues_xenial` to machine
-    And I run `pro api u.pro.security.vulnerabilities.cve.v1 --args data_file=/tmp/security_issues_xenial` as non-root
+    And I push static file `security_issues_xenial.json` to machine
+    And I run `pro api u.pro.security.vulnerabilities.cve.v1 --args data_file=/tmp/security_issues_xenial.json` as non-root
     And I apply this jq filter `.data.attributes.cves[] | select(.name == "CVE-2022-2286")` to the output
     Then stdout matches regexp:
       """
@@ -76,13 +76,13 @@ Feature: Client behaviour for CVE vulnerabilities API
       }
       """
     When I apt install `vim`
-    And I run `pro api u.pro.security.vulnerabilities.cve.v1 --args data_file=/tmp/security_issues_xenial` as non-root
+    And I run `pro api u.pro.security.vulnerabilities.cve.v1 --args data_file=/tmp/security_issues_xenial.json` as non-root
     And I apply this jq filter `.data.attributes.cves` to the output
     Then stdout does not contain substring:
       """
       "name": "CVE-2022-2286"
       """
-    When I run `pro api u.pro.security.vulnerabilities.cve.v1 --data '{"all": true, "data_file": "/tmp/security_issues_xenial"}'` as non-root
+    When I run `pro api u.pro.security.vulnerabilities.cve.v1 --data '{"all": true, "data_file": "/tmp/security_issues_xenial.json"}'` as non-root
     And I apply this jq filter `.data.attributes.cves[] | select (.name == "CVE-2017-11544")` to the output
     Then stdout matches regexp:
       """
@@ -109,7 +109,7 @@ Feature: Client behaviour for CVE vulnerabilities API
         "ubuntu_priority": "medium"
       }
       """
-    When I run `pro api u.pro.security.vulnerabilities.cve.v1 --data '{"unfixable": true, "data_file": "/tmp/security_issues_xenial"}'` as non-root
+    When I run `pro api u.pro.security.vulnerabilities.cve.v1 --data '{"unfixable": true, "data_file": "/tmp/security_issues_xenial.json"}'` as non-root
     And I apply this jq filter `.data.attributes.cves[] | select (.name == "CVE-2017-11544")` to the output
     Then stdout matches regexp:
       """
@@ -136,7 +136,7 @@ Feature: Client behaviour for CVE vulnerabilities API
         "ubuntu_priority": "medium"
       }
       """
-    When I verify that running `pro api u.pro.security.vulnerabilities.cve.v1 --data '{"unfixable": true, "all": true, "data_file": "/tmp/security_issues_xenial"}'` `as non-root` exits `1`
+    When I verify that running `pro api u.pro.security.vulnerabilities.cve.v1 --data '{"unfixable": true, "all": true, "data_file": "/tmp/security_issues_xenial.json"}'` `as non-root` exits `1`
     Then API errors field output is:
       """
       [
@@ -154,7 +154,7 @@ Feature: Client behaviour for CVE vulnerabilities API
       """
       libzstd1:amd64     1.3.1+dfsg-1~ubuntu0.16.04.1
       """
-    And I run `pro api u.pro.security.vulnerabilities.cve.v1 --args data_file=/tmp/security_issues_xenial manifest_file=/tmp/manifest` as non-root
+    And I run `pro api u.pro.security.vulnerabilities.cve.v1 --args data_file=/tmp/security_issues_xenial.json manifest_file=/tmp/manifest` as non-root
     Then API data field output matches regexp:
       """
       {

--- a/features/api_vulnerabilities_usn.feature
+++ b/features/api_vulnerabilities_usn.feature
@@ -3,6 +3,20 @@ Feature: Client behaviour for USN vulnerabilities API
   @uses.config.contract_token
   Scenario Outline: USN vulnerabilities for xenial machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I verify that running `pro api u.pro.security.vulnerabilities.usn.v1 --args series=jammy` `as non-root` exits `1`
+    Then API errors field output is:
+      """
+      [
+        {
+          "code": "depedent-option",
+          "meta": {
+            "option1": "series",
+            "option2": "manifest_file"
+          },
+          "title": "Error: series depends on manifest_file to work properly."
+        }
+      ]
+      """
     When I attach `contract_token` with sudo
     # Check we can download and parse the JSON data
     And I run `pro api u.pro.security.vulnerabilities.usn.v1` as non-root

--- a/features/api_vulnerabilities_usn.feature
+++ b/features/api_vulnerabilities_usn.feature
@@ -20,8 +20,8 @@ Feature: Client behaviour for USN vulnerabilities API
     When I attach `contract_token` with sudo
     # Check we can download and parse the JSON data
     And I run `pro api u.pro.security.vulnerabilities.usn.v1` as non-root
-    And I push static file `security_issues_xenial` to machine
-    And I run `pro api u.pro.security.vulnerabilities.usn.v1 --args data_file=/tmp/security_issues_xenial` as non-root
+    And I push static file `security_issues_xenial.json` to machine
+    And I run `pro api u.pro.security.vulnerabilities.usn.v1 --args data_file=/tmp/security_issues_xenial.json` as non-root
     And I apply this jq filter `.data.attributes.usns[] | select (.name == "USN-4976-2")` to the output
     Then stdout matches regexp:
       """
@@ -51,13 +51,13 @@ Feature: Client behaviour for USN vulnerabilities API
       }
       """
     When I apt install `dnsmasq-base`
-    And I run `pro api u.pro.security.vulnerabilities.usn.v1 --args data_file=/tmp/security_issues_xenial` as non-root
+    And I run `pro api u.pro.security.vulnerabilities.usn.v1 --args data_file=/tmp/security_issues_xenial.json` as non-root
     And I apply this jq filter `.data.attributes.usns` to the output
     Then stdout does not contain substring:
       """
       "name": "USN-4976-2",
       """
-    When I run `pro api u.pro.security.vulnerabilities.usn.v1 --data '{"unfixable": true, "data_file": "/tmp/security_issues_xenial"}'` as non-root
+    When I run `pro api u.pro.security.vulnerabilities.usn.v1 --data '{"unfixable": true, "data_file": "/tmp/security_issues_xenial.json"}'` as non-root
     Then API data field output matches regexp:
       """
       {
@@ -72,7 +72,7 @@ Feature: Client behaviour for USN vulnerabilities API
         "type": "USNVulnerabilities"
       }
       """
-    When I verify that running `pro api u.pro.security.vulnerabilities.usn.v1 --data '{"unfixable": true, "all": true, "data_file": "/tmp/security_issues_xenial"}'` `as non-root` exits `1`
+    When I verify that running `pro api u.pro.security.vulnerabilities.usn.v1 --data '{"unfixable": true, "all": true, "data_file": "/tmp/security_issues_xenial.json"}'` `as non-root` exits `1`
     Then API errors field output is:
       """
       [
@@ -90,7 +90,7 @@ Feature: Client behaviour for USN vulnerabilities API
       """
       libzstd1:amd64     1.3.1+dfsg-1~ubuntu0.16.04.1
       """
-    And I run `pro api u.pro.security.vulnerabilities.usn.v1 --args data_file=/tmp/security_issues_xenial manifest_file=/tmp/manifest` as non-root
+    And I run `pro api u.pro.security.vulnerabilities.usn.v1 --args data_file=/tmp/security_issues_xenial.json manifest_file=/tmp/manifest` as non-root
     Then API data field output matches regexp:
       """
       {

--- a/features/api_vulnerabilities_usn.feature
+++ b/features/api_vulnerabilities_usn.feature
@@ -8,7 +8,7 @@ Feature: Client behaviour for USN vulnerabilities API
       """
       [
         {
-          "code": "depedent-option",
+          "code": "dependent-option",
           "meta": {
             "option1": "series",
             "option2": "manifest_file"

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -19,6 +19,7 @@ Feature: Pro Client help text
       Security-related commands:
 
         fix              check for and mitigate the impact of a CVE/USN on this system
+        vulnerability    show information about system vulnerabilities
 
       Troubleshooting-related commands:
 
@@ -58,6 +59,7 @@ Feature: Pro Client help text
       Security-related commands:
 
         fix              check for and mitigate the impact of a CVE/USN on this system
+        vulnerability    show information about system vulnerabilities
 
       Troubleshooting-related commands:
 
@@ -458,6 +460,80 @@ Feature: Pro Client help text
                     vulnerability_data_url_prefix
 
       <options_string>:
+        -h, --help  show this help message and exit
+      """
+    When I run `pro vulnerability --help` as non-root
+    Then I will see the following on stdout
+      """
+      usage: pro vulnerability [-h] {show,update,list} ...
+
+      Allow users to better visualize the vulnerability issues that affects
+      the system.
+
+      optional arguments:
+        -h, --help          show this help message and exit
+
+      Available Commands:
+        {show,update,list}
+          show              show information about a vulnerability
+          update            update the vulnerability data in your machine
+          list              list the vulnerabilities that affect the system
+      """
+    When I run `pro vulnerability show --help` as non-root
+    Then I will see the following on stdout
+      """
+      usage: pro vulnerability show [-h] [--data-file DATA_FILE] [--update]
+                                    security_issue
+
+      Show all available information about a given security issue.
+
+      positional arguments:
+        security_issue        Security vulnerability ID to display information.
+                              Format: CVE-yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-dd
+
+      optional arguments:
+        -h, --help            show this help message and exit
+        --data-file DATA_FILE
+                              Static vulnerability JSON data to be used in the
+                              command
+        --update              update the vulnerability data in your machine
+      """
+    When I run `pro vulnerability list --help` as non-root
+    Then I will see the following on stdout
+      """
+      usage: pro vulnerability list [-h] [--data-file DATA_FILE] [--all] [--usns]
+                                    [--unfixable] [--manifest-file MANIFEST_FILE]
+                                    [--series SERIES] [--update]
+
+      List the fixable vulnerabilities that affects the system.
+      By default, the command will only list CVEs. To display
+      USNs instead, run the command with the --usns flag.
+
+      optional arguments:
+        -h, --help            show this help message and exit
+        --data-file DATA_FILE
+                              Static vulnerability JSON data to be used in the
+                              command
+        --all                 List all vulnerabilities that affect the machine, even
+                              if they can't be fixed
+        --usns                List USNs vulnerabilities instead of CVEs
+        --unfixable           List only vulnerabilities that don't have a fix
+                              available
+        --manifest-file MANIFEST_FILE
+                              Manifest file to be used by the command
+        --series SERIES       When a manifest file is provided, specify the series
+                              that generated using this parameter
+        --update              update the vulnerability data in your machine
+      """
+    When I run `pro vulnerability update --help` as non-root
+    Then I will see the following on stdout
+      """
+      usage: pro vulnerability update [-h]
+
+      Updates the vulnerability data stored in the machine.
+      If no vulnerability data exists yet, the command will download it
+
+      optional arguments:
         -h, --help  show this help message and exit
       """
 

--- a/features/cli/vulnerability_list.feature
+++ b/features/cli/vulnerability_list.feature
@@ -1,0 +1,121 @@
+Feature: CLI vulnerability list command
+
+  Scenario Outline: CLI vulnerability list
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I verify that running `pro vulnerability list --all --unfixable` `as non-root` exits `1`
+    Then I will see the following on stderr:
+      """
+      Error: Cannot use unfixable together with all.
+      """
+    When I create the file `/tmp/manifest` with the following:
+      """
+      libtasn1-6         4.7-3ubuntu0.16.04.3
+      libzstd1:amd64     1.3.1+dfsg-1~ubuntu0.16.04.1
+      screen             4.3.1-2ubuntu0.1
+      snapd              2.48.3
+      """
+    And I push static file `security_issues_xenial` to machine
+    And I run `pro vulnerability list --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    And I remove colors from output
+    Then I will see the following on stdout:
+      """
+      Vulnerabilities with applied fixes:
+          13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
+
+      Vulnerabilities with fixes available:
+          10 vulnerabilities found (3 high, 4 medium, 2 low, 1 negligible)
+
+      Common vulnerabilities and exposures (CVE):
+      VULNERABILITY     PRIORITY    FIX AVAILABLE FROM  AFFECTED INSTALLED PACKAGES
+      CVE-2021-44730    high        esm-infra           snapd
+      CVE-2021-44731    high        esm-infra           snapd
+      CVE-2022-3328     high        esm-infra           snapd
+      CVE-2019-11922    medium      esm-infra           libzstd1
+      CVE-2021-3155     medium      esm-infra           snapd
+      CVE-2021-4120     medium      esm-infra           snapd
+      CVE-2023-1523     medium      esm-infra           snapd
+      CVE-2021-46848    low         esm-infra           libtasn1-6
+      CVE-2023-24626    low         esm-infra           screen
+      CVE-2018-1000654  negligible  esm-infra           libtasn1-6
+      """
+    When I run `pro vulnerability list --all --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    And I remove colors from output
+    Then I will see the following on stdout:
+      """
+      Vulnerabilities with applied fixes:
+          13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
+
+      Vulnerabilities with fixes available:
+          10 vulnerabilities found (3 high, 4 medium, 2 low, 1 negligible)
+
+      Vulnerabilities with no fixes available:
+          10 unfixable vulnerabilities found (8 medium, 2 low)
+
+      Common vulnerabilities and exposures (CVE):
+      VULNERABILITY     PRIORITY    FIX AVAILABLE FROM  AFFECTED INSTALLED PACKAGES
+      CVE-2021-44730    high        esm-infra           snapd
+      CVE-2021-44731    high        esm-infra           snapd
+      CVE-2022-3328     high        esm-infra           snapd
+      CVE-2019-11840    medium      no-fix              snapd
+      CVE-2019-11922    medium      esm-infra           libzstd1
+      CVE-2021-24031    medium      no-fix              libzstd1
+      CVE-2021-24032    medium      no-fix              libzstd1
+      CVE-2021-3155     medium      esm-infra           snapd
+      CVE-2021-4120     medium      esm-infra           snapd
+      CVE-2022-28948    medium      no-fix              snapd
+      CVE-2023-1523     medium      esm-infra           snapd
+      CVE-2023-48795    medium      no-fix              snapd
+      CVE-2024-1724     medium      no-fix              snapd
+      CVE-2024-29068    medium      no-fix              snapd
+      CVE-2024-29069    medium      no-fix              snapd
+      CVE-2017-3204     low         no-fix              snapd
+      CVE-2021-46848    low         esm-infra           libtasn1-6
+      CVE-2023-24626    low         esm-infra           screen
+      CVE-2024-5138     low         no-fix              snapd
+      CVE-2018-1000654  negligible  esm-infra           libtasn1-6
+      """
+    When I run `pro vulnerability list --unfixable --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    And I remove colors from output
+    Then I will see the following on stdout:
+      """
+      Vulnerabilities with applied fixes:
+          13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
+
+      Vulnerabilities with no fixes available:
+          10 unfixable vulnerabilities found (8 medium, 2 low)
+
+      Common vulnerabilities and exposures (CVE):
+      VULNERABILITY   PRIORITY  FIX AVAILABLE FROM  AFFECTED INSTALLED PACKAGES
+      CVE-2019-11840  medium    no-fix              snapd
+      CVE-2021-24031  medium    no-fix              libzstd1
+      CVE-2021-24032  medium    no-fix              libzstd1
+      CVE-2022-28948  medium    no-fix              snapd
+      CVE-2023-48795  medium    no-fix              snapd
+      CVE-2024-1724   medium    no-fix              snapd
+      CVE-2024-29068  medium    no-fix              snapd
+      CVE-2024-29069  medium    no-fix              snapd
+      CVE-2017-3204   low       no-fix              snapd
+      CVE-2024-5138   low       no-fix              snapd
+      """
+    When I run `pro vulnerability list --usns --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    And I remove colors from output
+    Then I will see the following on stdout:
+      """
+      Vulnerabilities with applied fixes:
+          1 applied via Ubuntu Security
+
+      Vulnerabilities with fixes available:
+          5 vulnerabilities found
+
+      Ubuntu Security Notices (USN):
+      VULNERABILITY  FIX AVAILABLE FROM  AFFECTED INSTALLED PACKAGES
+      USN-5292-3     esm-infra           snapd
+      USN-5352-1     esm-infra           libtasn1-6
+      USN-5593-1     esm-infra           libzstd1
+      USN-5707-1     esm-infra           libtasn1-6
+      USN-5720-1     esm-infra           libzstd1
+      """
+
+    Examples: ubuntu
+      | release | machine_type  |
+      | xenial  | lxd-container |

--- a/features/cli/vulnerability_list.feature
+++ b/features/cli/vulnerability_list.feature
@@ -115,6 +115,22 @@ Feature: CLI vulnerability list command
       USN-5707-1     esm-infra           libtasn1-6
       USN-5720-1     esm-infra           libzstd1
       """
+    When I create the file `/tmp/manifest` with the following:
+      """
+      foobat         1.0
+      """
+    When I run `pro vulnerability list --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    And I remove colors from output
+    Then I will see the following on stdout:
+      """
+      No CVEs found that affects this system
+      """
+    When I run `pro vulnerability list --usns --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    And I remove colors from output
+    Then I will see the following on stdout:
+      """
+      No USNs found that affects this system
+      """
 
     Examples: ubuntu
       | release | machine_type  |

--- a/features/cli/vulnerability_list.feature
+++ b/features/cli/vulnerability_list.feature
@@ -19,8 +19,8 @@ Feature: CLI vulnerability list command
       screen             4.3.1-2ubuntu0.1
       snapd              2.48.3
       """
-    And I push static file `security_issues_xenial` to machine
-    And I run `pro vulnerability list --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    And I push static file `security_issues_xenial.json` to machine
+    And I run `pro vulnerability list --data-file=/tmp/security_issues_xenial.json --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
     And I remove links from output
     Then I will see the following on stdout:
@@ -44,7 +44,7 @@ Feature: CLI vulnerability list command
       Vulnerabilities with fixes available:
           10 fixable via Ubuntu Pro (3 high, 4 medium, 2 low, 1 negligible)
       """
-    When I run `pro vulnerability list --all --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    When I run `pro vulnerability list --all --data-file=/tmp/security_issues_xenial.json --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
     And I remove links from output
     Then I will see the following on stdout:
@@ -80,7 +80,7 @@ Feature: CLI vulnerability list command
       Vulnerabilities with no fixes available:
           9 unfixable vulnerabilities found (7 medium, 2 low)
       """
-    When I run `pro vulnerability list --unfixable --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    When I run `pro vulnerability list --unfixable --data-file=/tmp/security_issues_xenial.json --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
     And I remove links from output
     Then I will see the following on stdout:
@@ -103,7 +103,7 @@ Feature: CLI vulnerability list command
       Vulnerabilities with no fixes available:
           9 unfixable vulnerabilities found (7 medium, 2 low)
       """
-    When I run `pro vulnerability list --usns --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    When I run `pro vulnerability list --usns --data-file=/tmp/security_issues_xenial.json --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
     And I remove links from output
     Then I will see the following on stdout:
@@ -126,13 +126,13 @@ Feature: CLI vulnerability list command
       """
       foobat         1.0
       """
-    When I run `pro vulnerability list --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    When I run `pro vulnerability list --data-file=/tmp/security_issues_xenial.json --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
     Then I will see the following on stdout:
       """
       No CVEs found that affects this system
       """
-    When I run `pro vulnerability list --usns --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    When I run `pro vulnerability list --usns --data-file=/tmp/security_issues_xenial.json --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
     Then I will see the following on stdout:
       """

--- a/features/cli/vulnerability_list.feature
+++ b/features/cli/vulnerability_list.feature
@@ -24,12 +24,6 @@ Feature: CLI vulnerability list command
     And I remove colors from output
     Then I will see the following on stdout:
       """
-      Vulnerabilities with applied fixes:
-          13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
-
-      Vulnerabilities with fixes available:
-          10 vulnerabilities found (3 high, 4 medium, 2 low, 1 negligible)
-
       Common vulnerabilities and exposures (CVE):
       VULNERABILITY     PRIORITY    FIX AVAILABLE FROM  AFFECTED INSTALLED PACKAGES
       CVE-2021-44730    high        esm-infra           snapd
@@ -42,20 +36,17 @@ Feature: CLI vulnerability list command
       CVE-2021-46848    low         esm-infra           libtasn1-6
       CVE-2023-24626    low         esm-infra           screen
       CVE-2018-1000654  negligible  esm-infra           libtasn1-6
-      """
-    When I run `pro vulnerability list --all --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
-    And I remove colors from output
-    Then I will see the following on stdout:
-      """
+
       Vulnerabilities with applied fixes:
           13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
 
       Vulnerabilities with fixes available:
           10 vulnerabilities found (3 high, 4 medium, 2 low, 1 negligible)
-
-      Vulnerabilities with no fixes available:
-          10 unfixable vulnerabilities found (8 medium, 2 low)
-
+      """
+    When I run `pro vulnerability list --all --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
+    And I remove colors from output
+    Then I will see the following on stdout:
+      """
       Common vulnerabilities and exposures (CVE):
       VULNERABILITY     PRIORITY    FIX AVAILABLE FROM  AFFECTED INSTALLED PACKAGES
       CVE-2021-44730    high        esm-infra           snapd
@@ -69,7 +60,6 @@ Feature: CLI vulnerability list command
       CVE-2021-4120     medium      esm-infra           snapd
       CVE-2022-28948    medium      no-fix              snapd
       CVE-2023-1523     medium      esm-infra           snapd
-      CVE-2023-48795    medium      no-fix              snapd
       CVE-2024-1724     medium      no-fix              snapd
       CVE-2024-29068    medium      no-fix              snapd
       CVE-2024-29069    medium      no-fix              snapd
@@ -78,40 +68,42 @@ Feature: CLI vulnerability list command
       CVE-2023-24626    low         esm-infra           screen
       CVE-2024-5138     low         no-fix              snapd
       CVE-2018-1000654  negligible  esm-infra           libtasn1-6
+
+      Vulnerabilities with applied fixes:
+          13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
+
+      Vulnerabilities with fixes available:
+          10 vulnerabilities found (3 high, 4 medium, 2 low, 1 negligible)
+
+      Vulnerabilities with no fixes available:
+          9 unfixable vulnerabilities found (7 medium, 2 low)
       """
     When I run `pro vulnerability list --unfixable --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
     Then I will see the following on stdout:
       """
-      Vulnerabilities with applied fixes:
-          13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
-
-      Vulnerabilities with no fixes available:
-          10 unfixable vulnerabilities found (8 medium, 2 low)
-
       Common vulnerabilities and exposures (CVE):
       VULNERABILITY   PRIORITY  FIX AVAILABLE FROM  AFFECTED INSTALLED PACKAGES
       CVE-2019-11840  medium    no-fix              snapd
       CVE-2021-24031  medium    no-fix              libzstd1
       CVE-2021-24032  medium    no-fix              libzstd1
       CVE-2022-28948  medium    no-fix              snapd
-      CVE-2023-48795  medium    no-fix              snapd
       CVE-2024-1724   medium    no-fix              snapd
       CVE-2024-29068  medium    no-fix              snapd
       CVE-2024-29069  medium    no-fix              snapd
       CVE-2017-3204   low       no-fix              snapd
       CVE-2024-5138   low       no-fix              snapd
+
+      Vulnerabilities with applied fixes:
+          13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
+
+      Vulnerabilities with no fixes available:
+          9 unfixable vulnerabilities found (7 medium, 2 low)
       """
     When I run `pro vulnerability list --usns --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
     Then I will see the following on stdout:
       """
-      Vulnerabilities with applied fixes:
-          1 applied via Ubuntu Security
-
-      Vulnerabilities with fixes available:
-          5 vulnerabilities found
-
       Ubuntu Security Notices (USN):
       VULNERABILITY  FIX AVAILABLE FROM  AFFECTED INSTALLED PACKAGES
       USN-5292-3     esm-infra           snapd
@@ -119,6 +111,12 @@ Feature: CLI vulnerability list command
       USN-5593-1     esm-infra           libzstd1
       USN-5707-1     esm-infra           libtasn1-6
       USN-5720-1     esm-infra           libzstd1
+
+      Vulnerabilities with applied fixes:
+          1 applied via Ubuntu Security
+
+      Vulnerabilities with fixes available:
+          5 vulnerabilities found
       """
     When I create the file `/tmp/manifest` with the following:
       """

--- a/features/cli/vulnerability_list.feature
+++ b/features/cli/vulnerability_list.feature
@@ -2,6 +2,11 @@ Feature: CLI vulnerability list command
 
   Scenario Outline: CLI vulnerability list
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I verify that running `pro vulnerability list --series=jammy` `as non-root` exits `1`
+    Then I will see the following on stderr:
+      """
+      Error: series depends on manifest_file to work properly.
+      """
     When I verify that running `pro vulnerability list --all --unfixable` `as non-root` exits `1`
     Then I will see the following on stderr:
       """

--- a/features/cli/vulnerability_list.feature
+++ b/features/cli/vulnerability_list.feature
@@ -41,7 +41,7 @@ Feature: CLI vulnerability list command
           13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
 
       Vulnerabilities with fixes available:
-          10 vulnerabilities found (3 high, 4 medium, 2 low, 1 negligible)
+          10 fixable via Ubuntu Pro (3 high, 4 medium, 2 low, 1 negligible)
       """
     When I run `pro vulnerability list --all --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
@@ -73,7 +73,7 @@ Feature: CLI vulnerability list command
           13 applied via Ubuntu Security (2 high, 6 medium, 5 low)
 
       Vulnerabilities with fixes available:
-          10 vulnerabilities found (3 high, 4 medium, 2 low, 1 negligible)
+          10 fixable via Ubuntu Pro (3 high, 4 medium, 2 low, 1 negligible)
 
       Vulnerabilities with no fixes available:
           9 unfixable vulnerabilities found (7 medium, 2 low)
@@ -116,7 +116,7 @@ Feature: CLI vulnerability list command
           1 applied via Ubuntu Security
 
       Vulnerabilities with fixes available:
-          5 vulnerabilities found
+          5 fixable via Ubuntu Pro
       """
     When I create the file `/tmp/manifest` with the following:
       """

--- a/features/cli/vulnerability_list.feature
+++ b/features/cli/vulnerability_list.feature
@@ -22,6 +22,7 @@ Feature: CLI vulnerability list command
     And I push static file `security_issues_xenial` to machine
     And I run `pro vulnerability list --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
+    And I remove links from output
     Then I will see the following on stdout:
       """
       Common vulnerabilities and exposures (CVE):
@@ -45,6 +46,7 @@ Feature: CLI vulnerability list command
       """
     When I run `pro vulnerability list --all --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
+    And I remove links from output
     Then I will see the following on stdout:
       """
       Common vulnerabilities and exposures (CVE):
@@ -80,6 +82,7 @@ Feature: CLI vulnerability list command
       """
     When I run `pro vulnerability list --unfixable --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
+    And I remove links from output
     Then I will see the following on stdout:
       """
       Common vulnerabilities and exposures (CVE):
@@ -102,6 +105,7 @@ Feature: CLI vulnerability list command
       """
     When I run `pro vulnerability list --usns --data-file=/tmp/security_issues_xenial --manifest-file=/tmp/manifest` as non-root
     And I remove colors from output
+    And I remove links from output
     Then I will see the following on stdout:
       """
       Ubuntu Security Notices (USN):

--- a/features/cli/vulnerability_show.feature
+++ b/features/cli/vulnerability_show.feature
@@ -1,0 +1,142 @@
+Feature: CLI vulnerability show command
+
+  Scenario Outline: CLI vulnerability show
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I verify that running `pro vulnerability show invalid` `as non-root` exits `1`
+    Then I will see the following on stderr:
+      """
+      Error: issue "invalid" is not recognized.
+      Usage: "pro vulnerability show CVE-yyyy-nnnn" or "pro vulnerability show USN-nnnn"
+      """
+    When I push static file `security_issues_xenial` to machine
+    And I run `pro vulnerability show CVE-2024-7542 --data-file=/tmp/security_issues_xenial` as non-root
+    Then stdout matches regexp:
+      """
+      CVE-2024-7542
+      Public URL: https://ubuntu.com/CVE-2024-7542
+      Ubuntu vulnerability data published at: .*
+      APT package information updated at: .*
+
+      CVE-2024-7542 does not affect your system.
+      """
+    When I run `apt update` with sudo
+    And I run `apt install vim=2:7.4.1689-3ubuntu1.5 -y` with sudo
+    And I run `pro vulnerability show <cve> --data-file=/tmp/security_issues_xenial` as non-root
+    And I remove colors from output
+    Then stdout matches regexp:
+      """
+      CVE-2022-2286
+      Public URL: https://ubuntu.com/CVE-2022-2286
+      Published at: 2022-07-02 19:15:00
+      Ubuntu vulnerability data published at: .*
+      APT package information updated at: .*
+      Ubuntu priority: low
+      CVSS score: 7.8
+      CVSS severity: high
+
+      \[DESCRIPTION\]
+      Out-of-bounds Read in GitHub repository vim/vim prior to 9.0.
+
+      \[AFFECTED INSTALLED PACKAGES\]
+      NAME         STATUS  CURRENT VERSION        FIXED BY                     FIX AVAILABLE FROM
+      vim          fixed   2:7.4.1689-3ubuntu1.5  2:7.4.1689-3ubuntu1.5\+esm19  esm-infra
+      vim-common   fixed   2:7.4.1689-3ubuntu1.5  2:7.4.1689-3ubuntu1.5\+esm19  esm-infra
+      vim-runtime  fixed   2:7.4.1689-3ubuntu1.5  2:7.4.1689-3ubuntu1.5\+esm19  esm-infra
+      vim-tiny     fixed   2:7.4.1689-3ubuntu1.5  2:7.4.1689-3ubuntu1.5\+esm19  esm-infra
+
+      \[RELATED USNs\]
+      VULNERABILITY  TITLE                AFFECTED INSTALLED PACKAGES
+      USN-6270-1     Vim vulnerabilities  vim
+      """
+    When I run `pro vulnerability show <unfixable_cve> --data-file=/tmp/security_issues_xenial` as non-root
+    And I remove colors from output
+    Then stdout matches regexp:
+      """
+      CVE-2024-8088
+      Public URL: https://ubuntu.com/CVE-2024-8088
+      Published at: 2024-08-22 19:15:00
+      Ubuntu vulnerability data published at: .*
+      APT package information updated at: .*
+      Ubuntu priority: medium
+      CVSS score: None
+      CVSS severity: None
+
+      \[DESCRIPTION\]
+      There is a HIGH severity vulnerability affecting the CPython "zipfile"
+      module affecting "zipfile.Path". Note that the more common API
+      "zipfile.ZipFile" class is unaffected.
+      When iterating over names of entries in a zip archive \(for example, methods
+      of "zipfile.Path" like "namelist\(\)", "iterdir\(\)", etc\)
+      the process can be put into an infinite loop with a maliciously crafted
+      zip archive. This defect applies when reading only metadata or extracting
+      the contents of the zip archive. Programs that are not handling
+      user-controlled zip archives are not affected.
+
+      \[AFFECTED INSTALLED PACKAGES\]
+      NAME                  STATUS      CURRENT VERSION          FIXED BY  FIX AVAILABLE FROM
+      libpython3.5          vulnerable  3.5.2-2ubuntu0~16.04.13  -         no-fix
+      libpython3.5-minimal  vulnerable  3.5.2-2ubuntu0~16.04.13  -         no-fix
+      libpython3.5-stdlib   vulnerable  3.5.2-2ubuntu0~16.04.13  -         no-fix
+      python3.5             vulnerable  3.5.2-2ubuntu0~16.04.13  -         no-fix
+      python3.5-minimal     vulnerable  3.5.2-2ubuntu0~16.04.13  -         no-fix
+
+      \[NOTES\]
+      mdeslaur> The original fix lead to a regression, see subsequent commit.
+      There are two more commits in the Lib/zipfile directory that are
+      possibly related to this issue.
+      """
+    When I run `pro vulnerability show <usn> --data-file=/tmp/security_issues_xenial` as non-root
+    And I remove colors from output
+    Then stdout matches regexp:
+      """
+      USN-4976-2
+      Public URL: https://ubuntu.com/USN-4976-2
+      Published at: 2022-09-07 15:22:39
+      Ubuntu vulnerability data published at: .*
+      APT package information updated at: .*
+
+      \[DESCRIPTION\]
+      USN-4976-1 fixed a vulnerability in Dnsmasq. This update provides
+      the corresponding update for Ubuntu 16.04 ESM.
+
+      Dnsmasq has been updated to 2.79-1 for Ubuntu 16.04 ESM in order to fix
+      some security issues.
+
+      Original advisory details:
+
+       Petr Mensik discovered that Dnsmasq incorrectly randomized source ports in
+       certain configurations. A remote attacker could possibly use this issue to
+       facilitate DNS cache poisoning attacks.
+
+
+      \[AFFECTED INSTALLED PACKAGES\]
+      NAME          CURRENT VERSION         FIXED BY                    FIX AVAILABLE FROM
+      dnsmasq-base  2.75-1ubuntu0.16.04.10  2.79-1ubuntu0.16.04.1\+esm1  esm-infra
+
+      \[RELATED CVEs\]
+      VULNERABILITY  PRIORITY  AFFECTED INSTALLED PACKAGES
+      CVE-2021-3448  low       dnsmasq
+      """
+    When I run `mkdir -p /var/lib/ubuntu-advantage/vulnerability-data/xenial/` with sudo
+    When I run `cp /tmp/security_issues_xenial /var/lib/ubuntu-advantage/vulnerability-data/xenial/vilnerability-cache.json` with sudo
+    And I create the file `/var/lib/ubuntu-advantage/vulnerability-data/xenial/vulnerability-publish-date` with the following:
+      """
+      {"cache_date": "Thu, 10 Sep 2024 01:40:05 GMT"}
+      """
+    And I run `pro vulnerability show <usn>` with sudo
+    And I remove colors from output
+    Then stdout matches regexp:
+      """
+      The vulnerabilities data used in the system is outdated by \d+ days/hours
+      To update the data please run with --update:
+
+          \$ pro vulnerability show <vulnerability_issue> --update
+
+      .*USN-4976-2
+      Public URL: https://ubuntu.com/USN-4976-2
+      Published at: 2022-09-07 15:22:39
+      """
+
+    Examples: ubuntu
+      | release | machine_type  | cve           | unfixable_cve | usn        |
+      | xenial  | lxd-container | CVE-2022-2286 | CVE-2024-8088 | USN-4976-2 |

--- a/features/cli/vulnerability_show.feature
+++ b/features/cli/vulnerability_show.feature
@@ -8,8 +8,8 @@ Feature: CLI vulnerability show command
       Error: issue "invalid" is not recognized.
       Usage: "pro vulnerability show CVE-yyyy-nnnn" or "pro vulnerability show USN-nnnn"
       """
-    When I push static file `security_issues_xenial` to machine
-    And I run `pro vulnerability show CVE-2024-7542 --data-file=/tmp/security_issues_xenial` as non-root
+    When I push static file `security_issues_xenial.json` to machine
+    And I run `pro vulnerability show CVE-2024-7542 --data-file=/tmp/security_issues_xenial.json` as non-root
     Then stdout matches regexp:
       """
       CVE-2024-7542
@@ -21,7 +21,7 @@ Feature: CLI vulnerability show command
       """
     When I run `apt update` with sudo
     And I run `apt install vim=2:7.4.1689-3ubuntu1.5 -y` with sudo
-    And I run `pro vulnerability show <cve> --data-file=/tmp/security_issues_xenial` as non-root
+    And I run `pro vulnerability show <cve> --data-file=/tmp/security_issues_xenial.json` as non-root
     And I remove colors from output
     Then stdout matches regexp:
       """
@@ -48,7 +48,7 @@ Feature: CLI vulnerability show command
       VULNERABILITY  TITLE                AFFECTED INSTALLED PACKAGES
       USN-6270-1     Vim vulnerabilities  vim
       """
-    When I run `pro vulnerability show <unfixable_cve> --data-file=/tmp/security_issues_xenial` as non-root
+    When I run `pro vulnerability show <unfixable_cve> --data-file=/tmp/security_issues_xenial.json` as non-root
     And I remove colors from output
     Then stdout matches regexp:
       """
@@ -85,7 +85,7 @@ Feature: CLI vulnerability show command
       There are two more commits in the Lib/zipfile directory that are
       possibly related to this issue.
       """
-    When I run `pro vulnerability show <usn> --data-file=/tmp/security_issues_xenial` as non-root
+    When I run `pro vulnerability show <usn> --data-file=/tmp/security_issues_xenial.json` as non-root
     And I remove colors from output
     Then stdout matches regexp:
       """
@@ -118,7 +118,7 @@ Feature: CLI vulnerability show command
       CVE-2021-3448  low       dnsmasq
       """
     When I run `mkdir -p /var/lib/ubuntu-advantage/vulnerability-data/xenial/` with sudo
-    When I run `cp /tmp/security_issues_xenial /var/lib/ubuntu-advantage/vulnerability-data/xenial/vilnerability-cache.json` with sudo
+    When I run `cp /tmp/security_issues_xenial.json /var/lib/ubuntu-advantage/vulnerability-data/xenial/vilnerability-cache.json` with sudo
     And I create the file `/var/lib/ubuntu-advantage/vulnerability-data/xenial/vulnerability-publish-date` with the following:
       """
       {"cache_date": "Thu, 10 Sep 2024 01:40:05 GMT"}

--- a/features/cli/vulnerability_show.feature
+++ b/features/cli/vulnerability_show.feature
@@ -13,7 +13,7 @@ Feature: CLI vulnerability show command
     Then stdout matches regexp:
       """
       CVE-2024-7542
-      Public URL: https://ubuntu.com/CVE-2024-7542
+      Public URL: https://ubuntu.com/security/CVE-2024-7542
       Ubuntu vulnerability data published at: .*
       APT package information updated at: .*
 
@@ -26,7 +26,7 @@ Feature: CLI vulnerability show command
     Then stdout matches regexp:
       """
       CVE-2022-2286
-      Public URL: https://ubuntu.com/CVE-2022-2286
+      Public URL: https://ubuntu.com/security/CVE-2022-2286
       Published at: 2022-07-02 19:15:00
       Ubuntu vulnerability data published at: .*
       APT package information updated at: .*
@@ -53,7 +53,7 @@ Feature: CLI vulnerability show command
     Then stdout matches regexp:
       """
       CVE-2024-8088
-      Public URL: https://ubuntu.com/CVE-2024-8088
+      Public URL: https://ubuntu.com/security/CVE-2024-8088
       Published at: 2024-08-22 19:15:00
       Ubuntu vulnerability data published at: .*
       APT package information updated at: .*
@@ -90,7 +90,7 @@ Feature: CLI vulnerability show command
     Then stdout matches regexp:
       """
       USN-4976-2
-      Public URL: https://ubuntu.com/USN-4976-2
+      Public URL: https://ubuntu.com/security/notices/USN-4976-2
       Published at: 2022-09-07 15:22:39
       Ubuntu vulnerability data published at: .*
       APT package information updated at: .*
@@ -133,7 +133,7 @@ Feature: CLI vulnerability show command
           \$ pro vulnerability show <vulnerability_issue> --update
 
       .*USN-4976-2
-      Public URL: https://ubuntu.com/USN-4976-2
+      Public URL: https://ubuntu.com/security/notices/USN-4976-2
       Published at: 2022-09-07 15:22:39
       """
 

--- a/features/steps/output.py
+++ b/features/steps/output.py
@@ -284,3 +284,13 @@ def i_remove_colors_from_output(context):
     context.process.stdout = re.sub(
         COLOR_FORMATTING_PATTERN, "", context.process.stdout.strip()
     )
+
+
+@when("I remove links from output")
+def i_remove_links_from_output(context):
+    LINK_START_PATTERN = r"\033]8;;.+?\033\\+"
+    LINK_END = "\033]8;;\033\\"
+    context.process.stdout = re.sub(
+        LINK_START_PATTERN, "", context.process.stdout.strip()
+    )
+    context.process.stdout = context.process.stdout.replace(LINK_END, "")

--- a/features/steps/output.py
+++ b/features/steps/output.py
@@ -276,3 +276,11 @@ def i_apply_jq_filter(context, jq_filter):
 def i_apply_jq_filter_to_api_data(context, jq_filter):
     content = process_api_data(context, api_key="data", escape=False)
     context.process.stdout = jq.compile(jq_filter).input_text(content).text()
+
+
+@when("I remove colors from output")
+def i_remove_colors_from_output(context):
+    COLOR_FORMATTING_PATTERN = r"\033\[.*?m"
+    context.process.stdout = re.sub(
+        COLOR_FORMATTING_PATTERN, "", context.process.stdout.strip()
+    )

--- a/tools/spellcheck-allowed-words.txt
+++ b/tools/spellcheck-allowed-words.txt
@@ -41,6 +41,7 @@ customizable
 CVE
 CVEs
 CVES
+CVSS
 datestring
 depedent
 DISA
@@ -176,6 +177,8 @@ ubscribe
 ubuntu
 unbootable
 UNENTITLED
+unfixable
+UNFIXABLE
 url
 urls
 usg

--- a/uaclient/api/exceptions.py
+++ b/uaclient/api/exceptions.py
@@ -4,6 +4,7 @@ from uaclient.exceptions import (
     AlreadyAttachedError,
     ConnectivityError,
     ContractAPIError,
+    DepedentOptionError,
     EntitlementNotDisabledError,
     EntitlementNotEnabledError,
     EntitlementNotFoundError,
@@ -48,6 +49,7 @@ __all__ = [
     "IncompatibleServiceStopsEnable",
     "RequiredServiceStopsEnable",
     "UnsupportedManifestFile",
+    "DepedentOptionError",
 ]
 
 

--- a/uaclient/api/tests/test_api_u_pro_security_vulnerabilities_common_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_security_vulnerabilities_common_v1.py
@@ -231,7 +231,7 @@ class TestVulnerabilityParser:
         assert (
             parser.get_vulnerabilities_for_installed_pkgs(
                 vulnerabilities_data, installed_pkgs_by_source
-            ).vulnerabilities
+            ).vulnerabilities_info["vulnerabilities"]
             == expected_result
         )
 

--- a/uaclient/api/u/pro/security/vulnerabilities/_common/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/_common/v1.py
@@ -536,7 +536,7 @@ class VulnerabilityParser(metaclass=abc.ABCMeta):
         vulnerabilities = {}  # type: Dict[str, Any]
         applied_fixes_count = {
             "count": {
-                "ubuntu_standard": 0,
+                "ubuntu_security": 0,
                 "ubuntu_pro": 0,
             },
             "info": {},
@@ -645,7 +645,7 @@ class VulnerabilityParser(metaclass=abc.ABCMeta):
                     )
                 else:
                     ubuntu_pocket_translation = (
-                        "ubuntu_standard"
+                        "ubuntu_security"
                         if pocket in ("release", "updates", "security")
                         else "ubuntu_pro"
                     )

--- a/uaclient/api/u/pro/security/vulnerabilities/cve/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/cve/v1.py
@@ -477,7 +477,7 @@ def _vulnerabilities_with_applied_fixes_count(
             cve_vulnerabilities=cve_vulnerabilities,
             vulnerability_data_published_at=cve_vulnerabilities_result.vulnerability_data_published_at,  # noqa
         ),
-        cve_vulnerabilities_result.vulnerability_info.get(
+        cve_vulnerabilities_result.vulnerabilities_info.get(
             "applied_fixes_count", {}
         ),
     )

--- a/uaclient/api/u/pro/security/vulnerabilities/cve/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/cve/v1.py
@@ -4,7 +4,10 @@ from typing import Any, Dict, List, Optional, Tuple
 from uaclient import util
 from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
-from uaclient.api.exceptions import InvalidOptionCombination
+from uaclient.api.exceptions import (
+    DepedentOptionError,
+    InvalidOptionCombination,
+)
 from uaclient.api.u.pro.security.vulnerabilities._common.v1 import (
     VulnerabilityParser,
     VulnerabilityStatus,
@@ -428,6 +431,9 @@ def _vulnerabilities(
     if options.unfixable and options.all:
         raise InvalidOptionCombination(option1="unfixable", option2="all")
 
+    if options.series and not options.manifest_file:
+        raise DepedentOptionError(option1="series", option2="manifest_file")
+
     cve_vulnerabilities_result = get_vulnerabilities(
         parser=CVEParser(),
         cfg=cfg,
@@ -455,9 +461,11 @@ def _vulnerabilities_with_applied_fixes_count(
     This endpoint shows the CVE vulnerabilites in the system.
     By default, this API will only show fixable CVEs in the system.
     """
-
     if options.unfixable and options.all:
         raise InvalidOptionCombination(option1="unfixable", option2="all")
+
+    if options.series and not options.manifest_file:
+        raise DepedentOptionError(option1="series", option2="manifest_file")
 
     cve_vulnerabilities_result = get_vulnerabilities(
         parser=CVEParser(),

--- a/uaclient/api/u/pro/security/vulnerabilities/cve/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/cve/v1.py
@@ -342,7 +342,7 @@ def vulnerabilities(
     return _vulnerabilities(options, UAConfig())
 
 
-def _parse_vulnerbiliries(
+def _parse_vulnerabilities(
     options: CVEVulnerabilitiesOptions,
     cve_vulnerabilities: Dict[str, Any],
     vulnerability_data_published_at: str,
@@ -446,7 +446,7 @@ def _vulnerabilities(
         "vulnerabilities", {}
     )
 
-    return _parse_vulnerbiliries(
+    return _parse_vulnerabilities(
         options=options,
         cve_vulnerabilities=cve_vulnerabilities,
         vulnerability_data_published_at=cve_vulnerabilities_result.vulnerability_data_published_at,  # noqa
@@ -480,7 +480,7 @@ def _vulnerabilities_with_applied_fixes_count(
     )
 
     return (
-        _parse_vulnerbiliries(
+        _parse_vulnerabilities(
             options=options,
             cve_vulnerabilities=cve_vulnerabilities,
             vulnerability_data_published_at=cve_vulnerabilities_result.vulnerability_data_published_at,  # noqa

--- a/uaclient/api/u/pro/security/vulnerabilities/usn/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/usn/v1.py
@@ -4,7 +4,10 @@ from typing import Any, Dict, List, Optional, Tuple
 from uaclient import util
 from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
-from uaclient.api.exceptions import InvalidOptionCombination
+from uaclient.api.exceptions import (
+    DepedentOptionError,
+    InvalidOptionCombination,
+)
 from uaclient.api.u.pro.security.vulnerabilities._common.v1 import (
     VulnerabilityParser,
     VulnerabilityStatus,
@@ -377,6 +380,9 @@ def _vulnerabilities_with_applied_fixes_count(
     if options.unfixable and options.all:
         raise InvalidOptionCombination(option1="unfixable", option2="all")
 
+    if options.series and not options.manifest_file:
+        raise DepedentOptionError(option1="series", option2="manifest_file")
+
     usn_vulnerabilities_result = get_vulnerabilities(
         parser=USNParser(),
         cfg=cfg,
@@ -412,6 +418,9 @@ def _vulnerabilities(
 
     if options.unfixable and options.all:
         raise InvalidOptionCombination(option1="unfixable", option2="all")
+
+    if options.series and not options.manifest_file:
+        raise DepedentOptionError(option1="series", option2="manifest_file")
 
     usn_vulnerabilities_result = get_vulnerabilities(
         parser=USNParser(),

--- a/uaclient/api/u/pro/security/vulnerabilities/usn/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/usn/v1.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from uaclient import util
 from uaclient.api.api import APIEndpoint
@@ -297,28 +297,11 @@ def vulnerabilities(
     return _vulnerabilities(options, UAConfig())
 
 
-def _vulnerabilities(
+def _parse_vulnerabilities(
     options: USNVulnerabilitiesOptions,
-    cfg: UAConfig,
+    usn_vulnerabilities: Dict[str, Any],
+    vulnerability_data_published_at: str,
 ) -> USNVulnerabilitiesResult:
-    """
-    This endpoint shows the USN vulnerabilites in the system.
-    By default, this API will only show fixable USNs in the system.
-    """
-
-    if options.unfixable and options.all:
-        raise InvalidOptionCombination(option1="unfixable", option2="all")
-
-    usn_vulnerabilities_result = get_vulnerabilities(
-        parser=USNParser(),
-        cfg=cfg,
-        update_json_data=options.update,
-        series=options.series,
-        data_file=options.data_file,
-        manifest_file=options.manifest_file,
-    )
-    usn_vulnerabilities = usn_vulnerabilities_result.vulnerabilities
-
     if options.unfixable:
         block_fixable_usns = True
         block_unfixable_usns = False
@@ -379,11 +362,73 @@ def _vulnerabilities(
     return USNVulnerabilitiesResult(
         usns=usns,
         vulnerability_data_published_at=util.parse_rfc3339_date(
-            usn_vulnerabilities_result.vulnerability_data_published_at
+            vulnerability_data_published_at
         ),
         apt_updated_at=(
             get_apt_cache_datetime() if not options.manifest_file else None
         ),
+    )
+
+
+def _vulnerabilities_with_applied_fixes_count(
+    options: USNVulnerabilitiesOptions,
+    cfg: UAConfig,
+) -> Tuple[USNVulnerabilitiesResult, Dict[str, Any]]:
+    if options.unfixable and options.all:
+        raise InvalidOptionCombination(option1="unfixable", option2="all")
+
+    usn_vulnerabilities_result = get_vulnerabilities(
+        parser=USNParser(),
+        cfg=cfg,
+        update_json_data=options.update,
+        series=options.series,
+        data_file=options.data_file,
+        manifest_file=options.manifest_file,
+    )
+    usn_vulnerabilities = usn_vulnerabilities_result.vulnerabilities_info.get(
+        "vulnerabilities", {}
+    )
+
+    return (
+        _parse_vulnerabilities(
+            options=options,
+            usn_vulnerabilities=usn_vulnerabilities,
+            vulnerability_data_published_at=usn_vulnerabilities_result.vulnerability_data_published_at,  # noqa
+        ),
+        usn_vulnerabilities_result.vulnerabilities_info.get(
+            "applied_fixes_count", {}
+        ),
+    )
+
+
+def _vulnerabilities(
+    options: USNVulnerabilitiesOptions,
+    cfg: UAConfig,
+) -> USNVulnerabilitiesResult:
+    """
+    This endpoint shows the USN vulnerabilites in the system.
+    By default, this API will only show fixable USNs in the system.
+    """
+
+    if options.unfixable and options.all:
+        raise InvalidOptionCombination(option1="unfixable", option2="all")
+
+    usn_vulnerabilities_result = get_vulnerabilities(
+        parser=USNParser(),
+        cfg=cfg,
+        update_json_data=options.update,
+        series=options.series,
+        data_file=options.data_file,
+        manifest_file=options.manifest_file,
+    )
+    usn_vulnerabilities = usn_vulnerabilities_result.vulnerabilities_info.get(
+        "vulnerabilities", {}
+    )
+
+    return _parse_vulnerabilities(
+        options=options,
+        usn_vulnerabilities=usn_vulnerabilities,
+        vulnerability_data_published_at=usn_vulnerabilities_result.vulnerability_data_published_at,  # noqa
     )
 
 

--- a/uaclient/cli/__init__.py
+++ b/uaclient/cli/__init__.py
@@ -30,6 +30,7 @@ from uaclient.cli.refresh import refresh_command
 from uaclient.cli.security_status import security_status_command
 from uaclient.cli.status import status_command
 from uaclient.cli.system import system_command
+from uaclient.cli.vulnerability import vulnerability_command
 from uaclient.config import UAConfig
 from uaclient.log import get_user_or_root_log_file_path
 
@@ -53,6 +54,7 @@ COMMANDS = [
     security_status_command,
     status_command,
     system_command,
+    vulnerability_command,
 ]
 
 

--- a/uaclient/cli/cli_util.py
+++ b/uaclient/cli/cli_util.py
@@ -1,3 +1,4 @@
+import re
 from functools import wraps
 from typing import Optional
 
@@ -13,6 +14,7 @@ from uaclient import (
     status,
     util,
 )
+from uaclient.api.u.pro.security.fix._common import CVE_OR_USN_REGEX
 from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.apt import AptProxyScope, setup_apt_proxy
 from uaclient.config import UAConfig
@@ -138,6 +140,24 @@ def assert_not_attached(f):
         return f(args, cfg=cfg, **kwargs)
 
     return new_f
+
+
+def assert_vulnerability_issue_valid(cmd):
+    def wrapper(f):
+        @wraps(f)
+        def new_f(args, cfg, **kwargs):
+            security_issue = getattr(args, "security_issue", "")
+            if not re.match(CVE_OR_USN_REGEX, security_issue):
+                raise exceptions.InvalidSecurityIssueIdFormat(
+                    issue=security_issue,
+                    cmd=cmd,
+                )
+
+            return f(args, cfg=cfg, **kwargs)
+
+        return new_f
+
+    return wrapper
 
 
 def _raise_enable_disable_unattached_error(command, service_names, cfg):

--- a/uaclient/cli/fix.py
+++ b/uaclient/cli/fix.py
@@ -1,4 +1,3 @@
-import re
 import textwrap
 from typing import (  # noqa: F401
     Dict,
@@ -22,7 +21,6 @@ from uaclient.api.u.pro.attach.magic.wait.v1 import (
     _wait,
 )
 from uaclient.api.u.pro.security.fix._common import (
-    CVE_OR_USN_REGEX,
     FixStatus,
     UnfixedPackage,
     status_message,
@@ -57,6 +55,7 @@ from uaclient.api.u.pro.status.is_attached.v1 import (
     ContractExpiryStatus,
     _is_attached,
 )
+from uaclient.cli import cli_util
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
 from uaclient.cli.detach import action_detach
 from uaclient.cli.parser import HelpCategory
@@ -892,12 +891,8 @@ def execute_fix_plan(
     return (fix_context.fix_status, fix_context.unfixed_pkgs)
 
 
+@cli_util.assert_vulnerability_issue_valid(cmd="fix")
 def action_fix(args, *, cfg, **kwargs):
-    if not re.match(CVE_OR_USN_REGEX, args.security_issue):
-        raise exceptions.InvalidSecurityIssueIdFormat(
-            issue=args.security_issue
-        )
-
     if args.dry_run:
         print(messages.SECURITY_DRY_RUN_WARNING)
 

--- a/uaclient/cli/vulnerability/__init__.py
+++ b/uaclient/cli/vulnerability/__init__.py
@@ -1,5 +1,6 @@
 from uaclient import messages
 from uaclient.cli.commands import ProCommand
+from uaclient.cli.vulnerability.list import list_subcommand
 from uaclient.cli.vulnerability.show import show_subcommand
 from uaclient.cli.vulnerability.update import update_subcommand
 
@@ -16,5 +17,5 @@ vulnerability_command = ProCommand(
     help=messages.CLI_ROOT_VULNERABILITY,
     description=messages.CLI_VULNERABILITY_DESC,
     action=action_vulnerability,
-    subcommands=[show_subcommand, update_subcommand],
+    subcommands=[show_subcommand, update_subcommand, list_subcommand],
 )

--- a/uaclient/cli/vulnerability/__init__.py
+++ b/uaclient/cli/vulnerability/__init__.py
@@ -1,5 +1,6 @@
 from uaclient import messages
 from uaclient.cli.commands import ProCommand
+from uaclient.cli.parser import HelpCategory
 from uaclient.cli.vulnerability.list import list_subcommand
 from uaclient.cli.vulnerability.show import show_subcommand
 from uaclient.cli.vulnerability.update import update_subcommand
@@ -16,6 +17,8 @@ vulnerability_command = ProCommand(
     "vulnerability",
     help=messages.CLI_ROOT_VULNERABILITY,
     description=messages.CLI_VULNERABILITY_DESC,
+    help_category=HelpCategory.SECURITY,
+    preserve_description=True,
     action=action_vulnerability,
     subcommands=[show_subcommand, update_subcommand, list_subcommand],
 )

--- a/uaclient/cli/vulnerability/__init__.py
+++ b/uaclient/cli/vulnerability/__init__.py
@@ -1,6 +1,7 @@
 from uaclient import messages
 from uaclient.cli.commands import ProCommand
 from uaclient.cli.vulnerability.show import show_subcommand
+from uaclient.cli.vulnerability.update import update_subcommand
 
 
 def action_vulnerability(args, *, cfg, **kwargs):
@@ -15,5 +16,5 @@ vulnerability_command = ProCommand(
     help=messages.CLI_ROOT_VULNERABILITY,
     description=messages.CLI_VULNERABILITY_DESC,
     action=action_vulnerability,
-    subcommands=[show_subcommand],
+    subcommands=[show_subcommand, update_subcommand],
 )

--- a/uaclient/cli/vulnerability/__init__.py
+++ b/uaclient/cli/vulnerability/__init__.py
@@ -1,0 +1,19 @@
+from uaclient import messages
+from uaclient.cli.commands import ProCommand
+from uaclient.cli.vulnerability.show import show_subcommand
+
+
+def action_vulnerability(args, *, cfg, **kwargs):
+    # Avoiding a circular import
+    from uaclient.cli import get_parser
+
+    get_parser().print_help_for_command("vulnerability")
+
+
+vulnerability_command = ProCommand(
+    "vulnerability",
+    help=messages.CLI_ROOT_VULNERABILITY,
+    description=messages.CLI_VULNERABILITY_DESC,
+    action=action_vulnerability,
+    subcommands=[show_subcommand],
+)

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -327,8 +327,11 @@ def _list_cves(
     )
 
     if cve_vulnerabilities_result.cves:
+        print(messages.CLI_VULNERABILITY_LIST_CVE_HEADER)
+        print(_create_cve_table(cve_vulnerabilities_result.cves))
         print(
-            _create_list_header(
+            "\n"
+            + _create_list_header(
                 vulnerabilities=cve_vulnerabilities_result.cves,
                 applied_fixes_count=applied_fixes_count,
                 show_usns=False,
@@ -336,13 +339,12 @@ def _list_cves(
                 show_unfixable=show_unfixable,
             )
         )
-        print(messages.CLI_VULNERABILITY_LIST_CVE_HEADER)
-        print(_create_cve_table(cve_vulnerabilities_result.cves))
     else:
-        print(_create_already_fixed_cves_count(applied_fixes_count))
         print(
             messages.CLI_VULNERABILITY_LIST_NOT_AFFECTED.format(issue="CVEs")
+            + "\n"
         )
+        print(_create_already_fixed_cves_count(applied_fixes_count))
 
 
 def _list_usns(
@@ -365,8 +367,11 @@ def _list_usns(
     )
 
     if usn_vulnerabilities_result.usns:
+        print(messages.CLI_VULNERABILITY_LIST_USN_HEADER)
+        print(_create_usn_table(usn_vulnerabilities_result.usns))
         print(
-            _create_list_header(
+            "\n"
+            + _create_list_header(
                 vulnerabilities=usn_vulnerabilities_result.usns,
                 applied_fixes_count=applied_fixes_count,
                 show_usns=True,
@@ -374,13 +379,12 @@ def _list_usns(
                 show_unfixable=show_unfixable,
             )
         )
-        print(messages.CLI_VULNERABILITY_LIST_USN_HEADER)
-        print(_create_usn_table(usn_vulnerabilities_result.usns))
     else:
-        print(_create_already_fixed_usns_count(applied_fixes_count))
         print(
             messages.CLI_VULNERABILITY_LIST_NOT_AFFECTED.format(issue="USNs")
+            + "\n"
         )
+        print(_create_already_fixed_usns_count(applied_fixes_count))
 
 
 @vuln_util.assert_data_cache_updated("pro vulnerability list")

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -321,6 +321,11 @@ def _list_cves(
         )
         print(messages.CLI_VULNERABILITY_LIST_CVE_HEADER)
         _print_cve_table(cve_vulnerabilities_result.cves)
+    else:
+        _print_already_fixed_usns_count(applied_fixes_count)
+        print(
+            messages.CLI_VULNERABILITY_LIST_NOT_AFFECTED.format(issue="CVEs")
+        )
 
 
 def _list_usns(
@@ -352,6 +357,11 @@ def _list_usns(
         )
         print(messages.CLI_VULNERABILITY_LIST_USN_HEADER)
         _print_usn_table(usn_vulnerabilities_result.usns)
+    else:
+        _print_already_fixed_usns_count(applied_fixes_count)
+        print(
+            messages.CLI_VULNERABILITY_LIST_NOT_AFFECTED.format(issue="USNs")
+        )
 
 
 @vuln_util.assert_data_cache_updated("pro vulnerability list")

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -420,6 +420,11 @@ list_subcommand = ProCommand(
                     help=messages.CLI_VULNERABILITY_LIST_SERIES,
                     action="store",
                 ),
+                ProArgument(
+                    "--update",
+                    help=messages.CLI_VULNERABILITY_UPDATE,
+                    action="store_true",
+                ),
             ]
         )
     ],

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -23,38 +23,37 @@ VulnerabilityCountInfo = NamedTuple(
 )
 
 
-def _print_usn_table(usns):
+def _create_usn_table(usns, num_rows=None):
     usns_sorted_by_name = sorted(usns, key=lambda usn: usn.name)
 
-    print(
-        Table(
-            headers=[
-                "VULNERABILITY",
-                "FIX AVAILABLE FROM",
-                "AFFECTED INSTALLED PACKAGES",
-            ],
-            rows=[
-                [
-                    usn.name,
-                    ", ".join(
-                        set(
-                            [
-                                pkg.fix_available_from or "no-fix"
-                                for pkg in usn.affected_packages
-                            ]
-                        )
-                    ),
-                    ", ".join(
-                        set([pkg.name for pkg in usn.affected_packages])
-                    ),
-                ]
-                for usn in usns_sorted_by_name
-            ],
-        )
+    if num_rows:
+        usns_sorted_by_name = usns_sorted_by_name[:num_rows]
+
+    return Table(
+        headers=[
+            "VULNERABILITY",
+            "FIX AVAILABLE FROM",
+            "AFFECTED INSTALLED PACKAGES",
+        ],
+        rows=[
+            [
+                usn.name,
+                ", ".join(
+                    set(
+                        [
+                            pkg.fix_available_from or "no-fix"
+                            for pkg in usn.affected_packages
+                        ]
+                    )
+                ),
+                ", ".join(set([pkg.name for pkg in usn.affected_packages])),
+            ]
+            for usn in usns_sorted_by_name
+        ],
     )
 
 
-def _print_cve_table(cves):
+def _create_cve_table(cves, num_rows=None):
     cves_sorted_by_priority = sorted(
         cves,
         key=lambda cve: (
@@ -63,33 +62,32 @@ def _print_cve_table(cves):
         ),
     )
 
-    print(
-        Table(
-            headers=[
-                "VULNERABILITY",
-                "PRIORITY",
-                "FIX AVAILABLE FROM",
-                "AFFECTED INSTALLED PACKAGES",
-            ],
-            rows=[
-                [
-                    cve.name,
-                    vuln_util.get_priority_with_color(cve.ubuntu_priority),
-                    ", ".join(
-                        set(
-                            [
-                                pkg.fix_available_from or "no-fix"
-                                for pkg in cve.affected_packages
-                            ]
-                        )
-                    ),
-                    ", ".join(
-                        set([pkg.name for pkg in cve.affected_packages])
-                    ),
-                ]
-                for cve in cves_sorted_by_priority
-            ],
-        )
+    if num_rows:
+        cves_sorted_by_priority = cves_sorted_by_priority[:num_rows]
+
+    return Table(
+        headers=[
+            "VULNERABILITY",
+            "PRIORITY",
+            "FIX AVAILABLE FROM",
+            "AFFECTED INSTALLED PACKAGES",
+        ],
+        rows=[
+            [
+                cve.name,
+                vuln_util.get_priority_with_color(cve.ubuntu_priority),
+                ", ".join(
+                    set(
+                        [
+                            pkg.fix_available_from or "no-fix"
+                            for pkg in cve.affected_packages
+                        ]
+                    )
+                ),
+                ", ".join(set([pkg.name for pkg in cve.affected_packages])),
+            ]
+            for cve in cves_sorted_by_priority
+        ],
     )
 
 
@@ -155,13 +153,13 @@ def _get_count_msg_by_priority(count_by_priority):
     return ", ".join(msgs)
 
 
-def _print_fixable_cves_count(vulnerabilities):
-    print(messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER)
+def _create_fixable_cves_count(vulnerabilities) -> str:
+    msg = messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER + "\n"
     fixable_vulnerabilities_info = _get_info_from_vulnerabilities(
         vulnerabilities, fixable_vuln=True
     )
     count_with_color = _get_fixable_color_count(fixable_vulnerabilities_info)
-    print(
+    msg += (
         "    "
         + count_with_color
         + " "
@@ -174,27 +172,30 @@ def _print_fixable_cves_count(vulnerabilities):
         + "\n"
     )
 
+    return msg
 
-def _print_fixable_usns_count(vulnerabilities):
-    print(messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER)
+
+def _create_fixable_usns_count(vulnerabilities):
+    msg = messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER + "\n"
     fixable_vulnerabilities_info = _get_info_from_vulnerabilities(
         vulnerabilities, fixable_vuln=True
     )
-    print(
+    msg += (
         "    "
         + str(fixable_vulnerabilities_info.count)
         + " "
         + messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT
         + "\n"
     )
+    return msg
 
 
-def _print_unfixable_cves_count(vulnerabilities):
-    print(messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER)
+def _create_unfixable_cves_count(vulnerabilities) -> str:
+    msg = messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER + "\n"
     unfixable_vulnerabilities_info = _get_info_from_vulnerabilities(
         vulnerabilities, fixable_vuln=False
     )
-    print(
+    msg += (
         "    "
         + str(unfixable_vulnerabilities_info.count)
         + " "
@@ -207,13 +208,15 @@ def _print_unfixable_cves_count(vulnerabilities):
         + "\n"
     )
 
+    return msg
 
-def _print_unfixable_usns_count(vulnerabilities):
-    print(messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER)
+
+def _create_unfixable_usns_count(vulnerabilities):
+    msg = messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER + "\n"
     unfixable_vulnerabilities_info = _get_info_from_vulnerabilities(
         vulnerabilities, fixable_vuln=False
     )
-    print(
+    msg += (
         "    "
         + str(unfixable_vulnerabilities_info.count)
         + " "
@@ -222,14 +225,15 @@ def _print_unfixable_usns_count(vulnerabilities):
     )
 
 
-def _print_already_fixed_cves_count(applied_fixes_count):
+def _create_already_fixed_cves_count(applied_fixes_count):
+    msg = ""
     if any(count for pocket, count in applied_fixes_count["count"].items()):
-        print(messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER)
+        msg += messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER + "\n"
         for pocket, count in applied_fixes_count["count"].items():
             if not count:
                 continue
 
-            print(
+            msg += (
                 "    "
                 + "{}{}{} ".format(
                     messages.TxtColor.DISABLEGREY,
@@ -246,50 +250,61 @@ def _print_already_fixed_cves_count(applied_fixes_count):
                 + "\n"
             )
 
+    return msg
 
-def _print_already_fixed_usns_count(applied_fixes_count):
+
+def _create_already_fixed_usns_count(applied_fixes_count):
+    msg = ""
     if any(count for pocket, count in applied_fixes_count["count"].items()):
-        print(messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER)
+        msg = messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER + "\n"
         for pocket, count in applied_fixes_count["count"].items():
             if not count:
                 continue
 
-            print(
+            msg += (
                 "    "
                 + str(count)
                 + " "
                 + messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_COUNT
                 + " {}".format(pocket.title().replace("_", " "))
-                + "\n",
+                + "\n"
             )
 
+    return msg
 
-def _display_list_header(
+
+def _create_list_header(
     vulnerabilities,
     applied_fixes_count,
     show_usns: bool,
     show_all: bool,
     show_unfixable: bool,
-):
+) -> str:
+    msg = ""
     if show_usns:
-        _print_already_fixed_usns_count(applied_fixes_count)
-
+        msg += _create_already_fixed_usns_count(applied_fixes_count)
+        msg += "\n"
         if show_all:
-            _print_fixable_usns_count(vulnerabilities)
-            _print_unfixable_usns_count(vulnerabilities)
+            msg += _create_fixable_usns_count(vulnerabilities)
+            msg += "\n"
+            msg += _create_unfixable_usns_count(vulnerabilities)
         elif show_unfixable:
-            _print_unfixable_usns_count(vulnerabilities)
+            msg += _create_unfixable_usns_count(vulnerabilities)
         else:
-            _print_fixable_usns_count(vulnerabilities)
+            msg += _create_fixable_usns_count(vulnerabilities)
     else:
-        _print_already_fixed_cves_count(applied_fixes_count)
+        msg += _create_already_fixed_cves_count(applied_fixes_count)
+        msg += "\n"
         if show_all:
-            _print_fixable_cves_count(vulnerabilities)
-            _print_unfixable_cves_count(vulnerabilities)
+            msg += _create_fixable_cves_count(vulnerabilities)
+            msg += "\n"
+            msg += _create_unfixable_cves_count(vulnerabilities)
         elif show_unfixable:
-            _print_unfixable_cves_count(vulnerabilities)
+            msg += _create_unfixable_cves_count(vulnerabilities)
         else:
-            _print_fixable_cves_count(vulnerabilities)
+            msg += _create_fixable_cves_count(vulnerabilities)
+
+    return msg
 
 
 def _list_cves(
@@ -312,17 +327,19 @@ def _list_cves(
     )
 
     if cve_vulnerabilities_result.cves:
-        _display_list_header(
-            vulnerabilities=cve_vulnerabilities_result.cves,
-            applied_fixes_count=applied_fixes_count,
-            show_usns=False,
-            show_all=show_all,
-            show_unfixable=show_unfixable,
+        print(
+            _create_list_header(
+                vulnerabilities=cve_vulnerabilities_result.cves,
+                applied_fixes_count=applied_fixes_count,
+                show_usns=False,
+                show_all=show_all,
+                show_unfixable=show_unfixable,
+            )
         )
         print(messages.CLI_VULNERABILITY_LIST_CVE_HEADER)
-        _print_cve_table(cve_vulnerabilities_result.cves)
+        print(_create_cve_table(cve_vulnerabilities_result.cves))
     else:
-        _print_already_fixed_usns_count(applied_fixes_count)
+        print(_create_already_fixed_cves_count(applied_fixes_count))
         print(
             messages.CLI_VULNERABILITY_LIST_NOT_AFFECTED.format(issue="CVEs")
         )
@@ -348,17 +365,19 @@ def _list_usns(
     )
 
     if usn_vulnerabilities_result.usns:
-        _display_list_header(
-            vulnerabilities=usn_vulnerabilities_result.usns,
-            applied_fixes_count=applied_fixes_count,
-            show_usns=True,
-            show_all=show_all,
-            show_unfixable=show_unfixable,
+        print(
+            _create_list_header(
+                vulnerabilities=usn_vulnerabilities_result.usns,
+                applied_fixes_count=applied_fixes_count,
+                show_usns=True,
+                show_all=show_all,
+                show_unfixable=show_unfixable,
+            )
         )
         print(messages.CLI_VULNERABILITY_LIST_USN_HEADER)
-        _print_usn_table(usn_vulnerabilities_result.usns)
+        print(_create_usn_table(usn_vulnerabilities_result.usns))
     else:
-        _print_already_fixed_usns_count(applied_fixes_count)
+        print(_create_already_fixed_usns_count(applied_fixes_count))
         print(
             messages.CLI_VULNERABILITY_LIST_NOT_AFFECTED.format(issue="USNs")
         )

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -15,7 +15,7 @@ from uaclient.api.u.pro.security.vulnerabilities.usn.v1 import (
     _vulnerabilities_with_applied_fixes_count as usn_vulnerabilities,
 )
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
-from uaclient.cli.formatter import Table
+from uaclient.cli.formatter import Block, Table
 from uaclient.cli.vulnerability import util as vuln_util
 
 
@@ -189,7 +189,7 @@ def _get_count_msg_by_priority(count_by_priority):
 
 
 def _create_fixable_cves_count(vulnerabilities) -> str:
-    msg = messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER + "\n"
+    content = []
     fixable_vulnerabilities_info = _get_info_from_vulnerabilities(
         vulnerabilities
     )
@@ -198,25 +198,24 @@ def _create_fixable_cves_count(vulnerabilities) -> str:
         if not pocket_info["count"]:
             continue
 
-        count_with_color = _get_fixable_color_count(pocket_info)
-        msg += (
-            "    "
-            + count_with_color
-            + " "
-            + messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT.format(
-                pocket=pocket.title().replace("_", " ")
+        content.append(
+            "{} {} ({})".format(
+                _get_fixable_color_count(pocket_info),
+                messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT.format(
+                    pocket=pocket.title().replace("_", " ")
+                ),
+                _get_count_msg_by_priority(pocket_info["info"]),
             )
-            + " ("
-            + _get_count_msg_by_priority(pocket_info["info"])
-            + ")"
-            + "\n"
         )
 
-    return msg
+    return Block(
+        title=messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER,
+        content=content,
+    ).to_string()
 
 
-def _create_fixable_usns_count(vulnerabilities):
-    msg = messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER + "\n"
+def _create_fixable_usns_count(vulnerabilities) -> str:
+    content = []
     fixable_vulnerabilities_info = _get_info_from_vulnerabilities(
         vulnerabilities
     )
@@ -224,98 +223,103 @@ def _create_fixable_usns_count(vulnerabilities):
         if not pocket_info["count"]:
             continue
 
-        msg += (
-            "    "
-            + str(pocket_info["count"])
-            + " "
-            + messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT.format(
-                pocket=pocket.title().replace("_", " ")
+        content.append(
+            "{} {}".format(
+                str(pocket_info["count"]),
+                messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT.format(
+                    pocket=pocket.title().replace("_", " ")
+                ),
             )
-            + "\n"
         )
 
-    return msg
+    return Block(
+        title=messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER,
+        content=content,
+    ).to_string()
 
 
 def _create_unfixable_cves_count(vulnerabilities) -> str:
-    msg = messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER + "\n"
     count, unfixable_vulnerabilities_info = (
         _get_unfixable_info_from_vulnerabilities(vulnerabilities)  # noqa
     )
-    msg += (
-        "    "
-        + str(count)
-        + " "
-        + messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT
-        + " ("
-        + _get_count_msg_by_priority(unfixable_vulnerabilities_info)
-        + ")"
-        + "\n"
-    )
 
-    return msg
+    return Block(
+        title=messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER,
+        content=[
+            "{} {} ({})".format(
+                str(count),
+                messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT,
+                _get_count_msg_by_priority(unfixable_vulnerabilities_info),
+            )
+        ],
+    ).to_string()
 
 
-def _create_unfixable_usns_count(vulnerabilities):
-    msg = messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER + "\n"
+def _create_unfixable_usns_count(vulnerabilities) -> str:
     count, unfixable_vulnerabilities_info = (
         _get_unfixable_info_from_vulnerabilities(vulnerabilities)  # noqa
     )
-    msg += (
-        "    "
-        + str(count)
-        + " "
-        + messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT
-        + "\n"
-    )
+
+    return Block(
+        title=messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER,
+        content=[
+            "{} {}".format(
+                str(count),
+                messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT,
+            )
+        ],
+    ).to_string()
 
 
-def _create_already_fixed_cves_count(applied_fixes_count):
-    msg = ""
+def _create_already_fixed_cves_count(applied_fixes_count) -> str:
     if any(count for pocket, count in applied_fixes_count["count"].items()):
-        msg += messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER + "\n"
+        content = []
         for pocket, count in applied_fixes_count["count"].items():
             if not count:
                 continue
 
-            msg += (
-                "    "
-                + "{}{}{} ".format(
+            content.append(
+                "{}{}{} {} {} ({})".format(
                     messages.TxtColor.DISABLEGREY,
                     str(count),
                     messages.TxtColor.ENDC,
+                    messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_COUNT,
+                    pocket.title().replace("_", " "),
+                    _get_count_msg_by_priority(
+                        applied_fixes_count.get("info", {}).get(pocket, {})
+                    ),
                 )
-                + messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_COUNT
-                + " {}".format(pocket.title().replace("_", " "))
-                + " ("
-                + _get_count_msg_by_priority(
-                    applied_fixes_count.get("info", {}).get(pocket, {})
-                )
-                + ")"
-                + "\n"
             )
 
-    return msg
+        return Block(
+            title=messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER,
+            content=content,
+        ).to_string()
+
+    return ""
 
 
-def _create_already_fixed_usns_count(applied_fixes_count):
-    msg = ""
+def _create_already_fixed_usns_count(applied_fixes_count) -> str:
     if any(count for pocket, count in applied_fixes_count["count"].items()):
-        msg = messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER + "\n"
+        content = []
         for pocket, count in applied_fixes_count["count"].items():
             if not count:
                 continue
 
-            msg += (
-                "    "
-                + str(count)
-                + " "
-                + messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_COUNT
-                + " {}".format(pocket.title().replace("_", " "))
-                + "\n"
+            content.append(
+                "{} {} {}".format(
+                    str(count),
+                    messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_COUNT,
+                    pocket.title().replace("_", " "),
+                )
             )
 
-    return msg
+        return Block(
+            title=messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER,
+            content=content,
+        ).to_string()
+
+    return ""
 
 
 def _create_list_header(
@@ -375,8 +379,7 @@ def _list_cves(
         print(messages.CLI_VULNERABILITY_LIST_CVE_HEADER)
         print(_create_cve_table(cve_vulnerabilities_result.cves))
         print(
-            "\n"
-            + _create_list_header(
+            _create_list_header(
                 vulnerabilities=cve_vulnerabilities_result.cves,
                 applied_fixes_count=applied_fixes_count,
                 show_usns=False,
@@ -415,8 +418,7 @@ def _list_usns(
         print(messages.CLI_VULNERABILITY_LIST_USN_HEADER)
         print(_create_usn_table(usn_vulnerabilities_result.usns))
         print(
-            "\n"
-            + _create_list_header(
+            _create_list_header(
                 vulnerabilities=usn_vulnerabilities_result.usns,
                 applied_fixes_count=applied_fixes_count,
                 show_usns=True,

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -15,7 +15,7 @@ from uaclient.api.u.pro.security.vulnerabilities.usn.v1 import (
     _vulnerabilities_with_applied_fixes_count as usn_vulnerabilities,
 )
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
-from uaclient.cli.formatter import Block, Table
+from uaclient.cli.formatter import Block, Table, create_link
 from uaclient.cli.vulnerability import util as vuln_util
 
 
@@ -33,7 +33,12 @@ def _create_usn_table(usns, num_rows=None):
         ],
         rows=[
             [
-                usn.name,
+                create_link(
+                    text=usn.name,
+                    url="https://ubuntu.com/security/notices/{}".format(
+                        usn.name
+                    ),
+                ),
                 ", ".join(
                     set(
                         [
@@ -70,7 +75,10 @@ def _create_cve_table(cves, num_rows=None):
         ],
         rows=[
             [
-                cve.name,
+                create_link(
+                    text=cve.name,
+                    url="https://ubuntu.com/security/{}".format(cve.name),
+                ),
                 vuln_util.get_priority_with_color(cve.ubuntu_priority),
                 ", ".join(
                     set(

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -1,0 +1,426 @@
+from typing import Dict, NamedTuple
+
+from uaclient import config, exceptions, messages
+from uaclient.api.u.pro.security.vulnerabilities.cve.v1 import (
+    CVEVulnerabilitiesOptions,
+)
+from uaclient.api.u.pro.security.vulnerabilities.cve.v1 import (
+    _vulnerabilities_with_applied_fixes_count as cve_vulnerabilities,
+)
+from uaclient.api.u.pro.security.vulnerabilities.usn.v1 import (
+    USNVulnerabilitiesOptions,
+)
+from uaclient.api.u.pro.security.vulnerabilities.usn.v1 import (
+    _vulnerabilities_with_applied_fixes_count as usn_vulnerabilities,
+)
+from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.formatter import Table
+from uaclient.cli.vulnerability import util as vuln_util
+
+VulnerabilityCountInfo = NamedTuple(
+    "VulnerabilityCountInfo",
+    [("count", int), ("count_by_priority", Dict[str, int])],
+)
+
+
+def _print_usn_table(usns):
+    usns_sorted_by_name = sorted(usns, key=lambda usn: usn.name)
+
+    print(
+        Table(
+            headers=[
+                "VULNERABILITY",
+                "FIX AVAILABLE FROM",
+                "AFFECTED INSTALLED PACKAGES",
+            ],
+            rows=[
+                [
+                    usn.name,
+                    ", ".join(
+                        set(
+                            [
+                                pkg.fix_available_from or "no-fix"
+                                for pkg in usn.affected_packages
+                            ]
+                        )
+                    ),
+                    ", ".join(
+                        set([pkg.name for pkg in usn.affected_packages])
+                    ),
+                ]
+                for usn in usns_sorted_by_name
+            ],
+        )
+    )
+
+
+def _print_cve_table(cves):
+    cves_sorted_by_priority = sorted(
+        cves,
+        key=lambda cve: (
+            vuln_util.CVE_PRIORITIES.index(cve.ubuntu_priority),
+            cve.name,
+        ),
+    )
+
+    print(
+        Table(
+            headers=[
+                "VULNERABILITY",
+                "PRIORITY",
+                "FIX AVAILABLE FROM",
+                "AFFECTED INSTALLED PACKAGES",
+            ],
+            rows=[
+                [
+                    cve.name,
+                    vuln_util.get_priority_with_color(cve.ubuntu_priority),
+                    ", ".join(
+                        set(
+                            [
+                                pkg.fix_available_from or "no-fix"
+                                for pkg in cve.affected_packages
+                            ]
+                        )
+                    ),
+                    ", ".join(
+                        set([pkg.name for pkg in cve.affected_packages])
+                    ),
+                ]
+                for cve in cves_sorted_by_priority
+            ],
+        )
+    )
+
+
+def _get_info_from_vulnerabilities(vulnerabilities, fixable_vuln: bool):
+    count = 0
+    vulnerability_count_info = {}  # type: Dict[str, int]
+
+    for vuln in vulnerabilities:
+        if (vuln.fixable == "yes") is fixable_vuln:
+            count += 1
+
+            if not getattr(vuln, "ubuntu_priority", None):
+                continue
+
+            if vuln.ubuntu_priority in vulnerability_count_info:
+                vulnerability_count_info[vuln.ubuntu_priority] += 1
+            else:
+                vulnerability_count_info[vuln.ubuntu_priority] = 1
+
+    return VulnerabilityCountInfo(
+        count=count,
+        count_by_priority=vulnerability_count_info,
+    )
+
+
+def _get_fixable_color_count(fixable_vulnerabilities_info):
+    if "critical" in fixable_vulnerabilities_info.count_by_priority:
+        main_color = messages.TxtColor.FAIL
+    elif "high" in fixable_vulnerabilities_info.count_by_priority:
+        main_color = messages.TxtColor.ORANGE
+    elif "medium" in fixable_vulnerabilities_info.count_by_priority:
+        main_color = messages.TxtColor.WARNINGYELLOW
+    elif "low" in fixable_vulnerabilities_info.count_by_priority:
+        main_color = messages.TxtColor.INFOBLUE
+    else:
+        main_color = ""
+
+    if main_color:
+        return "{}{}{}".format(
+            main_color,
+            str(fixable_vulnerabilities_info.count),
+            messages.TxtColor.ENDC,
+        )
+
+    return str(fixable_vulnerabilities_info.count)
+
+
+def _get_count_msg_by_priority(count_by_priority):
+    msgs = []
+    sorted_priority_count = sorted(
+        count_by_priority.items(),
+        key=lambda item: vuln_util.CVE_PRIORITIES.index(item[0]),
+    )
+
+    for priority, count in sorted_priority_count:
+        if count:
+            msgs.append(
+                "{} {}".format(
+                    count, vuln_util.get_priority_with_color(priority)
+                )
+            )
+
+    return ", ".join(msgs)
+
+
+def _print_fixable_cves_count(vulnerabilities):
+    print(messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER)
+    fixable_vulnerabilities_info = _get_info_from_vulnerabilities(
+        vulnerabilities, fixable_vuln=True
+    )
+    count_with_color = _get_fixable_color_count(fixable_vulnerabilities_info)
+    print(
+        "    "
+        + count_with_color
+        + " "
+        + messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT
+        + " ("
+        + _get_count_msg_by_priority(
+            fixable_vulnerabilities_info.count_by_priority
+        )
+        + ")"
+        + "\n"
+    )
+
+
+def _print_fixable_usns_count(vulnerabilities):
+    print(messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER)
+    fixable_vulnerabilities_info = _get_info_from_vulnerabilities(
+        vulnerabilities, fixable_vuln=True
+    )
+    print(
+        "    "
+        + str(fixable_vulnerabilities_info.count)
+        + " "
+        + messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT
+        + "\n"
+    )
+
+
+def _print_unfixable_cves_count(vulnerabilities):
+    print(messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER)
+    unfixable_vulnerabilities_info = _get_info_from_vulnerabilities(
+        vulnerabilities, fixable_vuln=False
+    )
+    print(
+        "    "
+        + str(unfixable_vulnerabilities_info.count)
+        + " "
+        + messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT
+        + " ("
+        + _get_count_msg_by_priority(
+            unfixable_vulnerabilities_info.count_by_priority
+        )
+        + ")"
+        + "\n"
+    )
+
+
+def _print_unfixable_usns_count(vulnerabilities):
+    print(messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER)
+    unfixable_vulnerabilities_info = _get_info_from_vulnerabilities(
+        vulnerabilities, fixable_vuln=False
+    )
+    print(
+        "    "
+        + str(unfixable_vulnerabilities_info.count)
+        + " "
+        + messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT
+        + "\n"
+    )
+
+
+def _print_already_fixed_cves_count(applied_fixes_count):
+    if any(count for pocket, count in applied_fixes_count["count"].items()):
+        print(messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER)
+        for pocket, count in applied_fixes_count["count"].items():
+            if not count:
+                continue
+
+            print(
+                "    "
+                + "{}{}{} ".format(
+                    messages.TxtColor.DISABLEGREY,
+                    str(count),
+                    messages.TxtColor.ENDC,
+                )
+                + messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_COUNT
+                + " {}".format(pocket.title().replace("_", " "))
+                + " ("
+                + _get_count_msg_by_priority(
+                    applied_fixes_count.get("info", {}).get(pocket, {})
+                )
+                + ")"
+                + "\n"
+            )
+
+
+def _print_already_fixed_usns_count(applied_fixes_count):
+    if any(count for pocket, count in applied_fixes_count["count"].items()):
+        print(messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER)
+        for pocket, count in applied_fixes_count["count"].items():
+            if not count:
+                continue
+
+            print(
+                "    "
+                + str(count)
+                + " "
+                + messages.CLI_VULNERABILITY_LIST_FIXES_APPLIED_COUNT
+                + " {}".format(pocket.title().replace("_", " "))
+                + "\n",
+            )
+
+
+def _display_list_header(
+    vulnerabilities,
+    applied_fixes_count,
+    show_usns: bool,
+    show_all: bool,
+    show_unfixable: bool,
+):
+    if show_usns:
+        _print_already_fixed_usns_count(applied_fixes_count)
+
+        if show_all:
+            _print_fixable_usns_count(vulnerabilities)
+            _print_unfixable_usns_count(vulnerabilities)
+        elif show_unfixable:
+            _print_unfixable_usns_count(vulnerabilities)
+        else:
+            _print_fixable_usns_count(vulnerabilities)
+    else:
+        _print_already_fixed_cves_count(applied_fixes_count)
+        if show_all:
+            _print_fixable_cves_count(vulnerabilities)
+            _print_unfixable_cves_count(vulnerabilities)
+        elif show_unfixable:
+            _print_unfixable_cves_count(vulnerabilities)
+        else:
+            _print_fixable_cves_count(vulnerabilities)
+
+
+def _list_cves(
+    cfg: config.UAConfig,
+    show_all: bool,
+    show_unfixable: bool,
+    data_file: str,
+    manifest_file: str,
+    series: str,
+):
+    cve_vulnerabilities_result, applied_fixes_count = cve_vulnerabilities(
+        options=CVEVulnerabilitiesOptions(
+            all=show_all,
+            unfixable=show_unfixable,
+            data_file=data_file,
+            manifest_file=manifest_file,
+            series=series,
+        ),
+        cfg=cfg,
+    )
+
+    if cve_vulnerabilities_result.cves:
+        _display_list_header(
+            vulnerabilities=cve_vulnerabilities_result.cves,
+            applied_fixes_count=applied_fixes_count,
+            show_usns=False,
+            show_all=show_all,
+            show_unfixable=show_unfixable,
+        )
+        print(messages.CLI_VULNERABILITY_LIST_CVE_HEADER)
+        _print_cve_table(cve_vulnerabilities_result.cves)
+
+
+def _list_usns(
+    cfg: config.UAConfig,
+    show_all: bool,
+    show_unfixable: bool,
+    data_file: str,
+    manifest_file: str,
+    series: str,
+):
+    usn_vulnerabilities_result, applied_fixes_count = usn_vulnerabilities(
+        options=USNVulnerabilitiesOptions(
+            all=show_all,
+            unfixable=show_unfixable,
+            data_file=data_file,
+            manifest_file=manifest_file,
+            series=series,
+        ),
+        cfg=cfg,
+    )
+
+    if usn_vulnerabilities_result.usns:
+        _display_list_header(
+            vulnerabilities=usn_vulnerabilities_result.usns,
+            applied_fixes_count=applied_fixes_count,
+            show_usns=True,
+            show_all=show_all,
+            show_unfixable=show_unfixable,
+        )
+        print(messages.CLI_VULNERABILITY_LIST_USN_HEADER)
+        _print_usn_table(usn_vulnerabilities_result.usns)
+
+
+@vuln_util.assert_data_cache_updated("pro vulnerability list")
+def action_list(args, *, cfg, **kwargs):
+    if args.unfixable and args.all:
+        raise exceptions.InvalidOptionCombination(
+            option1="unfixable", option2="all"
+        )
+
+    if args.usns:
+        _list_usns(
+            cfg=cfg,
+            show_all=args.all,
+            show_unfixable=args.unfixable,
+            data_file=args.data_file,
+            manifest_file=args.manifest_file,
+            series=args.series,
+        )
+    else:
+        _list_cves(
+            cfg=cfg,
+            show_all=args.all,
+            show_unfixable=args.unfixable,
+            data_file=args.data_file,
+            manifest_file=args.manifest_file,
+            series=args.series,
+        )
+
+
+list_subcommand = ProCommand(
+    "list",
+    help=messages.CLI_VULNERABILITY_LIST,
+    description=messages.CLI_VULNERABILITY_LIST_DESC,
+    action=action_list,
+    preserve_description=True,
+    argument_groups=[
+        ProArgumentGroup(
+            arguments=[
+                ProArgument(
+                    "--data-file",
+                    help=messages.CLI_VULNERABILITY_DATA_FILE,
+                    action="store",
+                ),
+                ProArgument(
+                    "--all",
+                    help=messages.CLI_VULNERABILITY_LIST_ALL,
+                    action="store_true",
+                ),
+                ProArgument(
+                    "--usns",
+                    help=messages.CLI_VULNERABILITY_LIST_USNS,
+                    action="store_true",
+                ),
+                ProArgument(
+                    "--unfixable",
+                    help=messages.CLI_VULNERABILITY_LIST_UNFIXABLE,
+                    action="store_true",
+                ),
+                ProArgument(
+                    "--manifest-file",
+                    help=messages.CLI_VULNERABILITY_LIST_MANIFEST_FILE,
+                    action="store",
+                ),
+                ProArgument(
+                    "--series",
+                    help=messages.CLI_VULNERABILITY_LIST_SERIES,
+                    action="store",
+                ),
+            ]
+        )
+    ],
+)

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -1,4 +1,5 @@
-from typing import Dict, NamedTuple
+import re
+from typing import Any, Dict  # noqa: F401
 
 from uaclient import config, exceptions, messages
 from uaclient.api.u.pro.security.vulnerabilities.cve.v1 import (
@@ -16,11 +17,6 @@ from uaclient.api.u.pro.security.vulnerabilities.usn.v1 import (
 from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
 from uaclient.cli.formatter import Table
 from uaclient.cli.vulnerability import util as vuln_util
-
-VulnerabilityCountInfo = NamedTuple(
-    "VulnerabilityCountInfo",
-    [("count", int), ("count_by_priority", Dict[str, int])],
-)
 
 
 def _create_usn_table(usns, num_rows=None):
@@ -91,12 +87,12 @@ def _create_cve_table(cves, num_rows=None):
     )
 
 
-def _get_info_from_vulnerabilities(vulnerabilities, fixable_vuln: bool):
+def _get_unfixable_info_from_vulnerabilities(vulnerabilities):
     count = 0
     vulnerability_count_info = {}  # type: Dict[str, int]
 
     for vuln in vulnerabilities:
-        if (vuln.fixable == "yes") is fixable_vuln:
+        if vuln.fixable != "yes":
             count += 1
 
             if not getattr(vuln, "ubuntu_priority", None):
@@ -107,20 +103,59 @@ def _get_info_from_vulnerabilities(vulnerabilities, fixable_vuln: bool):
             else:
                 vulnerability_count_info[vuln.ubuntu_priority] = 1
 
-    return VulnerabilityCountInfo(
-        count=count,
-        count_by_priority=vulnerability_count_info,
-    )
+    return (count, vulnerability_count_info)
 
 
-def _get_fixable_color_count(fixable_vulnerabilities_info):
-    if "critical" in fixable_vulnerabilities_info.count_by_priority:
+def _get_info_from_vulnerabilities(vulnerabilities):
+    vulnerability_count_info = {
+        "ubuntu_security": {"count": 0, "info": {}},
+        "ubuntu_pro": {
+            "count": 0,
+            "info": {},
+        },
+    }  # type: Dict[str, Dict[str, Any]]
+
+    for vuln in vulnerabilities:
+        if vuln.fixable == "yes":
+            pocket = (
+                "ubuntu_pro"
+                if any(
+                    pkg
+                    for pkg in vuln.affected_packages
+                    if re.match(
+                        r"^(esm|fips)", pkg.fix_available_from or "no-fix"
+                    )
+                )
+                else "ubuntu_security"
+            )
+            vulnerability_count_info[pocket]["count"] += 1
+
+            if not getattr(vuln, "ubuntu_priority", None):
+                continue
+
+            if (
+                vuln.ubuntu_priority
+                in vulnerability_count_info[pocket]["info"]
+            ):
+                vulnerability_count_info[pocket]["info"][
+                    vuln.ubuntu_priority
+                ] += 1
+            else:
+                vulnerability_count_info[pocket]["info"][
+                    vuln.ubuntu_priority
+                ] = 1
+
+    return vulnerability_count_info
+
+
+def _get_fixable_color_count(pocket_info):
+    if "critical" in pocket_info["info"]:
         main_color = messages.TxtColor.FAIL
-    elif "high" in fixable_vulnerabilities_info.count_by_priority:
+    elif "high" in pocket_info["info"]:
         main_color = messages.TxtColor.ORANGE
-    elif "medium" in fixable_vulnerabilities_info.count_by_priority:
+    elif "medium" in pocket_info["info"]:
         main_color = messages.TxtColor.WARNINGYELLOW
-    elif "low" in fixable_vulnerabilities_info.count_by_priority:
+    elif "low" in pocket_info["info"]:
         main_color = messages.TxtColor.INFOBLUE
     else:
         main_color = ""
@@ -128,11 +163,11 @@ def _get_fixable_color_count(fixable_vulnerabilities_info):
     if main_color:
         return "{}{}{}".format(
             main_color,
-            str(fixable_vulnerabilities_info.count),
+            str(pocket_info["count"]),
             messages.TxtColor.ENDC,
         )
 
-    return str(fixable_vulnerabilities_info.count)
+    return str(pocket_info["count"])
 
 
 def _get_count_msg_by_priority(count_by_priority):
@@ -156,21 +191,26 @@ def _get_count_msg_by_priority(count_by_priority):
 def _create_fixable_cves_count(vulnerabilities) -> str:
     msg = messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER + "\n"
     fixable_vulnerabilities_info = _get_info_from_vulnerabilities(
-        vulnerabilities, fixable_vuln=True
+        vulnerabilities
     )
-    count_with_color = _get_fixable_color_count(fixable_vulnerabilities_info)
-    msg += (
-        "    "
-        + count_with_color
-        + " "
-        + messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT
-        + " ("
-        + _get_count_msg_by_priority(
-            fixable_vulnerabilities_info.count_by_priority
+
+    for pocket, pocket_info in fixable_vulnerabilities_info.items():
+        if not pocket_info["count"]:
+            continue
+
+        count_with_color = _get_fixable_color_count(pocket_info)
+        msg += (
+            "    "
+            + count_with_color
+            + " "
+            + messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT.format(
+                pocket=pocket.title().replace("_", " ")
+            )
+            + " ("
+            + _get_count_msg_by_priority(pocket_info["info"])
+            + ")"
+            + "\n"
         )
-        + ")"
-        + "\n"
-    )
 
     return msg
 
@@ -178,32 +218,37 @@ def _create_fixable_cves_count(vulnerabilities) -> str:
 def _create_fixable_usns_count(vulnerabilities):
     msg = messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER + "\n"
     fixable_vulnerabilities_info = _get_info_from_vulnerabilities(
-        vulnerabilities, fixable_vuln=True
+        vulnerabilities
     )
-    msg += (
-        "    "
-        + str(fixable_vulnerabilities_info.count)
-        + " "
-        + messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT
-        + "\n"
-    )
+    for pocket, pocket_info in fixable_vulnerabilities_info.items():
+        if not pocket_info["count"]:
+            continue
+
+        msg += (
+            "    "
+            + str(pocket_info["count"])
+            + " "
+            + messages.CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT.format(
+                pocket=pocket.title().replace("_", " ")
+            )
+            + "\n"
+        )
+
     return msg
 
 
 def _create_unfixable_cves_count(vulnerabilities) -> str:
     msg = messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER + "\n"
-    unfixable_vulnerabilities_info = _get_info_from_vulnerabilities(
-        vulnerabilities, fixable_vuln=False
+    count, unfixable_vulnerabilities_info = (
+        _get_unfixable_info_from_vulnerabilities(vulnerabilities)  # noqa
     )
     msg += (
         "    "
-        + str(unfixable_vulnerabilities_info.count)
+        + str(count)
         + " "
         + messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT
         + " ("
-        + _get_count_msg_by_priority(
-            unfixable_vulnerabilities_info.count_by_priority
-        )
+        + _get_count_msg_by_priority(unfixable_vulnerabilities_info)
         + ")"
         + "\n"
     )
@@ -213,12 +258,12 @@ def _create_unfixable_cves_count(vulnerabilities) -> str:
 
 def _create_unfixable_usns_count(vulnerabilities):
     msg = messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER + "\n"
-    unfixable_vulnerabilities_info = _get_info_from_vulnerabilities(
-        vulnerabilities, fixable_vuln=False
+    count, unfixable_vulnerabilities_info = (
+        _get_unfixable_info_from_vulnerabilities(vulnerabilities)  # noqa
     )
     msg += (
         "    "
-        + str(unfixable_vulnerabilities_info.count)
+        + str(count)
         + " "
         + messages.CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT
         + "\n"

--- a/uaclient/cli/vulnerability/show.py
+++ b/uaclient/cli/vulnerability/show.py
@@ -1,0 +1,307 @@
+from typing import Optional
+from urllib.parse import urljoin
+
+from uaclient import config, defaults, messages, util
+from uaclient.api.u.pro.security.vulnerabilities.cve.v1 import (
+    CVEVulnerabilitiesOptions,
+)
+from uaclient.api.u.pro.security.vulnerabilities.cve.v1 import (
+    _vulnerabilities as cve_vulnerabilities,
+)
+from uaclient.api.u.pro.security.vulnerabilities.usn.v1 import (
+    USNVulnerabilitiesOptions,
+)
+from uaclient.api.u.pro.security.vulnerabilities.usn.v1 import (
+    _vulnerabilities as usn_vulnerabilities,
+)
+from uaclient.cli import cli_util
+from uaclient.cli.commands import ProArgument, ProArgumentGroup, ProCommand
+from uaclient.cli.formatter import Table
+from uaclient.cli.vulnerability import util as vuln_util
+
+
+def _show_base_info_for_unaffected_issue(vulnerability_result, name: str):
+    print(util.handle_unicode_characters("● {}".format(name)))
+    print(
+        messages.CLI_VULNERABILITY_SHOW_PUBLIC_URL.format(
+            urljoin(defaults.BASE_SECURITY_URL, name)
+        )
+    )
+    print(
+        messages.CLI_VULNERABILITY_SHOW_JSON_PUBLISHED_AT.format(
+            vulnerability_result.vulnerability_data_published_at.strftime(  # noqa
+                "%Y-%m-%d %H:%M:%S"
+            )
+        )
+    )
+    print(
+        messages.CLI_VULNERABILITY_SHOW_APT_UPDATED_AT.format(
+            vulnerability_result.apt_updated_at.strftime("%Y-%m-%d %H:%M:%S")
+        )
+    )
+
+
+def _show_base_info(vulnerability_result, vulnerability_issue):
+    print(
+        util.handle_unicode_characters("● {}".format(vulnerability_issue.name))
+    )
+    print(
+        messages.CLI_VULNERABILITY_SHOW_PUBLIC_URL.format(
+            urljoin(defaults.BASE_SECURITY_URL, vulnerability_issue.name)
+        )
+    )
+    print(
+        messages.CLI_VULNERABILITY_SHOW_PUBLISHED_AT.format(
+            vulnerability_issue.published_at.strftime("%Y-%m-%d %H:%M:%S")
+        )
+    )
+    print(
+        messages.CLI_VULNERABILITY_SHOW_JSON_PUBLISHED_AT.format(
+            vulnerability_result.vulnerability_data_published_at.strftime(  # noqa
+                "%Y-%m-%d %H:%M:%S"
+            )
+        )
+    )
+    print(
+        messages.CLI_VULNERABILITY_SHOW_APT_UPDATED_AT.format(
+            vulnerability_result.apt_updated_at.strftime("%Y-%m-%d %H:%M:%S")
+        )
+    )
+
+
+def _show_description(vulnerability_issue):
+    print(
+        "\n"
+        + messages.CLI_VULNERABILITY_SHOW_DESCRIPTION.format(
+            vulnerability_issue.description
+        )
+        + "\n"
+    )
+
+
+def _show_cve_affected_packages(vulnerability_issue):
+    print(
+        messages.CLI_VULNERABILITY_SHOW_AFFECTED_PKGS
+        + str(
+            Table(
+                headers=[
+                    "NAME",
+                    "STATUS",
+                    "CURRENT VERSION",
+                    "FIXED BY",
+                    "FIX AVAILABLE FROM",
+                ],
+                rows=[
+                    [
+                        pkg.name,
+                        pkg.fix_status,
+                        pkg.current_version,
+                        pkg.fix_version or "-",
+                        pkg.fix_available_from or "no-fix",
+                    ]
+                    for pkg in vulnerability_issue.affected_packages
+                ],
+            )
+        )
+    )
+
+
+def _show_usn_affected_packages(vulnerability_issue):
+    print(
+        messages.CLI_VULNERABILITY_SHOW_AFFECTED_PKGS
+        + str(
+            Table(
+                headers=[
+                    "NAME",
+                    "CURRENT VERSION",
+                    "FIXED BY",
+                    "FIX AVAILABLE FROM",
+                ],
+                rows=[
+                    [
+                        pkg.name,
+                        pkg.current_version,
+                        pkg.fix_version or "-",
+                        pkg.fix_available_from or "no-fix",
+                    ]
+                    for pkg in vulnerability_issue.affected_packages
+                ],
+            )
+        )
+    )
+
+
+def _show_related_usns(related_usns):
+    rows = [
+        [
+            usn.name,
+            usn.title,
+            ", ".join(usn.affected_installed_packages),
+        ]
+        for usn in related_usns
+        if usn.title
+    ]
+
+    if rows:
+        print(
+            messages.CLI_VULNERABILITY_SHOW_RELATED_USNS
+            + str(
+                Table(
+                    headers=[
+                        "VULNERABILITY",
+                        "TITLE",
+                        "AFFECTED INSTALLED PACKAGES",
+                    ],
+                    rows=rows,
+                )
+            )
+            + "\n"
+        )
+
+
+def _show_related_cves(related_cves):
+    print(
+        messages.CLI_VULNERABILITY_SHOW_RELATED_CVES
+        + str(
+            Table(
+                headers=[
+                    "VULNERABILITY",
+                    "PRIORITY",
+                    "AFFECTED INSTALLED PACKAGES",
+                ],
+                rows=[
+                    [
+                        cve.name,
+                        vuln_util.get_priority_with_color(cve.priority),
+                        ", ".join(cve.affected_installed_packages),
+                    ]
+                    for cve in related_cves
+                ],
+            )
+        )
+        + "\n"
+    )
+
+
+def _show_cve_info(cfg: config.UAConfig, cve: str, data_file: Optional[str]):
+    cve_vulnerabilities_result = cve_vulnerabilities(
+        options=CVEVulnerabilitiesOptions(all=True, data_file=data_file),
+        cfg=cfg,
+    )
+
+    cve_data = None
+    for cve_info in cve_vulnerabilities_result.cves:
+        if cve_info.name == cve:
+            cve_data = cve_info
+            break
+
+    if not cve_data:
+        _show_base_info_for_unaffected_issue(
+            cve_vulnerabilities_result, name=cve
+        )
+        print(
+            "\n"
+            + messages.CLI_VULNERABILITY_SHOW_NOT_AFFECTED.format(issue=cve)
+        )
+        return
+
+    _show_base_info(cve_vulnerabilities_result, cve_data)
+    print(
+        messages.CLI_VULNERABILITY_SHOW_UBUNTU_PRIORITY.format(
+            cve_info.ubuntu_priority
+        )
+    )
+    print(
+        messages.CLI_VULNERABILITY_SHOW_CVSS_SCORE.format(cve_info.cvss_score)
+    )
+    print(
+        messages.CLI_VULNERABILITY_SHOW_CVSS_SEVERITY.format(
+            cve_info.cvss_severity
+        )
+    )
+    _show_description(cve_data)
+    _show_cve_affected_packages(cve_data)
+
+    if cve_data.notes:
+        print(
+            messages.CLI_VULNERABILITY_SHOW_NOTES.format(
+                "\n".join(note for note in cve_data.notes)
+            )
+            + "\n"
+        )
+
+    _show_related_usns(cve_data.related_usns)
+
+
+def _show_usn_info(cfg: config.UAConfig, usn: str, data_file: Optional[str]):
+    usn_vulnerabilities_result = usn_vulnerabilities(
+        options=USNVulnerabilitiesOptions(
+            all=True,
+            data_file=data_file,
+        ),
+        cfg=cfg,
+    )
+
+    usn_data = None
+    for usn_info in usn_vulnerabilities_result.usns:
+        if usn_info.name == usn:
+            usn_data = usn_info
+            break
+
+    if not usn_data:
+        _show_base_info_for_unaffected_issue(
+            usn_vulnerabilities_result, name=usn
+        )
+        print(
+            "\n"
+            + messages.CLI_VULNERABILITY_SHOW_NOT_AFFECTED.format(issue=usn)
+        )
+        return
+
+    _show_base_info(usn_vulnerabilities_result, usn_data)
+    _show_description(usn_data)
+    _show_usn_affected_packages(usn_data)
+
+    if usn_data.related_cves:
+        _show_related_cves(usn_data.related_cves)
+
+
+@cli_util.assert_vulnerability_issue_valid(cmd="vulnerability show")
+@vuln_util.assert_data_cache_updated(
+    cmd="pro vulnerability show <vulnerability_issue>"
+)
+def action_show(args, *, cfg, **kwargs):
+    if args.security_issue.startswith("CVE"):
+        _show_cve_info(
+            cfg=cfg, cve=args.security_issue, data_file=args.data_file
+        )
+    else:
+        _show_usn_info(
+            cfg=cfg, usn=args.security_issue, data_file=args.data_file
+        )
+
+    return 0
+
+
+show_subcommand = ProCommand(
+    "show",
+    help=messages.CLI_VULNERABILITY_SHOW,
+    description=messages.CLI_VULNERABILITY_SHOW_DESC,
+    action=action_show,
+    preserve_description=True,
+    argument_groups=[
+        ProArgumentGroup(
+            arguments=[
+                ProArgument(
+                    "security_issue",
+                    help=messages.CLI_VULNERABILITY_SHOW_ISSUE,
+                ),
+                ProArgument(
+                    "--data-file",
+                    help=messages.CLI_VULNERABILITY_DATA_FILE,
+                    action="store",
+                ),
+            ]
+        )
+    ],
+)

--- a/uaclient/cli/vulnerability/show.py
+++ b/uaclient/cli/vulnerability/show.py
@@ -20,11 +20,16 @@ from uaclient.cli.formatter import Table
 from uaclient.cli.vulnerability import util as vuln_util
 
 
-def _show_base_info_for_unaffected_issue(vulnerability_result, name: str):
+def _show_base_info_for_unaffected_issue(
+    vulnerability_result, name: str, security_url: str
+):
+    if not security_url.endswith("/"):
+        security_url += "/"
+
     print(util.handle_unicode_characters("● {}".format(name)))
     print(
         messages.CLI_VULNERABILITY_SHOW_PUBLIC_URL.format(
-            urljoin(defaults.BASE_SECURITY_URL, name)
+            urljoin(security_url, name)
         )
     )
     print(
@@ -41,13 +46,20 @@ def _show_base_info_for_unaffected_issue(vulnerability_result, name: str):
     )
 
 
-def _show_base_info(vulnerability_result, vulnerability_issue):
+def _show_base_info(
+    vulnerability_result,
+    vulnerability_issue,
+    security_url,
+):
+    if not security_url.endswith("/"):
+        security_url += "/"
+
     print(
         util.handle_unicode_characters("● {}".format(vulnerability_issue.name))
     )
     print(
         messages.CLI_VULNERABILITY_SHOW_PUBLIC_URL.format(
-            urljoin(defaults.BASE_SECURITY_URL, vulnerability_issue.name)
+            urljoin(security_url, vulnerability_issue.name)
         )
     )
     print(
@@ -197,7 +209,9 @@ def _show_cve_info(cfg: config.UAConfig, cve: str, data_file: Optional[str]):
 
     if not cve_data:
         _show_base_info_for_unaffected_issue(
-            cve_vulnerabilities_result, name=cve
+            cve_vulnerabilities_result,
+            name=cve,
+            security_url=defaults.BASE_SECURITY_URL,
         )
         print(
             "\n"
@@ -205,7 +219,11 @@ def _show_cve_info(cfg: config.UAConfig, cve: str, data_file: Optional[str]):
         )
         return
 
-    _show_base_info(cve_vulnerabilities_result, cve_data)
+    _show_base_info(
+        cve_vulnerabilities_result,
+        cve_data,
+        security_url=defaults.BASE_SECURITY_URL,
+    )
     print(
         messages.CLI_VULNERABILITY_SHOW_UBUNTU_PRIORITY.format(
             cve_info.ubuntu_priority
@@ -250,7 +268,9 @@ def _show_usn_info(cfg: config.UAConfig, usn: str, data_file: Optional[str]):
 
     if not usn_data:
         _show_base_info_for_unaffected_issue(
-            usn_vulnerabilities_result, name=usn
+            usn_vulnerabilities_result,
+            name=usn,
+            security_url=defaults.BASE_SECURITY_URL + "/notices",
         )
         print(
             "\n"
@@ -258,7 +278,11 @@ def _show_usn_info(cfg: config.UAConfig, usn: str, data_file: Optional[str]):
         )
         return
 
-    _show_base_info(usn_vulnerabilities_result, usn_data)
+    _show_base_info(
+        usn_vulnerabilities_result,
+        usn_data,
+        security_url=defaults.BASE_SECURITY_URL + "/notices",
+    )
     _show_description(usn_data)
     _show_usn_affected_packages(usn_data)
 

--- a/uaclient/cli/vulnerability/show.py
+++ b/uaclient/cli/vulnerability/show.py
@@ -301,6 +301,11 @@ show_subcommand = ProCommand(
                     help=messages.CLI_VULNERABILITY_DATA_FILE,
                     action="store",
                 ),
+                ProArgument(
+                    "--update",
+                    help=messages.CLI_VULNERABILITY_UPDATE,
+                    action="store_true",
+                ),
             ]
         )
     ],

--- a/uaclient/cli/vulnerability/update.py
+++ b/uaclient/cli/vulnerability/update.py
@@ -1,0 +1,28 @@
+from uaclient import messages
+from uaclient.api.u.pro.security.vulnerabilities._common.v1 import (
+    VulnerabilityData,
+)
+from uaclient.cli.commands import ProCommand
+
+
+def action_update(args, *, cfg, **kwargs):
+    print(messages.CLI_VULNERABILITY_UPDATE_CHECK_NEW_DATA)
+
+    vulnerability_data = VulnerabilityData(cfg)
+    cache_valid, _ = vulnerability_data.is_cache_valid()
+
+    if not cache_valid:
+        print(messages.CLI_VULNERABILITY_UPDATE_NEW_DATA_FOUND)
+        vulnerability_data.get()
+        print(messages.CLI_VULNERABILITY_UPDATE_DATA_UPDATED)
+    else:
+        print(messages.CLI_VULNERABILITY_UPDATE_NO_NEW_DATA_FOUND)
+
+
+update_subcommand = ProCommand(
+    "update",
+    help=messages.CLI_VULNERABILITY_UPDATE,
+    description=messages.CLI_VULNERABILITY_UPDATE_DESC,
+    action=action_update,
+    preserve_description=True,
+)

--- a/uaclient/cli/vulnerability/util.py
+++ b/uaclient/cli/vulnerability/util.py
@@ -1,0 +1,48 @@
+from functools import wraps
+
+from uaclient import messages
+from uaclient.api.u.pro.security.vulnerabilities._common.v1 import (
+    VulnerabilityData,
+)
+
+
+def _parse_cache_time_diff(cache_time_diff) -> int:
+    if cache_time_diff.days >= 1:
+        return cache_time_diff.days
+
+    return round(cache_time_diff.total_seconds() / 3600)
+
+
+def assert_data_cache_updated(cmd):
+    def wrapper(f):
+        @wraps(f)
+        def new_f(args, *, cfg, **kwargs):
+            vulnerability_data = VulnerabilityData(cfg)
+            cache_valid, cache_time_diff = vulnerability_data.is_cache_valid()
+            if not cache_valid and cache_time_diff:
+                print(
+                    messages.CLI_VULNERABILITY_DATE_OUTDATED.format(
+                        t_diff=_parse_cache_time_diff(cache_time_diff),
+                        cmd=cmd,
+                    )
+                )
+
+            retval = f(args, cfg=cfg, **kwargs)
+            return retval
+
+        return new_f
+
+    return wrapper
+
+
+def get_priority_with_color(priority):
+    if priority == "low":
+        return messages.TxtColor.INFOBLUE + priority + messages.TxtColor.ENDC
+    elif priority == "medium":
+        return (
+            messages.TxtColor.WARNINGYELLOW + priority + messages.TxtColor.ENDC
+        )
+    elif priority == "high":
+        return messages.TxtColor.ORANGE + priority + messages.TxtColor.ENDC
+    else:
+        return messages.TxtColor.FAIL + priority + messages.TxtColor.ENDC

--- a/uaclient/cli/vulnerability/util.py
+++ b/uaclient/cli/vulnerability/util.py
@@ -27,14 +27,19 @@ def assert_data_cache_updated(cmd):
         @wraps(f)
         def new_f(args, *, cfg, **kwargs):
             vulnerability_data = VulnerabilityData(cfg)
-            cache_valid, cache_time_diff = vulnerability_data.is_cache_valid()
-            if not cache_valid and cache_time_diff:
-                print(
-                    messages.CLI_VULNERABILITY_DATE_OUTDATED.format(
-                        t_diff=_parse_cache_time_diff(cache_time_diff),
-                        cmd=cmd,
-                    )
+            if args.update:
+                vulnerability_data.get()
+            else:
+                cache_valid, cache_time_diff = (
+                    vulnerability_data.is_cache_valid()
                 )
+                if not cache_valid and cache_time_diff:
+                    print(
+                        messages.CLI_VULNERABILITY_DATE_OUTDATED.format(
+                            t_diff=_parse_cache_time_diff(cache_time_diff),
+                            cmd=cmd,
+                        )
+                    )
 
             retval = f(args, cfg=cfg, **kwargs)
             return retval

--- a/uaclient/cli/vulnerability/util.py
+++ b/uaclient/cli/vulnerability/util.py
@@ -5,6 +5,15 @@ from uaclient.api.u.pro.security.vulnerabilities._common.v1 import (
     VulnerabilityData,
 )
 
+CVE_PRIORITIES = [
+    "critical",
+    "high",
+    "medium",
+    "low",
+    "negligible",
+    "unknown",
+]
+
 
 def _parse_cache_time_diff(cache_time_diff) -> int:
     if cache_time_diff.days >= 1:
@@ -44,5 +53,7 @@ def get_priority_with_color(priority):
         )
     elif priority == "high":
         return messages.TxtColor.ORANGE + priority + messages.TxtColor.ENDC
-    else:
+    elif priority == "critical":
         return messages.TxtColor.FAIL + priority + messages.TxtColor.ENDC
+    else:
+        return priority

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -563,6 +563,10 @@ class InvalidOptionCombination(UbuntuProError):
     _formatted_msg = messages.E_INVALID_OPTION_COMBINATION
 
 
+class DepedentOptionError(UbuntuProError):
+    _formatted_msg = messages.E_DEPEDENT_OPTION
+
+
 class NoHelpContent(UbuntuProError):
     _formatted_msg = messages.E_CLI_NO_HELP
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -564,7 +564,7 @@ class InvalidOptionCombination(UbuntuProError):
 
 
 class DepedentOptionError(UbuntuProError):
-    _formatted_msg = messages.E_DEPEDENT_OPTION
+    _formatted_msg = messages.E_DEPENDENT_OPTION
 
 
 class NoHelpContent(UbuntuProError):

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1343,7 +1343,7 @@ CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER = (
     + TxtColor.ENDC
 )
 CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT = t.gettext(
-    "vulnerabilities found"
+    "fixable via {pocket}"
 )
 CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT = t.gettext(
     "unfixable vulnerabilities found"

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1209,13 +1209,10 @@ CLI_ROOT_VULNERABILITY = t.gettext(
 )
 CLI_VULNERABILITY_DESC = t.gettext(
     """\
-Show information about system vulnerabilities.
-
-show: display all available information for a given CVE/USN.
-list: display all fixable CVEs in the system
-update: update the vulnerability data in the system
-"""
+Allow users to better visualize the vulnerability issues that affects
+the system."""
 )
+
 CLI_VULNERABILITY_DATA_FILE = t.gettext(
     """\
 Static vulnerability JSON data to be used in the command"""
@@ -1270,8 +1267,7 @@ CLI_VULNERABILITY_UPDATE = t.gettext(
 CLI_VULNERABILITY_UPDATE_DESC = t.gettext(
     """\
 Updates the vulnerability data stored in the machine.
-If no vulnerability data exists yet, the command will
-download it
+If no vulnerability data exists yet, the command will download it
 """
 )
 CLI_VULNERABILITY_UPDATE_CHECK_NEW_DATA = t.gettext(
@@ -1302,9 +1298,9 @@ CLI_VULNERABILITY_LIST = t.gettext(
 )
 CLI_VULNERABILITY_LIST_DESC = t.gettext(
     """\
-    List the fixable vulnerabilities that affects the system.
-    By default, the command will only list CVEs. To display
-    USNs instead, run the command with the --usns flag."""
+List the fixable vulnerabilities that affects the system.
+By default, the command will only list CVEs. To display
+USNs instead, run the command with the --usns flag."""
 )
 CLI_VULNERABILITY_LIST_CVE_HEADER = (
     TxtColor.DISABLEGREY

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -2704,6 +2704,11 @@ E_INVALID_OPTION_COMBINATION = FormattedNamedMessage(
     t.gettext("Error: Cannot use {option1} together with {option2}."),
 )
 
+E_DEPEDENT_OPTION = FormattedNamedMessage(
+    "depedent-option",
+    t.gettext("Error: {option1} depends on {option2} to work properly."),
+)
+
 E_CLI_NO_HELP = FormattedNamedMessage(
     "no-help-content", t.gettext("No help available for '{name}'")
 )

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1204,6 +1204,66 @@ CLI_ROOT_REFRESH = t.gettext("refresh Ubuntu Pro services")
 CLI_ROOT_STATUS = t.gettext("current status of all Ubuntu Pro services")
 CLI_ROOT_SYSTEM = t.gettext("show system information related to Pro services")
 
+CLI_ROOT_VULNERABILITY = t.gettext(
+    "show information about system vulnerabilities"
+)
+CLI_VULNERABILITY_DESC = t.gettext(
+    """\
+Show information about system vulnerabilities.
+
+show: display all available information for a given CVE/USN.
+list: display all fixable CVEs in the system
+update: update the vulnerability data in the system
+"""
+)
+CLI_VULNERABILITY_DATA_FILE = t.gettext(
+    """\
+Static vulnerability JSON data to be used in the command"""
+)
+CLI_VULNERABILITY_DATE_OUTDATED = t.gettext(
+    """\
+The vulnerabilities data used in the system is outdated by {t_diff} days/hours
+To update the data please run with --update:
+
+    $ {cmd} --update
+"""
+)
+
+CLI_VULNERABILITY_SHOW = t.gettext("show information about a vulnerability")
+CLI_VULNERABILITY_SHOW_DESC = t.gettext(
+    """\
+Show all available information about a given security issue.
+"""
+)
+CLI_VULNERABILITY_SHOW_ISSUE = t.gettext(
+    "Security vulnerability ID to display information."
+    " Format: CVE-yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-dd"
+)
+CLI_VULNERABILITY_SHOW_NOT_AFFECTED = t.gettext(
+    "{issue} does not affect your system."
+)
+CLI_VULNERABILITY_SHOW_PUBLIC_URL = t.gettext("Public URL: {}")
+CLI_VULNERABILITY_SHOW_PUBLISHED_AT = t.gettext("Published at: {}")
+CLI_VULNERABILITY_SHOW_JSON_PUBLISHED_AT = t.gettext(
+    "Ubuntu vulnerability data published at: {}"
+)
+CLI_VULNERABILITY_SHOW_APT_UPDATED_AT = t.gettext(
+    "APT package information updated at: {}"
+)
+CLI_VULNERABILITY_SHOW_APT_UPDATED_AT = t.gettext(
+    "APT package information updated at: {}"
+)
+CLI_VULNERABILITY_SHOW_UBUNTU_PRIORITY = t.gettext("Ubuntu priority: {}")
+CLI_VULNERABILITY_SHOW_CVSS_SCORE = t.gettext("CVSS score: {}")
+CLI_VULNERABILITY_SHOW_CVSS_SEVERITY = t.gettext("CVSS severity: {}")
+CLI_VULNERABILITY_SHOW_DESCRIPTION = t.gettext("[DESCRIPTION]\n{}")
+CLI_VULNERABILITY_SHOW_NOTES = t.gettext("[NOTES]\n{}")
+CLI_VULNERABILITY_SHOW_RELATED_USNS = t.gettext("[RELATED USNs]\n")
+CLI_VULNERABILITY_SHOW_RELATED_CVES = t.gettext("[RELATED CVEs]\n")
+CLI_VULNERABILITY_SHOW_AFFECTED_PKGS = t.gettext(
+    "[AFFECTED INSTALLED PACKAGES]\n"
+)
+
 WARNING_HUMAN_READABLE_OUTPUT = t.gettext(
     """\
 WARNING: this output is intended to be human readable, and subject to change.
@@ -2558,7 +2618,7 @@ E_SECURITY_FIX_CLI_ISSUE_REGEX_FAIL = FormattedNamedMessage(
     "invalid-security-issue-id-format",
     t.gettext(
         'Error: issue "{issue}" is not recognized.\n'
-        'Usage: "pro fix CVE-yyyy-nnnn" or "pro fix USN-nnnn"'
+        'Usage: "pro {cmd} CVE-yyyy-nnnn" or "pro {cmd} USN-nnnn"'
     ),
 )
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1264,6 +1264,40 @@ CLI_VULNERABILITY_SHOW_AFFECTED_PKGS = t.gettext(
     "[AFFECTED INSTALLED PACKAGES]\n"
 )
 
+CLI_VULNERABILITY_UPDATE = t.gettext(
+    "update the vulnerability data in your machine"
+)
+CLI_VULNERABILITY_UPDATE_DESC = t.gettext(
+    """\
+Updates the vulnerability data stored in the machine.
+If no vulnerability data exists yet, the command will
+download it
+"""
+)
+CLI_VULNERABILITY_UPDATE_CHECK_NEW_DATA = t.gettext(
+    """\
+Checking for the availability of newer vulnerability data.
+Please wait a moment while we verify if a new version is ready for download.
+"""
+)
+CLI_VULNERABILITY_UPDATE_NEW_DATA_FOUND = t.gettext(
+    """\
+Found a newer version of the data.
+Fetching and processing the new data…
+"""
+)
+CLI_VULNERABILITY_UPDATE_NO_NEW_DATA_FOUND = OKGREEN_CHECK + t.gettext(
+    """\
+ Vulnerability data in the system is already up-to-date
+"""
+)
+CLI_VULNERABILITY_UPDATE_DATA_UPDATED = OKGREEN_CHECK + t.gettext(
+    """\
+ Vulnerability data in the system is now up-to-date
+"""
+)
+
+
 WARNING_HUMAN_READABLE_OUTPUT = t.gettext(
     """\
 WARNING: this output is intended to be human readable, and subject to change.

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1297,6 +1297,63 @@ CLI_VULNERABILITY_UPDATE_DATA_UPDATED = OKGREEN_CHECK + t.gettext(
 """
 )
 
+CLI_VULNERABILITY_LIST = t.gettext(
+    "list the vulnerabilities that affect the system"
+)
+CLI_VULNERABILITY_LIST_DESC = t.gettext(
+    """\
+    List the fixable vulnerabilities that affects the system.
+    By default, the command will only list CVEs. To display
+    USNs instead, run the command with the --usns flag."""
+)
+CLI_VULNERABILITY_LIST_CVE_HEADER = (
+    TxtColor.DISABLEGREY
+    + t.gettext("Common vulnerabilities and exposures (CVE):")
+    + TxtColor.ENDC
+)
+CLI_VULNERABILITY_LIST_USN_HEADER = (
+    TxtColor.DISABLEGREY
+    + t.gettext("Ubuntu Security Notices (USN):")
+    + TxtColor.ENDC
+)
+CLI_VULNERABILITY_LIST_ALL = t.gettext(
+    "List all vulnerabilities that affect the machine, even if they can't be fixed"  # noqa
+)
+CLI_VULNERABILITY_LIST_USNS = t.gettext(
+    "List USNs vulnerabilities instead of CVEs"
+)
+CLI_VULNERABILITY_LIST_UNFIXABLE = t.gettext(
+    "List only vulnerabilities that don't have a fix available"
+)
+CLI_VULNERABILITY_LIST_MANIFEST_FILE = t.gettext(
+    "Manifest file to be used by the command"
+)
+CLI_VULNERABILITY_LIST_SERIES = t.gettext(
+    "When a manifest file is provided, specify the series that generated using this parameter"  # noqa
+)
+CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_HEADER = (
+    TxtColor.DISABLEGREY
+    + t.gettext("Vulnerabilities with fixes available:")
+    + TxtColor.ENDC
+)
+CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_HEADER = (
+    TxtColor.DISABLEGREY
+    + t.gettext("Vulnerabilities with no fixes available:")
+    + TxtColor.ENDC
+)
+CLI_VULNERABILITY_LIST_FIXES_APPLIED_HEADER = (
+    TxtColor.DISABLEGREY
+    + t.gettext("Vulnerabilities with applied fixes:")
+    + TxtColor.ENDC
+)
+CLI_VULNERABILITY_LIST_FIXES_AVAILABLE_COUNT = t.gettext(
+    "vulnerabilities found"
+)
+CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT = t.gettext(
+    "unfixable vulnerabilities found"
+)
+CLI_VULNERABILITY_LIST_FIXES_APPLIED_COUNT = t.gettext("applied via")
+
 
 WARNING_HUMAN_READABLE_OUTPUT = t.gettext(
     """\

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -2700,8 +2700,8 @@ E_INVALID_OPTION_COMBINATION = FormattedNamedMessage(
     t.gettext("Error: Cannot use {option1} together with {option2}."),
 )
 
-E_DEPEDENT_OPTION = FormattedNamedMessage(
-    "depedent-option",
+E_DEPENDENT_OPTION = FormattedNamedMessage(
+    "dependent-option",
     t.gettext("Error: {option1} depends on {option2} to work properly."),
 )
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1353,6 +1353,9 @@ CLI_VULNERABILITY_LIST_UNFIXABLE_AVAILABLE_COUNT = t.gettext(
     "unfixable vulnerabilities found"
 )
 CLI_VULNERABILITY_LIST_FIXES_APPLIED_COUNT = t.gettext("applied via")
+CLI_VULNERABILITY_LIST_NOT_AFFECTED = t.gettext(
+    "No {issue} found that affects this system"
+)
 
 
 WARNING_HUMAN_READABLE_OUTPUT = t.gettext(


### PR DESCRIPTION
## Why is this needed?
Add support for the following `pro vulnerability` commands:

* `show`: Show all available information we have for a CVE/USN that affects the system
* `list`: List the CVEs/USNs that affect the system
* `update`: Update the vulnerability JSON data on the machine


PS: We need to first merge #3318 and #3319 

## Test Steps
Run the new integration tests for these commands




---

- [ ] *(un)check this to re-run the checklist action*