### PR TITLE
Separate CIS and USG in the client

### DIFF
--- a/debian/ubuntu-advantage-tools.postinst
+++ b/debian/ubuntu-advantage-tools.postinst
@@ -476,7 +476,7 @@ case "$1" in
       fi
 
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "31~"; then
-          /usr/lib/ubuntu-advantage/postinst-migrations.sh $PREVIOUS_PKG_VER
+          /usr/lib/ubuntu-advantage/postinst-migrations.sh $PREVIOUS_PKG_VER $VERSION_ID
       fi
       ;;
 esac

--- a/debian/ubuntu-pro-client.postinst
+++ b/debian/ubuntu-pro-client.postinst
@@ -53,7 +53,7 @@ case "$1" in
       #
 
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" ge "31~"; then
-          /usr/lib/ubuntu-advantage/postinst-migrations.sh $PREVIOUS_PKG_VER
+          /usr/lib/ubuntu-advantage/postinst-migrations.sh $PREVIOUS_PKG_VER $VERSION_ID
       fi
 
       #

--- a/features/api/services_dependencies.feature
+++ b/features/api/services_dependencies.feature
@@ -64,26 +64,6 @@ Feature: u.pro.services.dependencies
               "depends_on": [],
               "incompatible_with": [
                 {
-                  "name": "fips",
-                  "reason": {
-                    "code": "fips-invalidates-fips-updates",
-                    "title": "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs security patches that aren't officially certified."
-                  }
-                },
-                {
-                  "name": "realtime-kernel",
-                  "reason": {
-                    "code": "realtime-fips-updates-incompatible",
-                    "title": "Realtime and FIPS Updates require different kernels, so you cannot enable both at the same time."
-                  }
-                }
-              ],
-              "name": "fips-updates"
-            },
-            {
-              "depends_on": [],
-              "incompatible_with": [
-                {
                   "name": "livepatch",
                   "reason": {
                     "code": "livepatch-invalidates-fips",
@@ -113,6 +93,26 @@ Feature: u.pro.services.dependencies
                 }
               ],
               "name": "fips-preview"
+            },
+            {
+              "depends_on": [],
+              "incompatible_with": [
+                {
+                  "name": "fips",
+                  "reason": {
+                    "code": "fips-invalidates-fips-updates",
+                    "title": "FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs security patches that aren't officially certified."
+                  }
+                },
+                {
+                  "name": "realtime-kernel",
+                  "reason": {
+                    "code": "realtime-fips-updates-incompatible",
+                    "title": "Realtime and FIPS Updates require different kernels, so you cannot enable both at the same time."
+                  }
+                }
+              ],
+              "name": "fips-updates"
             },
             {
               "depends_on": [],
@@ -268,19 +268,6 @@ Feature: u.pro.services.dependencies
         name: fips
       - depends_on: []
         incompatible_with:
-        - name: fips
-          reason:
-            code: fips-invalidates-fips-updates
-            title: FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs
-              security patches that aren't officially certified.
-        - name: realtime-kernel
-          reason:
-            code: realtime-fips-updates-incompatible
-            title: Realtime and FIPS Updates require different kernels, so you cannot enable
-              both at the same time.
-        name: fips-updates
-      - depends_on: []
-        incompatible_with:
         - name: livepatch
           reason:
             code: livepatch-invalidates-fips
@@ -303,6 +290,19 @@ Feature: u.pro.services.dependencies
             title: FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs
               security patches that aren't officially certified.
         name: fips-preview
+      - depends_on: []
+        incompatible_with:
+        - name: fips
+          reason:
+            code: fips-invalidates-fips-updates
+            title: FIPS Updates cannot be enabled if FIPS is enabled. FIPS Updates installs
+              security patches that aren't officially certified.
+        - name: realtime-kernel
+          reason:
+            code: realtime-fips-updates-incompatible
+            title: Realtime and FIPS Updates require different kernels, so you cannot enable
+              both at the same time.
+        name: fips-updates
       - depends_on: []
         incompatible_with: []
         name: landscape

--- a/lib/convert_list_to_deb822.py
+++ b/lib/convert_list_to_deb822.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     setup_cli_logging(logging.DEBUG, defaults.CONFIG_DEFAULTS["log_file"])
     cfg = UAConfig()
 
-    for entitlement_class in entitlements.ENTITLEMENT_CLASSES:
+    for entitlement_class in entitlements.get_entitlement_classes():
         if not issubclass(
             entitlement_class, entitlements.repo.RepoEntitlement
         ):

--- a/lib/postinst-migrations.sh
+++ b/lib/postinst-migrations.sh
@@ -45,6 +45,7 @@
 set -e
 
 PREVIOUS_PKG_VER=$1
+UBUNTU_RELEASE=$2
 
 if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "32~"; then
     # When we perform the write operation through
@@ -86,5 +87,16 @@ if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt "35~"; then
     # is updated to include the snapshot urls for esm-infra and esm-apps
     if [ -f "/var/lib/ubuntu-advantage/private/machine-token.json" ]; then
         /usr/bin/python3 /usr/lib/ubuntu-advantage/add_esm_snapshot_auth.py
+    fi
+
+    # On Focal and Jammy, the CIS service transitioned to USG from v35
+    # This changes the lists and authentication files to represent that
+    # in case CIS is enabled
+    if [ "$UBUNTU_RELEASE" = "20.04" ] || [ "$UBUNTU_RELEASE" = "22.04" ]; then
+        if [ -f /etc/apt/sources.list.d/ubuntu-cis.list ]; then
+            mv /etc/apt/sources.list.d/ubuntu-cis.list /etc/apt/sources.list.d/ubuntu-usg.list
+            sed -i 's#/cis/ubuntu#/usg/ubuntu#' /etc/apt/sources.list.d/ubuntu-usg.list
+            sed -i 's#/cis/ubuntu#/usg/ubuntu#' /etc/apt/auth.conf.d/90ubuntu-advantage
+        fi
     fi
 fi

--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -338,7 +338,7 @@ def _get_state_files(cfg: config.UAConfig):
         CLOUD_BUILD_INFO,
         *(
             entitlement_cls(cfg).repo_file
-            for entitlement_cls in entitlements.ENTITLEMENT_CLASSES
+            for entitlement_cls in entitlements.get_entitlement_classes()
             if issubclass(entitlement_cls, entitlements.repo.RepoEntitlement)
         ),
     ]

--- a/uaclient/api/tests/test_api_u_pro_services_dependencies_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_services_dependencies_v1.py
@@ -11,7 +11,9 @@ from uaclient.api.u.pro.services.dependencies.v1 import (
 
 
 class TestServicesDependenciesV1:
-    def test_dependencies(self):
+    @mock.patch("uaclient.system.get_release_info")
+    def test_dependencies(self, m_release_info):
+        m_release_info.return_value.series = "noble"
         assert _dependencies(cfg=mock.MagicMock()) == DependenciesResult(
             services=[
                 ServiceWithDependencies(
@@ -19,9 +21,6 @@ class TestServicesDependenciesV1:
                 ),
                 ServiceWithDependencies(
                     name="cc-eal", incompatible_with=[], depends_on=[]
-                ),
-                ServiceWithDependencies(
-                    name="cis", incompatible_with=[], depends_on=[]
                 ),
                 ServiceWithDependencies(
                     name="esm-apps", incompatible_with=[], depends_on=[]
@@ -57,26 +56,6 @@ class TestServicesDependenciesV1:
                     depends_on=[],
                 ),
                 ServiceWithDependencies(
-                    name="fips-updates",
-                    incompatible_with=[
-                        ServiceWithReason(
-                            name="fips",
-                            reason=Reason(
-                                code=messages.FIPS_INVALIDATES_FIPS_UPDATES.name,  # noqa: E501
-                                title=messages.FIPS_INVALIDATES_FIPS_UPDATES.msg,  # noqa: E501
-                            ),
-                        ),
-                        ServiceWithReason(
-                            name="realtime-kernel",
-                            reason=Reason(
-                                code=messages.REALTIME_FIPS_UPDATES_INCOMPATIBLE.name,  # noqa: E501
-                                title=messages.REALTIME_FIPS_UPDATES_INCOMPATIBLE.msg,  # noqa: E501
-                            ),
-                        ),
-                    ],
-                    depends_on=[],
-                ),
-                ServiceWithDependencies(
                     name="fips-preview",
                     incompatible_with=[
                         ServiceWithReason(
@@ -105,6 +84,26 @@ class TestServicesDependenciesV1:
                             reason=Reason(
                                 code=messages.FIPS_INVALIDATES_FIPS_UPDATES.name,  # noqa: E501
                                 title=messages.FIPS_INVALIDATES_FIPS_UPDATES.msg,  # noqa: E501
+                            ),
+                        ),
+                    ],
+                    depends_on=[],
+                ),
+                ServiceWithDependencies(
+                    name="fips-updates",
+                    incompatible_with=[
+                        ServiceWithReason(
+                            name="fips",
+                            reason=Reason(
+                                code=messages.FIPS_INVALIDATES_FIPS_UPDATES.name,  # noqa: E501
+                                title=messages.FIPS_INVALIDATES_FIPS_UPDATES.msg,  # noqa: E501
+                            ),
+                        ),
+                        ServiceWithReason(
+                            name="realtime-kernel",
+                            reason=Reason(
+                                code=messages.REALTIME_FIPS_UPDATES_INCOMPATIBLE.name,  # noqa: E501
+                                title=messages.REALTIME_FIPS_UPDATES_INCOMPATIBLE.msg,  # noqa: E501
                             ),
                         ),
                     ],
@@ -206,6 +205,9 @@ class TestServicesDependenciesV1:
                             ),
                         ),
                     ],
+                ),
+                ServiceWithDependencies(
+                    name="usg", incompatible_with=[], depends_on=[]
                 ),
             ]
         )

