### PR TITLE
Printing standardized output for CLI commands

### DIFF
--- a/uaclient/cli/formatter.py
+++ b/uaclient/cli/formatter.py
@@ -133,11 +133,12 @@ class Table:
         return column_sizes
 
     def __str__(self) -> str:
+        rows = self.rows
         if self._get_line_length() > self.max_length:
-            self.rows = self.wrap_last_column()
+            rows = self.wrap_last_column()
         output = ""
         output += TxtColor.BOLD + self._fill_row(self.headers) + TxtColor.ENDC
-        for row in self.rows:
+        for row in rows:
             output += "\n"
             output += self._fill_row(row)
         return output
@@ -158,8 +159,7 @@ class Table:
                 new_rows.append(row)
             else:
                 wrapped_last_column = wrap_text(row[-1], last_column_size)
-                row[-1] = wrapped_last_column[0]
-                new_rows.append(row)
+                new_rows.append(row[:-1] + [wrapped_last_column[0]])
                 for extra_line in wrapped_last_column[1:]:
                     new_row = [" "] * (len(self.column_sizes) - 1) + [
                         extra_line

--- a/uaclient/cli/formatter.py
+++ b/uaclient/cli/formatter.py
@@ -1,3 +1,4 @@
+import abc
 import os
 import re
 import sys
@@ -97,7 +98,16 @@ def wrap_text(text: str, max_width: int) -> List[str]:
     return wrapped_lines
 
 
-class Table:
+class ProOutputFormatter(abc.ABC):
+    @abc.abstractmethod
+    def to_string(self, line_length: Optional[int] = None) -> str:
+        pass
+
+    def __str__(self):
+        return self.to_string()
+
+
+class Table(ProOutputFormatter):
     SEPARATOR = " " * 2
 
     def __init__(
@@ -147,9 +157,6 @@ class Table:
             )
 
         return column_sizes
-
-    def __str__(self) -> str:
-        return self.to_string()
 
     def to_string(self, line_length: Optional[int] = None) -> str:
         if line_length is None:
@@ -204,7 +211,7 @@ class Table:
         return output
 
 
-class Block:
+class Block(ProOutputFormatter):
     INDENT_SIZE = 4
     INDENT_CHAR = " "
 
@@ -215,9 +222,6 @@ class Block:
     ):
         self.title = title
         self.content = content if content is not None else []
-
-    def __str__(self) -> str:
-        return self.to_string()
 
     def to_string(self, line_length: Optional[int] = None) -> str:
         if line_length is None:
@@ -237,7 +241,7 @@ class Block:
             )
 
         for item in self.content:
-            if isinstance(item, (Block, Table)):
+            if isinstance(item, ProOutputFormatter):
                 item_str = item.to_string(line_length=line_length)
             else:
                 item_str = "\n".join(wrap_text(str(item), line_length)) + "\n"

--- a/uaclient/cli/formatter.py
+++ b/uaclient/cli/formatter.py
@@ -137,10 +137,16 @@ class Table:
         if self._get_line_length() > self.max_length:
             rows = self.wrap_last_column()
         output = ""
-        output += TxtColor.BOLD + self._fill_row(self.headers) + TxtColor.ENDC
+        if self.headers:
+            output += (
+                TxtColor.BOLD
+                + self._fill_row(self.headers)
+                + TxtColor.ENDC
+                + "\n"
+            )
         for row in rows:
-            output += "\n"
             output += self._fill_row(row)
+            output += "\n"
         return output
 
     def _get_line_length(self) -> int:

--- a/uaclient/cli/tests/test_cli_formatter.py
+++ b/uaclient/cli/tests/test_cli_formatter.py
@@ -200,7 +200,8 @@ class TestTable:
         ]
 
     @mock.patch(M_PATH + "sys.stdout.isatty", return_value=True)
-    def test_to_string_wraps_to_length(self, _m_is_tty):
+    def test_to_string_wraps_to_length(self, _m_is_tty, FakeConfig):
+        POFC.init(FakeConfig())
         table = Table(
             ["header1", "h2", "h3", "h4"],
             [
@@ -226,8 +227,9 @@ class TestTable:
         return_value=mock.MagicMock(columns=40),
     )
     def test_to_string_wraps_to_terminal_size(
-        self, _m_terminal_size, _m_is_tty
+        self, _m_terminal_size, _m_is_tty, FakeConfig
     ):
+        POFC.init(FakeConfig())
         table = Table(
             ["header1", "h2", "h3", "h4"],
             [
@@ -253,7 +255,10 @@ class TestTable:
         M_PATH + "os.get_terminal_size",
         side_effect=OSError(),
     )
-    def test_to_string_no_wrap_if_no_tty(self, _m_terminal_size, _m_is_tty):
+    def test_to_string_no_wrap_if_no_tty(
+        self, _m_terminal_size, _m_is_tty, FakeConfig
+    ):
+        POFC.init(FakeConfig())
         table = Table(
             ["header1", "h2", "h3", "h4"],
             [
@@ -269,7 +274,7 @@ class TestTable:
         )
         assert table.to_string() == textwrap.dedent(
             """\
-            \x1b[1mheader1  h2  h3     h4\x1b[0m
+            header1  h2  h3     h4
             a        bc  de     f
             b        de  fg     wow this is a really big string of datawow this is a really big string of datawow this is a really big string of data
             c        fg  hijkl  m
@@ -284,8 +289,9 @@ class TestBlock:
         side_effect=OSError(),
     )
     def test_indents_and_wraps_content_when_len_specified(
-        self, _m_terminal_size, _m_is_tty
+        self, _m_terminal_size, _m_is_tty, FakeConfig
     ):
+        POFC.init(FakeConfig())
         block = Block(
             title="Example Title",
             content=[
@@ -318,10 +324,10 @@ class TestBlock:
         )
         assert block.to_string() == textwrap.dedent(
             """\
-            \x1b[1m\x1b[37mExample Title\x1b[0m
+            Example Title
                 Smaller content line
                 A slightly bigger line which needs to be wrapped to fit the screen
-                \x1b[1m\x1b[37mInner block\x1b[0m
+                Inner block
                     Another small content line
                     Another slightly bigger line which needs to be wrapped to fit the screen
                 1  Table bigger last column which needs to be wrapped to fit the screen
@@ -331,11 +337,11 @@ class TestBlock:
         )
         assert block.to_string(line_length=40) == textwrap.dedent(
             """\
-            \x1b[1m\x1b[37mExample Title\x1b[0m
+            Example Title
                 Smaller content line
                 A slightly bigger line which needs
                 to be wrapped to fit the screen
-                \x1b[1m\x1b[37mInner block\x1b[0m
+                Inner block
                     Another small content line
                     Another slightly bigger line
                     which needs to be wrapped to fit
@@ -359,7 +365,7 @@ class TestBlock:
         POFC.init(FakeConfig())
         assert suggestion_block.to_string() == textwrap.dedent(
             """\
-            \x1b[1m\x1b[37mSuggestion\x1b[0m
+            Suggestion
                 Some content
             """
         )


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it brings some tweaks to the Table implementation, includes the indented Block and SuggestionBlock implementation and adds a helper function which considers the formatter config when returning text.
This is the last base PR for the CLI before the commands start to appear.

## Test Steps
Unit tests cover the functionality
Integration and such will come with the commands

---

- [ ] *(un)check this to re-run the checklist action*