### PR TITLE
wsl: do not enable livepatch on wsl

### DIFF
--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -338,3 +338,27 @@ Feature: Livepatch
       | release | machine_type |
       | xenial  | lxd-vm       |
       | bionic  | lxd-vm       |
+
+  Scenario Outline: Livepatch doesn't enable on wsl from a systemd service
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I create the file `/lib/systemd/system/test.service` with the following
+      """
+      [Unit]
+      Description=test
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/pro attach <contract_token>
+      PrivateMounts=yes
+      """
+    When I replace `<contract_token>` in `/lib/systemd/system/test.service` with token `contract_token`
+    When I run `systemctl start test.service` with sudo
+    Then I verify that running `canonical-livepatch` `with sudo` exits `1`
+    Then I will see the following on stderr
+      """
+      sudo: canonical-livepatch: command not found
+      """
+
+    Examples: ubuntu release
+      | release | machine_type |
+      | jammy   | wsl          |

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -72,7 +72,8 @@ class LivepatchEntitlement(UAEntitlement):
                 messages.SERVICE_ERROR_INSTALL_ON_CONTAINER.format(
                     title=self.title
                 ),
-                lambda: system.is_container(),
+                lambda: system.is_container()
+                or system.get_virt_type() == "wsl",
                 False,
             ),
             (


### PR DESCRIPTION


## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
Fixes: #3156

FYI @CarlosNihelton

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the new test.

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*