### PR TITLE
relax onlySeries directive check

### DIFF
--- a/features/subscription_attach_restrictions.feature
+++ b/features/subscription_attach_restrictions.feature
@@ -35,15 +35,15 @@ Feature: One time pro subscription related tests
     When I attempt to attach `contract_token` with sudo
     Then stderr contains substring:
       """
-      Attaching to this contract is only allowed on the Ubuntu <onlyrelease> (<onlyseries_codename>) release
+      Attaching to this contract is only allowed on the Ubuntu <onlyrelease> (<onlyseries_codename>) and previous releases.
       """
     And the machine is unattached
 
     Examples: ubuntu release
       | release | machine_type  | onlyseries | onlyrelease | onlyseries_codename |
-      | xenial  | lxd-container | bionic     | 18.04 LTS   | Bionic Beaver       |
+      | xenial  | lxd-container | trusty     | 14.04 LTS   | Trusty Tahr         |
       | bionic  | lxd-container | xenial     | 16.04 LTS   | Xenial Xerus        |
-      | focal   | lxd-container | noble      | 24.04 LTS   | Noble Numbat        |
+      | focal   | lxd-container | bionic     | 18.04 LTS   | Bionic Beaver       |
       | jammy   | lxd-container | focal      | 20.04 LTS   | Focal Fossa         |
       | noble   | lxd-container | jammy      | 22.04 LTS   | Jammy Jellyfish     |
 
@@ -108,13 +108,18 @@ Feature: One time pro subscription related tests
     When I run `pro status` with sudo
     Then stdout contains substring:
       """
-      Limited to release: Ubuntu <onlyrelease> (<onlyseries_codename>)
+      Limited to Ubuntu <onlyrelease> (<onlyseries_codename>) and previous releases
       """
 
     Examples: ubuntu release
       | release | machine_type  | onlyseries | onlyrelease | onlyseries_codename |
       | xenial  | lxd-container | xenial     | 16.04 LTS   | Xenial Xerus        |
+      | xenial  | lxd-container | bionic     | 18.04 LTS   | Bionic Beaver       |
+      | xenial  | lxd-container | noble      | 24.04 LTS   | Noble Numbat        |
       | bionic  | lxd-container | bionic     | 18.04 LTS   | Bionic Beaver       |
+      | bionic  | lxd-container | focal      | 20.04 LTS   | Focal Fossa         |
       | focal   | lxd-container | focal      | 20.04 LTS   | Focal Fossa         |
+      | focal   | lxd-container | jammy      | 22.04 LTS   | Jammy Jellyfish     |
       | jammy   | lxd-container | jammy      | 22.04 LTS   | Jammy Jellyfish     |
