### PR TITLE
Test adjustments for version 35 validation

### DIFF
--- a/features/cli/attach.feature
+++ b/features/cli/attach.feature
@@ -1,41 +1,42 @@
 @uses.config.contract_token
 Feature: CLI attach command
 
-  # To be uncommented when Oracular backend definitions are done (at least for landscape)
-  # Scenario Outline: Attached command in a non-lts ubuntu machine
-  # Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-  # When I attach `contract_token` with sudo
-  # And I run `pro status` as non-root
-  # Then stdout matches regexp:
-  # """
-  # <status_string>
-  # """
-  # And stdout matches regexp:
-  # """
-  # For a list of all Ubuntu Pro services, run 'pro status --all'
-  # """
-  # When I run `pro status --all` as non-root
-  # Then stdout matches regexp:
-  # """
-  # SERVICE       +ENTITLED +STATUS   +DESCRIPTION
-  # anbox-cloud   +yes      +n/a      +.*
-  # cc-eal        +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
-  # cis           +yes      +n/a      +Security compliance and audit tools
-  # esm-apps      +yes      +n/a      +Expanded Security Maintenance for Applications
-  # esm-infra     +yes      +n/a      +Expanded Security Maintenance for Infrastructure
-  # fips          +yes      +n/a      +NIST-certified FIPS crypto packages
-  # fips-preview  +yes      +n/a      +.*
-  # fips-updates  +yes      +n/a      +FIPS compliant crypto packages with stable security updates
-  # landscape     +yes      +<landscape>      +Management and administration tool for Ubuntu
-  # livepatch     +yes      +n/a      +Canonical Livepatch service
-  # """
-  # And stdout does not match regexp:
-  # """
-  # For a list of all Ubuntu Pro services, run 'pro status --all'
-  # """
-  # Examples: ubuntu release
-  # | release  | machine_type  | landscape | status_string                                                           |
-  # | oracular | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
+  Scenario Outline: Attached command in a non-lts ubuntu machine
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I attach `contract_token` with sudo
+    And I run `pro status` as non-root
+    Then stdout matches regexp:
+      """
+      <status_string>
+      """
+    And stdout matches regexp:
+      """
+      For a list of all Ubuntu Pro services, run 'pro status --all'
+      """
+    When I run `pro status --all` as non-root
+    Then stdout matches regexp:
+      """
+      SERVICE       +ENTITLED +STATUS   +DESCRIPTION
+      anbox-cloud   +yes      +n/a      +.*
+      cc-eal        +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
+      cis           +yes      +n/a      +Security compliance and audit tools
+      esm-apps      +yes      +n/a      +Expanded Security Maintenance for Applications
+      esm-infra     +yes      +n/a      +Expanded Security Maintenance for Infrastructure
+      fips          +yes      +n/a      +NIST-certified FIPS crypto packages
+      fips-preview  +yes      +n/a      +.*
+      fips-updates  +yes      +n/a      +FIPS compliant crypto packages with stable security updates
+      landscape     +yes      +<landscape>      +Management and administration tool for Ubuntu
+      livepatch     +yes      +n/a      +Canonical Livepatch service
+      """
+    And stdout does not match regexp:
+      """
+      For a list of all Ubuntu Pro services, run 'pro status --all'
+      """
+
+    Examples: ubuntu release
+      | release  | machine_type  | landscape | status_string                                                           |
+      | oracular | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
+
   Scenario Outline: Attach command with attach config
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # simplest happy path

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -367,7 +367,7 @@ Feature: Pro Client help text
       """
       usage: pro system [-h] {reboot-required} ...
 
-      Outputs system-related information about Pro services.
+      Output system-related information about Pro services.
 
       <options_string>:
         -h, --help         show this help message and exit
@@ -529,7 +529,7 @@ Feature: Pro Client help text
       {
         "name": "esm-infra",
         "entitled": "yes",
-        "status": "enabled",
+        "status": "<infra-status>",
         "help": "Expanded Security Maintenance for Infrastructure provides access to a private\nPPA which includes available high and critical CVE fixes for Ubuntu LTS\npackages in the Ubuntu Main repository between the end of the standard Ubuntu\nLTS security maintenance and its end of life. It is enabled by default with\nUbuntu Pro. You can find out more about the service at\nhttps://ubuntu.com/security/esm"
       }
       """

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -492,12 +492,13 @@ Feature: Pro Client help text
       """
 
     Examples: ubuntu release
-      | release | machine_type  | options_string     |
-      | xenial  | lxd-container | optional arguments |
-      | bionic  | lxd-container | optional arguments |
-      | focal   | lxd-container | optional arguments |
-      | jammy   | lxd-container | options            |
-      | noble   | lxd-container | options            |
+      | release  | machine_type  | options_string     |
+      | xenial   | lxd-container | optional arguments |
+      | bionic   | lxd-container | optional arguments |
+      | focal    | lxd-container | optional arguments |
+      | jammy    | lxd-container | options            |
+      | noble    | lxd-container | options            |
+      | oracular | lxd-container | options            |
 
   Scenario Outline: Help command on an attached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/security_status.feature
+++ b/features/cli/security_status.feature
@@ -88,7 +88,6 @@ Feature: CLI security-status command
       | release | machine_type  | package | service   |
       | xenial  | lxd-container | apport  | esm-infra |
       | bionic  | lxd-container | ansible | esm-apps  |
-      | bionic  | wsl           | ansible | esm-apps  |
 
   @uses.config.contract_token
   Scenario: Check for livepatch CVEs in security-status on an Ubuntu machine

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -442,6 +442,7 @@ Feature: CLI status command
       esm-apps        +yes      +enabled  +Expanded Security Maintenance for Applications
       esm-infra       +yes      +enabled  +Expanded Security Maintenance for Infrastructure
       landscape       +yes      +disabled +Management and administration tool for Ubuntu
+      usg             +yes      +disabled +Security compliance and audit tools
 
       For a list of all Ubuntu Pro services, run 'pro status --all'
       Enable services with: pro enable <service>
@@ -466,7 +467,7 @@ Feature: CLI status command
       └ raspi         +yes      +n/a      +24.04 Real-time kernel optimised for Raspberry Pi
       ros             +yes      +n/a      +Security Updates for the Robot Operating System
       ros-updates     +yes      +n/a      +All Updates for the Robot Operating System
-      usg             +yes      +n/a      +Security compliance and audit tools
+      usg             +yes      +disabled +Security compliance and audit tools
 
       Enable services with: pro enable <service>
       """
