### PR TITLE
fips: include `openssl-fips-module-3` when enabling FIPS on Jammy

### DIFF
--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -307,7 +307,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         install_all_updates_override = util.is_config_value_true(
             config=self.cfg.cfg, path_to_value="features.fips_auto_upgrade_all"
         )
-        # noble onward automatically uses new auto-upgrade logic
+        # jammy onward automatically uses new auto-upgrade logic
         hardcoded_release = system.get_release_info().series in {
             "xenial",
             "bionic",
@@ -324,6 +324,10 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 self.origin
             )
         ]
+
+        # See GH #3390
+        if system.get_release_info().series == "jammy":
+            to_upgrade.append("openssl-fips-module-3")
 
         to_upgrade.sort()
         if len(to_upgrade) > 0:


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it

Fixes: #3390 

This is a temporary fix for the bug, as it only includes the missing package when calculating what to install/upgrade on Jammy.
There are ongoing conversations with @Ek0n about creating a metapackage for containers, only with the userspace dependencies, and this will be a definitive solution in the future.


## Test Steps
Enable `fips-updates` or `fips-preview` on Jammy, and verify `openssl-fips-module-3` is present.

---

- [x] *(un)check this to re-run the checklist action*