### PR TITLE
docs: add documentation for dep8 tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,18 +9,18 @@ This section contains developer documentation for the Ubuntu Pro Client project.
 
 ## How-to guides
 
-* [Run the code formatting tools](dev-docs/code_formatting.md)
-* [How to spellcheck messages](dev-docs/spellcheck.md)
-* [Release a new version](dev-docs/release_a_new_version.md)
-* [Release a hotfix](dev-docs/release_a_hotfix.md)
-* [Use the contract staging environment](dev-docs/use_staging_environment.md)
-* [Use the magic attach endpoints](dev-docs/magic_attach_endpoints.md)
-* [Permanently detach Pro instances](dev-docs/detach_pro_instances.md)
-* [Troubleshoot security confinement](dev-docs/troubleshoot_security_confinement.md)
-* [Troubleshoot APT news security confinement](dev-docs/troubleshoot_apt_news_security_confinement.md)
-* [Set up a Windows machine for WSL testing](dev-docs/wsl_testing_setup.md)
-* [Run unit tests](dev-docs/unit_testing.md)
-* [Run integration tests](dev-docs/integration_testing.md)
+* [Run the code formatting tools](dev-docs/how-to/code_formatting.md)
+* [How to spellcheck messages](dev-docs/how-to/spellcheck.md)
+* [Release a new version](dev-docs/how-to/release_a_new_version.md)
+* [Release a hotfix](dev-docs/how-to/release_a_hotfix.md)
+* [Use the contract staging environment](dev-docs/how-to/use_staging_environment.md)
+* [Use the magic attach endpoints](dev-docs/how-to/magic_attach_endpoints.md)
+* [Permanently detach Pro instances](dev-docs/how-to/detach_pro_instances.md)
+* [Troubleshoot security confinement](dev-docs/how-to/troubleshoot_security_confinement.md)
+* [Troubleshoot APT news security confinement](dev-docs/how-to/troubleshoot_apt_news_security_confinement.md)
+* [Set up a Windows machine for WSL testing](dev-docs/how-to/wsl_testing_setup.md)
+* [Run unit tests](dev-docs/how-to/unit_testing.md)
+* [Run integration tests](dev-docs/how-to/integration_testing.md)
 * [Run dep8 tests](dev-docs/how-to/run_dep8_tests.md)
 
 ## Reference

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ This section contains developer documentation for the Ubuntu Pro Client project.
 * [Set up a Windows machine for WSL testing](dev-docs/wsl_testing_setup.md)
 * [Run unit tests](dev-docs/unit_testing.md)
 * [Run integration tests](dev-docs/integration_testing.md)
+* [Run dep8 tests](dev-docs/how-to/run_dep8_tests.md)
 
 ## Reference
 
@@ -36,4 +37,3 @@ This section contains developer documentation for the Ubuntu Pro Client project.
 * [Auto-attach mechanisms](dev-docs/explanation/autoattach_mechanisms.md)
 * [How auto-attach works](dev-docs/explanation/how_auto_attach_works.md)
 * [What happens during attach](dev-docs/explanation/what_happens_during_attach.md)
-

--- a/dev-docs/how-to/run_dep8_tests.md
+++ b/dev-docs/how-to/run_dep8_tests.md
@@ -1,0 +1,27 @@
+# How to run dep8 tests
+
+The ubuntu-advantage-tools source package currently supports [dep8
+tests]( https://salsa.debian.org/ci-team/autopkgtest/-/blob/master/doc/README.package-tests.rst).
+Those dep8 tests can be found under `debian/tests/usage` and although they are currently only
+running a few Pro client commands, the idea is to verify if any modification to our package dependencies
+will affect the Pro client.
+
+Right now, we are looking for signal from our `python3-apt` dependency. That's why we are running
+the `packages` API there, as those endpoints directly interact with APT.
+
+If you perform any modification to those tests, you can verify it by following these steps:
+
+1. Install the `autopkgtest` application:
+
+```shell
+sudo apt install autopkgtest
+```
+
+2. Run the following command:
+
+```shell
+autopkgtest -U --shell-fail . -- lxd ubuntu:xenial
+```
+
+Note that you can run this command on any release we support, not only Xenial,
+and it will run for all releases by launchpad when dependencies are updated.


### PR DESCRIPTION


## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
We are now documenting our rationale for our dep8 tests while also documenting how to run them locally

This PR depends on #3353 to be merged first

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
These docs have already been tested, just moving to the new place.
<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*