### PR TITLE
cli: update Anbox installation output message

### DIFF
--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -96,11 +96,11 @@ Feature: Enable anbox on Ubuntu
       The `prepare-node-script` command lets you preview a script that installs some additional packages,
       kernel modules and GPU driver packages, if a GPU is available:
 
-      $ anbox-cloud-appliance prepare-node-script
+      $ anbox-cloud-appliance prepare-node-script > prepare.sh
 
-      Once you have previewed the script, apply it to complete the installation:
+      Preview the script and when ready, apply it to complete the installation:
 
-      $ anbox-cloud-appliance prepare-node-script | sudo bash -ex
+      $ sudo bash -ex prepare.sh
 
       Once installed, to initialise Anbox Cloud, run:
 

--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -90,7 +90,19 @@ Feature: Enable anbox on Ubuntu
       Configuring APT access to Anbox Cloud
       Updating Anbox Cloud package lists
       Anbox Cloud enabled
-      To finish setting up the Anbox Cloud Appliance, run:
+      To finish setting up the Anbox Cloud Appliance, run the following commands
+      sequentially:
+
+      The `prepare-node-script` command lets you preview a script that installs some additional packages,
+      kernel modules and GPU driver packages, if a GPU is available:
+
+      $ anbox-cloud-appliance prepare-node-script
+
+      Once you have previewed the script, apply it to complete the installation:
+
+      $ anbox-cloud-appliance prepare-node-script | sudo bash -ex
+
+      Once installed, to initialise Anbox Cloud, run:
 
       $ sudo anbox-cloud-appliance init
 

--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -102,13 +102,13 @@ Feature: Enable anbox on Ubuntu
 
       $ sudo bash -ex prepare.sh
 
-      Once installed, to initialise Anbox Cloud, run:
+      Once installed, to initialize Anbox Cloud, run:
 
       $ sudo anbox-cloud-appliance init
 
       You can accept the default answers if you do not have any specific
       configuration changes.
-      For more information, see https://anbox-cloud.io/docs/tut/installing-appliance#initialise
+      For more information, see https://documentation.ubuntu.com/anbox-cloud/tutorial/installing-appliance/#initialize-the-appliance
       """
     Then I verify that `anbox-cloud` is enabled
     When I run `apt-cache policy` with sudo

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1294,7 +1294,19 @@ image server credentials. To learn more about Anbox Cloud, see
 ).format(url=urls.ANBOX_HOME_PAGE)
 ANBOX_RUN_INIT_CMD = t.gettext(
     """\