@@ -774,6 +775,7 @@ Feature: CLI status command
       landscape       +yes       +Management and administration tool for Ubuntu
       livepatch       +yes       +Canonical Livepatch service
       realtime-kernel +yes       +Ubuntu kernel with PREEMPT_RT patches integrated
+      usg             +yes       +Security compliance and audit tools
 
       For a list of all Ubuntu Pro services, run 'pro status --all'
 
@@ -797,7 +799,7 @@ Feature: CLI status command
       realtime-kernel +yes       +Ubuntu kernel with PREEMPT_RT patches integrated
       ros             +no        +Security Updates for the Robot Operating System
       ros-updates     +no        +All Updates for the Robot Operating System
-      usg             +no        +Security compliance and audit tools
+      usg             +yes       +Security compliance and audit tools
 
       This machine is not attached to an Ubuntu Pro subscription.
       See https://ubuntu.com/pro
@@ -818,6 +820,7 @@ Feature: CLI status command
       landscape       +yes       +Management and administration tool for Ubuntu
       livepatch       +yes       +Canonical Livepatch service
       realtime-kernel +yes       +Ubuntu kernel with PREEMPT_RT patches integrated
+      usg             +yes       +Security compliance and audit tools
 
       FEATURES
       allow_beta: True
@@ -965,6 +968,7 @@ Feature: CLI status command
       landscape       +yes       +yes       +no           +Management and administration tool for Ubuntu
       livepatch       +yes       +yes       +yes          +Canonical Livepatch service
       realtime-kernel +yes       +yes       +no           +Ubuntu kernel with PREEMPT_RT patches integrated
