### PR TITLE
api: cache result of source pkg version function

### DIFF
--- a/uaclient/api/u/pro/security/vulnerabilities/_common/v1.py
+++ b/uaclient/api/u/pro/security/vulnerabilities/_common/v1.py
@@ -4,6 +4,7 @@ import enum
 import json
 import os
 import re
+from functools import lru_cache
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 from urllib.parse import urljoin
 
@@ -422,6 +423,7 @@ class VulnerabilityParser(metaclass=abc.ABCMeta):
 
         return False
 
+    @lru_cache(maxsize=None)
     def _get_installed_source_pkg_version(self, binary_pkg_name: str):
         out, _ = system.subp(
             [


### PR DESCRIPTION
## Why is this needed?
We are now caching the result _get_installed_source_pkg_version. This is because we realized we were calling dpkg-query multiple times without a reason, as the result should not change when running any of the vulnerabilities API

## Test Steps
Test can you can run `pro vulnerability list` on a Xenial or Bionic VM and that the command only takes some seconds to complete

---

- [x] *(un)check this to re-run the checklist action*