### PR TITLE
cli: do not overwrite file on collect-logs

### DIFF
--- a/features/cli/collect_logs.feature
+++ b/features/cli/collect_logs.feature
@@ -38,6 +38,14 @@ Feature: CLI collect-logs command
       ubuntu-advantage.log.2.gz
       ubuntu-advantage.service.txt
       """
+    When I verify that running `pro collect-logs -o pro_logs.tar.gz` `with sudo` exits `1`
+    Then stderr matches regexp:
+      """
+      The file pro_logs.tar.gz already exists in the system.
+      """
+    When I run `rm pro_logs.tar.gz` with sudo
+    And I run `pro collect-logs` <user_spec>
+    Then I verify that files exist matching `pro_logs.tar.gz`
 
     Examples: ubuntu release
       | release  | machine_type  | user_spec   |
@@ -89,6 +97,19 @@ Feature: CLI collect-logs command
       ubuntu-esm-apps.(list|sources)
       ubuntu-esm-infra.(list|sources)
       """
+    When I verify that running `pro collect-logs -o pro_logs.tar.gz` `with sudo` exits `1`
+    Then stderr matches regexp:
+      """
+      The file pro_logs.tar.gz already exists in the system.
+      """
+    When I verify that running `pro collect-logs -o pro_logs.tar.gz` `with sudo` exits `1`
+    Then stderr matches regexp:
+      """
+      The file pro_logs.tar.gz already exists in the system.
+      """
+    When I run `rm pro_logs.tar.gz` with sudo
+    And I run `pro collect-logs` <user_spec>
+    Then I verify that files exist matching `pro_logs.tar.gz`
 
     Examples: ubuntu release
       | release | machine_type  | user_spec   |

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -92,11 +92,11 @@ Feature: Pro Client help text
       Collect logs and relevant system information into a tarball.
       This information can be later used for triaging/debugging issues.
 
-      <options_string>:
+      optional arguments:
         -h, --help            show this help message and exit
         -o OUTPUT, --output OUTPUT
                               tarball where the logs will be stored. (Defaults to
-                              ./pro_logs.tar.gz)
+                              ./pro_logs.tar.gz).
       """
     When I run `pro api --help` as non-root
     Then stdout matches regexp:

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -92,7 +92,7 @@ Feature: Pro Client help text
       Collect logs and relevant system information into a tarball.
       This information can be later used for triaging/debugging issues.
 
-      optional arguments:
+      <options_string>:
         -h, --help            show this help message and exit
         -o OUTPUT, --output OUTPUT
                               tarball where the logs will be stored. (Defaults to

--- a/uaclient/cli/collect_logs.py
+++ b/uaclient/cli/collect_logs.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import tarfile
 import tempfile
 
@@ -17,11 +18,21 @@ def action_collect_logs(args, *, cfg, **kwargs):
     with tempfile.TemporaryDirectory() as output_dir:
         collect_logs(cfg, output_dir)
         try:
-            with tarfile.open(output_file, "w:gz") as results:
+            with tarfile.open(output_file, "x:gz") as results:
                 results.add(output_dir, arcname="logs/")
         except PermissionError as e:
             LOG.error(e)
             return 1
+        except FileExistsError as e:
+            LOG.error(e)
+            print(
+                messages.E_FILE_ALREADY_EXISTS.format(
+                    filename=output_file,
+                ),
+                file=sys.stderr,
+            )
+            return 1
+
     return 0
 
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -942,7 +942,8 @@ Collect logs and relevant system information into a tarball.
 This information can be later used for triaging/debugging issues."""
 )
 CLI_COLLECT_LOGS_OUTPUT = t.gettext(
-    "tarball where the logs will be stored. (Defaults to " "./pro_logs.tar.gz)"
+    """\
+tarball where the logs will be stored. (Defaults to ./pro_logs.tar.gz)."""
 )
 
 CLI_CONFIG_SHOW_DESC = t.gettext("Show customizable configuration settings.")
@@ -2864,4 +2865,9 @@ E_FEATURE_NOT_SUPPORTED_OLD_TOKEN = FormattedNamedMessage(
 E_ETAG_UNCHANGED = FormattedNamedMessage(
     "etag-unchanged",
     t.gettext("The etag for resource: {url} has not changed"),
+)
+
+E_FILE_ALREADY_EXISTS = FormattedNamedMessage(
+    "file-already-exists",
+    t.gettext("The file {filename} already exists in the system."),
 )


### PR DESCRIPTION
## Why is this needed?
We no longer override any file when an user runs the collect-logs command


## Test Steps
Check that the modified integration tests are passing


---

- [x] *(un)check this to re-run the checklist action*