### PR TITLE
debian: remove mention to /var/lib/ubuntu-pro

### DIFF
--- a/debian/ubuntu-pro-client.postrm
+++ b/debian/ubuntu-pro-client.postrm
@@ -10,7 +10,6 @@ remove_apt_auth(){
 
 remove_cache_dir(){
     rm -rf /var/lib/ubuntu-advantage
-    rm -rf /var/lib/ubuntu-pro
 }
 
 remove_logs(){


### PR DESCRIPTION
## Why is this needed?
We will no longer ship that file on the package, so there is no need to remove it on postrm

---

- [ ] *(un)check this to re-run the checklist action*