### PR TITLE
fix: use explicit apt auth files/dirs in assert_valid_apt_credentials

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -68,8 +68,6 @@ def assert_valid_apt_credentials(repo_url, username, password):
     if not os.path.exists("/usr/lib/apt/apt-helper"):
         return
     protocol, repo_path = repo_url.split("://")
-    apt_auth_file = get_apt_auth_file_from_apt_config()
-    auth_path = apt_auth_file + "-validation"
     if not repo_path.endswith("/"):
         repo_path_slash = repo_path + "/"
     else:
@@ -83,14 +81,24 @@ def assert_valid_apt_credentials(repo_url, username, password):
         )
     )
     try:
-        util.write_file(auth_path, auth_line, mode=0o600)
         with tempfile.TemporaryDirectory() as tmpd:
+            # Use a fully self-contained apt auth configuration for this
+            # validation so that apt-helper reads exactly the credentials we
+            # provide, regardless of how the system's apt auth is configured.
+            auth_file = os.path.join(tmpd, "ubuntu-advantage-auth-temp.conf")
+            empty_netrcparts = os.path.join(tmpd, "empty-auth.conf.d")
+            os.makedirs(empty_netrcparts, mode=0o700)
+            util.write_file(auth_file, auth_line, mode=0o600)
             util.subp(
                 [
                     "/usr/lib/apt/apt-helper",
                     "download-file",
                     "{}://{}/ubuntu/pool/".format(protocol, repo_path),
                     os.path.join(tmpd, "apt-helper-output"),
+                    "-o",
+                    "Dir::Etc::netrc={}".format(auth_file),
+                    "-o",
+                    "Dir::Etc::netrcparts={}".format(empty_netrcparts),
                 ],
                 timeout=APT_HELPER_TIMEOUT,
             )
@@ -117,8 +125,6 @@ def assert_valid_apt_credentials(repo_url, username, password):
                 APT_HELPER_TIMEOUT, repo_path
             )
         )
-    finally:
-        util.del_file(auth_path)
 
 
 def run_apt_command(cmd, error_msg) -> str:

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -189,19 +189,14 @@ class TestValidAptCredentials:
 
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.util.subp")
-    @mock.patch("uaclient.util.del_file")
+    @mock.patch("uaclient.apt.os.makedirs")
     @mock.patch("uaclient.util.write_file")
-    @mock.patch(
-        "uaclient.apt.get_apt_auth_file_from_apt_config",
-        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
-    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_passes_on_valid_creds(
         self,
         m_exists,
-        m_get_apt_auth,
         m_write_file,
-        m_del_file,
+        m_makedirs,
         m_subp,
         m_temporary_directory,
     ):
@@ -221,24 +216,28 @@ class TestValidAptCredentials:
             m_temporary_directory.return_value.__enter__.return_value,
             "apt-helper-output",
         )
+        auth_file = "/does/not/exist/ubuntu-advantage-auth-temp.conf"
+        auth_parts_dir = "/does/not/exist/empty-auth.conf.d"
         apt_helper_call = mock.call(
             [
                 "/usr/lib/apt/apt-helper",
                 "download-file",
                 "http://fakerepo/ubuntu/pool/",
                 expected_path,
+                "-o",
+                "Dir::Etc::netrc={}".format(auth_file),
+                "-o",
+                "Dir::Etc::netrcparts={}".format(auth_parts_dir),
             ],
             timeout=20,
         )
         assert [apt_helper_call] == m_subp.call_args_list
-        # Verify credentials are written to auth file, not in argv
-        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
         m_write_file.assert_called_once_with(
-            auth_path,
+            auth_file,
             "machine fakerepo/ login user password pwd\n",
             mode=0o600,
         )
-        m_del_file.assert_called_once_with(auth_path)
+        m_makedirs.assert_called_once_with(auth_parts_dir, mode=0o700)
 
     @pytest.mark.parametrize(
         "exit_code,stderr,error_msg",
@@ -267,19 +266,14 @@ class TestValidAptCredentials:
     )
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.util.subp")
-    @mock.patch("uaclient.util.del_file")
+    @mock.patch("uaclient.apt.os.makedirs")
     @mock.patch("uaclient.util.write_file")
