### PR TITLE
postrm: remove /var/lib/ubuntu-pro cache dir on purge

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ ubuntu-advantage-tools (35) plucky; urgency=medium
   * d/tests/usage: add more scenarios to dep8 tests
   * d/control: drop strict dependency on python3-pkg-resources (LP: #2083665)
   * d/rules: add conditional python3-pkg-resources dependency up to noble
+  * d/ubuntu-pro-client.postrm: remove /var/lib/ubuntu-pro cache dir on purge
   * New upstream release 35: (LP: #2083973)
     - api:
       + new endpoints:

--- a/debian/ubuntu-pro-client.postrm
+++ b/debian/ubuntu-pro-client.postrm
@@ -10,6 +10,7 @@ remove_apt_auth(){
 
 remove_cache_dir(){
     rm -rf /var/lib/ubuntu-advantage
+    rm -rf /var/lib/ubuntu-pro
 }
 
 remove_logs(){


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because there is a new `/var/lib` directory around, and it should go away when the package is purged.

Purging `ubuntu-advantage-tools` is not really supported but we can make sure it is doing the right thing

## Test Steps
- `sudo apt purge ubuntu-advantage-tools`
- make sure `/var/lib/ubuntu-pro` is gone for good

---

- [ ] *(un)check this to re-run the checklist action*