### PR TITLE
tests: fix realtime-kernel output check

### DIFF
--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -248,9 +248,10 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
     Then stdout matches regexp:
       """
       realtime-kernel\* yes +enabled +Ubuntu kernel with PREEMPT_RT patches integrated
-      usg +yes +disabled +Security compliance and audit tools
-
-       \* Service has variants
+      """
+    Then stdout contains substring:
+      """
+      * Service has variants
       """
     Then stdout contains substring:
       """


### PR DESCRIPTION
## Why is this needed?
For the realtime-kernel check, we are also checking the presence of the usg service on the output. We are updating the test to not check for that anymore, as it doesn't have any relation with the feature being tested

## Test Steps
Check the integration test is now working


---

- [x] *(un)check this to re-run the checklist action*