### PR TITLE
tests: turn future onlyseries unit test into a behave test

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -158,7 +158,7 @@ Feature: Pro is expected version
     And I verify that files exist matching `/run/ubuntu-advantage/candidate-version`
     # We forge a candidate to see results
     When I delete the file `/run/ubuntu-advantage/candidate-version`
-    And I create the file `/run/ubuntu-advantage/candidate-version` with the following
+    And I create the file `/run/ubuntu-advantage/candidate-version` with the following:
       """
       2:99.9.9
       """

--- a/features/api/configure_retry_service.feature
+++ b/features/api/configure_retry_service.feature
@@ -3,7 +3,7 @@ Feature: api.u.pro.attach.auto.configure_retry_service
   Scenario Outline: v1 successfully triggers retry service when run during startup
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I change contract to staging with sudo
-    When I create the file `/lib/systemd/system/apitest.service` with the following
+    When I create the file `/lib/systemd/system/apitest.service` with the following:
       """
       [Unit]
       Description=test

--- a/features/cli/attach.feature
+++ b/features/cli/attach.feature
@@ -41,7 +41,7 @@ Feature: CLI attach command
   Scenario Outline: Attach command with attach config
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # simplest happy path
-    When I create the file `/tmp/attach.yaml` with the following
+    When I create the file `/tmp/attach.yaml` with the following:
       """
       token: <contract_token>
       """
@@ -59,7 +59,7 @@ Feature: CLI attach command
       Include the token in the attach-config file instead.
       """
     # happy path with service overrides
-    When I create the file `/tmp/attach.yaml` with the following
+    When I create the file `/tmp/attach.yaml` with the following:
       """
       token: <contract_token>
       enable_services:
@@ -73,7 +73,7 @@ Feature: CLI attach command
     And I verify that `<cis_or_usg>` is enabled
     When I run `pro detach --assume-yes` with sudo
     # missing token
-    When I create the file `/tmp/attach.yaml` with the following
+    When I create the file `/tmp/attach.yaml` with the following:
       """
       enable_services:
         - esm-apps
@@ -87,7 +87,7 @@ Feature: CLI attach command
       Expected value with type StringDataValue but got type: null
       """
     # other schema error
-    When I create the file `/tmp/attach.yaml` with the following
+    When I create the file `/tmp/attach.yaml` with the following:
       """
       token: <contract_token>
       enable_services: {cis: true}
@@ -101,7 +101,7 @@ Feature: CLI attach command
       Expected value with type list but got type: dict
       """
     # invalid service name
-    When I create the file `/tmp/attach.yaml` with the following
+    When I create the file `/tmp/attach.yaml` with the following:
       """
       token: <contract_token>
       enable_services:

--- a/features/contract_expired.feature
+++ b/features/contract_expired.feature
@@ -10,7 +10,7 @@ Feature: End of contract messages
     # HACK NOTICE: This part relies on implementation details of pro-client
     # we hack apt-helper to let pro enable go through to simulate being expired with services enabled
     # we can't just enable before expiring the contract because esm-auth is cached
-    When I create the file `/usr/bin/apt-helper-always-true` with the following
+    When I create the file `/usr/bin/apt-helper-always-true` with the following:
       """
       #!/usr/bin/bash
       true

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -311,7 +311,7 @@ Feature: Livepatch
   Scenario Outline: Attach works when snapd cannot be installed
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I apt remove `snapd`
-    And I create the file `/etc/apt/preferences.d/no-snapd` with the following
+    And I create the file `/etc/apt/preferences.d/no-snapd` with the following:
       """
       Package: snapd
       Pin: release o=*
@@ -342,7 +342,7 @@ Feature: Livepatch
 
   Scenario Outline: Livepatch doesn't enable on wsl from a systemd service
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-    When I create the file `/lib/systemd/system/test.service` with the following
+    When I create the file `/lib/systemd/system/test.service` with the following:
       """
       [Unit]
       Description=test

--- a/features/lxd.feature
+++ b/features/lxd.feature
@@ -81,7 +81,7 @@ Feature: LXD Pro features
       """
     When I run `pro detach --assume-yes` with sudo
     Then I verify that no files exist matching `/var/lib/ubuntu-advantage/interfaces/lxd-config.json`
