### PR TITLE
fix(docs): bad RUN cmd in create_a_fips_docker_image.rst

### DIFF
--- a/docs/howtoguides/create_a_fips_docker_image.rst
+++ b/docs/howtoguides/create_a_fips_docker_image.rst
@@ -85,7 +85,7 @@ Edit the file and add the following contents:
         && pro attach --attach-config /run/secrets/pro-attach-config \
         && apt-get upgrade -y \
         && apt-get install -y openssl libssl1.1 libssl1.1-hmac libgcrypt20 libgcrypt20-hmac strongswan strongswan-hmac openssh-client openssh-server \
-        && pro detach --assume-yes
+        && pro detach --assume-yes \
         && apt-get purge --auto-remove -y ubuntu-pro-client ca-certificates \
         && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->

The Dockerfile in this guide is missing a `\`, which cause the `docker build` to fail.

<!-- By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing. If your PR is small enough and you prefer, you can write a suggested commit message here and request a squashed PR. -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if this is a bug fix) this change on a live deployed system, including any necessary configuration files, user-data, setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

Simply `docker build` with the current Dockerfile, and you'll get `ERROR: failed to solve: dockerfile parse error on line 10: unknown instruction: &&`

This PR fixes it.

