### PR TITLE
chore: fix daily ppa builds

### DIFF
--- a/tools/check-versions-are-consistent.py
+++ b/tools/check-versions-are-consistent.py
@@ -18,9 +18,12 @@ changelog_version = (
 # GH: 32.3ubuntu1~1.gbp761c11~noble1 -> 32.3
 # backports: 32.3~22.04 -> 32.3
 # ppa test builds: 32.3~22.04~ppa1 -> 32.3
-# devel: 1:1+devel -> 1:1+devel
+# daily ppa: 1:1+devel-35-3475~gc001b39f~ubuntu24.10.1 -> 35
 #
-m = re.match(r"((\d+:\d+\+devel)|\d+(\.\d+)*)", changelog_version)
+# focal and earlier don't have `removeprefix`
+if changelog_version.startswith("1:1+devel-"):
+    changelog_version = changelog_version[10:]
+m = re.match(r"(\d+(\.\d+)*)", changelog_version)
 if m:
     base_changelog_version = m.group()
 else:


### PR DESCRIPTION


## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
The daily ppa now prepends "1:1+devel-" instead of expecting it in the changelog already. This script needs to be updated to strip that prefix when looking at the changelog version.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Manually change the changelog version to what the daily PPA was just failing on: `1:1+devel-35-3475~gc001b39f~ubuntu24.10.1`.
Run the version check script, it should return 0.
<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*