### PR TITLE
Add Anbox Cloud to recommended services

### DIFF
--- a/custom_wordlist.txt
+++ b/custom_wordlist.txt
@@ -104,6 +104,7 @@ ROS
 runtime
 Runtime
 SaaS
+scalable
 SecurityIssueNotFixedData
 Specialty
 SRU

--- a/docs/explanations/which_services.rst
+++ b/docs/explanations/which_services.rst
@@ -19,25 +19,6 @@ that stream specifically on those machines.
 
     .. tab-item:: Commercial
 
-       * **Anbox Cloud**
-
-         Canonical Anbox Cloud makes large-scale Android development easier by
-         running Android in secure, scalable containers or virtual machines.
-
-         Compared to other Android emulation solutions, Anbox Cloud can provide
-         at least twice the density and can serve up to 100 Android instances per
-         server.
-
-         Due to its highly scalable nature and performance optimization, Anbox Cloud enables
-         delivering device-agnostic mobile applications. Popular use cases of Anbox Cloud
-         include mobile game streaming services, corporate application streaming,
-         application automation and testing.
-
-         * `Try the appliance`_ variant offered by Anbox Cloud.
-
-         * Find out more about Anbox Cloud in the `official documentation`_.
-
-
        * **Expanded Security Maintenance (ESM)**
 
          If you're using any Ubuntu LTS -- Desktop or Server -- in a commercial
@@ -158,7 +139,24 @@ that stream specifically on those machines.
 
        Want more information?
 
-    .. tab-item:: Specialty services
+    .. tab-item:: Specialty products
+
+       * **Anbox Cloud**
+        
+         Canonical Anbox Cloud makes large-scale Android development easier by
+         running Android in secure, scalable containers or virtual machines. 
+         Compared to other Android emulation solutions, Anbox Cloud can provide
+         at least twice the density and can serve up to 100 Android instances per
+         server.
+
+         Due to its highly scalable nature and performance optimization, Anbox Cloud
+         enables delivering device-agnostic mobile applications. Popular use cases
+         of Anbox Cloud include mobile game streaming services,
+         corporate application streaming, application automation and testing.
+
+         :ref:`Enabling the Anbox Cloud service <manage-anbox>` lets you try out
+         the Anbox Cloud Appliance. Anbox Cloud also has a charm-based offering
+         for deployments in production. Find out more in the `official documentation`_.
 
        * **ROS ESM**
 
@@ -189,7 +187,7 @@ that stream specifically on those machines.
            do for your organisation. 
 
          * Or see our guide on
-           :ref:`how to enable the real-time kernel<manage-realtime>`. 
+           :ref:`how to enable the real-time kernel<manage-realtime>`.
 
        Want more information?
        
@@ -204,6 +202,5 @@ that stream specifically on those machines.
 .. _self-hosted: https://ubuntu.com/landscape/pricing
 .. _Landscape SaaS: https://ubuntu.com/landscape/pricing
 .. _more information about real-time Ubuntu: https://ubuntu.com/kernel/real-time/contact-us
-.. _Try the appliance: https://documentation.ubuntu.com/anbox-cloud/tutorial/installing-appliance/
 .. _official documentation: https://documentation.ubuntu.com/anbox-cloud/
 

--- a/docs/explanations/which_services.rst
+++ b/docs/explanations/which_services.rst
@@ -149,7 +149,7 @@ that stream specifically on those machines.
          at least twice the density and can serve up to 100 Android instances per
          server.
 
-         Due to its highly scalable nature and performance optimization, Anbox Cloud
+         Due to its highly scalable nature and performance optimisation, Anbox Cloud
          enables delivering device-agnostic mobile applications. Popular use cases
          of Anbox Cloud include mobile game streaming services,
          corporate application streaming, application automation and testing.

--- a/docs/explanations/which_services.rst
+++ b/docs/explanations/which_services.rst
@@ -19,6 +19,25 @@ that stream specifically on those machines.
 
     .. tab-item:: Commercial
 
+       * **Anbox Cloud**
+
+         Canonical Anbox Cloud makes large-scale Android development easier by
+         running Android in secure, scalable containers or virtual machines.
+
+         Compared to other Android emulation solutions, Anbox Cloud can provide
+         at least twice the density and can serve up to 100 Android instances per
+         server.
+
+         Due to its highly scalable nature and performance optimization, Anbox Cloud enables
+         delivering device-agnostic mobile applications. Popular use cases of Anbox Cloud
+         include mobile game streaming services, corporate application streaming,
+         application automation and testing.
+
+         * `Try the appliance`_ variant offered by Anbox Cloud.
+
+         * Find out more about Anbox Cloud in the `official documentation`_.
+
+
        * **Expanded Security Maintenance (ESM)**
 
          If you're using any Ubuntu LTS -- Desktop or Server -- in a commercial
@@ -185,4 +204,6 @@ that stream specifically on those machines.
 .. _self-hosted: https://ubuntu.com/landscape/pricing
 .. _Landscape SaaS: https://ubuntu.com/landscape/pricing
 .. _more information about real-time Ubuntu: https://ubuntu.com/kernel/real-time/contact-us
+.. _Try the appliance: https://documentation.ubuntu.com/anbox-cloud/tutorial/installing-appliance/
+.. _official documentation: https://documentation.ubuntu.com/anbox-cloud/
 


### PR DESCRIPTION
## Why is this needed?
Anbox Cloud is a service available via Ubuntu Pro and hence it should be included in the services topic.

- [ ] *(un)check this to re-run the checklist action*