+      usg             +yes       +yes       +no           +Security compliance and audit tools
       """
     When I do a preflight check for `contract_token` with the all flag
     Then stdout matches regexp:
@@ -982,7 +986,7 @@ Feature: CLI status command
       realtime-kernel +yes       +yes       +no           +Ubuntu kernel with PREEMPT_RT patches integrated
       ros             +no        +yes       +no           +Security Updates for the Robot Operating System
       ros-updates     +no        +yes       +no           +All Updates for the Robot Operating System
-      usg             +no        +yes       +no           +Security compliance and audit tools
+      usg             +yes       +yes       +no           +Security compliance and audit tools
       """
 
     Examples: ubuntu release

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -379,7 +379,10 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       """
     When I apt remove `ubuntu-advantage-tools ubuntu-pro-client`
     When I run `cloud-init clean --logs` with sudo
+    When I run `systemctl mask cloud-config.service` with sudo
     When I reboot the machine
+    When I run `systemctl unmask cloud-config.service` with sudo
+    When I run `systemctl enable --now cloud-config.service` with sudo
     When I run `journalctl -b -o cat -u ubuntu-advantage.service` with sudo
     Then stdout contains substring:
       """

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -270,28 +270,29 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | jammy   | azure.generic |
       | noble   | azure.generic |
 