--- a/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
@@ -22,7 +22,6 @@ class TestEnabledServicesV1:
         type(m_inst_1).presentation_name = mock.PropertyMock(
             return_value="ent1"
         )
-        type(m_inst_1).valid_names = mock.PropertyMock(return_value=["ent1"])
         m_inst_1.user_facing_status.return_value = (
             UserFacingStatus.ACTIVE,
             "",
@@ -44,7 +43,6 @@ class TestEnabledServicesV1:
         type(m_inst_2).presentation_name = mock.PropertyMock(
             return_value="ent2"
         )
-        type(m_inst_2).valid_names = mock.PropertyMock(return_value=["ent2"])
         m_inst_2.user_facing_status.return_value = (
             UserFacingStatus.ACTIVE,
             "",
@@ -58,7 +56,6 @@ class TestEnabledServicesV1:
         type(m_inst_3).presentation_name = mock.PropertyMock(
             return_value="ent3"
         )
-        type(m_inst_3).valid_names = mock.PropertyMock(return_value=["ent3"])
         m_inst_3.user_facing_status.return_value = (
             UserFacingStatus.INACTIVE,
             "",
@@ -72,7 +69,6 @@ class TestEnabledServicesV1:
         type(m_inst_4).presentation_name = mock.PropertyMock(
             return_value="ent4"
         )
-        type(m_inst_4).valid_names = mock.PropertyMock(return_value=["ent4"])
         m_inst_4.user_facing_status.return_value = (
             UserFacingStatus.INAPPLICABLE,
             "",
@@ -86,7 +82,6 @@ class TestEnabledServicesV1:
         type(m_inst_5).presentation_name = mock.PropertyMock(
             return_value="ent5"
         )
-        type(m_inst_5).valid_names = mock.PropertyMock(return_value=["ent5"])
         m_inst_5.user_facing_status.return_value = (
             UserFacingStatus.WARNING,
             NamedMessage(name="warning_code", msg="warning_msg"),

--- a/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_status_enabled_services_v1.py
@@ -1,6 +1,5 @@
 import mock
 
-from uaclient import entitlements
 from uaclient.api.data_types import ErrorWarningObject
 from uaclient.api.u.pro.status.enabled_services.v1 import (
     EnabledService,
@@ -107,7 +106,9 @@ class TestEnabledServicesV1:
             )
         ]
 
-        with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
+        with mock.patch(
+            "uaclient.entitlements.get_entitlement_classes", return_value=ents
+        ):
             enabled_services_ret = _enabled_services(cfg=mock.MagicMock())
 
         assert 1 == m_is_attached.call_count

--- a/uaclient/api/u/pro/services/dependencies/v1.py
+++ b/uaclient/api/u/pro/services/dependencies/v1.py
@@ -110,7 +110,7 @@ def _dependencies(cfg: UAConfig) -> DependenciesResult:
     dependencies between services.
     """
     services = []
-    for ent_cls in entitlements.ENTITLEMENT_CLASSES:
+    for ent_cls in entitlements.get_entitlement_classes():
         ent = ent_cls(cfg)
         incompatible_with = []
         depends_on = []

--- a/uaclient/api/u/pro/services/disable/v1.py
+++ b/uaclient/api/u/pro/services/disable/v1.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List, Optional
 
-from uaclient import entitlements, lock, messages, status, util
+from uaclient import entitlements, lock, messages, status, system, util
 from uaclient.api import AbstractProgress, ProgressWrapper, exceptions
 from uaclient.api.api import APIEndpoint
 from uaclient.api.data_types import AdditionalInfo
@@ -78,9 +78,17 @@ def _disable(
     if not _is_attached(cfg).is_attached:
         raise exceptions.UnattachedError()
 
+    service_to_disable = options.service
+
+    if (
+        service_to_disable == "cis"
+        and system.get_release_info().series == "focal"
+    ):
+        service_to_disable = "usg"
+
     entitlement = entitlements.entitlement_factory(
         cfg=cfg,
-        name=options.service,
+        name=service_to_disable,
         purge=options.purge,
     )
 
@@ -88,7 +96,7 @@ def _disable(
 
     # Do this after getting the class so that the factory can raise an
     # exception for invalid service names
-    if options.service not in enabled_services_before:
+    if service_to_disable not in enabled_services_before:
         # nothing to do
         return DisableResult(
             disabled=[],
@@ -118,7 +126,7 @@ def _disable(
         else:
             reason = messages.GENERIC_UNKNOWN_ISSUE
         raise exceptions.EntitlementNotDisabledError(
-            service=options.service, reason=reason
+            service=service_to_disable, reason=reason
         )
 
     enabled_services_after = _enabled_services_names(cfg)

--- a/uaclient/api/u/pro/services/list/v1.py
+++ b/uaclient/api/u/pro/services/list/v1.py
@@ -114,7 +114,7 @@ def unattached_services(cfg: UAConfig) -> ServiceListResult:
             )
             continue
         service = ServiceInfo(
-            name=resource.get("presentedAs", resource["name"]),
+            name=ent.name,
             desc=ent.description,
             available=available,
             entitled=None,

--- a/uaclient/api/u/pro/status/enabled_services/v1.py
+++ b/uaclient/api/u/pro/status/enabled_services/v1.py
@@ -62,7 +62,7 @@ def _enabled_services(cfg: UAConfig) -> EnabledServicesResult:
     """
     This endpoint shows the Pro services that are enabled on the machine.
     """
-    from uaclient.entitlements import ENTITLEMENT_CLASSES
+    from uaclient.entitlements import get_entitlement_classes
     from uaclient.entitlements.entitlement_status import UserFacingStatus
 
     if not _is_attached(cfg).is_attached:
@@ -70,7 +70,7 @@ def _enabled_services(cfg: UAConfig) -> EnabledServicesResult:
 
     enabled_services = []  # type: List[EnabledService]
     warnings = []  # type: List[ErrorWarningObject]
-    for ent_cls in ENTITLEMENT_CLASSES:
+    for ent_cls in get_entitlement_classes():
         ent = ent_cls(cfg)
         ent_status, details = ent.user_facing_status()
 

--- a/uaclient/api/u/pro/token_info/v1.py
+++ b/uaclient/api/u/pro/token_info/v1.py
@@ -192,7 +192,7 @@ def _get_token_info(
         )
         services.append(
             ServiceInfo(
-                name=resource.get("presentedAs", ent.name),
+                name=ent.name,
                 description=ent.description,
                 entitled=entitlement_information["entitled"],
                 auto_enabled=entitlement_information["auto_enabled"],

--- a/uaclient/cli/disable.py
+++ b/uaclient/cli/disable.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import textwrap
-from typing import Dict, List  # noqa: F401
+from typing import Any, Dict, List  # noqa: F401
 
 from uaclient import (
     config,
@@ -115,7 +115,7 @@ def action_disable(args, *, cfg, **kwargs):
     """
     processed_services = []
     failed_services = []
-    errors = []
+    errors = []  # type: List[Dict[str, Any]]
     warnings = []  # type: List[Dict[str, str]]
 
     json_response = {

--- a/uaclient/cli/disable.py
+++ b/uaclient/cli/disable.py
@@ -33,7 +33,6 @@ def prompt_for_dependency_handling(
     service: str,
     all_dependencies: List[ServiceWithDependencies],
     enabled_service_names: List[str],
-    called_name: str,
     service_title: str,
 ):
     dependent_services = []
@@ -171,7 +170,6 @@ def action_disable(args, *, cfg, **kwargs):
                     ent.name,
                     all_dependencies,
                     enabled_service_names,
-                    called_name=ent_name,
                     service_title=ent.title,
                 )
             except exceptions.UbuntuProError as e:

--- a/uaclient/cli/disable.py
+++ b/uaclient/cli/disable.py
@@ -11,6 +11,7 @@ from uaclient import (
     exceptions,
     messages,
     status,
+    system,
     util,
 )
 from uaclient.api import ProgressWrapper
@@ -144,6 +145,11 @@ def action_disable(args, *, cfg, **kwargs):
         entitlements_found,
         entitlements_not_found,
     ) = entitlements.get_valid_entitlement_names(names, cfg)
+
+    if "cis" in names and system.get_release_info().series == "focal":
+        entitlements_found.append("usg")
+        entitlements_not_found.remove("cis")
+
     enabled_service_names = [
         s.name for s in _enabled_services(cfg).enabled_services
     ]

--- a/uaclient/cli/enable.py
+++ b/uaclient/cli/enable.py
@@ -59,7 +59,6 @@ def _enable_landscape(
     progress = api.ProgressWrapper(progress_object)
     landscape = entitlements.LandscapeEntitlement(
         cfg,
-        called_name="landscape",
         access_only=access_only,
         extra_args=extra_args,
     )
@@ -93,7 +92,6 @@ def prompt_for_dependency_handling(
     service: str,
     all_dependencies: List[ServiceWithDependencies],
     enabled_services: List[EnabledService],
-    called_name: str,
     variant: str,
     service_title: str,
 ):
@@ -268,7 +266,6 @@ def _enable_one_service(
                 real_name,
                 all_dependencies,
                 enabled_services,
-                called_name=ent_name,
                 variant=variant,
                 service_title=ent_title,
             )

--- a/uaclient/cli/tests/test_cli_collect_logs.py
+++ b/uaclient/cli/tests/test_cli_collect_logs.py
@@ -153,9 +153,6 @@ class TestActionCollectLogs:
                 "/etc/apt/sources.list.d/ubuntu-cc-eal.{}".format(extension)
             ),
             mock.call(
-                "/etc/apt/sources.list.d/ubuntu-cis.{}".format(extension)
-            ),
-            mock.call(
                 "/etc/apt/sources.list.d/ubuntu-esm-apps.{}".format(extension)
             ),
             mock.call(
@@ -165,12 +162,12 @@ class TestActionCollectLogs:
                 "/etc/apt/sources.list.d/ubuntu-fips.{}".format(extension)
             ),
             mock.call(
-                "/etc/apt/sources.list.d/ubuntu-fips-updates.{}".format(
+                "/etc/apt/sources.list.d/ubuntu-fips-preview.{}".format(
                     extension
                 )
             ),
             mock.call(
-                "/etc/apt/sources.list.d/ubuntu-fips-preview.{}".format(
+                "/etc/apt/sources.list.d/ubuntu-fips-updates.{}".format(
                     extension
                 )
             ),
@@ -186,6 +183,9 @@ class TestActionCollectLogs:
                 "/etc/apt/sources.list.d/ubuntu-ros-updates.{}".format(
                     extension
                 )
+            ),
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-usg.{}".format(extension)
             ),
             mock.call("/var/log/ubuntu-advantage.log"),
             mock.call("/var/log/ubuntu-advantage.log.1"),

--- a/uaclient/cli/tests/test_cli_disable.py
+++ b/uaclient/cli/tests/test_cli_disable.py
@@ -632,7 +632,6 @@ class TestPromptForDependencyHandling:
             "service",
             "all_dependencies",
             "enabled_service_names",
-            "called_name",
             "service_title",
             "prompt_side_effects",
             "expected_prompts",
@@ -648,7 +647,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [],
-                "one",
                 "One",
                 [],
                 [],
@@ -669,7 +667,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [],
-                "one",
                 "One",
                 [],
                 [],
@@ -690,7 +687,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 ["two"],
-                "one",
                 "One",
                 [True],
                 [mock.call(msg=mock.ANY)],
@@ -711,7 +707,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 ["two"],
-                "one",
                 "One",
                 [False],
                 [mock.call(msg=mock.ANY)],
@@ -741,7 +736,6 @@ class TestPromptForDependencyHandling:
                     ),
                 ],
                 ["three"],
-                "one",
                 "One",
                 [True],
                 [mock.call(msg=mock.ANY)],
@@ -758,7 +752,6 @@ class TestPromptForDependencyHandling:
         service,
         all_dependencies,
         enabled_service_names,
-        called_name,
         service_title,
         prompt_side_effects,
         expected_prompts,
@@ -776,7 +769,6 @@ class TestPromptForDependencyHandling:
                 service,
                 all_dependencies,
                 enabled_service_names,
-                called_name,
                 service_title,
             )
 