-    @mock.patch(
-        "uaclient.apt.get_apt_auth_file_from_apt_config",
-        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
-    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_errors_on_process_execution_errors(
         self,
         m_exists,
-        m_get_apt_auth,
         m_write_file,
-        m_del_file,
+        m_makedirs,
         m_subp,
         m_temporary_directory,
         exit_code,
@@ -309,35 +303,39 @@ class TestValidAptCredentials:
             m_temporary_directory.return_value.__enter__.return_value,
             "apt-helper-output",
         )
+        auth_file = "/does/not/exist/ubuntu-advantage-auth-temp.conf"
+        auth_parts_dir = "/does/not/exist/empty-auth.conf.d"
         apt_helper_call = mock.call(
             [
                 "/usr/lib/apt/apt-helper",
                 "download-file",
                 "http://fakerepo/ubuntu/pool/",
                 expected_path,
+                "-o",
+                "Dir::Etc::netrc={}".format(auth_file),
+                "-o",
+                "Dir::Etc::netrcparts={}".format(auth_parts_dir),
             ],
             timeout=20,
         )
         assert [apt_helper_call] == m_subp.call_args_list
-        # Verify auth file is always cleaned up even on error
-        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
-        m_del_file.assert_called_once_with(auth_path)
+        m_write_file.assert_called_once_with(
+            auth_file,
+            "machine fakerepo/ login user password pwd\n",
+            mode=0o600,
+        )
+        m_makedirs.assert_called_once_with(auth_parts_dir, mode=0o700)
 
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.util.subp")
-    @mock.patch("uaclient.util.del_file")
+    @mock.patch("uaclient.apt.os.makedirs")
     @mock.patch("uaclient.util.write_file")
-    @mock.patch(
-        "uaclient.apt.get_apt_auth_file_from_apt_config",
-        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
-    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_errors_on_apt_helper_process_timeout(
         self,
         m_exists,
-        m_get_apt_auth,
         m_write_file,
-        m_del_file,
+        m_makedirs,
         m_subp,
         m_temporary_directory,
     ):
@@ -366,35 +364,39 @@ class TestValidAptCredentials:
             m_temporary_directory.return_value.__enter__.return_value,
             "apt-helper-output",
         )
+        auth_file = "/does/not/exist/ubuntu-advantage-auth-temp.conf"
+        auth_parts_dir = "/does/not/exist/empty-auth.conf.d"
         apt_helper_call = mock.call(
             [
                 "/usr/lib/apt/apt-helper",
                 "download-file",
                 "http://fakerepo/ubuntu/pool/",
                 expected_path,
+                "-o",
+                "Dir::Etc::netrc={}".format(auth_file),
+                "-o",
+                "Dir::Etc::netrcparts={}".format(auth_parts_dir),
             ],
             timeout=apt.APT_HELPER_TIMEOUT,
         )
         assert [apt_helper_call] == m_subp.call_args_list
-        # Verify auth file is always cleaned up even on timeout
-        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
-        m_del_file.assert_called_once_with(auth_path)
+        m_write_file.assert_called_once_with(
+            auth_file,
+            "machine fakerepo/ login user password pwd\n",
+            mode=0o600,
+        )
+        m_makedirs.assert_called_once_with(auth_parts_dir, mode=0o700)
 
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.util.subp")
-    @mock.patch("uaclient.util.del_file")
+    @mock.patch("uaclient.apt.os.makedirs")
     @mock.patch("uaclient.util.write_file")
-    @mock.patch(
-        "uaclient.apt.get_apt_auth_file_from_apt_config",
-        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
-    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_credentials_not_in_subprocess_argv(
         self,
         m_exists,
-        m_get_apt_auth,
         m_write_file,
-        m_del_file,
+        m_makedirs,
         m_subp,
         m_temporary_directory,
     ):
@@ -430,15 +432,15 @@ class TestValidAptCredentials:
             )
 
         # Assert credentials are instead written to the auth file
-        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
+        auth_file = "/does/not/exist/ubuntu-advantage-auth-temp.conf"
+        auth_parts_dir = "/does/not/exist/empty-auth.conf.d"
         m_write_file.assert_called_once_with(
-            auth_path,
+            auth_file,
             "machine esm.ubuntu.com/infra/ubuntu/ login bearer"
             " password super-secret-bearer-token-value\n",
             mode=0o600,
         )
-        # Assert auth file is cleaned up
-        m_del_file.assert_called_once_with(auth_path)
+        m_makedirs.assert_called_once_with(auth_parts_dir, mode=0o700)
 
 
 class TestAddAuthAptRepo:


### PR DESCRIPTION
## Why is this needed?

Trusty does not always pick up on the tempfile used for the ESM repo authentication. The credential is correct, but the `ua enable esm-infra-legacy` command fails because `assert_valid_apt_credentials` fails.

## Test Steps

Spin up a trusty machine. You'll also need an Ubuntu Pro token that has legacy products entitled

```sh
sudo apt update && sudo apt install --upgrade-only ubuntu-advantage-tools
sudo ua attach <TOKEN>
sudo ua enable esm-infra-legacy
```

This should repro the issue. Next, build:

```sh
sudo sbuild-adduser "$USER"
mk-sbuild trusty
sbuild --dist=trusty .
```

Push this build into your machine and install it. Try enabling again:

```sh
sudo dpkg -i ./your/new/build
sudo ua enable esm-infra-legacy
```

I had good luck with VirtualBox.

More comprehensive UATs will be performed prior to a release. This review should verify that the bug is fixed and identify any obvious regressions.