-  # Not available yet - uncomment when oracular is in the clouds
-  # @uses.config.contract_token
-  # Scenario Outline: daemon does not start on gcp,azure generic non lts
-  # Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-  # When I wait `1` seconds
-  # When I run `journalctl -o cat -u ubuntu-advantage.service` with sudo
-  # Then stdout contains substring:
-  # """
-  # daemon starting
-  # """
-  # Then stdout contains substring:
-  # """
-  # Not on LTS, shutting down
-  # """
-  # Then stdout contains substring:
-  # """
-  # daemon ending
-  # """
-  # Examples: version
-  # | release  | machine_type  |
-  # | oracular | azure.generic |
-  # | oracular | gcp.generic   |
+  @uses.config.contract_token
+  Scenario Outline: daemon does not start on gcp,azure generic non lts
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I wait `1` seconds
+    When I run `journalctl -o cat -u ubuntu-advantage.service` with sudo
+    Then stdout contains substring:
+      """
+      daemon starting
+      """
+    Then stdout contains substring:
+      """
+      Not on LTS, shutting down
+      """
+    Then stdout contains substring:
+      """
+      daemon ending
+      """
+
+    Examples: version
+      | release  | machine_type  |
+      | oracular | azure.generic |
+      | oracular | gcp.generic   |
+
   @uses.config.contract_token
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -312,14 +313,14 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       """
 
     Examples: version
-      | release | machine_type |
-      | xenial  | aws.generic  |
-      | bionic  | aws.generic  |
-      | focal   | aws.generic  |
-      | jammy   | aws.generic  |
-      | noble   | aws.generic  |
+      | release  | machine_type |
+      | xenial   | aws.generic  |
+      | bionic   | aws.generic  |
+      | focal    | aws.generic  |
+      | jammy    | aws.generic  |
+      | noble    | aws.generic  |
+      | oracular | aws.generic  |
 
-  # | oracular | aws.generic   | - not there yet
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I create the file `/etc/ubuntu-advantage/uaclient.conf` with the following:

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -104,7 +104,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
     Then on `xenial`, systemd status output says memory usage is less than `18` MB
     Then on `bionic`, systemd status output says memory usage is less than `15` MB
     Then on `focal`, systemd status output says memory usage is less than `14` MB
-    Then on `jammy`, systemd status output says memory usage is less than `14` MB
+    Then on `jammy`, systemd status output says memory usage is less than `15` MB
     Then on `noble`, systemd status output says memory usage is less than `17` MB
     When I run `journalctl -o cat -u ubuntu-advantage.service` with sudo
     Then stdout contains substring:

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -149,7 +149,7 @@ Feature: FIPS enablement in lxd VMs
       """
     And if `<release>` in `jammy` and stdout contains substring:
       """
-      Installing libcharon-extauth-plugins libstrongswan libstrongswan-standard-plugins openssh-client openssh-server openssh-sftp-server strongswan strongswan-charon strongswan-libcharon strongswan-starter
+      Installing libcharon-extauth-plugins libstrongswan libstrongswan-standard-plugins openssh-client openssh-server openssh-sftp-server openssl-fips-module-3 strongswan strongswan-charon strongswan-libcharon strongswan-starter
       """
     And stdout contains substring:
       """

--- a/features/landscape.feature
+++ b/features/landscape.feature
@@ -102,9 +102,9 @@ Feature: Enable landscape on Ubuntu
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      # | oracular | lxd-container | - not yet in the backend
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | oracular | lxd-container |
+      | noble    | lxd-container |
 
   Scenario Outline: Enable Landscape interactively
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -177,9 +177,9 @@ Feature: Enable landscape on Ubuntu
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      # | oracular | lxd-container | - not yet in the backend
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | oracular | lxd-container |
+      | noble    | lxd-container |
 
   Scenario Outline: Easily re-enable Landscape non-interactively after a disable
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -264,9 +264,9 @@ Feature: Enable landscape on Ubuntu
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      # | oracular | lxd-container | - not yet in the backend
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | oracular | lxd-container |
+      | noble    | lxd-container |
 
   Scenario Outline: Detaching/reattaching on an unsupported release does not affect landscape
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -146,13 +146,10 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       """
       {"_schema_version": "v1", "data": {"attributes": {"enabled_services": \[{"name": "realtime-kernel", "variant_enabled": true, "variant_name": "generic"}\]}, "meta": {"environment_vars": \[\]}, "type": "EnabledServices"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
       """
-    When I run `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `y\ny\ny`
-    Then stdout contains substring:
-      """
-      Real-time Intel IOTG Kernel cannot be enabled with Real-time kernel.
-      Disable Real-time kernel and proceed to enable Real-time Intel IOTG Kernel? (y/N)
-      """
-    When I run `apt-cache policy ubuntu-intel-iot-realtime` as non-root
+    # The kernel version of generic is now higher than the intel one, so we need to uninstall it
+    When I run `DEBIAN_FRONTEND=noninteractive apt -y remove --purge linux*realtime` with sudo
+    And I run `pro enable realtime-kernel --variant intel-iotg` `with sudo` and stdin `y`
+    And I run `apt-cache policy ubuntu-intel-iot-realtime` as non-root
     Then stdout does not match regexp:
       """
       Installed: \(none\)

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -194,7 +194,7 @@ def when_i_ensure_proposed_not_enabled(context, machine_name=SUT):
     if context.pro_config.install_from is InstallationSource.PROPOSED:
         when_i_run_command(
             context,
-            "rm /etc/apt/sources.list.d/uaclient-proposed.list",
+            "rm -f /etc/apt/sources.list.d/proposed.list",
             "with sudo",
             machine_name=machine_name,
         )


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because it fixes and adjusts tests to match the desired capabilities of the Pro Client. Those cases were found when validating v35.

None of those changes are modifying the package behavior, or fixing bugs, or changing messaging. If a test is being changed here, it's because the test was wrong.

## Test Steps
Run the changed tests with `tox -e behave -- -n "<test name>"` and see they pass.

---

- [x] *(un)check this to re-run the checklist action*