--- a/uaclient/cli/tests/test_cli_enable.py
+++ b/uaclient/cli/tests/test_cli_enable.py
@@ -577,7 +577,6 @@ class TestActionEnable:
                         "one",
                         [],
                         [],
-                        called_name="one",
                         variant="",
                         service_title=mock.sentinel.ent_title,
                     )
@@ -805,7 +804,6 @@ class TestActionEnable:
         assert [
             mock.call(
                 mock.ANY,
-                called_name="landscape",
                 access_only=mock.sentinel.access_only,
                 extra_args=mock.sentinel.extra_args,
             )
@@ -835,7 +833,6 @@ class TestPromptForDependencyHandling:
             "service",
             "all_dependencies",
             "enabled_services",
-            "called_name",
             "service_title",
             "variant",
             "cfg_block_disable_on_enable",
@@ -853,7 +850,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [],
-                "one",
                 "One",
                 "",
                 False,
@@ -876,7 +872,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [],
-                "one",
                 "One",
                 "",
                 False,
@@ -899,7 +894,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [EnabledService(name="two")],
-                "one",
                 "One",
                 "",
                 False,
@@ -922,7 +916,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [EnabledService(name="two")],
-                "one",
                 "One",
                 "",
                 True,
@@ -945,7 +938,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [EnabledService(name="two")],
-                "one",
                 "One",
                 "",
                 False,
@@ -971,7 +963,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [EnabledService(name="three")],
-                "one",
                 "One",
                 "",
                 False,
@@ -994,7 +985,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [EnabledService(name="two")],
-                "one",
                 "One",
                 "",
                 False,
@@ -1017,7 +1007,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [],
-                "one",
                 "One",
                 "",
                 False,
@@ -1040,7 +1029,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [],
-                "one",
                 "One",
                 "",
                 False,
@@ -1066,7 +1054,6 @@ class TestPromptForDependencyHandling:
                     )
                 ],
                 [EnabledService(name="two")],
