### PR TITLE
fix: load wsl config with hook

### DIFF
--- a/features/cloud.py
+++ b/features/cloud.py
@@ -795,8 +795,8 @@ class WSLCloud(pycloudlib.cloud.BaseCloud):
         self.wsl_ip_address = wsl_ip_address
         super().__init__(tag="wsl")
 
-    def _check_and_set_config(self, config_file, required_values):
-        self.config = {
+    def _check_and_get_config(self, config_file, required_values):
+        return {
             "public_key_path": self.wsl_pubkey_path,
             "private_key_path": self.wsl_privkey_path,
         }


### PR DESCRIPTION
## Why is this needed?

WSL tests require a `[base]` section in `pycloudlib.toml` even if private/public keys are passed with environment variables. This is because they load the 

## Test Steps

Try running a test that uses WSL; pass your WSL parameters as env. They don't need to be "real"; no WSL functionality is exercised here:

```sh
UACLIENT_BEHAVE_WSL_IP_ADDRESS=...
UACLIENT_BEHAVE_WSL_PRIVKEY_PATH=...
UACLIENT_BEHAVE_WSL_PUBKEY_PATH=...
```

Ensure you have no `[base]` section in your `pycloudlib.toml`. See that it fails:

```sh
KeyError: 'base must be defined in pycloudlib.toml to make this call'
```

Check out this branch and try again. You should get a "real" error, like a failure to connect, which at least indicates that you are loading your config from the env vars.