+      | jammy   | lxd-container | noble      | 24.04 LTS   | Noble Numbat        |
       | noble   | lxd-container | noble      | 24.04 LTS   | Noble Numbat        |

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -84,7 +84,7 @@ RELEASE_UPGRADE_SUCCESS = t.gettext(
 
 PRO_ONLY_ALLOWED_FOR_RELEASE = t.gettext(
     "Detaching Ubuntu Pro. Previously attached subscription \
-was only valid for Ubuntu {release} ({series_codename}) release."
+was only valid for releases prior to Ubuntu {release} ({series_codename})."
 )
 
 MISSING_YAML_MODULE = t.gettext(
@@ -315,7 +315,7 @@ And provide the following code: {bold}{{user_code}}{end_bold}"""
 CLI_MAGIC_ATTACH_PROCESSING = t.gettext("Attaching the machine...")
 
 LIMITED_TO_RELEASE = t.gettext(
-    "Limited to release: Ubuntu {release} ({series_codename})."
+    "Limited to Ubuntu {release} ({series_codename}) and previous releases."
 )
 
 # DETACH
@@ -1718,7 +1718,7 @@ ATTACH_FAILURE_RESTRICTED_RELEASE = FormattedNamedMessage(
     "attach-failure-restricted-release",
     t.gettext(
         "Attach failed. Attaching to this contract \
-is only allowed on the Ubuntu {release} ({series_codename}) release."
+is only allowed on the Ubuntu {release} ({series_codename}) and previous releases."  # noqa
     ),
 )
 

--- a/uaclient/tests/test_update_contract_info.py
+++ b/uaclient/tests/test_update_contract_info.py
@@ -1,13 +1,23 @@
+import datetime
+
 import mock
 import pytest
 
+from uaclient import exceptions
 from uaclient.update_contract_info import validate_release_series
 
 M_PATH = "uaclient.update_contract_info."
 
 
 class TestValidateReleaseSeries:
-    @pytest.mark.parametrize("allowed_series", ("bionic", "jammy"))
+    @pytest.mark.parametrize(
+        "only_series,eol,is_valid",
+        (
+            ("bionic", datetime.date(2023, 5, 31), False),
+            ("jammy", datetime.date(2027, 6, 1), True),
+            ("noble", datetime.date(2029, 5, 31), True),
+        ),
+    )
     @mock.patch(
         "uaclient.system.get_release_info",
         return_value=mock.MagicMock(series="jammy"),
@@ -24,32 +34,56 @@ class TestValidateReleaseSeries:
         m_detach,
         m_get_distro_info,
         m_get_release_info,
-        allowed_series,
+        only_series,
+        eol,
+        is_valid,
         FakeConfig,
         fake_machine_token_file,
     ):
         fake_machine_token_file._entitlements = {
             "support": {
-                "entitlement": {"affordances": {"onlySeries": allowed_series}}
+                "entitlement": {"affordances": {"onlySeries": only_series}}
             }
         }
         m_get_distro_info.side_effect = [
             mock.MagicMock(
-                release="20.04",
-                series_codename="Bionic Beaver",
-                series="bionic",
+                series=only_series,
+                eol=eol,
             ),
             mock.MagicMock(
-                release="22.04",
-                series_codename="Jammy Jellyfish",
                 series="jammy",
+                eol=datetime.date(2027, 6, 1),
             ),
         ]
-        validate_release_series(cfg=FakeConfig(), only_series=allowed_series)
-        if allowed_series:
-            if allowed_series != "jammy":
-                assert m_get_distro_info.call_count == 1
-                assert m_detach.call_count == 1
-        else:
-            assert m_get_distro_info.call_count == 0
+        validate_release_series(cfg=FakeConfig(), only_series=only_series)
+        if is_valid:
+            assert m_get_distro_info.call_count == 2
             assert m_detach.call_count == 0
+        else:
+            assert m_get_distro_info.call_count == 2
+            assert m_detach.call_count == 1
+
+    @mock.patch(
+        "uaclient.system.get_release_info",
+        return_value=mock.MagicMock(series="jammy"),
+    )
+    @mock.patch("uaclient.system.get_distro_info")
+    @mock.patch(M_PATH + "detach")
+    @mock.patch(
+        M_PATH + "_is_attached",
+        return_value=mock.MagicMock(is_attached=True),
+    )
+    def test_validate_release_series_not_found(
+        self,
+        m_is_attached,
+        m_detach,
+        m_get_distro_info,
+        m_get_release_info,
+        FakeConfig,
+    ):
+        m_get_distro_info.side_effect = (
+            exceptions.MissingSeriesInDistroInfoFile(series="plucky")
+        )
+        validate_release_series(cfg=FakeConfig(), only_series="plucky")
+        assert m_get_distro_info.call_count == 1
+        assert m_detach.call_count == 0

--- a/uaclient/update_contract_info.py
+++ b/uaclient/update_contract_info.py
@@ -1,6 +1,6 @@
 import logging
 
-from uaclient import lock, messages, system, util
+from uaclient import exceptions, lock, messages, system, util
 from uaclient.api.u.pro.detach.v1 import detach
 from uaclient.api.u.pro.status.is_attached.v1 import _is_attached
 from uaclient.config import UAConfig
@@ -12,20 +12,30 @@ def validate_release_series(cfg: UAConfig, only_series, show_message=False):
     LOG.debug("Validating release series")
     if not _is_attached(cfg).is_attached:
         return
+
     current_series = system.get_release_info().series
-    if only_series != current_series:
-        LOG.debug(
-            "Detaching due to current series being %s. only_series: %s",
-            current_series,
-            only_series,
-        )
-        lock.clear_lock_file_if_present()
-        detach()
+    try:
         allowed_release = system.get_distro_info(only_series)
-        message = messages.PRO_ONLY_ALLOWED_FOR_RELEASE.format(
-            release=allowed_release.release,
-            series_codename=allowed_release.series_codename,
-        )
-        if show_message:
-            print(message)
-        LOG.warning(message)
+    except exceptions.MissingSeriesInDistroInfoFile:
+        # If onlySeries is not present on the distro-info CSV
+        # we consider that it is newer than the current release
+        pass
+    else:
+        current_release = system.get_distro_info(current_series)
+        # Only series is now meant to be allowed on the specified release
+        # and all previous releases
+        if current_release.eol > allowed_release.eol:
+            LOG.debug(
+                "Detaching due to current series %s being higher than only_series: %s",  # noqa
+                current_series,
+                only_series,
+            )
+            lock.clear_lock_file_if_present()
+            detach()
+            message = messages.PRO_ONLY_ALLOWED_FOR_RELEASE.format(
+                release=allowed_release.release,
+                series_codename=allowed_release.series_codename,
+            )
+            if show_message:
+                print(message)
+            LOG.warning(message)


### PR DESCRIPTION
## Why is this needed?
If a token is associated with a `onlySeries` directive, we will allow the `onlySeries` release and all previous releases to attach using the token, instead of only the release specified by `onlySeries`

## Test Steps
Run the modified integration tests

---

- [x] *(un)check this to re-run the checklist action*