### PR TITLE
docs: improve explanation about the ESM pinning

### DIFF
--- a/docs/explanations/about_esm.rst
+++ b/docs/explanations/about_esm.rst
@@ -92,7 +92,31 @@ Although the preference files listed above will always be delivered by the
 package, they will only take effect when the referenced sources are available, i.e. when the services are enabled. Otherwise, it
 is safe to keep those files around.
 
-Check the `APT configuration article`_ in the Debian Wiki to learn more about
+check the `APT configuration article`_ in the Debian wiki to learn more about
+pinning and priorities.
+
+Why do we set this preference for the ESM packages ?
+====================================================
+
+Once you enable the ESM services you have immediate access to the security
+updates provided by Canonical for your Ubuntu system. Setting the preference
+guarantees that no automatically installed updates will ever revert a
+previously applied security patch, unless some manual operation overrides the
+default behaviour set by the Pro Client.
+
+How does this preference affect PPAs ?
+======================================
+
+If you have any third party PPAs configured on your system, then the ESM
+repositories will be preferred over these as well. That means if a
+particular package has two different versions (one coming from the
+PPA and the other from ESM) the ESM version will be chosen, even if the
+PPA version is higher.
+
+If you don't want this behaviour, and you want the the PPA version to be
+automatically installed instead, you need to set at least the same preference
+value used for ESM (510) for the PPA. To do that, please check the
+`APT configuration article`_ in the Debian wiki to learn more about
 pinning and priorities.
 
 .. LINKS


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because pinning and PPAs are not friends. We clarify the reason, and document that people must change their preferences if they want PPA versions to be preferred (or even considered) when automatically upgrading.

---

- [ ] *(un)check this to re-run the checklist action*