### PR TITLE
fix: tolerate lack of netrc dir for apt creds

### DIFF
--- a/features/esm.feature
+++ b/features/esm.feature
@@ -102,3 +102,39 @@ Feature: ESM Resource Specificities
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | resolute | lxd-container |
+
+  Scenario Outline: enable esm works with nonstandard apt auth locations
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I create the file `/etc/apt/apt.conf.d/99-pro-nonstandard-auth` with the following:
+      """
+      Dir::Etc::netrc "pro-auth.conf";
+      Dir::Etc::netrcparts "pro-auth.conf.d";
+      """
+    And I run `mkdir -p /etc/apt/pro-auth.conf.d` with sudo
+    And I attach `contract_token` with sudo and options `--no-auto-enable`
+    And I run `pro enable esm-infra esm-apps` with sudo
+    Then I verify that `esm-infra` is enabled
+    And I verify that `esm-apps` is enabled
+    # Credentials must be written to the relocated auth parts dir...
+    When I run `cat /etc/apt/pro-auth.conf.d/90ubuntu-advantage` with sudo
+    Then stdout contains substring:
+      """
+      machine esm.ubuntu.com/infra/ubuntu/ login bearer password
+      """
+    And stdout contains substring:
+      """
+      machine esm.ubuntu.com/apps/ubuntu/ login bearer password
+      """
+    # ...and not to the default location apt is no longer configured to read
+    Then I verify that no files exist matching `/etc/apt/auth.conf.d/90ubuntu-advantage`
+    # apt must be able to authenticate against ESM using the relocated creds
+    Then I ensure apt update runs without errors
+
+    Examples: ubuntu release
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | resolute | lxd-container |

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -139,8 +139,6 @@ def assert_valid_apt_credentials(repo_url, username, password):
     if not os.path.exists("/usr/lib/apt/apt-helper"):
         return
     protocol, repo_path = repo_url.split("://")
-    apt_auth_file = get_apt_auth_file_from_apt_config()
-    auth_path = apt_auth_file + "-validation"
     if not repo_path.endswith("/"):
         repo_path_slash = repo_path + "/"
     else:
@@ -154,14 +152,24 @@ def assert_valid_apt_credentials(repo_url, username, password):
         )
     )
     try:
-        system.write_file(auth_path, auth_line, mode=0o600)
         with tempfile.TemporaryDirectory() as tmpd:
