### PR TITLE
version: don't present the ubuntu0 suffix in pro version

### DIFF
--- a/tools/check-versions-are-consistent.py
+++ b/tools/check-versions-are-consistent.py
@@ -23,7 +23,7 @@ changelog_version = (
 # focal and earlier don't have `removeprefix`
 if changelog_version.startswith("1:1+devel-"):
     changelog_version = changelog_version[10:]
-m = re.match(r"(\d+(\.\d+)*ubuntu0)", changelog_version)
+m = re.match(r"(\d+(\.\d+)*)", changelog_version)
 if m:
     base_changelog_version = m.group()
 else:

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -15,7 +15,7 @@ from uaclient.defaults import CANDIDATE_CACHE_PATH, UAC_RUN_PATH
 from uaclient.exceptions import ProcessExecutionError
 from uaclient.system import subp
 
-__VERSION__ = "35.1ubuntu0"
+__VERSION__ = "35.1"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we don't need the suffixes in `pro version`

## Test Steps
`python tools/check-versions-are-consistent.py`

---

- [x] *(un)check this to re-run the checklist action*