### PR TITLE
test(behave): require staging creds for contract_expired

### DIFF
--- a/features/contract_expired.feature
+++ b/features/contract_expired.feature
@@ -1,6 +1,6 @@
 Feature: End of contract messages
 
-  @vpn @uses.config.contract_token
+  @vpn @uses.config.contract_token @uses.config.contract_token_staging_expired_sometimes @uses.config.contract_staging_service_account_username @uses.config.contract_staging_service_account_password
   Scenario Outline: Display expired messages in all relevant places
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I apt upgrade

--- a/features/contract_expired.feature
+++ b/features/contract_expired.feature
@@ -1,6 +1,6 @@
 Feature: End of contract messages
 
-  @vpn @uses.config.contract_token @uses.config.contract_token_staging_expired_sometimes @uses.config.contract_staging_service_account_username @uses.config.contract_staging_service_account_password
+  @vpn @uses.config.contract_token_staging_expired_sometimes @uses.config.contract_staging_service_account_username @uses.config.contract_staging_service_account_password
   Scenario Outline: Display expired messages in all relevant places
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I apt upgrade


### PR DESCRIPTION
## Why is this needed?

This skips the test if creds aren't provided. Creds are available in the Bitwarden as "Ubuntu Pro client CI service account". You'll need to be on the VPN as well.

## Test Steps

```sh
UACLIENT_BEHAVE_CONTRACT_STAGING_SERVICE_ACCOUNT_USERNAME=pro-client-ci \
UACLIENT_BEHAVE_CONTRACT_STAGING_SERVICE_ACCOUNT_PASSWORD=<THE PASSWORD> \
UACLIENT_BEHAVE_CONTRACT_TOKEN_STAGING_EXPIRED_SOMETIMES=<THE TOKEN> \
UACLIENT_BEHAVE_INSTALL_FROM=local \
tox -e behave -- features/contract_expired.feature:63
```