### PR TITLE
tests: fix collect-logs test

### DIFF
--- a/features/logs.feature
+++ b/features/logs.feature
@@ -70,7 +70,8 @@ Feature: Logs in Json Array Formatter
       """
       user0.log
       """
-    When i verify that running `pro status` `as non-root` exits `0`
+    When I delete the file `pro_logs.tar.gz`
+    And I verify that running `pro status` `as non-root` exits `0`
     And I verify that running `pro collect-logs` `with sudo` exits `0`
     And I run `tar -tf pro_logs.tar.gz` as non-root
     Then stdout contains substring


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because we like to see tests passing.

This test was overwriting the target file for collect-logs, which is not supported anymore.

Fixes: #3451

## Test Steps
Run the modified test.

---

- [x] *(un)check this to re-run the checklist action*