### PR TITLE
Add debug logging of masked exception

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -419,7 +419,8 @@ def update_sources_list(sources_list_path: str):
             with lock:
                 cache.update(fetch_progress, sources_list, 0)
         # No apt_pkg.Error on Xenial
-        except getattr(apt_pkg, "Error", ()):
+        except getattr(apt_pkg, "Error", ()) as e:
+            LOG.debug(str(e))
             raise exceptions.APTProcessConflictError()
         except SystemError as e:
             raise exceptions.APTUpdateFailed(detail=str(e))


### PR DESCRIPTION
## Why is this needed?
Customers very occasionally run into this exception handling logic; the real error is eaten in favor of the unhelpfully generic `Another process is running APT`. A log entry would save us some consternation.

(Not sure which branch is appropriate here, happy to reopen if needed).

## Test Steps
Based on our records this happens most often when internal repos aren't mirroring i386 packages; I don't have a reproducer handy to double check. Please let me know if you need me to chase this down.

---

- [ ] *(un)check this to re-run the checklist action*