### PR TITLE
tests: fix lxd test setup

### DIFF
--- a/features/lxd.feature
+++ b/features/lxd.feature
@@ -152,7 +152,7 @@ Feature: LXD Pro features
   Scenario Outline: LXD guest auto-attach
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # Ensure default is "off" and setup lxd
-    When I run `snap refresh lxd --channel latest/edge` with sudo
+    When I run `snap refresh lxd --channel 6/stable` with sudo
     When I run `lxd init --minimal` with sudo
     When I start `lxd-download` command `lxc image copy ubuntu-daily:noble local:` in the background
     When I run `pro config show` with sudo

--- a/features/steps/ubuntu_advantage_tools.py
+++ b/features/steps/ubuntu_advantage_tools.py
@@ -165,6 +165,8 @@ def when_i_install_uat_on_lxd_guest(context, guest_name):
             "with sudo",
         )
     else:
+        setup_pro_package_sources(context)
+
         when_i_run_command(
             context,
             "lxc file push /tmp/setup_pro.sh {guest_name}/root/setup_pro.sh".format(  # noqa: E501


### PR DESCRIPTION
## Why is this needed?
We are now adding a missing step when running the lxd integration test with a package coming from proposed


## Test Steps
Check that  the LXD integration test works with a package from proposed


---

- [x] *(un)check this to re-run the checklist action*