### PR TITLE
Add new Minimal Pro licenses for GCP

### DIFF
--- a/uaclient/clouds/gcp.py
+++ b/uaclient/clouds/gcp.py
@@ -24,12 +24,12 @@ LAST_ETAG = "&last_etag={etag}"
 DMI_PRODUCT_NAME = "/sys/class/dmi/id/product_name"
 GCP_PRODUCT_NAME = "Google Compute Engine"
 
-GCP_LICENSES = {
-    "xenial": "8045211386737108299",
-    "bionic": "6022427724719891830",
-    "focal": "599959289349842382",
-    "jammy": "2592866803419978320",
-    "noble": "2176054482269786025",
+GCP_LICENSES = {  # Base [0], Minimal [1]
+    "xenial": ["8045211386737108299"],
+    "bionic": ["6022427724719891830", "7427070211152946628"],
+    "focal": ["599959289349842382", "7818678586103571931"],
+    "jammy": ["2592866803419978320", "160084055690847662"],
+    "noble": ["2176054482269786025", "4168323874790319525"],
 }
 
 
@@ -111,7 +111,10 @@ class GCPAutoAttachInstance(PublicCloudAutoAttachInstance):
             license_ids = [license["id"] for license in response.json_list]
             self.etag = response.headers.get("etag")
             series = system.get_release_info().series
-            return GCP_LICENSES.get(series) in license_ids
+            for lic in GCP_LICENSES.get(series, []):
+                if lic in license_ids:
+                    return True
+            return False
 
         LOG.error(response.body)
         if response.code == 400:


### PR DESCRIPTION
 ## Why is this needed?
We (CPC) have recently started building Minimal Pro images (as well as the usual "Base" images). This commit adds the new license codes to the appropriate suites in gcp.py:GCP_LICENSES.

* Also edited the login in `gcp.py:is_pro_license_present()` to facilitate the new dict{list[]}

 ## Test Steps
ran `tox -r` locally and all green

 * [ ]  _(un)check this to re-run the checklist action_
