### PR TITLE
help: deduplicate 'pro help' command entries

### DIFF
--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -41,6 +41,45 @@ Feature: Pro Client help text
 
       Use pro <command> --help for more information about a command.
       """
+    # '--help' and 'help' should both work and produce the same output
+    When I run `pro help` as non-root
+    Then I will see the following on stdout
+      """
+      usage: pro [-h] [--debug] [--version] <command> ...
+
+      Quick start commands:
+
+        status           current status of all Ubuntu Pro services
+        attach           attach this machine to an Ubuntu Pro subscription
+        enable           enable a specific Ubuntu Pro service on this machine
+        system           show system information related to Pro services
+        security-status  list available security updates for the system
+
+      Security-related commands:
+
+        fix              check for and mitigate the impact of a CVE/USN on this system
+
+      Troubleshooting-related commands:
+
+        collect-logs     collect Pro logs and debug information
+
+      Other commands:
+
+        api              Calls the Client API endpoints.
+        auto-attach      automatically attach on supported platforms
+        config           manage Ubuntu Pro configuration on this machine
+        detach           remove this machine from an Ubuntu Pro subscription
+        disable          disable a specific Ubuntu Pro service on this machine
+        refresh          refresh Ubuntu Pro services
+
+      Flags:
+
+        -h, --help       Displays help on pro and command line options
+        --debug          show all debug log messages to console
+        --version        show version of pro
+
+      Use pro <command> --help for more information about a command.
+      """
     When I run `pro collect-logs --help` as non-root
     Then I will see the following on stdout
       """

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -308,7 +308,7 @@ Feature: Pro Client help text
             entitles use of this service. Possible values are: yes or no.
           * STATUS: Whether the service is enabled on this machine. Possible
             values are: enabled, disabled, n/a (if your contract entitles
-            you to the service, but it isn't available for this machine) or — (if
+            you to the service, but it isn't available for this machine) or - (if
             you aren't entitled to this service).
           * DESCRIPTION: A brief description of the service.
 

--- a/uaclient/cli/parser.py
+++ b/uaclient/cli/parser.py
@@ -52,9 +52,11 @@ class ProArgumentParser(argparse.ArgumentParser):
         help_string: str,
         position: int = 0,
     ):
-        cls.help_entries[category].append(
-            HelpEntry(position=position, name=name, help_string=help_string)
+        entry = HelpEntry(
+            position=position, name=name, help_string=help_string
         )
+        if entry not in cls.help_entries[category]:
+            cls.help_entries[category].append(entry)
 
     def __init__(self, *args, use_main_help: bool = True, **kwargs):
         super().__init__(*args, **kwargs)

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1147,7 +1147,7 @@ The attached status output has four columns:
       entitles use of this service. Possible values are: yes or no.
     * STATUS: Whether the service is enabled on this machine. Possible
       values are: enabled, disabled, n/a (if your contract entitles
-      you to the service, but it isn't available for this machine) or — (if
+      you to the service, but it isn't available for this machine) or - (if
       you aren't entitled to this service).
     * DESCRIPTION: A brief description of the service.
 


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because This PR solves all our problems because

it deduplicates the `pro help` entries.

## Test Steps
Integration test added

---

- [x] *(un)check this to re-run the checklist action*