-    When I create the file `/var/lib/ubuntu-advantage/private/user-config.json` with the following
+    When I create the file `/var/lib/ubuntu-advantage/private/user-config.json` with the following:
       """
       {"lxd_guest_attach": "on"}
       """

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -968,7 +968,7 @@ Feature: Proxy configuration
     And I run `openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes -out ca.crt -keyout ca.key -subj "/C=CN/ST=BJ/O=STS/CN=CA"` `with sudo` on the `proxy` machine
     And I run `openssl genrsa -out $behave_var{machine-name proxy}.lxd.key` `with sudo` on the `proxy` machine
     And I run `openssl req -new -key $behave_var{machine-name proxy}.lxd.key -out $behave_var{machine-name proxy}.lxd.csr -subj "/C=CN/ST=BJ/O=STS/CN=$behave_var{machine-name proxy}.lxd"` `with sudo` on the `proxy` machine
-    And I create the file `/home/ubuntu/data.ext` on the `proxy` machine with the following
+    And I create the file `/home/ubuntu/data.ext` on the `proxy` machine with the following:
       """
       authorityKeyIdentifier=keyid,issuer
       basicConstraints=CA:FALSE

--- a/features/steps/files.py
+++ b/features/steps/files.py
@@ -57,9 +57,9 @@ def when_i_verify_file_is_empty_on_machine(
 
 
 @when(
-    "I create the file `{file_path}` on the `{machine_name}` machine with the following"  # noqa: E501
+    "I create the file `{file_path}` on the `{machine_name}` machine with the following:"  # noqa: E501
 )
-@when("I create the file `{file_path}` with the following")
+@when("I create the file `{file_path}` with the following:")
 def when_i_create_file_with_content(
     context, file_path, machine_name=SUT, text=None
 ):

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -11,7 +11,7 @@ Feature: Upgrade between releases when uaclient is attached
     And I run `DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade --assume-yes` with sudo
     # Some packages upgrade may require a reboot
     And I reboot the machine
-    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
+    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following:
       """
       [Sources]
       AllowThirdParty=yes
@@ -91,7 +91,7 @@ Feature: Upgrade between releases when uaclient is attached
     And I run `DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y --allow-downgrades` with sudo
     # A package may need a reboot after running dist-upgrade
     And I reboot the machine
-    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
+    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following:
       """
       [Sources]
       AllowThirdParty=yes
@@ -187,7 +187,7 @@ Feature: Upgrade between releases when uaclient is attached
     And I run `DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade --assume-yes` with sudo
     # Some packages upgrade may require a reboot
     And I reboot the machine
-    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
+    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following:
       """
       [Sources]
       AllowThirdParty=yes
@@ -221,7 +221,7 @@ Feature: Upgrade between releases when uaclient is attached
     And I run `DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade --assume-yes` with sudo
     # Some packages upgrade may require a reboot
     And I reboot the machine
-    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
+    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following:
       """
       [Sources]
       AllowThirdParty=yes

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -21,7 +21,7 @@ Feature: Upgrade between releases when uaclient is unattached
     When I apt dist-upgrade
     # Some packages upgrade may require a reboot
     And I reboot the machine
-    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following
+    And I create the file `/etc/update-manager/release-upgrades.d/ua-test.cfg` with the following:
       """
       [Sources]
       AllowThirdParty=yes

--- a/uaclient/tests/test_actions.py
+++ b/uaclient/tests/test_actions.py
@@ -151,59 +151,6 @@ class TestAttachWithToken:
                 [mock.call()],
                 helpers.does_not_raise(),
             ),
-            # Simulate onlySeries with a not yet released series
-            (
-                "token",
-                True,
-                [
-                    {
-                        "machineTokenInfo": {
-                            "contractInfo": {
-                                "resourceEntitlements": [
-                                    {
-                                        "name": "foobar",
-                                        "type": "support",
-                                        "affordances": {
-                                            "onlySeries": "future",
-                                        },
-                                    }
-                                ],
-                            }
-                        },
-                    }
-                ],
-                "get-machine-id-result",
-                [(True, None)],
-                [mock.call(contract_token="token", attachment_dt=mock.ANY)],
-                [
-                    mock.call(
-                        {
-                            "machineTokenInfo": {
-                                "contractInfo": {
-                                    "resourceEntitlements": [
-                                        {
-                                            "name": "foobar",
-                                            "type": "support",
-                                            "affordances": {
-                                                "onlySeries": "future",
-                                            },
-                                        }
-                                    ],
-                                }
-                            },
-                        }
-                    )
-                ],
-                [mock.call(mock.ANY)],
-                1,
-                [mock.call(mock.ANY)],
-                [],
-                [mock.call(mock.ANY)],
-                [],
-                [mock.call()],
-                [mock.call()],
-                helpers.does_not_raise(),
-            ),
         ],
     )
     @mock.patch(


### PR DESCRIPTION
This unit test is breaking builds in environmentes without distro-info-data. Bringing the package as a build dependency for a single unit test is overkill.

TBH this only shows how our unit tests cry for refactoring :/