### PR TITLE
test(behave): display cis as usg for resolute

### DIFF
--- a/features/cli/disable.feature
+++ b/features/cli/disable.feature
@@ -187,16 +187,14 @@ Feature: CLI disable command
       """
 
     Examples: ubuntu release
-      | release | machine_type  | msg                                                                                                                                                                                |
-      | xenial  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-apps-legacy, esm-infra,\nesm-infra-legacy, fips, fips-preview, fips-updates, landscape, livepatch,\nrealtime-kernel, ros, ros-updates. |
-      | bionic  | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-apps-legacy, esm-infra,\nesm-infra-legacy, fips, fips-preview, fips-updates, landscape, livepatch,\nrealtime-kernel, ros, ros-updates. |
-      | focal   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
-      | jammy   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
-      | noble   | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
+      | release  | machine_type  | msg                                                                                                                                                                                |
+      | xenial   | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-apps-legacy, esm-infra,\nesm-infra-legacy, fips, fips-preview, fips-updates, landscape, livepatch,\nrealtime-kernel, ros, ros-updates. |
+      | bionic   | lxd-container | Try anbox-cloud, cc-eal, cis, esm-apps, esm-apps-legacy, esm-infra,\nesm-infra-legacy, fips, fips-preview, fips-updates, landscape, livepatch,\nrealtime-kernel, ros, ros-updates. |
+      | focal    | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
+      | jammy    | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
+      | noble    | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
+      | resolute | lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
 
-  # TODO: Re-enable resolute once ua-contracts resource definitions are
-  # updated to present CIS as usg like noble.
-  # | resolute| lxd-container | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
   @uses.config.contract_token
   Scenario Outline: Disable with purge does not work with assume-yes
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/enable.feature
+++ b/features/cli/enable.feature
@@ -539,10 +539,11 @@ Feature: CLI enable command
       """
 
     Examples: ubuntu release
-      | release | machine_type  | infra-pkg | apps-pkg | msg                                                                                                                                                                                |
-      | xenial  | lxd-container | libkrad0  | jq       | Try anbox-cloud, cc-eal, cis, esm-apps, esm-apps-legacy, esm-infra,\nesm-infra-legacy, fips, fips-preview, fips-updates, landscape, livepatch,\nrealtime-kernel, ros, ros-updates. |
-      | bionic  | lxd-container | libkrad0  | bundler  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-apps-legacy, esm-infra,\nesm-infra-legacy, fips, fips-preview, fips-updates, landscape, livepatch,\nrealtime-kernel, ros, ros-updates. |
-      | focal   | lxd-container | hello     | ant      | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
+      | release  | machine_type  | infra-pkg | apps-pkg | msg                                                                                                                                                                                |
+      | xenial   | lxd-container | libkrad0  | jq       | Try anbox-cloud, cc-eal, cis, esm-apps, esm-apps-legacy, esm-infra,\nesm-infra-legacy, fips, fips-preview, fips-updates, landscape, livepatch,\nrealtime-kernel, ros, ros-updates. |
+      | bionic   | lxd-container | libkrad0  | bundler  | Try anbox-cloud, cc-eal, cis, esm-apps, esm-apps-legacy, esm-infra,\nesm-infra-legacy, fips, fips-preview, fips-updates, landscape, livepatch,\nrealtime-kernel, ros, ros-updates. |
+      | focal    | lxd-container | hello     | ant      | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
+      | resolute | lxd-container | hello     | acmetool | Try anbox-cloud, cc-eal, esm-apps, esm-apps-legacy, esm-infra, esm-infra-legacy,\nfips, fips-preview, fips-updates, landscape, livepatch, realtime-kernel, ros,\nros-updates, usg. |
 
   Scenario Outline: Attached enable not entitled service in a ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -1097,7 +1097,7 @@ Feature: CLI status command
       | release | machine_type  |
       | noble   | lxd-container |
 
-  Scenario Outline: Unattached status in a ubuntu machine - resolute
+  Scenario Outline: Unattached status in a Resolute ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I verify root and non-root `pro status` calls have the same output
     And I run `pro status` as non-root
@@ -1122,7 +1122,6 @@ Feature: CLI status command
       SERVICE          +AVAILABLE +DESCRIPTION
       anbox-cloud      +yes       +.*
       cc-eal           +no        +Common Criteria EAL2 Provisioning Packages
-      cis              +no        +Security compliance and audit tools
       esm-apps         +yes       +Expanded Security Maintenance for Applications
       esm-apps-legacy  +no        +Expanded Security Maintenance for Applications on Legacy Instances
       esm-infra        +yes       +Expanded Security Maintenance for Infrastructure
@@ -1135,6 +1134,7 @@ Feature: CLI status command
       realtime-kernel  +no        +Ubuntu kernel with PREEMPT_RT patches integrated
       ros              +no        +Security Updates for the Robot Operating System
       ros-updates      +no        +All Updates for the Robot Operating System
+      usg              +no        +Security compliance and audit tools
 
       This machine is not attached to an Ubuntu Pro subscription.
       See https://ubuntu.com/pro

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -622,7 +622,6 @@ Feature: CLI status command
       SERVICE          +ENTITLED +STATUS   +DESCRIPTION
       anbox-cloud      +yes      +disabled +.*
       cc-eal           +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
-      cis              +yes      +n/a      +Security compliance and audit tools
       esm-apps         +yes      +enabled  +Expanded Security Maintenance for Applications
       esm-infra        +yes      +enabled  +Expanded Security Maintenance for Infrastructure
       fips             +yes      +n/a      +NIST-certified FIPS crypto packages
@@ -633,6 +632,7 @@ Feature: CLI status command
       realtime-kernel  +yes      +n/a      +Ubuntu kernel with PREEMPT_RT patches integrated
       ros              +yes      +n/a      +Security Updates for the Robot Operating System
       ros-updates      +yes      +n/a      +All Updates for the Robot Operating System
+      usg              +yes      +n/a      +Security compliance and audit tools
 
       Enable services with: pro enable <service>
       """


### PR DESCRIPTION
## Why is this needed?

CIS is always displayed as USG on modern releases. This feature is not actually available yet, but we still need to display it correctly in "disabled/unavailable" menus. These tests are now possible to run correctly following an update to the contract server product definition.

## Test Steps

Export your token, then run the behave tests that have been modified, e.g.,:

```sh
 UACLIENT_BEHAVE_INSTALL_FROM=local tox -e behave -- features/cli/disable.feature:642
```