### PR TITLE
fix: use USNs directly from the CVE response

### DIFF
--- a/uaclient/api/u/pro/security/fix/_common/plan/v1.py
+++ b/uaclient/api/u/pro/security/fix/_common/plan/v1.py
@@ -742,7 +742,7 @@ def _get_cve_data(
 ) -> Tuple[CVE, List[USN]]:
     try:
         cve = client.get_cve(cve_id=issue_id)
-        usns = client.get_notices(cves=issue_id)
+        usns = cve.notices
     except exceptions.SecurityAPIError as e:
         if e.code == 404:
             raise exceptions.SecurityIssueNotFound(issue_id=issue_id)


### PR DESCRIPTION
## Why is this needed?
We need to fetch the USNs related to a CVE to extract the ubuntu version of the packages affected by the CVE. In the past, we where running another request to fetch all USNs related to the CVEs. To make this process less demanding on the API side, we are now relaying on the related USNs already delivered by the CVE endpoint instead

## Test Steps
Check that CVE related tests for the fix command are still passing


---

- [x] *(un)check this to re-run the checklist action*