### PR TITLE
usg: install the `usg` package when enabling

### DIFF
--- a/features/usg.feature
+++ b/features/usg.feature
@@ -10,10 +10,13 @@ Feature: Enable usg on Ubuntu
       One moment, checking your subscription first
       Configuring APT access to Ubuntu Security Guide
       Updating Ubuntu Security Guide package lists
+      Updating standard Ubuntu package lists
+      Installing Ubuntu Security Guide packages
       Ubuntu Security Guide enabled
       Visit https://ubuntu.com/security/certifications/docs/usg for the next steps
       """
     And I verify that `usg` is enabled
+    And I verify that `usg` is installed
     When I run `pro disable usg` with sudo
     Then stdout matches regexp:
       """

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -30,7 +30,7 @@ class CISEntitlement(repo.RepoEntitlement):
     @property
     def packages(self) -> List[str]:
         if self._called_name == "usg":
-            return []
+            return ["usg"]
         return super().packages
 
     @property

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -65,7 +65,7 @@ class TestCISEntitlement:
         "called_name,expected",
         (
             ("cis", ["test-package"]),
-            ("usg", []),
+            ("usg", ["usg"]),
         ),
     )
     def test_packages(self, called_name, expected, cis_entitlement):


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because when the user runs `pro enable usg`, it is expected by product that `usg` is installed in the system.

In time: I know this could be done via contracts, setting `additionalPackages` there - but we would still need a workaround for `focal`, so change by change I preferred this one.
If in the future having this hardcoded bite us back, we can consider changing the resource in the backend.
Note that the USG resource already has this in place, it's just the CIS resource that will not return the additionalPackages we expect. But that is the resource this client will be using.

## Test Steps
enable usg on a machine
verify the usg package is installed

---

- [x] *(un)check this to re-run the checklist action*