### PR TITLE
docs: standardize the page header to match the Ubuntu Pro Handbook

### DIFF
--- a/docs/_static/css/header.css
+++ b/docs/_static/css/header.css
@@ -30,7 +30,7 @@ ul.p-navigation__links {
   margin-left: 0;
   margin-top: auto;
   margin-bottom: auto;
-  max-width: 800px;
+  max-width: 1000px;
   width: 100%;
 }
 
@@ -73,26 +73,18 @@ ul.p-navigation__links .p-navigation__link:hover {
 }
 
 ul.p-navigation__links .p-dropdown__link:hover {
-  background-color: var(--color-sidebar-item-background--hover);
+  background-color: #2b2b2b;
 }
 
 ul.p-navigation__links .p-navigation__sub-link {
-  background: var(--color-background-primary);
+  background: #333333;
   padding: .5rem 0 .5rem .5rem;
   font-weight: 300;
 }
 
-ul.p-navigation__links .more-links-dropdown li a {
-  border-left: 1px solid var(--color-sidebar-background-border);
-  border-right: 1px solid var(--color-sidebar-background-border);
-}
-
-ul.p-navigation__links .more-links-dropdown li:first-child a {
-  border-top: 1px solid var(--color-sidebar-background-border);
-}
-
-ul.p-navigation__links .more-links-dropdown li:last-child a {
-  border-bottom: 1px solid var(--color-sidebar-background-border);
+ul.p-navigation__links .pro-services-dropdown li a {
+  color: #ffffff;
+  text-decoration: none;
 }
 
 ul.p-navigation__links .p-navigation__logo {
@@ -103,7 +95,7 @@ ul.p-navigation__links .p-navigation__logo img {
   width: 40px;
 }
 
-ul.more-links-dropdown {
+ul.pro-services-dropdown {
   display: none;
   overflow-x: visible;
   height: 0;
@@ -115,7 +107,7 @@ ul.more-links-dropdown {
   margin-top: 0;
 }
 
-.nav-more-links::after {
+.nav-pro-services::after {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='%23111' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
   background-position: center;
   background-repeat: no-repeat;
@@ -136,6 +128,10 @@ ul.more-links-dropdown {
   display: none;
 }
 
+.nav-highlighted {
+  border-bottom: 5px solid #DD4814;
+}
+
 @media only screen and (min-width: 480px) {
   ul.p-navigation__links li {
     width: 100%;
@@ -147,7 +143,7 @@ ul.more-links-dropdown {
 }
 
 @media only screen and (max-width: 800px) {
-  .nav-more-links {
+  .nav-pro-services {
     margin-left: auto !important;
     padding-right: 2rem !important;
     width: 8rem !important;

--- a/docs/_static/js/header-nav.js
+++ b/docs/_static/js/header-nav.js
@@ -1,10 +1,10 @@
 $(document).ready(function() {
     $(document).on("click", function () {
-        $(".more-links-dropdown").hide();
+        $(".pro-services-dropdown").hide();
     });
 
-    $('.nav-more-links').click(function(event) {
-        $('.more-links-dropdown').toggle();
+    $('.nav-pro-services').click(function(event) {
+        $('.pro-services-dropdown').toggle();
         event.stopPropagation();
     });
 })

--- a/docs/_templates/header.html
+++ b/docs/_templates/header.html
@@ -13,17 +13,16 @@
       </li>
 
       <li class="nav-ubuntu-com">
-        <a href="https://discourse.ubuntu.com/c/ubuntu-pro/116" class="p-navigation__link">Forum</a>
-      </li>
-      
-      <li class="nav-ubuntu-com">
-        <a href="https://discourse.ubuntu.com/t/ubuntu-pro-faq/34042" class="p-navigation__link">Ubuntu Pro FAQ</a>
+        <a href="https://documentation.ubuntu.com/pro" class="p-navigation__link">Pro overview</a>
       </li>
 
+      <li class="nav-ubuntu-com nav-highlighted">
+        <a href="https://canonical-ubuntu-pro-client.readthedocs-hosted.com" class="p-navigation__link">Pro Client</a>
+      </li>
 
       <li>
-        <a href="#" class="p-navigation__link nav-more-links">Pro services</a>
-        <ul class="more-links-dropdown">
+        <a href="#" class="p-navigation__link nav-pro-services">Pro services</a>
+        <ul class="pro-services-dropdown">
 
           <li>
             <a href="https://ubuntu.com/security/esm" class="p-navigation__sub-link p-dropdown__link">Expanded Security Maintenance (ESM)</a>
@@ -37,26 +36,21 @@
             <a href="https://ubuntu.com/security/fips" class="p-navigation__sub-link p-dropdown__link">FIPS 140-2</a>
           </li>
 
-
           <li>
             <a href="https://ubuntu.com/security/certifications/docs/usg" class="p-navigation__sub-link p-dropdown__link">Ubuntu Security Guide (USG)</a>
           </li>
-
-
-          <li>
-            <a href="https://ubuntu.com/security/cis" class="p-navigation__sub-link p-dropdown__link">CIS benchmarking</a>
-          </li>
-
 
           <li>
             <a href="https://ubuntu.com/security/cc" class="p-navigation__sub-link p-dropdown__link">Common Criteria EAL2</a>
           </li>
 
+          <li>
+            <a href="https://anbox-cloud.io/" class="p-navigation__sub-link p-dropdown__link">Anbox Cloud</a>
+          </li>
 
           <li>
             <a href="https://ubuntu.com/robotics/ros-esm" class="p-navigation__sub-link p-dropdown__link">ROS ESM</a>
           </li>
-
 
           <li>
             <a href="https://ubuntu.com/realtime-kernel" class="p-navigation__sub-link p-dropdown__link">Real-time kernel</a>

--- a/docs/_templates/sidebar/search.html
+++ b/docs/_templates/sidebar/search.html
@@ -1,0 +1,7 @@
+<form class="sidebar-search-container" method="get" action="{{ pathto('search') }}" role="search">
+    <input class="sidebar-search" placeholder="{{ _("Search") }}" name="q" aria-label="{{ _("Search" ) }}">
+    <input type="submit" value="Go">
+    <input type="hidden" name="check_keywords" value="yes">
+    <input type="hidden" name="area" value="default">
+  </form>
+  <div id="searchbox"></div>


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it addresses SD-1780 - this is part of the effort to implement a seamless-like experience for users reading the Ubuntu Pro Client docs and the Ubuntu Pro Handbook

- added links to the handbook and to the CLI docs to the header, highlighting the CLI one here
- Removed cis and added anbox to the pro services dropdown
- JS and CSS to make dropdowns work and adjust header size (ugly ugly but that's what it is)

Please review and merge this together with https://github.com/canonical/ubuntu-pro-docs/pull/61

## Test Steps
Build docs and see the magic, ahem

---

- [ ] *(un)check this to re-run the checklist action*