### PR TITLE
esm: add snapshot urls to apt auth

### DIFF
--- a/features/cli/enable.feature
+++ b/features/cli/enable.feature
@@ -452,7 +452,7 @@ Feature: CLI enable command
     When I run `wc -l /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
     Then I will see the following on stdout:
       """
-      2 /etc/apt/auth.conf.d/90ubuntu-advantage
+      6 /etc/apt/auth.conf.d/90ubuntu-advantage
       """
     # simulate a scenario where the line should get replaced
     When I run `cp /etc/apt/auth.conf.d/90ubuntu-advantage /etc/apt/auth.conf.d/90ubuntu-advantage.backup` with sudo
@@ -462,13 +462,13 @@ Feature: CLI enable command
     When I run `wc -l /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
     Then I will see the following on stdout:
       """
-      2 /etc/apt/auth.conf.d/90ubuntu-advantage
+      6 /etc/apt/auth.conf.d/90ubuntu-advantage
       """
     When I run `pro enable cis` with sudo
     When I run `wc -l /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
     Then I will see the following on stdout:
       """
-      3 /etc/apt/auth.conf.d/90ubuntu-advantage
+      7 /etc/apt/auth.conf.d/90ubuntu-advantage
       """
 
     Examples: ubuntu release

--- a/features/esm.feature
+++ b/features/esm.feature
@@ -1,0 +1,106 @@
+Feature: ESM Resource Specificities
+
+  Scenario Outline: esm apt auth includes snapshot urls
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I attach `contract_token` with sudo and options `--no-auto-enable`
+    When I run `pro enable esm-infra esm-apps` with sudo
+    When I run `cat /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
+    Then stdout contains substring:
+      """
+      machine esm.ubuntu.com/infra/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine snapshot.infra-security.esm.ubuntu.com/infra/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine snapshot.infra-updates.esm.ubuntu.com/infra/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine esm.ubuntu.com/apps/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine snapshot.apps-security.esm.ubuntu.com/apps/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine snapshot.apps-updates.esm.ubuntu.com/apps/ubuntu/ login bearer password m
+      """
+
+    Examples: ubuntu release
+      | release | machine_type  |
+      | xenial  | lxd-container |
+      | bionic  | lxd-container |
+      | focal   | lxd-container |
+      | jammy   | lxd-container |
+      | noble   | lxd-container |
+
+  @oneoff
+  Scenario Outline: attached upgrade to v35 adds snapshot urls for esm
+    Given a `<release>` `<machine_type>` machine
+    When I apt update
+    When I apt upgrade
+    When I attach `contract_token` with sudo and options `--no-auto-enable`
+    When I run `pro enable esm-infra esm-apps` with sudo
+    When I run `cat /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
+    Then stdout contains substring:
+      """
+      machine esm.ubuntu.com/infra/ubuntu/ login bearer password m
+      """
+    Then stdout does not contain substring:
+      """
+      machine snapshot.infra-security.esm.ubuntu.com/infra/ubuntu/ login bearer password m
+      """
+    Then stdout does not contain substring:
+      """
+      machine snapshot.infra-updates.esm.ubuntu.com/infra/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine esm.ubuntu.com/apps/ubuntu/ login bearer password m
+      """
+    Then stdout does not contain substring:
+      """
+      machine snapshot.apps-security.esm.ubuntu.com/apps/ubuntu/ login bearer password m
+      """
+    Then stdout does not contain substring:
+      """
+      machine snapshot.apps-updates.esm.ubuntu.com/apps/ubuntu/ login bearer password m
+      """
+    When I install ubuntu-advantage-tools
+    When I run `cat /etc/apt/auth.conf.d/90ubuntu-advantage` with sudo
+    Then stdout contains substring:
+      """
+      machine esm.ubuntu.com/infra/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine snapshot.infra-security.esm.ubuntu.com/infra/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine snapshot.infra-updates.esm.ubuntu.com/infra/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine esm.ubuntu.com/apps/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine snapshot.apps-security.esm.ubuntu.com/apps/ubuntu/ login bearer password m
+      """
+    Then stdout contains substring:
+      """
+      machine snapshot.apps-updates.esm.ubuntu.com/apps/ubuntu/ login bearer password m
+      """
+
+    Examples: ubuntu release
+      | release | machine_type  |
+      | xenial  | lxd-container |
+      | bionic  | lxd-container |
+      | focal   | lxd-container |
+      | jammy   | lxd-container |
+      | noble   | lxd-container |

--- a/lib/add_esm_snapshot_auth.py
+++ b/lib/add_esm_snapshot_auth.py
@@ -1,0 +1,58 @@
+import logging
+
+from uaclient import config, defaults, log
+from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
+from uaclient.entitlements.entitlement_status import ApplicationStatus
+from uaclient.entitlements.esm import ESMAppsEntitlement, ESMInfraEntitlement
+
+LOG = logging.getLogger("ubuntupro.lib.add_esm_snapshot_auth")
+
+ESM_APPS_SNAPSHOT_URLS = [
+    "snapshot.apps-security.esm.ubuntu.com/apps/ubuntu/",
+    "snapshot.apps-updates.esm.ubuntu.com/apps/ubuntu/",
+]
+ESM_INFRA_SNAPSHOT_URLS = [
+    "snapshot.infra-security.esm.ubuntu.com/infra/ubuntu/",
+    "snapshot.infra-updates.esm.ubuntu.com/infra/ubuntu/",
+]
+
+
+def add_esm_snapshot_auth(cfg):
+    if not _is_attached(cfg).is_attached:
+        LOG.info("Not attached. Not adding ESM snapshot URLs to APT auth.")
+        return
+    for esm, urls in [
+        (ESMAppsEntitlement(cfg), ESM_APPS_SNAPSHOT_URLS),
+        (ESMInfraEntitlement(cfg), ESM_INFRA_SNAPSHOT_URLS),
+    ]:
+        if (
+            esm.application_status()[0] != ApplicationStatus.DISABLED
+            and esm.apt_url is not None
+            and "https://esm.ubuntu.com/" in esm.apt_url
+        ):
+            LOG.info(
+                (
+                    "%s is enabled and using default apt url,"
+                    " adding snapshot auth"
+                ),
+                esm.name,
+            )
+            esm.update_apt_auth(override_snapshot_urls=urls)
+        else:
+            LOG.info(
+                "%s is disabled or not using default apt url, skipping",
+                esm.name,
+                extra=log.extra(apt_url=esm.apt_url),
+            )
+
+
+if __name__ == "__main__":
+    try:
+        log.setup_cli_logging(
+            logging.DEBUG, defaults.CONFIG_DEFAULTS["log_level"]
+        )
+        cfg = config.UAConfig()
+        log.setup_cli_logging(cfg.log_level, cfg.log_file)
+        add_esm_snapshot_auth(cfg)
+    except Exception as e:
+        print(e)

--- a/lib/postinst-migrations.sh
+++ b/lib/postinst-migrations.sh
@@ -81,4 +81,10 @@ if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "35~"; then
     if [ -f "/var/lib/ubuntu-advantage/private/machine-token.json" ]; then
         touch "/var/lib/ubuntu-advantage/marker-only-series-check"
     fi
+
+    # For attached machines, we need to ensure that the apt auth configuration
+    # is updated to include the snapshot urls for esm-infra and esm-apps
+    if [ -f "/var/lib/ubuntu-advantage/private/machine-token.json" ]; then
+        /usr/bin/python3 /usr/lib/ubuntu-advantage/add_esm_snapshot_auth.py
+    fi
 fi

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -379,6 +379,7 @@ class TestAddAuthAptRepo:
             credentials="mycreds",
             suites=(series,),
             keyring_file="keyring",
+            snapshot_urls=[],
         )
 
         if series in SERIES_NOT_USING_DEB822:
@@ -446,6 +447,7 @@ class TestAddAuthAptRepo:
                 "trusty-gone",
             ),
             keyring_file="keyring",
+            snapshot_urls=[],
         )
 
         if series in SERIES_NOT_USING_DEB822:
@@ -508,6 +510,7 @@ class TestAddAuthAptRepo:
                 "trusty-gone",
             ),
             keyring_file="keyring",
+            snapshot_urls=[],
         )
 
         if series in SERIES_NOT_USING_DEB822:
@@ -562,6 +565,7 @@ class TestAddAuthAptRepo:
             credentials="user:password",
             suites=("xenial",),
             keyring_file="keyring",
+            snapshot_urls=[],
         )
 
         expected_content = (
@@ -599,6 +603,7 @@ class TestAddAuthAptRepo:
             credentials="SOMELONGTOKEN",
             suites=("xenia",),
             keyring_file="keyring",
+            snapshot_urls=[],
         )
 
         expected_content = (
@@ -737,7 +742,7 @@ class TestRemoveAuthAptRepo:
         repo_url = mock.sentinel.url
 
         remove_auth_apt_repo(
-            repo_filename, repo_url, **remove_auth_apt_repo_kwargs
+            repo_filename, repo_url, [], **remove_auth_apt_repo_kwargs
         )
 
         assert mock.call(repo_filename) in m_ensure_file_absent.call_args_list
@@ -753,7 +758,7 @@ class TestRemoveAuthAptRepo:
         repo_url = mock.sentinel.url
 
         remove_auth_apt_repo(
-            repo_filename, repo_url, **remove_auth_apt_repo_kwargs
+            repo_filename, repo_url, [], **remove_auth_apt_repo_kwargs
         )
 
         assert mock.call(repo_filename) in m_ensure_file_absent.call_args_list
@@ -774,7 +779,7 @@ class TestRemoveAuthAptRepo:
         repo_url = mock.sentinel.url
 
         remove_auth_apt_repo(
-            repo_filename, repo_url, **remove_auth_apt_repo_kwargs
+            repo_filename, repo_url, [], **remove_auth_apt_repo_kwargs
         )
 
         assert mock.call(repo_url) in m_remove_repo.call_args_list
@@ -791,7 +796,7 @@ class TestRemoveAuthAptRepo:
         repo_url = mock.sentinel.url
 
         remove_auth_apt_repo(
-            repo_filename, repo_url, **remove_auth_apt_repo_kwargs
+            repo_filename, repo_url, [], **remove_auth_apt_repo_kwargs
         )
 
         keyring_file = remove_auth_apt_repo_kwargs.get("keyring_file")

--- a/uaclient/tests/test_lib_add_esm_snapshot_auth.py
+++ b/uaclient/tests/test_lib_add_esm_snapshot_auth.py
@@ -1,0 +1,146 @@
+import mock
+import pytest
+
+from lib.add_esm_snapshot_auth import add_esm_snapshot_auth
+from uaclient.entitlements.entitlement_status import ApplicationStatus
+
+MOCK_ESM_INFRA_AUTH_UPDATE_CALL = mock.call(
+    override_snapshot_urls=[
+        "snapshot.infra-security.esm.ubuntu.com/infra/ubuntu/",
+        "snapshot.infra-updates.esm.ubuntu.com/infra/ubuntu/",
+    ]
+)
+MOCK_ESM_APPS_AUTH_UPDATE_CALL = mock.call(
+    override_snapshot_urls=[
+        "snapshot.apps-security.esm.ubuntu.com/apps/ubuntu/",
+        "snapshot.apps-updates.esm.ubuntu.com/apps/ubuntu/",
+    ]
+)
+
+
+class TestAddEsmSnapshotAuth:
+    @pytest.mark.parametrize(
+        [
+            "is_attached",
+            "esm_infra_application_status",
+            "esm_apps_application_status",
+            "esm_infra_apt_url",
+            "esm_apps_apt_url",
+            "esm_infra_update_apt_auth_calls",
+            "esm_apps_update_apt_auth_calls",
+        ],
+        [
+            (False, None, None, None, None, [], []),
+            (
+                True,
+                ApplicationStatus.DISABLED,
+                ApplicationStatus.DISABLED,
+                None,
+                None,
+                [],
+                [],
+            ),
+            (
+                True,
+                ApplicationStatus.ENABLED,
+                ApplicationStatus.ENABLED,
+                None,
+                None,
+                [],
+                [],
+            ),
+            (
+                True,
+                ApplicationStatus.ENABLED,
+                ApplicationStatus.ENABLED,
+                "http://custom",
+                "http://custom",
+                [],
+                [],
+            ),
+            (
+                True,
+                ApplicationStatus.ENABLED,
+                ApplicationStatus.WARNING,
+                "https://esm.ubuntu.com/infra",
+                "https://esm.ubuntu.com/apps",
+                [MOCK_ESM_INFRA_AUTH_UPDATE_CALL],
+                [MOCK_ESM_APPS_AUTH_UPDATE_CALL],
+            ),
+            (
+                True,
+                ApplicationStatus.WARNING,
+                ApplicationStatus.DISABLED,
+                "https://esm.ubuntu.com/infra",
+                "https://esm.ubuntu.com/apps",
+                [MOCK_ESM_INFRA_AUTH_UPDATE_CALL],
+                [],
+            ),
+            (
+                True,
+                ApplicationStatus.DISABLED,
+                ApplicationStatus.ENABLED,
+                "https://esm.ubuntu.com/infra",
+                "https://esm.ubuntu.com/apps",
+                [],
+                [MOCK_ESM_APPS_AUTH_UPDATE_CALL],
+            ),
+        ],
+    )
+    @mock.patch("lib.add_esm_snapshot_auth.ESMAppsEntitlement.update_apt_auth")
+    @mock.patch(
+        "lib.add_esm_snapshot_auth.ESMInfraEntitlement.update_apt_auth"
+    )
+    @mock.patch(
+        "lib.add_esm_snapshot_auth.ESMAppsEntitlement.apt_url",
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch(
+        "lib.add_esm_snapshot_auth.ESMInfraEntitlement.apt_url",
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch(
+        "lib.add_esm_snapshot_auth.ESMAppsEntitlement.application_status"
+    )
+    @mock.patch(
+        "lib.add_esm_snapshot_auth.ESMInfraEntitlement.application_status"
+    )
+    @mock.patch("lib.add_esm_snapshot_auth._is_attached")
+    def test_add_esm_snapshot_auth(
+        self,
+        m_is_attached,
+        m_esm_infra_application_status,
+        m_esm_apps_application_status,
+        m_esm_infra_apt_url,
+        m_esm_apps_apt_url,
+        m_esm_infra_update_apt_auth,
+        m_esm_apps_update_apt_auth,
+        is_attached,
+        esm_infra_application_status,
+        esm_apps_application_status,
+        esm_infra_apt_url,
+        esm_apps_apt_url,
+        esm_infra_update_apt_auth_calls,
+        esm_apps_update_apt_auth_calls,
+        FakeConfig,
+    ):
+        m_is_attached.return_value.is_attached = is_attached
+        m_esm_infra_application_status.return_value = (
+            esm_infra_application_status,
+            None,
+        )
+        m_esm_apps_application_status.return_value = (
+            esm_apps_application_status,
+            None,
+        )
+        m_esm_infra_apt_url.return_value = esm_infra_apt_url
+        m_esm_apps_apt_url.return_value = esm_apps_apt_url
+        add_esm_snapshot_auth(FakeConfig())
+        assert (
+            m_esm_infra_update_apt_auth.call_args_list
+            == esm_infra_update_apt_auth_calls
+        )
+        assert (
+            m_esm_apps_update_apt_auth.call_args_list
+            == esm_apps_update_apt_auth_calls
+        )


### PR DESCRIPTION


## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
esm-apps and esm-infra now have apt snapshots available; however, without the apt auth configured properly, downloads from the snapshot servers will fail. This ensures new enablements will include the snapshot urls, and it migrates existing enablements to include the snapshot urls on upgrade.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the new integration tests
Consider how I did the one-time sru test in a feature file
<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*