### PR TITLE
Add links and alignment functionality to the CLI formatter tooling

### DIFF
--- a/uaclient/cli/formatter.py
+++ b/uaclient/cli/formatter.py
@@ -84,7 +84,7 @@ def process_formatter_config(text: str) -> str:
 # We can't rely on textwrap because of the len_no_color function
 # Textwrap is using a magic regex instead
 def wrap_text(text: str, max_width: int) -> List[str]:
-    if len_no_color(text) < max_width:
+    if len_no_color(text) <= max_width:
         return [text]
 
     words = text.split()


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it implements some needed niceties on top of the CLI tools we are working on.

This is based on #3323 and should be merged after that. (It is the same context though, I didn't push the commits there because that one is kinda approved I guess)

## Test Steps
Unit tests cover functionality, integration will come because the new CLI commands depend on this.

---

- [x] *(un)check this to re-run the checklist action*