### PR TITLE
tests: fix xenial security-status test

### DIFF
--- a/uaclient/tests/test_security_status.py
+++ b/uaclient/tests/test_security_status.py
@@ -639,7 +639,13 @@ class TestSecurityStatus:
             "livepatch": {"fixed_cves": []},
         }
 
-        assert expected_output == security_status_dict(cfg)
+        result = security_status_dict(cfg)
+        assert expected_output["_schema_version"] == result["_schema_version"]
+        assert expected_output["livepatch"] == result["livepatch"]
+        assert expected_output["summary"] == result["summary"]
+        assert expected_output["packages"] == sorted(
+            result["packages"], key=lambda x: x["version"]
+        )
 
 
 @mock.patch(M_PATH + "livepatch.status")


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because this was blocking xenial builds, as there is no guaranteed dict order in python 3.5

## Test Steps
This was a flaky issue on Xenial builds.
Those should not fail anymore.
Locally, comment the "nocheck" in the build_debs function and trigger xenial builds.


---

- [x] *(un)check this to re-run the checklist action*