### PR TITLE
CSS-16885 Fix notice for LTS + 1 onlySeries

### DIFF
--- a/uaclient/actions.py
+++ b/uaclient/actions.py
@@ -191,12 +191,12 @@ def attach_with_token(
                     series_codename=allowed_release.series_codename,
                 )
 
-        notices.add(
-            notices.Notice.LIMITED_TO_RELEASE,
-            release=allowed_release.release,
-            series_codename=allowed_release.series_codename,
-        )
-        only_series_check_marker_file.write(only_series)
+            notices.add(
+                notices.Notice.LIMITED_TO_RELEASE,
+                release=allowed_release.release,
+                series_codename=allowed_release.series_codename,
+            )
+            only_series_check_marker_file.write(only_series)
 
     machine_token_file.write(new_machine_token)
     try:

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -151,6 +151,59 @@ class TestAttachWithToken:
                 [mock.call()],
                 helpers.does_not_raise(),
             ),
+            # Simulate onlySeries with a not yet released series
+            (
+                "token",
+                True,
+                [
+                    {
+                        "machineTokenInfo": {
+                            "contractInfo": {
+                                "resourceEntitlements": [
+                                    {
+                                        "name": "foobar",
+                                        "type": "support",
+                                        "affordances": {
+                                            "onlySeries": "future",
+                                        },
+                                    }
+                                ],
+                            }
+                        },
+                    }
+                ],
+                "get-machine-id-result",
+                [(True, None)],
+                [mock.call(contract_token="token", attachment_dt=mock.ANY)],
+                [
+                    mock.call(
+                        {
+                            "machineTokenInfo": {
+                                "contractInfo": {
+                                    "resourceEntitlements": [
+                                        {
+                                            "name": "foobar",
+                                            "type": "support",
+                                            "affordances": {
+                                                "onlySeries": "future",
+                                            },
+                                        }
+                                    ],
+                                }
+                            },
+                        }
+                    )
+                ],
+                [mock.call(mock.ANY)],
+                1,
+                [mock.call(mock.ANY)],
+                [],
+                [mock.call(mock.ANY)],
+                [],
+                [mock.call()],
+                [mock.call()],
+                helpers.does_not_raise(),
+            ),
         ],
     )
     @mock.patch(


### PR DESCRIPTION
## Why is this needed?
If the series doesn't yet exist, the Pro client should not emit a notice related to onlySeries, only allow the attach process to proceed.

Fixes: #3485

## Test Steps
Run the modified unit test for this change.
Also, perform an attach operation with a LTS + 1 token and see that it no longer fails
