### PR TITLE
Tests on plucky

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -79,9 +79,10 @@ Feature: Pro is expected version
       | noble    | gcp.generic    |
       | noble    | gcp.pro        |
       | noble    | gcp.pro-fips   |
-      # no oracular on clouds yet - add it when those are available
       | oracular | lxd-container  |
       | oracular | lxd-vm         |
+      | plucky   | lxd-container  |
+      | plucky   | lxd-vm         |
 
   @uses.config.check_version @upgrade
   Scenario Outline: Check pro version
@@ -113,6 +114,7 @@ Feature: Pro is expected version
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: Attached show version in a ubuntu machine
@@ -135,6 +137,7 @@ Feature: Pro is expected version
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @arm64
   Scenario Outline: Check for newer versions of the client in an ubuntu machine
@@ -218,3 +221,4 @@ Feature: Pro is expected version
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/api/api.feature
+++ b/features/api/api.feature
@@ -36,6 +36,7 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @arm64
   Scenario Outline: API invalid endpoint or args
@@ -86,6 +87,7 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @arm64
   Scenario Outline: Basic endpoints
@@ -179,6 +181,7 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @uses.config.contract_token @arm64
   Scenario Outline: u.pro.status.is_attached.v1
@@ -291,3 +294,4 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/api/enable.feature
+++ b/features/api/enable.feature
@@ -170,6 +170,7 @@ Feature: u.pro.services.enable
       | release  | machine_type  |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: u.pro.services.enable.v1 vm services
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/api/fix_plan.feature
+++ b/features/api/fix_plan.feature
@@ -3013,3 +3013,4 @@ Feature: Fix plan API endpoints
     Examples: ubuntu release details
       | release  | machine_type |
       | oracular | lxd-vm       |
+      | plucky   | lxd-vm       |

--- a/features/api/services_dependencies.feature
+++ b/features/api/services_dependencies.feature
@@ -372,3 +372,4 @@ Feature: u.pro.services.dependencies
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/api/unattended_upgrades.feature
+++ b/features/api/unattended_upgrades.feature
@@ -254,3 +254,4 @@ Feature: api.u.unattended_upgrades.status.v1
       | jammy    | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
       | noble    | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
       | oracular | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
+      | plucky   | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -727,6 +727,8 @@ Feature: APT Messages
       | release  | machine_type  |
       | oracular | lxd-container |
       | oracular | lxd-vm        |
+      | plucky   | lxd-container |
+      | plucky   | lxd-vm        |
 
   Scenario Outline: Cloud and series-specific URLs
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -1565,6 +1567,7 @@ Feature: APT Messages
     Examples: ubuntu release
       | release  | machine_type  | wrong_release | package     | installed_version |
       | oracular | lxd-container | jammy         | libcurl4t64 | 8.9.1-2ubuntu2    |
+      | plucky   | lxd-container | jammy         | libcurl4t64 | 8.12.1-3ubuntu1   |
 
   Scenario Outline: APT Hook does not error when run as non-root
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -1582,6 +1585,7 @@ Feature: APT Messages
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: APT Hook do not advertises esm-apps on upgrade for interim releases
@@ -1634,3 +1638,4 @@ Feature: APT Messages
     Examples: ubuntu release
       | release  | machine_type  |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/autocomplete.feature
+++ b/features/autocomplete.feature
@@ -63,3 +63,4 @@ Feature: Pro autocomplete commands
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/cc_eal.feature
+++ b/features/cc_eal.feature
@@ -71,3 +71,4 @@ Feature: Enable cc-eal on Ubuntu
       | jammy    | lxd-container | 22.04 LTS | Jammy Jellyfish |
       | noble    | lxd-container | 24.04 LTS | Noble Numbat    |
       | oracular | lxd-container | 24.10     | Oracular Oriole |
+      | plucky   | lxd-container | 25.04     | Plucky Puffin   |

--- a/features/cli/attach.feature
+++ b/features/cli/attach.feature
@@ -36,6 +36,7 @@ Feature: CLI attach command
     Examples: ubuntu release
       | release  | machine_type  | landscape | status_string                                                           |
       | oracular | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
+      | plucky   | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
 
   Scenario Outline: Attach command with attach config
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -349,6 +350,7 @@ Feature: CLI attach command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @uses.config.contract_token_staging_expired
   Scenario Outline: Attach command failure on expired token
@@ -395,6 +397,7 @@ Feature: CLI attach command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Attach operation on a lxd vm
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/auto_attach.feature
+++ b/features/cli/auto_attach.feature
@@ -35,6 +35,7 @@ Feature: CLI auto-attach command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @arm64
   Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
