### PR TITLE
use openssl abstraction in apparmor profile

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -118,6 +118,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
   profile cloud_id flags=(attach_disconnected) {
     include <abstractions/base>
     include <abstractions/nameservice>
+    include <abstractions/openssl>
     include <abstractions/python>
 
     ptrace read peer=unconfined,
@@ -125,7 +126,6 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     /etc/cloud/** r,
     /etc/apt/** r,
     /etc/apport/** r,
-    /etc/ssl/openssl.cnf r,
 
     @{PROC}/@{pid}/fd/ r,
     @{PROC}/cmdline r,


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
ubuntu_pro_esm_cache apparmor profile is denying access to custom ssl engine configurations.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

1. Modify `/etc/ssl/openssl.cnf` to include another file supported by the apparmor openssl abstraction, example `.include /etc/ssl/engines.d/custom.cnf`.

2. Run the cache service: `systemctl start esm-cache.service`

3. Review the kernel log (dmesg), there will be a apparmor deny message like:
   > [1831.626508] audit: type=1400 audit(1745170012.847:58): apparmor="DENIED" operation="open" profile="ubuntu_pro_esm_cache//cloud_id" name="/etc/ssl/engines.d/custom.cnf" pid=19229 comm="cloud-id" requested_mask="r" denied_mask="r" fsuid=0 ouid=0

---

- [x] *(un)check this to re-run the checklist action*