### PR TITLE
Bring releases 34.x changes from launchpad

### DIFF
--- a/apt-hook/Makefile
+++ b/apt-hook/Makefile
@@ -3,10 +3,10 @@ all: build
 build: json-hook
 
 json-hook: json-hook.cc
-	$(CXX) -Wall -Wextra -Wshadow -pedantic -std=c++11 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o json-hook json-hook-main.cc json-hook.cc esm-counts.cc -ljson-c -lapt-pkg $(LDLIBS)
+	$(CXX) -Wall -Wextra -Wshadow -pedantic -std=c++17 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o json-hook json-hook-main.cc json-hook.cc esm-counts.cc -ljson-c -lapt-pkg $(LDLIBS)
 
 test:
-	$(CXX) -Wall -Wextra -Wshadow -pedantic -std=c++11 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o json-hook-test json-hook.cc json-hook.test.cc esm-counts.cc -ljson-c -lapt-pkg -lboost_unit_test_framework $(LDLIBS)
+	$(CXX) -Wall -Wextra -Wshadow -pedantic -std=c++17 $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o json-hook-test json-hook.cc json-hook.test.cc esm-counts.cc -ljson-c -lapt-pkg -lboost_unit_test_framework $(LDLIBS)
 	./json-hook-test
 
 install-conf:

--- a/debian/changelog
+++ b/debian/changelog
@@ -46,6 +46,41 @@ ubuntu-advantage-tools (35) oracular; urgency=medium
 
  -- Lucas Moura <lucas.moura@canonical.com>  Tue, 08 Oct 2024 16:50:42 -0300
 