-                "one",
                 "One",
                 "",
                 False,
@@ -1083,7 +1070,6 @@ class TestPromptForDependencyHandling:
                         name="two", variant_enabled=True, variant_name="one"
                     )
                 ],
-                "two",
                 "Two",
                 "two",
                 False,
@@ -1126,7 +1112,6 @@ class TestPromptForDependencyHandling:
                     EnabledService(name="four"),
                     EnabledService(name="six"),
                 ],
-                "one",
                 "One",
                 "",
                 False,
@@ -1152,7 +1137,6 @@ class TestPromptForDependencyHandling:
         service,
         all_dependencies,
         enabled_services,
-        called_name,
         service_title,
         variant,
         cfg_block_disable_on_enable,
@@ -1173,7 +1157,6 @@ class TestPromptForDependencyHandling:
                 service,
                 all_dependencies,
                 enabled_services,
-                called_name,
                 variant,
                 service_title,
             )

--- a/uaclient/contract_data_types.py
+++ b/uaclient/contract_data_types.py
@@ -37,7 +37,6 @@ class AvailableResource(DataObject):
         Field("available", BoolDataValue, False),
         Field("name", StringDataValue, False),
         Field("description", StringDataValue, False),
-        Field("presentedAs", StringDataValue, False),
     ]
 
     def __init__(
@@ -45,12 +44,10 @@ class AvailableResource(DataObject):
         available: Optional[bool],
         name: Optional[str],
         description: Optional[str],
-        presentedAs: Optional[str],
     ):
         self.available = available
         self.name = name
         self.description = description
-        self.presentedAs = presentedAs
 
 
 class ExternalID(DataObject):
