### PR TITLE
Update vulnerability list applied fixes message

### DIFF
--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -470,7 +470,7 @@ Feature: Pro Client help text
       Allow users to better visualize the vulnerability issues that affects
       the system.
 
-      optional arguments:
+      <options_string>:
         -h, --help          show this help message and exit
 
       Available Commands:
@@ -491,7 +491,7 @@ Feature: Pro Client help text
         security_issue        Security vulnerability ID to display information.
                               Format: CVE-yyyy-nnnn, CVE-yyyy-nnnnnnn or USN-nnnn-dd
 
-      optional arguments:
+      <options_string>:
         -h, --help            show this help message and exit
         --data-file DATA_FILE
                               Static vulnerability JSON data to be used in the
@@ -509,7 +509,7 @@ Feature: Pro Client help text
       By default, the command will only list CVEs. To display
       USNs instead, run the command with the --usns flag.
 
-      optional arguments:
+      <options_string>:
         -h, --help            show this help message and exit
         --data-file DATA_FILE
                               Static vulnerability JSON data to be used in the
@@ -533,7 +533,7 @@ Feature: Pro Client help text
       Updates the vulnerability data stored in the machine.
       If no vulnerability data exists yet, the command will download it
 
-      optional arguments:
+      <options_string>:
         -h, --help  show this help message and exit
       """
 

--- a/features/cli/vulnerability_list.feature
+++ b/features/cli/vulnerability_list.feature
@@ -142,3 +142,37 @@ Feature: CLI vulnerability list command
     Examples: ubuntu
       | release | machine_type  |
       | xenial  | lxd-container |
+
+  @slow
+  Scenario Outline: CLI vulnerability list after upgrade
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I push static file `security_issues_xenial.json` to machine
+    And I run `pro vulnerability list --data-file=/tmp/security_issues_xenial.json` as non-root
+    And I remove colors from output
+    And I remove links from output
+    Then stdout contains substring:
+      """
+      Vulnerabilities with applied fixes:
+          861 applied via Ubuntu Security (32 high, 494 medium, 322 low, 13 negligible)
+
+      Vulnerabilities with fixes available:
+          461 fixable via Ubuntu Pro (10 high, 293 medium, 136 low, 22 negligible)
+          1 fixable via Ubuntu Security (1 medium)
+      """
+    When I attach `contract_token` with sudo
+    And I apt upgrade
+    When I run `pro vulnerability list --data-file=/tmp/security_issues_xenial.json` as non-root
+    And I remove colors from output
+    And I remove links from output
+    Then stdout contains substring:
+      """
+      No CVEs found that affects this system
+
+      Vulnerabilities with applied fixes:
+          461 applied via Ubuntu Pro (10 high, 293 medium, 136 low, 22 negligible)
+          862 applied via Ubuntu Security (32 high, 495 medium, 322 low, 13 negligible)
+      """
+
+    Examples: ubuntu
+      | release | machine_type  |
+      | xenial  | lxd-container |

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -202,7 +202,7 @@ def _create_fixable_cves_count(vulnerabilities) -> str:
         vulnerabilities
     )
 
-    for pocket, pocket_info in fixable_vulnerabilities_info.items():
+    for pocket, pocket_info in sorted(fixable_vulnerabilities_info.items()):
         if not pocket_info["count"]:
             continue
 
@@ -227,7 +227,7 @@ def _create_fixable_usns_count(vulnerabilities) -> str:
     fixable_vulnerabilities_info = _get_info_from_vulnerabilities(
         vulnerabilities
     )
-    for pocket, pocket_info in fixable_vulnerabilities_info.items():
+    for pocket, pocket_info in sorted(fixable_vulnerabilities_info.items()):
         if not pocket_info["count"]:
             continue
 
@@ -282,7 +282,7 @@ def _create_unfixable_usns_count(vulnerabilities) -> str:
 def _create_already_fixed_cves_count(applied_fixes_count) -> str:
     if any(count for pocket, count in applied_fixes_count["count"].items()):
         content = []
-        for pocket, count in applied_fixes_count["count"].items():
+        for pocket, count in sorted(applied_fixes_count["count"].items()):
             if not count:
                 continue
 
@@ -310,7 +310,7 @@ def _create_already_fixed_cves_count(applied_fixes_count) -> str:
 def _create_already_fixed_usns_count(applied_fixes_count) -> str:
     if any(count for pocket, count in applied_fixes_count["count"].items()):
         content = []
-        for pocket, count in applied_fixes_count["count"].items():
+        for pocket, count in sorted(applied_fixes_count["count"].items()):
             if not count:
                 continue
 

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -125,33 +125,32 @@ def _get_info_from_vulnerabilities(vulnerabilities):
 
     for vuln in vulnerabilities:
         if vuln.fixable == "yes":
-            pocket = (
-                "ubuntu_pro"
-                if any(
-                    pkg
-                    for pkg in vuln.affected_packages
-                    if re.match(
-                        r"^(esm|fips)", pkg.fix_available_from or "no-fix"
-                    )
-                )
-                else "ubuntu_security"
-            )
-            vulnerability_count_info[pocket]["count"] += 1
+            pockets = set()
+            for pkg in vuln.affected_packages:
+                if re.match(
+                    r"^(esm|fips)", pkg.fix_available_from or "no-fix"
+                ):
+                    pockets.add("ubuntu_pro")
+                else:
+                    pockets.add("ubuntu_security")
 
-            if not getattr(vuln, "ubuntu_priority", None):
-                continue
+            for pocket in pockets:
+                vulnerability_count_info[pocket]["count"] += 1
 
-            if (
-                vuln.ubuntu_priority
-                in vulnerability_count_info[pocket]["info"]
-            ):
-                vulnerability_count_info[pocket]["info"][
+                if not getattr(vuln, "ubuntu_priority", None):
+                    continue
+
+                if (
                     vuln.ubuntu_priority
-                ] += 1
-            else:
-                vulnerability_count_info[pocket]["info"][
-                    vuln.ubuntu_priority
-                ] = 1
+                    in vulnerability_count_info[pocket]["info"]
+                ):
+                    vulnerability_count_info[pocket]["info"][
+                        vuln.ubuntu_priority
+                    ] += 1
+                else:
+                    vulnerability_count_info[pocket]["info"][
+                        vuln.ubuntu_priority
+                    ] = 1
 
     return vulnerability_count_info
 


### PR DESCRIPTION
## Why is this needed?
Instead of showing the count of applied fixes per package, we are now switching to count be vulnerability instead. The
main reason is to make the count consistent with the other summary information we have on pro vulnerability list

## Test Steps
Run the modified integration tests

---

- [ ] *(un)check this to re-run the checklist action*