### PR TITLE
ci: bump has-signed-canonical-cla

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@v2


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because cla check v2 is here

Fixes: #3408

## Test Steps
just make sure the check still works in the CI runs

---

- [x] *(un)check this to re-run the checklist action*