+ubuntu-advantage-tools (34.1.3) plucky; urgency=medium
+
+  * apt-hook: set C++ standards version to c++17 for APT 2.9.30 compatibility
+    (LP: #2098862)
+  * tests: remove argparse error tests from unit tests (LP: #2098862)
+
+ -- Renan Rodrigo <renanrodrigo@canonical.com>  Wed, 19 Feb 2025 11:53:40 -0300
+
+ubuntu-advantage-tools (34.1.2build1) plucky; urgency=high
+
+  * No change rebuild against libapt-pkg7.0.
+
+ -- Julian Andres Klode <juliank@ubuntu.com>  Mon, 17 Feb 2025 22:47:04 +0100
+
+ubuntu-advantage-tools (34.1.2) oracular; urgency=medium
+
+  * check-versions-are-consistent.py: fix regexp to cope with X.Y.Z version
+    formats
+  * version.py: bump to 34.1.2
+
+ -- Andreas Hasenack <andreas@canonical.com>  Fri, 04 Oct 2024 17:06:07 -0300
+
+ubuntu-advantage-tools (34.1.1) oracular; urgency=medium
+
+  * Bump version.py.
+
+ -- Robie Basak <robie.basak@ubuntu.com>  Fri, 04 Oct 2024 20:34:56 +0100
+
+ubuntu-advantage-tools (34.1) oracular; urgency=medium
+
+  * Drop direct dependency on python3-pkg-resources to resolve priority
+    mismatch (LP: #2083665)
+
+ -- Robie Basak <robie.basak@ubuntu.com>  Fri, 04 Oct 2024 17:51:47 +0100
+
 ubuntu-advantage-tools (34) oracular; urgency=medium
 
   * d/rules: check that version.py is consistent with changelog (GH: #3154)

--- a/debian/changelog
+++ b/debian/changelog
@@ -25,7 +25,7 @@ ubuntu-advantage-tools (35) oracular; urgency=medium
       + gcp: add minimal image license codes
     - cli:
       + add support for vulnerability commands:
-        * pro cves: List fixable cves in the machine
+        * pro cves: List cves in the machine
         * pro cve: Show information about a specific cve
       + deduplicate entries in 'pro help' output (LP: #2091327)
     - config: add option lxd_guest_attach to control LXD integration with Pro

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,25 +1,16 @@
 ubuntu-advantage-tools (35) oracular; urgency=medium
 
   * d/tests/usage: add more scenarios to dep8 tests
+  * d/control: drop strict dependency on python3-pkg-resources (LP: #2083665)
+  * d/rules: add conditional python3-pkg-resources dependency up to noble
   * New upstream release 35: (LP: #2083973)
     - api:
       + new endpoints:
         * u.pro.attach.guest.get_guest_token.v1: Get the Pro client guest
           token
-        * u.pro.config.v1: Show the Pro configuration in the machine
-        * u.pro.packages.updates_with_cves.v1: List the package updates
-          available and the CVEs that will be fixed by those updates
-        * u.pro.security.vulnerabilities.cve.v1: List the fixable CVEs that
-          affect the system
-        * u.pro.security.vulnerabilities.usn.v1: List the fixable USNs that
-          affect the system
-        * u.pro.services.list.v1: Show the services provided by Pro
-        * u.pro.status.notices.v1: Show the active Pro notices in the machine
-        * u.pro.subscription.v1: Show information about the Pro subscription
-          in the machine
-        * u.pro.token_info.v1: Show the Pro token information
-      + u.pro.packages.updates.v1: create new package
-        status: upgrade_available_not_preferred (GH: #3184)
+        * u.pro.security.cves.v1: List the fixable CVEs that affect the system
+      + u.pro.packages.updates.v1: create new package status:
+        upgrade_available_not_preferred (GH: #3184)
       + fixes for u.unattended_upgrades.status.v1:
         * do not crash when a Unattended-Upgrade config is missing
         * do not report unattended-upgrade disabled if any config is false
@@ -29,22 +20,24 @@ ubuntu-advantage-tools (35) oracular; urgency=medium
       + silence warnings when fetching apt-news (GH: #3209, LP: #2070095)
       + update logging for apt errors (GH: #3299)
       + only run the apt upgrade hook when run as root (LP: #2084677)
+    - auto-attach:
+      + aws: skip operation if no product codes found
+      + gcp: add minimal image license codes
     - cli:
       + add support for vulnerability commands:
-        * pro vulnerability list: List fixable vulnerabilities in the machine
-        * pro vulnerability show: Show information about an affected
-          vulnerability
-        * pro vulnerability update: Update the vulnerability data on the
-          machine
+        * pro cves: List fixable cves in the machine
+        * pro cve: Show information about a specific cve
+      + deduplicate entries in 'pro help' output (LP: #2091327)
     - config: add option lxd_guest_attach to control LXD integration with Pro
     - contract:
       + check onlySeries on reboot (GH: #3189)
       + collect cpu type for activity info
     - landscape:
       + update message if service not available through Pro (GH: #3331)
+    - livepatch: do not enable livepatch on wsl (GH: #3156)
     - lxd: allow pro auto-attach to work on a LXD container
 
- -- Lucas Moura <lucas.moura@canonical.com>  Tue, 08 Oct 2024 16:50:42 -0300
+ -- Renan Rodrigo <renanrodrigo@canonical.com>  Thu, 20 Feb 2025 12:00:14 -0300
 
 ubuntu-advantage-tools (34.1.3) plucky; urgency=medium
 

--- a/features/cli/config.feature
+++ b/features/cli/config.feature
@@ -50,6 +50,16 @@ Feature: CLI config command
     Then I will see the following on stderr:
       """
       """
+    When I verify that running `pro config invalid` `as non-root` exits `2`
+    Then I will see the following on stdout:
+      """
+      """
+    # When testing on plucky, the '' in the options need to be removed.
+    Then I will see the following on stderr:
+      """
+      usage: pro config [-h] {show,set,unset} ...
+      pro config: error: argument command: invalid choice: 'invalid' (choose from 'show', 'set', 'unset')
+      """
 
     Examples: ubuntu release
       | release  | machine_type  |

--- a/uaclient/cli/tests/test_cli_config_show.py
+++ b/uaclient/cli/tests/test_cli_config_show.py
@@ -1,36 +1,9 @@
 import mock
 import pytest
 
-from uaclient.cli import main
 from uaclient.cli.config import show_subcommand
 
 M_PATH = "uaclient.cli."
-
-
-@mock.patch("uaclient.cli.logging.error")
-@mock.patch("uaclient.log.setup_cli_logging")
-@mock.patch("uaclient.contract.get_available_resources")
-class TestMainConfigShow:
-    def test_config_show_error_on_invalid_subcommand(
-        self, _m_resources, _logging, _logging_error, capsys, FakeConfig
-    ):
-        """Exit 1 on invalid subcommands."""
-        with pytest.raises(SystemExit):
-            with mock.patch("sys.argv", ["/usr/bin/ua", "config", "invalid"]):
-                with mock.patch(
-                    "uaclient.config.UAConfig",
-                    return_value=FakeConfig(),
-                ):
-                    main()
-        out, err = capsys.readouterr()
-        assert "" == out
-        expected_logs = [
-            "usage: pro config [-h] {show,set,unset} ...",
-            "argument command: invalid choice: 'invalid' (choose from 'show',"
-            " 'set', 'unset')",
-        ]
-        for log in expected_logs:
-            assert log in err
 
 
 class TestActionConfigShow:

--- a/uaclient/cli/tests/test_cli_security_status.py
+++ b/uaclient/cli/tests/test_cli_security_status.py
@@ -1,7 +1,6 @@
 import mock
 import pytest
 
-from uaclient.cli import main
 from uaclient.cli.security_status import security_status_command
 from uaclient.util import DatetimeAwareJSONEncoder
 
@@ -56,40 +55,3 @@ class TestActionSecurityStatus:
             assert m_safe_dump.call_count == 0
             assert m_security_status.call_args_list == [mock.call(cfg)]
             assert m_security_status.call_count == 1
-
-    # This will be an integration test in the future
-    # need to sanitize the whole module
-    @mock.patch("uaclient.cli.log.setup_cli_logging")
-    def test_error_on_wrong_format(
-        self,
-        _m_setup_logging,
-        _m_resources,
-        _m_security_status_dict,
-        _m_security_status,
-        FakeConfig,
-        capsys,
-    ):
-        cmdline_args = [
-            "/usr/bin/ua",
-            "security-status",
-            "--format",
-            "unsupported",
-        ]
-
-        with pytest.raises(SystemExit):
-            with mock.patch("sys.argv", cmdline_args):
-                with mock.patch(
-                    "uaclient.config.UAConfig",
-                    return_value=FakeConfig(),
-                ):
-                    main()
-
-        _, err = capsys.readouterr()
-        assert (
-            "usage: pro security-status [-h] [--format {json,yaml,text}]"
-            in err
-        )
-        assert (
-            "argument --format: invalid choice: 'unsupported'"
-            " (choose from 'json', 'yaml', 'text')"
-        ) in err


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it syncs the LP changes with what we have here, to facilitate reviews and uploads.

A couple changes appear only in the changelog (python3-pkg-resources dependency and version check) because they have been applied in a better way in the current codebase, the LP versions were workarounds.

I also updated the actual changelog for v35 here.


## Test Steps
Make sure CI works as it was working before

---

- [x] *(un)check this to re-run the checklist action*