+            # Use a fully self-contained apt auth configuration for this
+            # validation so that apt-helper reads exactly the credentials we
+            # provide, regardless of how the system's apt auth is configured.
+            auth_file = os.path.join(tmpd, "auth.conf")
+            empty_netrcparts = os.path.join(tmpd, "auth.conf.d")
+            os.makedirs(empty_netrcparts, mode=0o700)
+            system.write_file(auth_file, auth_line, mode=0o600)
             system.subp(
                 [
                     "/usr/lib/apt/apt-helper",
                     "download-file",
                     "{}://{}/pool/".format(protocol, repo_path),
                     os.path.join(tmpd, "apt-helper-output"),
+                    "-o",
+                    "Dir::Etc::netrc={}".format(auth_file),
+                    "-o",
+                    "Dir::Etc::netrcparts={}".format(empty_netrcparts),
                 ],
                 timeout=APT_HELPER_TIMEOUT,
                 retry_sleeps=APT_RETRIES,
@@ -179,8 +187,6 @@ def assert_valid_apt_credentials(repo_url, username, password):
         raise exceptions.APTCommandTimeout(
             seconds=APT_HELPER_TIMEOUT, repo=repo_path
         )
-    finally:
-        system.ensure_file_absent(auth_path)
 
 
 def _parse_apt_update_for_invalid_apt_config(

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -156,8 +156,8 @@ def assert_valid_apt_credentials(repo_url, username, password):
             # Use a fully self-contained apt auth configuration for this
             # validation so that apt-helper reads exactly the credentials we
             # provide, regardless of how the system's apt auth is configured.
-            auth_file = os.path.join(tmpd, "auth.conf")
-            empty_netrcparts = os.path.join(tmpd, "auth.conf.d")
+            auth_file = os.path.join(tmpd, "ubuntu-advantage-auth-temp.conf")
+            empty_netrcparts = os.path.join(tmpd, "empty-auth.conf.d")
             os.makedirs(empty_netrcparts, mode=0o700)
             system.write_file(auth_file, auth_line, mode=0o600)
             system.subp(

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -194,26 +194,20 @@ class TestValidAptCredentials:
 
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.system.subp")
-    @mock.patch("uaclient.system.ensure_file_absent")
+    @mock.patch("uaclient.apt.os.makedirs")
     @mock.patch("uaclient.system.write_file")
-    @mock.patch(
-        "uaclient.apt.get_apt_auth_file_from_apt_config",
-        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
-    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_passes_on_valid_creds(
         self,
         m_exists,
-        m_get_apt_auth,
         m_write_file,
-        m_ensure_file_absent,
+        m_makedirs,
         m_subp,
         m_temporary_directory,
     ):
         """Succeed when apt-helper succeeds in authenticating to repo."""
-        m_temporary_directory.return_value.__enter__.return_value = (
-            "/does/not/exist"
-        )
+        tmpd = "/does/not/exist"
+        m_temporary_directory.return_value.__enter__.return_value = tmpd
         # Success apt-helper response
         m_subp.return_value = "Get:1 https://fakerepo\nFetched 285 B in 1s", ""
 
@@ -222,29 +216,33 @@ class TestValidAptCredentials:
         )
         exists_calls = [mock.call("/usr/lib/apt/apt-helper")]
         assert exists_calls == m_exists.call_args_list
-        expected_path = os.path.join(
-            m_temporary_directory.return_value.__enter__.return_value,
-            "apt-helper-output",
-        )
+        expected_path = os.path.join(tmpd, "apt-helper-output")
+        auth_file = os.path.join(tmpd, "auth.conf")
+        netrcparts = os.path.join(tmpd, "auth.conf.d")
         apt_helper_call = mock.call(
             [
                 "/usr/lib/apt/apt-helper",
                 "download-file",
                 "http://fakerepo/pool/",
                 expected_path,
+                "-o",
+                "Dir::Etc::netrc={}".format(auth_file),
+                "-o",
+                "Dir::Etc::netrcparts={}".format(netrcparts),
             ],
             timeout=60,
             retry_sleeps=APT_RETRIES,
         )
         assert [apt_helper_call] == m_subp.call_args_list
-        # Verify credentials are written to auth file, not in argv
-        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
+        # Credentials are written to an isolated 0600 auth file inside the
+        # temp dir, never passed on the command line.
         m_write_file.assert_called_once_with(
-            auth_path,
+            auth_file,
             "machine fakerepo/ login user password pwd\n",
             mode=0o600,
         )
-        m_ensure_file_absent.assert_called_once_with(auth_path)
+        # The isolated netrcparts dir is created empty so only our creds apply
+        m_makedirs.assert_called_once_with(netrcparts, mode=0o700)
 
     @pytest.mark.parametrize(
         "exit_code,stderr,error_msg",
@@ -278,19 +276,14 @@ class TestValidAptCredentials:
     )
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.system.subp")
-    @mock.patch("uaclient.system.ensure_file_absent")
+    @mock.patch("uaclient.apt.os.makedirs")
     @mock.patch("uaclient.system.write_file")
-    @mock.patch(
-        "uaclient.apt.get_apt_auth_file_from_apt_config",
-        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
-    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_errors_on_process_execution_errors(
         self,
         m_exists,
-        m_get_apt_auth,
         m_write_file,
-        m_ensure_file_absent,
+        m_makedirs,
         m_subp,
         m_temporary_directory,
         exit_code,
@@ -298,9 +291,8 @@ class TestValidAptCredentials:
         error_msg,
     ):
         """Raise the appropriate user facing error from apt-helper failure."""
-        m_temporary_directory.return_value.__enter__.return_value = (
-            "/does/not/exist"
-        )
+        tmpd = "/does/not/exist"
+        m_temporary_directory.return_value.__enter__.return_value = tmpd
         # Failure apt-helper response
         m_subp.side_effect = exceptions.ProcessExecutionError(
             cmd="apt-helper ",
@@ -316,47 +308,44 @@ class TestValidAptCredentials:
         assert error_msg == str(excinfo.value)
         exists_calls = [mock.call("/usr/lib/apt/apt-helper")]
         assert exists_calls == m_exists.call_args_list
-        expected_path = os.path.join(
-            m_temporary_directory.return_value.__enter__.return_value,
-            "apt-helper-output",
-        )
+        expected_path = os.path.join(tmpd, "apt-helper-output")
+        auth_file = os.path.join(tmpd, "auth.conf")
+        netrcparts = os.path.join(tmpd, "auth.conf.d")
         apt_helper_call = mock.call(
             [
                 "/usr/lib/apt/apt-helper",
                 "download-file",
                 "http://fakerepo/pool/",
                 expected_path,
+                "-o",
+                "Dir::Etc::netrc={}".format(auth_file),
+                "-o",
+                "Dir::Etc::netrcparts={}".format(netrcparts),
             ],
             timeout=60,
             retry_sleeps=APT_RETRIES,
         )
         assert [apt_helper_call] == m_subp.call_args_list
-        # Verify auth file is always cleaned up even on error
-        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
-        m_ensure_file_absent.assert_called_once_with(auth_path)
+        # The temp dir (and the auth file within it) is always cleaned up,
+        # even on error, by the TemporaryDirectory context manager.
+        m_temporary_directory.return_value.__exit__.assert_called_once()
 
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.system.subp")
-    @mock.patch("uaclient.system.ensure_file_absent")
+    @mock.patch("uaclient.apt.os.makedirs")
     @mock.patch("uaclient.system.write_file")
-    @mock.patch(
-        "uaclient.apt.get_apt_auth_file_from_apt_config",
-        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
-    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_errors_on_apt_helper_process_timeout(
         self,
         m_exists,
-        m_get_apt_auth,
         m_write_file,
-        m_ensure_file_absent,
+        m_makedirs,
         m_subp,
         m_temporary_directory,
     ):
         """Raise the appropriate user facing error from apt-helper timeout."""
-        m_temporary_directory.return_value.__enter__.return_value = (
-            "/does/not/exist"
-        )
+        tmpd = "/does/not/exist"
+        m_temporary_directory.return_value.__enter__.return_value = tmpd
         # Failure apt-helper response
         m_subp.side_effect = subprocess.TimeoutExpired(
             "something timed out", timeout=1000000
@@ -374,40 +363,38 @@ class TestValidAptCredentials:
         assert error_msg == excinfo.value.msg
         exists_calls = [mock.call("/usr/lib/apt/apt-helper")]
         assert exists_calls == m_exists.call_args_list
-        expected_path = os.path.join(
-            m_temporary_directory.return_value.__enter__.return_value,
-            "apt-helper-output",
-        )
+        expected_path = os.path.join(tmpd, "apt-helper-output")
+        auth_file = os.path.join(tmpd, "auth.conf")
+        netrcparts = os.path.join(tmpd, "auth.conf.d")
         apt_helper_call = mock.call(
             [
                 "/usr/lib/apt/apt-helper",
                 "download-file",
                 "http://fakerepo/pool/",
                 expected_path,
+                "-o",
+                "Dir::Etc::netrc={}".format(auth_file),
+                "-o",
+                "Dir::Etc::netrcparts={}".format(netrcparts),
             ],
             timeout=APT_HELPER_TIMEOUT,
             retry_sleeps=APT_RETRIES,
         )
         assert [apt_helper_call] == m_subp.call_args_list
-        # Verify auth file is always cleaned up even on timeout
-        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
-        m_ensure_file_absent.assert_called_once_with(auth_path)
+        # The temp dir (and the auth file within it) is always cleaned up,
+        # even on timeout, by the TemporaryDirectory context manager.
+        m_temporary_directory.return_value.__exit__.assert_called_once()
 
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.system.subp")
-    @mock.patch("uaclient.system.ensure_file_absent")
+    @mock.patch("uaclient.apt.os.makedirs")
     @mock.patch("uaclient.system.write_file")
-    @mock.patch(
-        "uaclient.apt.get_apt_auth_file_from_apt_config",
-        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
-    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_credentials_not_in_subprocess_argv(
         self,
         m_exists,
-        m_get_apt_auth,
         m_write_file,
-        m_ensure_file_absent,
+        m_makedirs,
         m_subp,
         m_temporary_directory,
     ):
@@ -417,9 +404,8 @@ class TestValidAptCredentials:
         of the subprocess command line, preventing leakage via
         /proc/<pid>/cmdline.
         """
-        m_temporary_directory.return_value.__enter__.return_value = (
-            "/does/not/exist"
-        )
+        tmpd = "/does/not/exist"
+        m_temporary_directory.return_value.__enter__.return_value = tmpd
         m_subp.return_value = "Get:1 https://esm.ubuntu.com\nFetched 285 B", ""
         secret_token = "super-secret-bearer-token-value"
 
@@ -439,16 +425,16 @@ class TestValidAptCredentials:
                 "Username leaked into subprocess argv: %s" % arg
             )
 
-        # Assert credentials are instead written to the auth file
-        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
+        # Assert credentials are instead written to the isolated auth file
+        auth_file = os.path.join(tmpd, "auth.conf")
         m_write_file.assert_called_once_with(
-            auth_path,
+            auth_file,
             "machine esm.ubuntu.com/infra/ubuntu/ login bearer"
             " password super-secret-bearer-token-value\n",
             mode=0o600,
         )
-        # Assert auth file is cleaned up
-        m_ensure_file_absent.assert_called_once_with(auth_path)
+        # Assert the temp dir (holding the auth file) is cleaned up
+        m_temporary_directory.return_value.__exit__.assert_called_once()
 
 
 class TestAddAuthAptRepo:

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -217,8 +217,8 @@ class TestValidAptCredentials:
         exists_calls = [mock.call("/usr/lib/apt/apt-helper")]
         assert exists_calls == m_exists.call_args_list
         expected_path = os.path.join(tmpd, "apt-helper-output")
-        auth_file = os.path.join(tmpd, "auth.conf")
-        netrcparts = os.path.join(tmpd, "auth.conf.d")
+        auth_file = os.path.join(tmpd, "ubuntu-advantage-auth-temp.conf")
+        netrcparts = os.path.join(tmpd, "empty-auth.conf.d")
         apt_helper_call = mock.call(
             [
                 "/usr/lib/apt/apt-helper",
@@ -309,8 +309,8 @@ class TestValidAptCredentials:
         exists_calls = [mock.call("/usr/lib/apt/apt-helper")]
         assert exists_calls == m_exists.call_args_list
         expected_path = os.path.join(tmpd, "apt-helper-output")
-        auth_file = os.path.join(tmpd, "auth.conf")
-        netrcparts = os.path.join(tmpd, "auth.conf.d")
+        auth_file = os.path.join(tmpd, "ubuntu-advantage-auth-temp.conf")
+        netrcparts = os.path.join(tmpd, "empty-auth.conf.d")
         apt_helper_call = mock.call(
             [
                 "/usr/lib/apt/apt-helper",
@@ -364,8 +364,8 @@ class TestValidAptCredentials:
         exists_calls = [mock.call("/usr/lib/apt/apt-helper")]
         assert exists_calls == m_exists.call_args_list
         expected_path = os.path.join(tmpd, "apt-helper-output")
-        auth_file = os.path.join(tmpd, "auth.conf")
-        netrcparts = os.path.join(tmpd, "auth.conf.d")
+        auth_file = os.path.join(tmpd, "ubuntu-advantage-auth-temp.conf")
+        netrcparts = os.path.join(tmpd, "empty-auth.conf.d")
         apt_helper_call = mock.call(
             [
                 "/usr/lib/apt/apt-helper",

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -426,7 +426,7 @@ class TestValidAptCredentials:
             )
 
         # Assert credentials are instead written to the isolated auth file
-        auth_file = os.path.join(tmpd, "auth.conf")
+        auth_file = os.path.join(tmpd, "ubuntu-advantage-auth-temp.conf")
         m_write_file.assert_called_once_with(
             auth_file,
             "machine esm.ubuntu.com/infra/ubuntu/ login bearer"


### PR DESCRIPTION
## Why is this needed?

Releases back to trusty have an `apt` version that supports `auth.conf.d`, so we have not seen this in practice in standard deployments. However... it could be possible. We want to ensure `assert_valid_apt_credentials` is robust against differences in `apt` configurations.

## Test Steps

Run the new feature test and the unit tests.