-To finish setting up the Anbox Cloud Appliance, run:
+To finish setting up the Anbox Cloud Appliance, run the following commands
+sequentially:
+
+The following command lets you preview a script that installs some additional packages,
+kernel modules and GPU driver packages, if a GPU is available:
+
+$ anbox-cloud-appliance prepare-node-script
+
+Once you have previewed the script, apply it to complete the installation:
+
+$ anbox-cloud-appliance prepare-node-script | sudo bash -ex
+
+Once installed, to initialise Anbox Cloud, run:
 
 $ sudo anbox-cloud-appliance init
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1297,7 +1297,7 @@ ANBOX_RUN_INIT_CMD = t.gettext(
 To finish setting up the Anbox Cloud Appliance, run the following commands
 sequentially:
 
-The following command lets you preview a script that installs some additional packages,
+The `prepare-node-script` command lets you preview a script that installs some additional packages,
 kernel modules and GPU driver packages, if a GPU is available:
 
 $ anbox-cloud-appliance prepare-node-script

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1307,7 +1307,7 @@ Preview the script and when ready, apply it to complete the installation:
 
 $ sudo bash -ex prepare.sh
 
-Once installed, to initialise Anbox Cloud, run:
+Once installed, to initialize Anbox Cloud, run:
 
 $ sudo anbox-cloud-appliance init
 

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -1297,14 +1297,15 @@ ANBOX_RUN_INIT_CMD = t.gettext(
 To finish setting up the Anbox Cloud Appliance, run the following commands
 sequentially:
 
-The `prepare-node-script` command lets you preview a script that installs some additional packages,
-kernel modules and GPU driver packages, if a GPU is available:
+The `prepare-node-script` command lets you preview a script that installs some
+additional packages, kernel modules and GPU driver packages, if a GPU is
+available:
 
-$ anbox-cloud-appliance prepare-node-script
+$ anbox-cloud-appliance prepare-node-script > prepare.sh
 
-Once you have previewed the script, apply it to complete the installation:
+Preview the script and when ready, apply it to complete the installation:
 
-$ anbox-cloud-appliance prepare-node-script | sudo bash -ex
+$ sudo bash -ex prepare.sh
 
 Once installed, to initialise Anbox Cloud, run:
 

--- a/uaclient/messages/urls.py
+++ b/uaclient/messages/urls.py
@@ -24,7 +24,7 @@ PRO_ON_AZURE_HOME_PAGE = "https://ubuntu.com/azure/pro"
 PRO_ON_GCP_HOME_PAGE = "https://ubuntu.com/gcp/pro"
 
 ANBOX_HOME_PAGE = "https://anbox-cloud.io"
-ANBOX_DOCS_APPLIANCE_INITIALIZE = "https://anbox-cloud.io/docs/tutorial/installing-appliance/#initialize-the-appliance"
+ANBOX_DOCS_APPLIANCE_INITIALIZE = "https://anbox-cloud.io/docs/tutorial/installing-appliance/#initialize-the-appliance"  # noqa: E501
 CIS_HOME_PAGE = "https://ubuntu.com/security/cis"
 COMMON_CRITERIA_HOME_PAGE = "https://ubuntu.com/security/cc"
 ESM_HOME_PAGE = "https://ubuntu.com/security/esm"

--- a/uaclient/messages/urls.py
+++ b/uaclient/messages/urls.py
@@ -24,9 +24,7 @@ PRO_ON_AZURE_HOME_PAGE = "https://ubuntu.com/azure/pro"
 PRO_ON_GCP_HOME_PAGE = "https://ubuntu.com/gcp/pro"
 
 ANBOX_HOME_PAGE = "https://anbox-cloud.io"
-ANBOX_DOCS_APPLIANCE_INITIALIZE = (
-    "https://documentation.ubuntu.com/anbox-cloud/tutorial/installing-appliance/#initialize-the-appliance"
-)
+ANBOX_DOCS_APPLIANCE_INITIALIZE = "https://anbox-cloud.io/docs/tutorial/installing-appliance/#initialize-the-appliance"
 CIS_HOME_PAGE = "https://ubuntu.com/security/cis"
 COMMON_CRITERIA_HOME_PAGE = "https://ubuntu.com/security/cc"
 ESM_HOME_PAGE = "https://ubuntu.com/security/esm"

--- a/uaclient/messages/urls.py
+++ b/uaclient/messages/urls.py
@@ -25,7 +25,7 @@ PRO_ON_GCP_HOME_PAGE = "https://ubuntu.com/gcp/pro"
 
 ANBOX_HOME_PAGE = "https://anbox-cloud.io"
 ANBOX_DOCS_APPLIANCE_INITIALIZE = (
-    "https://anbox-cloud.io/docs/tut/installing-appliance#initialise"
+    "https://documentation.ubuntu.com/anbox-cloud/tutorial/installing-appliance/#initialize-the-appliance"
 )
 CIS_HOME_PAGE = "https://ubuntu.com/security/cis"
 COMMON_CRITERIA_HOME_PAGE = "https://ubuntu.com/security/cc"


### PR DESCRIPTION
## Why is this needed?
The Anbox Cloud appliance installation message is missing a step before initialising it. Adding this to the CLI output so that users can follow the correct sequence of commands.

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
1. Enable `anbox-cloud` on Ubuntu Pro
2. Verify if the output contains the updated text.

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [ ] *(un)check this to re-run the checklist action*