@@ -106,7 +103,6 @@ class PlatformChecks(DataObject):
 class Affordances(DataObject):
     fields = [
         Field("architectures", data_list(StringDataValue), False),
-        Field("presentedAs", StringDataValue, False),
         Field("series", data_list(StringDataValue), False),
         Field("kernelFlavors", data_list(StringDataValue), False),
         Field("minKernelVersion", StringDataValue, False),
@@ -118,7 +114,6 @@ class Affordances(DataObject):
     def __init__(
         self,
         architectures: Optional[List[str]],
-        presentedAs: Optional[str],
         series: List[Optional[str]],
         kernelFlavors: List[Optional[str]],
         minKernelVersion: Optional[str],
@@ -127,7 +122,6 @@ class Affordances(DataObject):
         platformChecks: Optional[PlatformChecks],
     ):
         self.architectures = architectures
-        self.presentedAs = presentedAs
         self.series = series
         self.kernelFlavors = kernelFlavors
         self.minKernelVersion = minKernelVersion

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -3,7 +3,7 @@ import textwrap
 from collections import defaultdict
 from typing import Dict, List, Optional, Type
 
-from uaclient import exceptions
+from uaclient import exceptions, system
 from uaclient.config import UAConfig
 from uaclient.entitlements import fips
 from uaclient.entitlements.anbox import AnboxEntitlement
@@ -17,23 +17,36 @@ from uaclient.entitlements.livepatch import LivepatchEntitlement
 from uaclient.entitlements.realtime import RealtimeKernelEntitlement
 from uaclient.entitlements.repo import RepoEntitlement
 from uaclient.entitlements.ros import ROSEntitlement, ROSUpdatesEntitlement
+from uaclient.entitlements.usg import USGEntitlement
 from uaclient.exceptions import EntitlementNotFoundError
 
-ENTITLEMENT_CLASSES = [
-    AnboxEntitlement,
-    CommonCriteriaEntitlement,
-    CISEntitlement,
-    ESMAppsEntitlement,
-    ESMInfraEntitlement,
-    fips.FIPSEntitlement,
-    fips.FIPSUpdatesEntitlement,
-    fips.FIPSPreviewEntitlement,
-    LandscapeEntitlement,
-    LivepatchEntitlement,
-    RealtimeKernelEntitlement,
-    ROSEntitlement,
-    ROSUpdatesEntitlement,
-]  # type: List[Type[UAEntitlement]]
+
+def __get_entitlement_classes() -> List[Type[UAEntitlement]]:
+    result = [
+        AnboxEntitlement,
+        CommonCriteriaEntitlement,
+        ESMAppsEntitlement,
+        ESMInfraEntitlement,
+        fips.FIPSEntitlement,
+        fips.FIPSUpdatesEntitlement,
+        fips.FIPSPreviewEntitlement,
+        LandscapeEntitlement,
+        LivepatchEntitlement,
+        RealtimeKernelEntitlement,
+        ROSEntitlement,
+        ROSUpdatesEntitlement,
+    ]
+
+    series = system.get_release_info().series
+    if series in ("xenial", "bionic"):
+        result.append(CISEntitlement)
+    else:
+        result.append(USGEntitlement)
+
+    return result
+
+
+ENTITLEMENT_CLASSES = sorted(__get_entitlement_classes(), key=lambda x: x.name)
 
 
 def entitlement_factory(

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -60,47 +60,31 @@ def entitlement_factory(
     """
 
     for entitlement in ENTITLEMENT_CLASSES:
-        ent = entitlement(
-            cfg=cfg,
-            access_only=access_only,
-            called_name=name,
-            purge=purge,
-            extra_args=extra_args,
-        )
-        if name in ent.valid_names:
+        if name == entitlement.name:
+            ent = entitlement(
+                cfg=cfg,
+                access_only=access_only,
+                purge=purge,
+                extra_args=extra_args,
+            )
             if not variant:
                 return ent
-            elif variant in ent.variants:
+            if variant in ent.variants:
                 return ent.variants[variant](
                     cfg=cfg,
-                    called_name=name,
                     purge=purge,
                     extra_args=extra_args,
                 )
-            else:
-                raise EntitlementNotFoundError(entitlement_name=variant)
+            raise EntitlementNotFoundError(entitlement_name=variant)
     raise EntitlementNotFoundError(entitlement_name=name)
 
 
-def valid_services(cfg: UAConfig, all_names: bool = False) -> List[str]:
-    """Return a list of valid services.
-
-    :param cfg: UAConfig instance
-    :param all_names: if we should return all the names for a service instead
-        of just the presentation_name
-    """
-    entitlements = ENTITLEMENT_CLASSES
-    if all_names:
-        names = []
-        for entitlement_cls in entitlements:
-            names.extend(entitlement_cls(cfg=cfg).valid_names)
-
-        return sorted(names)
-
+def valid_services(cfg: UAConfig) -> List[str]:
+    """Return a list of valid services."""
     return sorted(
         [
             entitlement_cls(cfg=cfg).presentation_name
-            for entitlement_cls in entitlements
+            for entitlement_cls in ENTITLEMENT_CLASSES
         ]
     )
 
@@ -195,10 +179,11 @@ def get_valid_entitlement_names(names: List[str], cfg: UAConfig):
     :param names: List of entitlements to validate
     :return: a tuple of List containing the valid and invalid entitlements
     """
+    known_services = valid_services(cfg=cfg)
     entitlements_found = []
 
     for ent_name in names:
-        if ent_name in valid_services(cfg=cfg, all_names=True):
+        if ent_name in known_services:
             entitlements_found.append(ent_name)
 
     entitlements_not_found = sorted(set(names) - set(entitlements_found))

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -21,7 +21,7 @@ from uaclient.entitlements.usg import USGEntitlement
 from uaclient.exceptions import EntitlementNotFoundError
 
 
-def __get_entitlement_classes() -> List[Type[UAEntitlement]]:
+def get_entitlement_classes() -> List[Type[UAEntitlement]]:
     result = [
         AnboxEntitlement,
         CommonCriteriaEntitlement,
@@ -43,10 +43,7 @@ def __get_entitlement_classes() -> List[Type[UAEntitlement]]:
     else:
         result.append(USGEntitlement)
 
-    return result
-
-
-ENTITLEMENT_CLASSES = sorted(__get_entitlement_classes(), key=lambda x: x.name)
+    return sorted(result, key=lambda x: x.name)
 
 
 def entitlement_factory(
@@ -71,7 +68,7 @@ def entitlement_factory(
       name is found.
     """
 
-    for entitlement in ENTITLEMENT_CLASSES:
+    for entitlement in get_entitlement_classes():
         if name == entitlement.name:
             ent = entitlement(
                 cfg=cfg,
@@ -96,7 +93,7 @@ def valid_services(cfg: UAConfig) -> List[str]:
     return sorted(
         [
             entitlement_cls(cfg=cfg).presentation_name
-            for entitlement_cls in ENTITLEMENT_CLASSES
+            for entitlement_cls in get_entitlement_classes()
         ]
     )
 
@@ -173,7 +170,7 @@ def _sort_entitlements(cfg: UAConfig, sort_order: SortOrder) -> List[str]:
     order = []  # type: List[str]
     visited = {}  # type: Dict[str, bool]
 
-    for ent_cls in ENTITLEMENT_CLASSES:
+    for ent_cls in get_entitlement_classes():
         _sort_entitlements_visit(
             cfg=cfg,
             ent_cls=ent_cls,

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -86,14 +86,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         return ""
 
     @property
-    def valid_names(self) -> List[str]:
-        """The list of names this entitlement may be called."""
-        valid_names = [self.name]
-        if self.presentation_name != self.name:
-            valid_names.append(self.presentation_name)
-        return valid_names
-
-    @property
     @abc.abstractmethod
     def title(self) -> str:
         """The human readable title of this entitlement"""
@@ -247,7 +239,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 continue
             variant = variant_cls(
                 cfg=self.cfg,
-                called_name=self._called_name,
                 access_only=self.access_only,
             )
             status, _ = variant.application_status()
@@ -285,7 +276,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
     def __init__(
         self,
         cfg: Optional[config.UAConfig] = None,
-        called_name: str = "",
         access_only: bool = False,
         purge: bool = False,
         extra_args: Optional[List[str]] = None,
@@ -304,7 +294,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             self.extra_args = extra_args
         else:
             self.extra_args = []
-        self._called_name = called_name
         self._valid_service = None  # type: Optional[bool]
         self._is_sources_list_updated = False
 

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -110,14 +110,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         """The user-facing name shown for this entitlement"""
         if self.is_variant:
             return self.variant_name
-        elif self.machine_token_file.is_present:
-            return (
-                self.entitlement_cfg.get("entitlement", {})
-                .get("affordances", {})
-                .get("presentedAs", self.name)
-            )
-        else:
-            return self.name
+        return self.name
 
     def verify_platform_checks(
         self, platform_check: Dict[str, Any]

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from uaclient import messages
 from uaclient.entitlements import repo
 from uaclient.types import MessagingOperationsDict
@@ -9,6 +7,7 @@ class CISEntitlement(repo.RepoEntitlement):
 
     help_doc_url = messages.urls.USG_DOCS
     name = "cis"
+    title = messages.CIS_TITLE
     description = messages.CIS_DESCRIPTION
     help_text = messages.CIS_HELP_TEXT
     repo_key_file = "ubuntu-pro-cis.gpg"
@@ -18,23 +17,4 @@ class CISEntitlement(repo.RepoEntitlement):
 
     @property
     def messaging(self) -> MessagingOperationsDict:
-        if self._called_name == "usg":
-            return {"post_enable": [messages.CIS_USG_POST_ENABLE]}
-        ret = {
-            "post_enable": [messages.CIS_POST_ENABLE]
-        }  # type: MessagingOperationsDict
-        if "usg" in self.valid_names:
-            ret["pre_can_enable"] = [messages.CIS_IS_NOW_USG]
-        return ret
-
-    @property
-    def packages(self) -> List[str]:
-        if self._called_name == "usg":
-            return []
-        return super().packages
-
-    @property
-    def title(self) -> str:
-        if self._called_name == "cis":
-            return messages.CIS_TITLE
-        return messages.CIS_USG_TITLE
+        return {"post_enable": [messages.CIS_POST_ENABLE]}

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -101,7 +101,6 @@ def entitlement_factory(tmpdir, FakeConfig, fake_machine_token_file):
         obligations: Optional[Dict[str, Any]] = None,
         overrides: Optional[List[Dict[str, Any]]] = None,
         entitled: bool = True,
-        called_name: str = "",
         access_only: bool = False,
         purge: bool = False,
         suites: Optional[List[str]] = None,
@@ -134,7 +133,6 @@ def entitlement_factory(tmpdir, FakeConfig, fake_machine_token_file):
             )
 
         args = {
-            "called_name": called_name,
             "access_only": access_only,
             "purge": purge,
         }

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -125,36 +125,16 @@ class TestEntitlement:
 
 
 class TestEntitlementNames:
-    @pytest.mark.parametrize(
-        "p_name,expected",
-        (
-            ("pretty_name", ["testconcreteentitlement", "pretty_name"]),
-            ("testconcreteentitlement", ["testconcreteentitlement"]),
-        ),
-    )
-    def test_valid_names(self, p_name, expected, base_entitlement_factory):
-        entitlement = base_entitlement_factory(
-            entitled=True,
-            affordances={"presentedAs": p_name},
-        )
-        assert expected == entitlement.valid_names
+    def test_valid_names(self, base_entitlement_factory):
+        entitlement = base_entitlement_factory(entitled=True)
+        assert ["testconcreteentitlement"] == entitlement.valid_names
 
-    @pytest.mark.parametrize(
-        "affordances,expected_value",
-        (
-            ({}, "testconcreteentitlement"),
-            ({"presentedAs": "something_else"}, "something_else"),
-        ),
-    )
-    def test_presentation_name(
-        self, affordances, expected_value, entitlement_factory
-    ):
+    def test_presentation_name(self, entitlement_factory):
         entitlement = entitlement_factory(
             ConcreteTestEntitlement,
             entitled=True,
-            affordances=affordances,
         )
-        assert expected_value == entitlement.presentation_name
+        assert "testconcreteentitlement" == entitlement.presentation_name
 
 
 class TestEntitlementCanEnable:

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -125,10 +125,6 @@ class TestEntitlement:
 
 
 class TestEntitlementNames:
-    def test_valid_names(self, base_entitlement_factory):
-        entitlement = base_entitlement_factory(entitled=True)
-        assert ["testconcreteentitlement"] == entitlement.valid_names
-
     def test_presentation_name(self, entitlement_factory):
         entitlement = entitlement_factory(
             ConcreteTestEntitlement,

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -18,32 +18,15 @@ def cis_entitlement(entitlement_factory):
 
 class TestCISEntitlement:
     @pytest.mark.parametrize(
-        "called_name,presentation_name,expected",
+        "called_name,expected",
         (
             (
                 "cis",
-                "cis",
                 {
                     "post_enable": [messages.CIS_POST_ENABLE],
                 },
             ),
             (
-                "cis",
-                "usg",
-                {
-                    "pre_can_enable": [messages.CIS_IS_NOW_USG],
-                    "post_enable": [messages.CIS_POST_ENABLE],
-                },
-            ),
-            (
-                "usg",
-                "cis",
-                {
-                    "post_enable": [messages.CIS_USG_POST_ENABLE],
-                },
-            ),
-            (
-                "usg",
                 "usg",
                 {
                     "post_enable": [messages.CIS_USG_POST_ENABLE],
@@ -51,12 +34,9 @@ class TestCISEntitlement:
             ),
         ),
     )
-    def test_messages(
-        self, called_name, presentation_name, expected, cis_entitlement
-    ):
+    def test_messages(self, called_name, expected, cis_entitlement):
         entitlement = cis_entitlement(
             called_name=called_name,
-            affordances={"presentedAs": presentation_name},
         )
 
         assert expected == entitlement.messaging

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -17,57 +17,9 @@ def cis_entitlement(entitlement_factory):
 
 
 class TestCISEntitlement:
-    @pytest.mark.parametrize(
-        "called_name,expected",
-        (
-            (
-                "cis",
-                {
-                    "post_enable": [messages.CIS_POST_ENABLE],
-                },
-            ),
-            (
-                "usg",
-                {
-                    "post_enable": [messages.CIS_USG_POST_ENABLE],
-                },
-            ),
-        ),
-    )
-    def test_messages(self, called_name, expected, cis_entitlement):
-        entitlement = cis_entitlement(
-            called_name=called_name,
-        )
+    def test_messages(self, cis_entitlement):
+        entitlement = cis_entitlement()
 
-        assert expected == entitlement.messaging
-
-    @pytest.mark.parametrize(
-        "called_name,expected",
-        (
-            ("cis", ["test-package"]),
-            ("usg", []),
-        ),
-    )
-    def test_packages(self, called_name, expected, cis_entitlement):
-        entitlement = cis_entitlement(
-            called_name=called_name,
-            directives={
-                "additionalPackages": ["test-package"],
-            },
-        )
-
-        assert expected == entitlement.packages
-
-    @pytest.mark.parametrize(
-        "called_name,expected",
-        (
-            ("cis", messages.CIS_TITLE),
-            ("usg", messages.CIS_USG_TITLE),
-        ),
-    )
-    def test_title(self, called_name, expected, cis_entitlement):
-        entitlement = cis_entitlement(
-            called_name=called_name,
-        )
-
-        assert expected == entitlement.title
+        assert {
+            "post_enable": [messages.CIS_POST_ENABLE]
+        } == entitlement.messaging

--- a/uaclient/entitlements/tests/test_entitlements.py
+++ b/uaclient/entitlements/tests/test_entitlements.py
@@ -24,7 +24,9 @@ class TestValidServices:
 
         ents = {m_cls_1, m_cls_2}
 
-        with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
+        with mock.patch(
+            "uaclient.entitlements.get_entitlement_classes", return_value=ents
+        ):
             expected_services = ["ent1", "ent2"]
             assert expected_services == entitlements.valid_services(
                 cfg=FakeConfig()
@@ -47,7 +49,9 @@ class TestEntitlementFactory:
         ents = {m_cls_1, m_cls_2}
         cfg = FakeConfig()
 
-        with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
+        with mock.patch(
+            "uaclient.entitlements.get_entitlement_classes", return_value=ents
+        ):
             assert m_obj_1 == entitlements.entitlement_factory(
                 cfg=cfg, name="ent1"
             )
@@ -118,8 +122,9 @@ class TestSortEntitlements:
             m_cls_6,
         ]
 
-        with mock.patch.object(
-            entitlements, "ENTITLEMENT_CLASSES", m_entitlements
+        with mock.patch(
+            "uaclient.entitlements.get_entitlement_classes",
+            return_value=m_entitlements,
         ):
             assert [
                 "ent1",
@@ -182,8 +187,9 @@ class TestSortEntitlements:
             m_cls_6,
         ]
 
-        with mock.patch.object(
-            entitlements, "ENTITLEMENT_CLASSES", m_entitlements
+        with mock.patch(
+            "uaclient.entitlements.get_entitlement_classes",
+            return_value=m_entitlements,
         ):
             assert [
                 "ent2",
@@ -246,8 +252,9 @@ class TestSortEntitlements:
             m_cls_6,
         ]
 
-        with mock.patch.object(
-            entitlements, "ENTITLEMENT_CLASSES", m_entitlements
+        with mock.patch(
+            "uaclient.entitlements.get_entitlement_classes",
+            return_value=m_entitlements,
         ):
             assert [
                 "ent2",

--- a/uaclient/entitlements/tests/test_entitlements.py
+++ b/uaclient/entitlements/tests/test_entitlements.py
@@ -5,6 +5,7 @@ import pytest
 
 from uaclient import entitlements, exceptions, messages
 from uaclient.entitlements.entitlement_status import ApplicabilityStatus
+from uaclient.entitlements.repo import RepoEntitlement
 
 
 class TestValidServices:
@@ -319,16 +320,12 @@ class TestCheckEntitlementAPTDefinitionsAreUnique:
             ),
         ),
     )
-    @mock.patch(
-        "uaclient.entitlements._is_repo_entitlement", return_value=True
-    )
     @mock.patch("uaclient.entitlements.entitlement_factory")
     @mock.patch("uaclient.entitlements.valid_services")
     def test_check_entitlement_definitions_are_unique(
         self,
         m_valid_services,
         m_ent_factory,
-        _m_is_repo_ent,
         applicability_status1,
         applicability_status2,
         apt_url1,
@@ -339,13 +336,13 @@ class TestCheckEntitlementAPTDefinitionsAreUnique:
     ):
         m_valid_services.return_value = ["ent1", "ent2"]
 
-        m_ent1_obj = mock.MagicMock()
+        m_ent1_obj = mock.MagicMock(RepoEntitlement)
         m_ent1_obj.applicability_status.return_value = applicability_status1
         type(m_ent1_obj).apt_url = apt_url1
         type(m_ent1_obj).apt_suites = suite1
         type(m_ent1_obj).repo_policy_check_tmpl = "{}/ubuntu {}"
 
-        m_ent2_obj = mock.MagicMock()
+        m_ent2_obj = mock.MagicMock(RepoEntitlement)
         m_ent2_obj.applicability_status.return_value = applicability_status2
         type(m_ent2_obj).apt_url = apt_url2
         type(m_ent2_obj).apt_suites = suite2

--- a/uaclient/entitlements/tests/test_entitlements.py
+++ b/uaclient/entitlements/tests/test_entitlements.py
@@ -8,49 +8,39 @@ from uaclient.entitlements.entitlement_status import ApplicabilityStatus
 
 
 class TestValidServices:
-    @pytest.mark.parametrize("show_all_names", ((True), (False)))
-    def test_valid_services(
-        self,
-        show_all_names,
-        FakeConfig,
-    ):
+    def test_valid_services(self, FakeConfig):
         m_cls_1 = mock.MagicMock()
         m_inst_1 = mock.MagicMock()
         type(m_cls_1).name = mock.PropertyMock(return_value="ent1")
         m_inst_1.presentation_name = "ent1"
-        m_inst_1.valid_names = ["ent1", "othername"]
         m_cls_1.return_value = m_inst_1
 
         m_cls_2 = mock.MagicMock()
         m_inst_2 = mock.MagicMock()
         type(m_cls_2).name = mock.PropertyMock(return_value="ent2")
         m_inst_2.presentation_name = "ent2"
-        m_inst_2.valid_names = ["ent2"]
         m_cls_2.return_value = m_inst_2
 
         ents = {m_cls_1, m_cls_2}
 
         with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
             expected_services = ["ent1", "ent2"]
-            if show_all_names:
-                expected_services.append("othername")
-
             assert expected_services == entitlements.valid_services(
-                cfg=FakeConfig(), all_names=show_all_names
+                cfg=FakeConfig()
             )
 
 
 class TestEntitlementFactory:
     def test_entitlement_factory(self, FakeConfig):
         m_cls_1 = mock.MagicMock()
+        m_cls_1.name = "ent1"
         m_variant = mock.MagicMock()
         m_variant_obj = m_variant.return_value
-        m_cls_1.return_value.valid_names = ["ent1", "othername"]
         m_cls_1.return_value.variants = {"variant1": m_variant}
         m_obj_1 = m_cls_1.return_value
 
         m_cls_2 = mock.MagicMock()
-        m_cls_2.return_value.valid_names = ["ent2"]
+        m_cls_2.name = "ent2"
         m_obj_2 = m_cls_2.return_value
 
         ents = {m_cls_1, m_cls_2}
@@ -58,7 +48,7 @@ class TestEntitlementFactory:
 
         with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
             assert m_obj_1 == entitlements.entitlement_factory(
-                cfg=cfg, name="othername"
+                cfg=cfg, name="ent1"
             )
             assert m_obj_2 == entitlements.entitlement_factory(
                 cfg=cfg, name="ent2"
@@ -66,10 +56,9 @@ class TestEntitlementFactory:
             assert m_variant_obj == entitlements.entitlement_factory(
                 cfg=cfg, name="ent1", variant="variant1"
             )
-        with pytest.raises(exceptions.EntitlementNotFoundError):
-            entitlements.entitlement_factory(cfg=cfg, name="nonexistent")
+            with pytest.raises(exceptions.EntitlementNotFoundError):
+                entitlements.entitlement_factory(cfg=cfg, name="nonexistent")
 
-        with mock.patch.object(entitlements, "ENTITLEMENT_CLASSES", ents):
             with pytest.raises(exceptions.EntitlementNotFoundError) as excinfo:
                 entitlements.entitlement_factory(
                     cfg=cfg, name="ent1", variant="nonexistent"
@@ -87,19 +76,16 @@ class TestSortEntitlements:
     def test_disable_order(self, FakeConfig):
         m_cls_1 = mock.MagicMock()
         m_obj_1 = m_cls_1.return_value
-        m_obj_1.valid_names = ["ent1"]
         type(m_obj_1).dependent_services = mock.PropertyMock(return_value=())
         type(m_cls_1).name = mock.PropertyMock(return_value="ent1")
 
         m_cls_2 = mock.MagicMock()
         m_obj_2 = m_cls_2.return_value
-        m_obj_2.valid_names = ["ent2"]
         type(m_obj_2).dependent_services = mock.PropertyMock(return_value=())
         type(m_cls_2).name = mock.PropertyMock(return_value="ent2")
 
         m_cls_3 = mock.MagicMock()
         m_obj_3 = m_cls_3.return_value
-        m_obj_3.valid_names = ["ent3"]
         type(m_obj_3).dependent_services = mock.PropertyMock(
             return_value=(m_cls_1, m_cls_2)
         )
@@ -107,19 +93,16 @@ class TestSortEntitlements:
 
         m_cls_5 = mock.MagicMock()
         m_obj_5 = m_cls_5.return_value
-        m_obj_5.valid_names = ["ent5"]
         type(m_obj_5).dependent_services = mock.PropertyMock(return_value=())
         type(m_cls_5).name = mock.PropertyMock(return_value="ent5")
 
         m_cls_6 = mock.MagicMock()
         m_obj_6 = m_cls_6.return_value
-        m_obj_6.valid_names = ["ent6"]
         type(m_obj_6).dependent_services = mock.PropertyMock(return_value=())
         type(m_cls_6).name = mock.PropertyMock(return_value="ent6")
 
         m_cls_4 = mock.MagicMock()
         m_obj_4 = m_cls_4.return_value
-        m_obj_4.valid_names = ["ent4"]
         type(m_obj_4).dependent_services = mock.PropertyMock(
             return_value=(m_cls_5, m_cls_6)
         )
@@ -149,13 +132,11 @@ class TestSortEntitlements:
     def test_enable_order(self, FakeConfig):
         m_cls_2 = mock.MagicMock()
         m_obj_2 = m_cls_2.return_value
-        m_obj_2.valid_names = ["ent2"]
         type(m_obj_2).required_services = mock.PropertyMock(return_value=())
         type(m_cls_2).name = mock.PropertyMock(return_value="ent2")
 
         m_cls_1 = mock.MagicMock()
         m_obj_1 = m_cls_1.return_value
-        m_obj_1.valid_names = ["ent1"]
         type(m_obj_1).required_services = mock.PropertyMock(
             return_value=(mock.MagicMock(entitlement=m_cls_2),)
         )
@@ -163,7 +144,6 @@ class TestSortEntitlements:
 
         m_cls_3 = mock.MagicMock()
         m_obj_3 = m_cls_3.return_value
-        m_obj_3.valid_names = ["ent3"]
         type(m_obj_3).required_services = mock.PropertyMock(
             return_value=(
                 mock.MagicMock(entitlement=m_cls_1),
@@ -174,19 +154,16 @@ class TestSortEntitlements:
 
         m_cls_5 = mock.MagicMock()
         m_obj_5 = m_cls_5.return_value
-        m_obj_5.valid_names = ["ent5"]
         type(m_obj_5).required_services = mock.PropertyMock(return_value=())
         type(m_cls_5).name = mock.PropertyMock(return_value="ent5")
 
         m_cls_6 = mock.MagicMock()
         m_obj_6 = m_cls_6.return_value
-        m_obj_6.valid_names = ["ent6"]
         type(m_obj_6).required_services = mock.PropertyMock(return_value=())
         type(m_cls_6).name = mock.PropertyMock(return_value="ent6")
 
         m_cls_4 = mock.MagicMock()
         m_obj_4 = m_cls_4.return_value
-        m_obj_4.valid_names = ["ent4"]
         type(m_obj_4).required_services = mock.PropertyMock(
             return_value=(
                 mock.MagicMock(entitlement=m_cls_5),
@@ -219,13 +196,11 @@ class TestSortEntitlements:
     def test_order_entitlements_for_enabling(self, FakeConfig):
         m_cls_2 = mock.MagicMock()
         m_obj_2 = m_cls_2.return_value
-        m_obj_2.valid_names = ["ent2"]
         type(m_obj_2).required_services = mock.PropertyMock(return_value=())
         type(m_cls_2).name = mock.PropertyMock(return_value="ent2")
 
         m_cls_1 = mock.MagicMock()
         m_obj_1 = m_cls_1.return_value
-        m_obj_1.valid_names = ["ent1"]
         type(m_obj_1).required_services = mock.PropertyMock(
             return_value=(mock.MagicMock(entitlement=m_cls_2),)
         )
@@ -233,7 +208,6 @@ class TestSortEntitlements:
 
         m_cls_3 = mock.MagicMock()
         m_obj_3 = m_cls_3.return_value
-        m_obj_3.valid_names = ["ent3"]
         type(m_obj_3).required_services = mock.PropertyMock(
             return_value=(
                 mock.MagicMock(entitlement=m_cls_1),
@@ -244,19 +218,16 @@ class TestSortEntitlements:
 
         m_cls_5 = mock.MagicMock()
         m_obj_5 = m_cls_5.return_value
-        m_obj_5.valid_names = ["ent5"]
         type(m_obj_5).required_services = mock.PropertyMock(return_value=())
         type(m_cls_5).name = mock.PropertyMock(return_value="ent5")
 
         m_cls_6 = mock.MagicMock()
         m_obj_6 = m_cls_6.return_value
-        m_obj_6.valid_names = ["ent6"]
         type(m_obj_6).required_services = mock.PropertyMock(return_value=())
         type(m_cls_6).name = mock.PropertyMock(return_value="ent6")
 
         m_cls_4 = mock.MagicMock()
         m_obj_4 = m_cls_4.return_value
-        m_obj_4.valid_names = ["ent4"]
         type(m_obj_4).required_services = mock.PropertyMock(
             return_value=(
                 mock.MagicMock(entitlement=m_cls_5),

--- a/uaclient/entitlements/tests/test_usg.py
+++ b/uaclient/entitlements/tests/test_usg.py
@@ -2,6 +2,7 @@
 
 from functools import partial
 
+import mock
 import pytest
 
 from uaclient import messages
@@ -20,6 +21,14 @@ class TestUSGEntitlement:
     def test_messages(self, usg_entitlement):
         entitlement = usg_entitlement()
 
-        assert {
-            "post_enable": [messages.USG_POST_ENABLE]
-        } == entitlement.messaging
+        with mock.patch.object(entitlement, "cis_version", False):
+            assert {
+                "pre_enable": None,
+                "post_enable": [messages.USG_POST_ENABLE],
+            } == entitlement.messaging
+
+        with mock.patch.object(entitlement, "cis_version", True):
+            assert {
+                "pre_enable": [messages.CIS_IS_NOW_USG],
+                "post_enable": [messages.USG_POST_ENABLE],
+            } == entitlement.messaging

--- a/uaclient/entitlements/tests/test_usg.py
+++ b/uaclient/entitlements/tests/test_usg.py
@@ -1,0 +1,25 @@
+"""Tests related to uaclient.entitlement.base module."""
+
+from functools import partial
+
+import pytest
+
+from uaclient import messages
+from uaclient.entitlements.usg import USGEntitlement
+
+
+@pytest.fixture
+def usg_entitlement(entitlement_factory):
+    return partial(
+        entitlement_factory,
+        USGEntitlement,
+    )
+
+
+class TestUSGEntitlement:
+    def test_messages(self, usg_entitlement):
+        entitlement = usg_entitlement()
+
+        assert {
+            "post_enable": [messages.USG_POST_ENABLE]
+        } == entitlement.messaging

--- a/uaclient/entitlements/usg.py
+++ b/uaclient/entitlements/usg.py
@@ -3,11 +3,11 @@ from uaclient.entitlements import repo
 from uaclient.types import MessagingOperationsDict
 
 
-class CISEntitlement(repo.RepoEntitlement):
+class USGEntitlement(repo.RepoEntitlement):
 
     help_doc_url = messages.urls.USG_DOCS
-    name = "cis"
-    title = messages.CIS_TITLE
+    name = "usg"
+    title = messages.USG_TITLE
     description = messages.CIS_USG_DESCRIPTION
     help_text = messages.CIS_USG_HELP_TEXT
     repo_key_file = "ubuntu-pro-cis.gpg"
@@ -17,4 +17,4 @@ class CISEntitlement(repo.RepoEntitlement):
 
     @property
     def messaging(self) -> MessagingOperationsDict:
-        return {"post_enable": [messages.CIS_POST_ENABLE]}
+        return {"post_enable": [messages.USG_POST_ENABLE]}

--- a/uaclient/entitlements/usg.py
+++ b/uaclient/entitlements/usg.py
@@ -1,10 +1,16 @@
+from typing import List, Optional  # noqa: F401
+
 from uaclient import messages
 from uaclient.entitlements import repo
-from uaclient.types import MessagingOperationsDict
+from uaclient.entitlements.cis import CISEntitlement
+from uaclient.types import (  # noqa: F401
+    MessagingOperations,
+    MessagingOperationsDict,
+)
 
 
 class USGEntitlement(repo.RepoEntitlement):
-
+    cis_version = False
     help_doc_url = messages.urls.USG_DOCS
     name = "usg"
     title = messages.USG_TITLE
@@ -17,4 +23,16 @@ class USGEntitlement(repo.RepoEntitlement):
 
     @property
     def messaging(self) -> MessagingOperationsDict:
-        return {"post_enable": [messages.USG_POST_ENABLE]}
+        pre_enable = None  # type: Optional[MessagingOperations]
+        if self.cis_version:
+            pre_enable = [messages.CIS_IS_NOW_USG]
+        return {
+            "pre_enable": pre_enable,
+            "post_enable": [messages.USG_POST_ENABLE],
+        }
+
+    @property
+    def packages(self) -> List[str]:
+        if self.cis_version:
+            return CISEntitlement().packages
+        return super().packages

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1421,9 +1421,9 @@ CC_POST_ENABLE = t.gettext(
 )
 
 CIS_TITLE = t.gettext("CIS Audit")
-CIS_USG_TITLE = t.gettext("Ubuntu Security Guide")
-CIS_DESCRIPTION = t.gettext("Security compliance and audit tools")
-CIS_HELP_TEXT = t.gettext(
+USG_TITLE = t.gettext("Ubuntu Security Guide")
+CIS_USG_DESCRIPTION = t.gettext("Security compliance and audit tools")
+CIS_USG_HELP_TEXT = t.gettext(
     """\
 Ubuntu Security Guide is a tool for hardening and auditing and allows for
 environment-specific customizations. It enables compliance with profiles such
@@ -1433,7 +1433,7 @@ as DISA-STIG and the CIS benchmarks. Find out more at
 CIS_POST_ENABLE = t.gettext("Visit {url} to learn how to use CIS").format(
     url=urls.CIS_HOME_PAGE
 )
-CIS_USG_POST_ENABLE = t.gettext("Visit {url} for the next steps").format(
+USG_POST_ENABLE = t.gettext("Visit {url} for the next steps").format(
     url=urls.USG_DOCS
 )
 CIS_IS_NOW_USG = t.gettext(

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -299,7 +299,7 @@ def _unattached_status(cfg: UAConfig) -> Dict[str, Any]:
 
         response["services"].append(
             {
-                "name": resource.get("presentedAs", resource["name"]),
+                "name": ent.name,
                 "description": ent.description,
                 "description_override": descr_override,
                 "available": available,
@@ -490,7 +490,7 @@ def simulate_status(
         )
         response["services"].append(
             {
-                "name": resource.get("presentedAs", ent.name),
+                "name": ent.name,
                 "description": ent.description,
                 "entitled": entitlement_information["entitled"],
                 "auto_enabled": entitlement_information["auto_enabled"],
@@ -793,7 +793,7 @@ def help(cfg, name):
     response_dict["name"] = name
 
     for resource in resources:
-        if resource["name"] == name or resource.get("presentedAs") == name:
+        if resource["name"] == name:
             try:
                 help_ent = entitlement_factory(cfg=cfg, name=resource["name"])
             except exceptions.EntitlementNotFoundError:

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -7,8 +7,8 @@ import pytest
 
 from uaclient import messages, status
 from uaclient.entitlements import (
-    ENTITLEMENT_CLASSES,
     entitlement_factory,
+    get_entitlement_classes,
     valid_services,
 )
 from uaclient.entitlements.base import EntitlementWithMessage
@@ -464,7 +464,7 @@ class TestStatus:
                     {"name": cls.name, "available": True} in avail_res
                 ),
             }
-            for cls in ENTITLEMENT_CLASSES
+            for cls in get_entitlement_classes()
         ]
         if avail_res:
             token["availableResources"] = available_resource_response
@@ -495,7 +495,7 @@ class TestStatus:
                 "warning": None,
                 "variants": {},
             }
-            for cls in ENTITLEMENT_CLASSES
+            for cls in get_entitlement_classes()
         ]
         expected_services.sort(key=lambda x: x.get("name", ""))
         expected = copy.deepcopy(DEFAULT_STATUS)
@@ -793,7 +793,7 @@ class TestStatus:
             },
         }
 
-        for cls in ENTITLEMENT_CLASSES:
+        for cls in get_entitlement_classes():
             if cls.name == "realtime-kernel":
                 if variants_in_contract:
                     m_contract_variants.return_value = set(


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it implements the changes needed to turn USG into an actual resource on the client side. This aligns client behaviour with the implementation done for the backend

## Test Steps
kept behavior:
- enabling CIS should work on X, B
- enabling USG should work on J
- both should work on F, but USG gets enabled in both cases , with a message telling about the transition

new behavior:
- upgrading from older versions of pro client where CIS was enabled as USG on F, J should enable the actual USG resource

Integration tests TBD
---

- [x] *(un)check this to re-run the checklist action*