### PR TITLE
apt-hook: only run apt upgrade hook when run as root

### DIFF
--- a/apt-hook/20apt-esm-hook.conf
+++ b/apt-hook/20apt-esm-hook.conf
@@ -3,5 +3,5 @@ APT::Update::Pre-Invoke {
 };
 
 binary::apt::AptCli::Hooks::Upgrade {
-	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-json-hook ] || /usr/lib/ubuntu-advantage/apt-esm-json-hook 2>> /var/log/ubuntu-advantage-apt-hook.log || true";
+	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-json-hook ] || [ $(id -u) -ne 0 ] || /usr/lib/ubuntu-advantage/apt-esm-json-hook 2>> /var/log/ubuntu-advantage-apt-hook.log || true";
 };

--- a/debian/changelog
+++ b/debian/changelog
@@ -28,6 +28,7 @@ ubuntu-advantage-tools (35) oracular; urgency=medium
       + always ensure the ESM cache is present (GH: #3132)
       + silence warnings when fetching apt-news (GH: #3209, LP: #2070095)
       + update logging for apt errors (GH: #3299)
+      + only run the apt upgrade hook when run as root (LP: #2084677)
     - cli:
       + add support for vulnerability commands:
         * pro vulnerability list: List fixable vulnerabilities in the machine

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -1158,6 +1158,22 @@ Feature: APT Messages
       # | oracular | lxd-container | jammy         | libcurl4t64     | 8.8.0-3ubuntu3    |
       | noble   | lxd-container | jammy         | libcurl4t64     | 8.5.0-2ubuntu10   |
 
+  Scenario Outline: APT Hook does not error when run as non-root
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I run `apt upgrade --simulate` as non-root
+    Then I will see the following on stderr
+      """
+      WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+      """
+
+    Examples: ubuntu release
+      | release | machine_type  |
+      | xenial  | lxd-container |
+      | bionic  | lxd-container |
+      | focal   | lxd-container |
+      | jammy   | lxd-container |
+      | noble   | lxd-container |
+
   @uses.config.contract_token
   Scenario Outline: APT Hook do not advertises esm-apps on upgrade for interim releases
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
LP: #2084677

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Verify new test fails before change and passes after.

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*