### PR TITLE
cli: vulnerability alias to vulnerability list

### DIFF
--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -465,19 +465,35 @@ Feature: Pro Client help text
     When I run `pro vulnerability --help` as non-root
     Then I will see the following on stdout
       """
-      usage: pro vulnerability [-h] {show,update,list} ...
+      usage: pro vulnerability [-h] [--data-file DATA_FILE] [--all] [--usns]
+                               [--unfixable] [--manifest-file MANIFEST_FILE]
+                               [--series SERIES] [--update]
+                               {show,update,list} ...
 
       Allow users to better visualize the vulnerability issues that affects
-      the system.
+      the system. By default, this command will execute pro vulnerability list
 
       <options_string>:
-        -h, --help          show this help message and exit
+        -h, --help            show this help message and exit
+        --data-file DATA_FILE
+                              Static vulnerability JSON data to be used in the
+                              command
+        --all                 List all vulnerabilities that affect the machine, even
+                              if they can't be fixed
+        --usns                List USNs vulnerabilities instead of CVEs
+        --unfixable           List only vulnerabilities that don't have a fix
+                              available
+        --manifest-file MANIFEST_FILE
+                              Manifest file to be used by the command
+        --series SERIES       When a manifest file is provided, specify the series
+                              that generated using this parameter
+        --update              update the vulnerability data in your machine
 
       Available Commands:
         {show,update,list}
-          show              show information about a vulnerability
-          update            update the vulnerability data in your machine
-          list              list the vulnerabilities that affect the system
+          show                show information about a vulnerability
+          update              update the vulnerability data in your machine
+          list                list the vulnerabilities that affect the system
       """
     When I run `pro vulnerability show --help` as non-root
     Then I will see the following on stdout

--- a/uaclient/cli/vulnerability/__init__.py
+++ b/uaclient/cli/vulnerability/__init__.py
@@ -1,17 +1,13 @@
 from uaclient import messages
 from uaclient.cli.commands import ProCommand
 from uaclient.cli.parser import HelpCategory
-from uaclient.cli.vulnerability.list import list_subcommand
+from uaclient.cli.vulnerability.list import (
+    action_list,
+    list_subcommand,
+    vulnerability_list_args_group,
+)
 from uaclient.cli.vulnerability.show import show_subcommand
 from uaclient.cli.vulnerability.update import update_subcommand
-
-
-def action_vulnerability(args, *, cfg, **kwargs):
-    # Avoiding a circular import
-    from uaclient.cli import get_parser
-
-    get_parser().print_help_for_command("vulnerability")
-
 
 vulnerability_command = ProCommand(
     "vulnerability",
@@ -19,6 +15,7 @@ vulnerability_command = ProCommand(
     description=messages.CLI_VULNERABILITY_DESC,
     help_category=HelpCategory.SECURITY,
     preserve_description=True,
-    action=action_vulnerability,
+    action=action_list,
     subcommands=[show_subcommand, update_subcommand, list_subcommand],
+    argument_groups=[vulnerability_list_args_group],
 )

--- a/uaclient/cli/vulnerability/list.py
+++ b/uaclient/cli/vulnerability/list.py
@@ -513,51 +513,51 @@ def action_list(args, *, cfg, **kwargs):
         )
 
 
+vulnerability_list_args_group = ProArgumentGroup(
+    arguments=[
+        ProArgument(
+            "--data-file",
+            help=messages.CLI_VULNERABILITY_DATA_FILE,
+            action="store",
+        ),
+        ProArgument(
+            "--all",
+            help=messages.CLI_VULNERABILITY_LIST_ALL,
+            action="store_true",
+        ),
+        ProArgument(
+            "--usns",
+            help=messages.CLI_VULNERABILITY_LIST_USNS,
+            action="store_true",
+        ),
+        ProArgument(
+            "--unfixable",
+            help=messages.CLI_VULNERABILITY_LIST_UNFIXABLE,
+            action="store_true",
+        ),
+        ProArgument(
+            "--manifest-file",
+            help=messages.CLI_VULNERABILITY_LIST_MANIFEST_FILE,
+            action="store",
+        ),
+        ProArgument(
+            "--series",
+            help=messages.CLI_VULNERABILITY_LIST_SERIES,
+            action="store",
+        ),
+        ProArgument(
+            "--update",
+            help=messages.CLI_VULNERABILITY_UPDATE,
+            action="store_true",
+        ),
+    ]
+)
+
 list_subcommand = ProCommand(
     "list",
     help=messages.CLI_VULNERABILITY_LIST,
     description=messages.CLI_VULNERABILITY_LIST_DESC,
     action=action_list,
     preserve_description=True,
-    argument_groups=[
-        ProArgumentGroup(
-            arguments=[
-                ProArgument(
-                    "--data-file",
-                    help=messages.CLI_VULNERABILITY_DATA_FILE,
-                    action="store",
-                ),
-                ProArgument(
-                    "--all",
-                    help=messages.CLI_VULNERABILITY_LIST_ALL,
-                    action="store_true",
-                ),
-                ProArgument(
-                    "--usns",
-                    help=messages.CLI_VULNERABILITY_LIST_USNS,
-                    action="store_true",
-                ),
-                ProArgument(
-                    "--unfixable",
-                    help=messages.CLI_VULNERABILITY_LIST_UNFIXABLE,
-                    action="store_true",
-                ),
-                ProArgument(
-                    "--manifest-file",
-                    help=messages.CLI_VULNERABILITY_LIST_MANIFEST_FILE,
-                    action="store",
-                ),
-                ProArgument(
-                    "--series",
-                    help=messages.CLI_VULNERABILITY_LIST_SERIES,
-                    action="store",
-                ),
-                ProArgument(
-                    "--update",
-                    help=messages.CLI_VULNERABILITY_UPDATE,
-                    action="store_true",
-                ),
-            ]
-        )
-    ],
+    argument_groups=[vulnerability_list_args_group],
 )

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1216,7 +1216,7 @@ CLI_ROOT_VULNERABILITY = t.gettext(
 CLI_VULNERABILITY_DESC = t.gettext(
     """\
 Allow users to better visualize the vulnerability issues that affects
-the system."""
+the system. By default, this command will execute pro vulnerability list"""
 )
 
 CLI_VULNERABILITY_DATA_FILE = t.gettext(


### PR DESCRIPTION
## Why is this needed?
Running pro vulnerability is now an alias for running pro vulnerability list

## Test Steps
Check that `pro vulnerability` works the same way as `pro vulnerability list`


---

- [ ] *(un)check this to re-run the checklist action*