@@ -67,3 +68,4 @@ Feature: CLI auto-attach command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/cli/collect_logs.feature
+++ b/features/cli/collect_logs.feature
@@ -55,6 +55,7 @@ Feature: CLI collect-logs command
       | jammy    | lxd-container | as non-root |
       | noble    | lxd-container | with sudo   |
       | oracular | lxd-container | with sudo   |
+      | plucky   | lxd-container | with sudo   |
 
   @uses.config.contract_token @arm64
   Scenario Outline: Run collect-logs on an attached machine

--- a/features/cli/config.feature
+++ b/features/cli/config.feature
@@ -54,11 +54,15 @@ Feature: CLI config command
     Then I will see the following on stdout:
       """
       """
-    # When testing on plucky, the '' in the options need to be removed.
-    Then I will see the following on stderr:
+    Then if `<release>` in `xenial or jammy or noble or oracular` and stderr contains substring:
       """
       usage: pro config [-h] {show,set,unset} ...
       pro config: error: argument command: invalid choice: 'invalid' (choose from 'show', 'set', 'unset')
+      """
+    Then if `<release>` in `plucky` and stderr contains substring:
+      """
+      usage: pro config [-h] {show,set,unset} ...
+      pro config: error: argument command: invalid choice: 'invalid' (choose from show, set, unset)
       """
 
     Examples: ubuntu release
@@ -67,3 +71,4 @@ Feature: CLI config command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/cli/detach.feature
+++ b/features/cli/detach.feature
@@ -170,3 +170,4 @@ Feature: CLI detach command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/cli/disable.feature
+++ b/features/cli/disable.feature
@@ -480,3 +480,4 @@ Feature: CLI disable command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/cli/enable.feature
+++ b/features/cli/enable.feature
@@ -630,3 +630,4 @@ Feature: CLI enable command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -85,7 +85,7 @@ Feature: Pro Client help text
       Use pro <command> --help for more information about a command.
       """
     When I run `pro collect-logs --help` as non-root
-    Then I will see the following on stdout
+    Then if `<release>` not in `plucky` I will see the following on stdout
       """
       usage: pro collect-logs [-h] [-o OUTPUT]
 
@@ -97,6 +97,18 @@ Feature: Pro Client help text
         -o OUTPUT, --output OUTPUT
                               tarball where the logs will be stored. (Defaults to
                               ./pro_logs.tar.gz).
+      """
+    And if `<release>` in `plucky` I will see the following on stdout
+      """
+      usage: pro collect-logs [-h] [-o OUTPUT]
+
+      Collect logs and relevant system information into a tarball.
+      This information can be later used for triaging/debugging issues.
+
+      options:
+        -h, --help           show this help message and exit
+        -o, --output OUTPUT  tarball where the logs will be stored. (Defaults to
+                             ./pro_logs.tar.gz).
       """
     When I run `pro api --help` as non-root
     Then stdout matches regexp:
@@ -231,11 +243,18 @@ Feature: Pro Client help text
         --format {cli,json}  output in the specified format (default: cli)
       """
     When I run `pro security-status --help` as non-root
