### PR TITLE
CVE features improvements

### DIFF
--- a/features/cli/cve.feature
+++ b/features/cli/cve.feature
@@ -91,11 +91,10 @@ Feature: CLI cve command
         libaccountsservice0:  vulnerable
       """
     When I run `pro cve CVE-2025-26520` as non-root
-    Then I will see the following on stdout:
+    Then I will see the following on stderr:
       """
-      CVE-2025-26520 not present in xenial security data.
-      You may be able to find more information at:
-      - https://ubuntu.com/security/CVE-2025-26520
+      CVE-2025-26520 doesn't affect Ubuntu 16.04.
+      For more information, visit: https://ubuntu.com/security/CVE-2025-26520
       """
 
     Examples: ubuntu release

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -471,7 +471,7 @@ Feature: Pro Client help text
 
       List the CVE vulnerabilities that affects the system.
 
-      optional arguments:
+      <options_string>:
         -h, --help   show this help message and exit
         --unfixable  List only vulnerabilities without a fix available
         --fixable    List only vulnerabilities with a fix available
@@ -487,7 +487,7 @@ Feature: Pro Client help text
         cve         CVE to display information. Format: CVE-yyyy-nnnn or CVE-yyyy-
                     nnnnnnn
 
-      optional arguments:
+      <options_string>:
         -h, --help  show this help message and exit
       """
 

--- a/tools/spellcheck-allowed-words.txt
+++ b/tools/spellcheck-allowed-words.txt
@@ -61,6 +61,8 @@ EOL
 EPILOG
 esm
 ESM
+ETAG
+etag
 experied
 F401
 FedRAMP

--- a/uaclient/api/tests/test_api_u_pro_security_cves_v1.py
+++ b/uaclient/api/tests/test_api_u_pro_security_cves_v1.py
@@ -308,12 +308,15 @@ class TestCVEs:
     )
     @mock.patch(M_PATH + "get_apt_cache_datetime")
     @mock.patch(M_VULN_COMMON_PATH + "VulnerabilityData.get")
-    @mock.patch(M_VULN_COMMON_PATH + "VulnerabilityData.is_cache_valid")
+    @mock.patch(
+        M_VULN_COMMON_PATH + "VulnerabilityData.refreshed",
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch(M_VULN_COMMON_PATH + "query_installed_source_pkg_versions")
     def test_parse_data(
         self,
         m_get_source_pkgs,
-        m_vulnerability_data_is_cache_valid,
+        m_vulnerability_data_refreshed,
         m_vulnerability_data_get,
         m_get_apt_cache_datetime,
         _m_vulnerability_result_save_cache,
@@ -322,7 +325,7 @@ class TestCVEs:
         cve_options,
         expected_result,
     ):
-        m_vulnerability_data_is_cache_valid.return_value = (False, None)
+        m_vulnerability_data_refreshed.return_vale = True
         m_get_source_pkgs.return_value = installed_pkgs_by_source
         m_vulnerability_data_get.return_value = copy.deepcopy(
             vulnerabilities_data

--- a/uaclient/cli/cve.py
+++ b/uaclient/cli/cve.py
@@ -1,3 +1,4 @@
+import sys
 import textwrap
 from collections import namedtuple
 
@@ -89,13 +90,14 @@ def action_cve(args, *, cfg, **kwargs):
         )
 
         if not cve_data:
-            series = system.get_release_info().series
+            release = system.get_release_info().release
             print(
                 messages.CLI_CVE_NOT_FOUND_IN_DATA.format(
                     issue=args.cve,
-                    series=series,
+                    release=release,
                     url="{}/{}".format(defaults.BASE_SECURITY_URL, cve_name),
-                )
+                ),
+                file=sys.stderr,
             )
             return
 

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -30,7 +30,7 @@ PRIVATE_ESM_CACHE_SUBDIR = "apt-esm"
 VULNERABILITY_SUBDIR = "vulnerability-data"
 VULNERABILITY_DATA_CACHE = "vulnerability-cache.json"
 VULNERABILITY_RESULT_CACHE = "vulnerability-result.json"
-VULNERABILITY_PUBLISH_DATE_CACHE = "vulnerability-publish-date"
+VULNERABILITY_ETAG_CACHE = "vulnerability-etag"
 VULNERABILITY_DPKG_STATUS_DATE_CACHE = "vulnerability-dpkg-status-date"
 
 DEFAULT_PRIVATE_MACHINE_TOKEN_PATH = os.path.join(

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -667,3 +667,7 @@ class UnknownProcessorType(UbuntuProError):
 
 class FeatureNotSupportedOldTokenError(UbuntuProError):
     _formatted_msg = messages.E_FEATURE_NOT_SUPPORTED_OLD_TOKEN
+
+
+class ETagUnchanged(UbuntuProError):
+    _formatted_msg_ = messages.E_ETAG_UNCHANGED

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1239,8 +1239,8 @@ CLI_CVE_ISSUE = t.gettext(
 )
 CLI_CVE_NOT_FOUND_IN_DATA = t.gettext(
     """\
-{issue} not present in {series} security data.
-You may be able to find more information at:\n- {url}"""
+{issue} doesn't affect Ubuntu {release}.
+For more information, visit: {url}"""
 )
 
 CLI_CVES = t.gettext("list the vulnerabilities that affect the system")

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -2860,3 +2860,8 @@ E_FEATURE_NOT_SUPPORTED_OLD_TOKEN = FormattedNamedMessage(
         " format. Please detach and reattach to give this machine a new token."
     ),
 )
+
+E_ETAG_UNCHANGED = FormattedNamedMessage(
+    "etag-unchanged",
+    t.gettext("The etag for resource: {url} has not changed"),
+)


### PR DESCRIPTION
## Why is this needed?
We are now improving the error message for the case where a CVE is not in the vulnerability data on `pro cve` and also improving how we fetch the vulnerability data by relying on the etag of the resource.

## Test Steps
Guarantee that all cve related feature tests are still passing

- [x] *(un)check this to re-run the checklist action*