### PR TITLE
docs: suggest fips-updates instead of fips

### DIFF
--- a/custom_wordlist.txt
+++ b/custom_wordlist.txt
@@ -21,6 +21,7 @@ codename
 conf
 conffile
 config
+cryptographic
 cron
 Ctrl
 CTRL
@@ -42,6 +43,7 @@ enablement
 esm
 ESM
 FailedUpgrade
+FedRAMP
 fips
 FIPS
 firewalled
@@ -84,6 +86,7 @@ nginx
 NoOpAlreadyFixed
 NoOpLivepatchFixData
 num
+organizations
 PackageCannotBeInstalledData
 PEM
 PID

--- a/docs/howtoguides/enable_fips.rst
+++ b/docs/howtoguides/enable_fips.rst
@@ -5,7 +5,17 @@ How to manage FIPS
 
 .. note::
 
-    FIPS is supported on Ubuntu `16.04, 18.04 and 20.04`_ releases.
+    The latest FedRAMP policy on the use of cryptographic modules relaxes some
+    of the past restrictions that prevented organizations from applying
+    critical security updates. Because of that, we don't recommend enabling
+    ``fips`` anymore - please use ``fips-updates`` instead. Read more in
+    `our blog post`_. Jammy Jellyfish (22.04) and later releases will not
+    have the legacy ``fips`` service available.
+
+.. note::
+
+    Check `the FIPS documentation`_ to verify which Ubuntu releases have FIPS
+    available.
 
 .. caution::
 
@@ -25,15 +35,15 @@ To enable FIPS, run:
 
 .. code-block:: bash
 
-    $ sudo pro enable fips
+    $ sudo pro enable fips-updates
 
 You should see output like the following, indicating that the FIPS packages
 have been installed:
 
 .. code-block:: text
 
-    Installing FIPS packages
-    FIPS enabled
+    Installing FIPS Updates packages
+    FIPS Updates enabled
     A reboot is required to complete install.
 
 Enabling FIPS should be performed during a system maintenance window since
@@ -42,7 +52,7 @@ a reboot into the FIPS-certified kernel.
 
 .. caution::
     
-    Once you enable FIPS, enabling some Pro services will not be possible. For
+    Once you enable FIPS, enabling some Pro services may not be possible. For
     a complete view of which services are incompatible with FIPS, refer to the
     :doc:`services compatibility matrix <../references/compatibility_matrix>`
 
@@ -54,7 +64,7 @@ If you wish to disable FIPS, you can use the following command:
 
 .. code-block:: bash
 
-    sudo pro disable fips
+    sudo pro disable fips-updates
 
 Note that this command will only remove the APT sources, but not uninstall the
 packages installed with the service. Your system will **still have the FIPS
@@ -69,4 +79,5 @@ removing also the FIPS kernel, see
 
 .. include:: ../links.txt
 
-.. _16.04, 18.04 and 20.04: https://ubuntu.com/tutorials/using-the-ubuntu-pro-client-to-enable-fips
+.. _the FIPS documentation: https://ubuntu.com/security/certifications/docs/fips
+.. _our blog post: https://ubuntu.com/blog/the-role-of-fips-140-3-in-the-latest-fedramp-guidance


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we now recommend `fips-updates`, as `fips` is deprecated from Jammy

Fixes: #3388 

---

- [ ] *(un)check this to re-run the checklist action*