-    Then I will see the following on stdout
+    Then if `<release>` in `plucky` I will see the following on stdout
+      """
+      usage: pro security-status [-h] [--format {json,yaml,text}] [--thirdparty |
+                                 --unavailable | --esm-infra | --esm-apps]
+      """
+    And if `<release>` not in `plucky` I will see the following on stdout
       """
       usage: pro security-status [-h] [--format {json,yaml,text}]
                                  [--thirdparty | --unavailable | --esm-infra | --esm-apps]
-
+      """
+    And I will see the following on stdout
+      """
       Show security updates for packages in the system, including all
       available Expanded Security Maintenance (ESM) related content.
 
@@ -499,6 +518,7 @@ Feature: Pro Client help text
       | jammy    | lxd-container | options            |
       | noble    | lxd-container | options            |
       | oracular | lxd-container | options            |
+      | plucky   | lxd-container | options            |
 
   Scenario Outline: Help command on an attached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -547,6 +567,7 @@ Feature: Pro Client help text
       | jammy    | lxd-container | enabled      |
       | noble    | lxd-container | enabled      |
       | oracular | lxd-container | n/a          |
+      | plucky   | lxd-container | n/a          |
 
   @arm64
   Scenario Outline: Help command on an unattached machine
@@ -596,3 +617,4 @@ Feature: Pro Client help text
       | jammy    | wsl           | yes             |
       | noble    | lxd-container | yes             |
       | oracular | lxd-container | no              |
+      | plucky   | lxd-container | no              |

--- a/features/cli/refresh.feature
+++ b/features/cli/refresh.feature
@@ -46,6 +46,7 @@ Feature: CLI refresh command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -72,3 +73,4 @@ Feature: CLI refresh command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/cli/security_status.feature
+++ b/features/cli/security_status.feature
@@ -790,7 +790,7 @@ Feature: CLI security-status command
           pro security-status --help
       for a list of available options\.
 
-      Main/Restricted packages receive updates until 7/2025\.
+      Main/Restricted packages receive updates until 1/2026\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
@@ -801,7 +801,7 @@ Feature: CLI security-status command
       \d+ packages installed:
        +\d+ packages from Ubuntu Main/Restricted repository
 
-      Main/Restricted packages receive updates until 7/2025\.
+      Main/Restricted packages receive updates until 1/2026\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
@@ -832,7 +832,7 @@ Feature: CLI security-status command
           sudo apt update
       to get the latest package information from apt\.
 
-      Main/Restricted packages receive updates until 7/2025\.
+      Main/Restricted packages receive updates until 1/2026\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
@@ -854,14 +854,14 @@ Feature: CLI security-status command
           sudo apt update
       to get the latest package information from apt\.
 
-      Main/Restricted packages receive updates until 7/2025\.
+      Main/Restricted packages receive updates until 1/2026\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
 
     Examples: ubuntu release
-      | release  | machine_type  |
-      | oracular | lxd-container |
+      | release | machine_type  |
+      | plucky  | lxd-container |
 
   Scenario Outline: Pass custom APT configuration to the Client for updates information
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -76,6 +76,7 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @uses.config.contract_token @arm64
   Scenario Outline: Non-root status can see in-progress operations
@@ -530,6 +531,7 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @arm64
   Scenario Outline: Unattached status in a ubuntu machine
@@ -1203,6 +1205,7 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Warn users not to redirect/pipe human readable output
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -1297,3 +1300,4 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -16,6 +16,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @uses.config.contract_token @arm64
   Scenario Outline: cloud-id-shim should run in postinst and on boot
@@ -292,6 +293,8 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | release  | machine_type  |
       | oracular | azure.generic |
       | oracular | gcp.generic   |
+      | plucky   | azure.generic |
+      | plucky   | gcp.generic   |
 
   @uses.config.contract_token
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
@@ -320,6 +323,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | jammy    | aws.generic  |
       | noble    | aws.generic  |
       | oracular | aws.generic  |
+      | plucky   | aws.generic  |
 
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/docker.feature
+++ b/features/docker.feature
@@ -72,6 +72,9 @@ Feature: Build docker images with pro services
       | oracular | lxd-vm       | xenial            | [ esm-infra ]   | curl              | esm                  |
       | oracular | lxd-vm       | bionic            | [ fips ]        | openssl           | fips                 |
       | oracular | lxd-vm       | focal             | [ esm-apps ]    | hello             | esm                  |
+      | plucky   | lxd-vm       | xenial            | [ esm-infra ]   | curl              | esm                  |
+      | plucky   | lxd-vm       | bionic            | [ fips ]        | openssl           | fips                 |
+      | plucky   | lxd-vm       | focal             | [ esm-apps ]    | hello             | esm                  |
 
   Scenario Outline: Build pro docker images auto-attached instances - settings_overrides method
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -29,6 +29,7 @@ Feature: Ua fix command behaviour
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Fix command on an unattached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -64,6 +64,7 @@ Feature: Pro supports multiple languages
     Examples: ubuntu release
       | release  | machine_type  |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   # Note: Translations do work on xenial, but our test environment triggers a bug in python that
   # causes it to think we're in an ascii-only environment
@@ -228,6 +229,7 @@ Feature: Pro supports multiple languages
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: Pro client's commands run successfully in a non-utf8 locale
@@ -286,3 +288,4 @@ Feature: Pro supports multiple languages
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -13,6 +13,7 @@ Feature: Pro Install and Uninstall related tests
       | jammy    | lxd-container | ubuntu-advantage-tools |
       | noble    | lxd-container | ubuntu-pro-client      |
       | oracular | lxd-container | ubuntu-pro-client      |
+      | plucky   | lxd-container | ubuntu-pro-client      |
 
   @uses.config.contract_token
   Scenario Outline: Purge package after attaching it to a machine
@@ -129,6 +130,7 @@ Feature: Pro Install and Uninstall related tests
       | jammy    | lxd-container | ubuntu_advantage |
       | noble    | lxd-container | ubuntu_pro       |
       | oracular | lxd-container | ubuntu_pro       |
+      | plucky   | lxd-container | ubuntu-pro       |
 
   @uses.config.contract_token
   Scenario Outline: Create public machine token on postinst

--- a/features/landscape.feature
+++ b/features/landscape.feature
@@ -105,6 +105,7 @@ Feature: Enable landscape on Ubuntu
       | release  | machine_type  |
       | oracular | lxd-container |
       | noble    | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Enable Landscape interactively
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -180,6 +181,7 @@ Feature: Enable landscape on Ubuntu
       | release  | machine_type  |
       | oracular | lxd-container |
       | noble    | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Easily re-enable Landscape non-interactively after a disable
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -267,6 +269,7 @@ Feature: Enable landscape on Ubuntu
       | release  | machine_type  |
       | oracular | lxd-container |
       | noble    | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Detaching/reattaching on an unsupported release does not affect landscape
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -193,6 +193,7 @@ Feature: Livepatch
     Examples: ubuntu release
       | release  | machine_type | pretty_name             |
       | oracular | lxd-vm       | 24.10 (Oracular Oriole) |
+      | plucky   | lxd-vm       | 25.04 (Plucky Puffin)   |
 
   Scenario Outline: Livepatch is supported on interim HWE kernel
     # This test is intended to ensure that an interim HWE kernel has the correct support status

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -27,6 +27,7 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container | as non-root |
       | noble    | lxd-container | with sudo   |
       | oracular | lxd-container | with sudo   |
+      | plucky   | lxd-container | with sudo   |
 
   Scenario Outline: Non-root user and root user log files are different
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -60,6 +61,7 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Non-root user log files included in collect logs
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -87,6 +89,7 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: logrotate configuration works
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -136,3 +139,4 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |

--- a/features/steps/output.py
+++ b/features/steps/output.py
@@ -27,24 +27,35 @@ def then_i_will_see_on_stream(context, stream):
         )
 
 
-@then("if `{value1}` in `{value2}` and stdout matches regexp")
-def then_conditional_stdout_matches_regexp(context, value1, value2):
+@then("if `{value1}` in `{value2}` I will see the following on {stream}")
+def then_conditional_i_will_see_on_stream(context, value1, value2, stream):
     """Only apply regex assertion if value1 in value2."""
     if value1 in value2.split(" or "):
-        then_stream_matches_regexp(context, "stdout")
+        then_i_will_see_on_stream(context, stream)
 
 
-@then("if `{value1}` in `{value2}` and stdout contains substring")
-def then_conditional_stdout_contains_substring(context, value1, value2):
-    if value1 in value2.split(" or "):
-        then_stream_contains_substring(context, "stdout")
+@then("if `{value1}` not in `{value2}` I will see the following on {stream}")
+def then_not_in_conditional_stream_matches_regexp(
+    context, value1, value2, stream
+):
+    """Only apply regex assertion if value1 in value2."""
+    if value1 not in value2.split(" or "):
+        then_i_will_see_on_stream(context, stream)
 
 
-@then("if `{value1}` in `{value2}` and stderr matches regexp")
-def then_conditional_stderr_matches_regexp(context, value1, value2):
+@then("if `{value1}` in `{value2}` and {stream} matches regexp")
+def then_conditional_stream_matches_regexp(context, value1, value2, stream):
     """Only apply regex assertion if value1 in value2."""
     if value1 in value2.split(" or "):
-        then_stream_matches_regexp(context, "stderr")
+        then_stream_matches_regexp(context, stream)
+
+
+@then("if `{value1}` in `{value2}` and {stream} contains substring")
+def then_conditional_stdout_contains_substring(
+    context, value1, value2, stream
+):
+    if value1 in value2.split(" or "):
+        then_stream_contains_substring(context, stream)
 
 
 @then("if `{value1}` in `{value2}` and stdout does not match regexp")

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -18,6 +18,7 @@ Feature: Timer for regular background jobs while attached
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Run timer script on an attached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -95,6 +96,7 @@ Feature: Timer for regular background jobs while attached
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | oracular | lxd-container |
+      | plucky   | lxd-container |
 
   Scenario Outline: Run timer script to validate machine activity endpoint
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
     behave
     jsonschema
     jq
-    pycloudlib==1!9.2.0
+    pycloudlib==1!10.13.0
     PyHamcrest
     requests
     toml==0.10


### PR DESCRIPTION
## Why is this needed?
This PR solves all of our problems because if we want to SRU to plucky we need to test on plucky.

## Test Steps
Run the integration tests.

There are a couple things failing in this new set:
- landscape tests, because landscape client has different output now, the test needs adjustment
- apt news tests, because it checks for the whole apt output (as it should), but on plucky some phrases are duplicated... (because of the new apt experience).

I am sending this now, and will fix those details when running the tests for the validation.
