### PR TITLE
Revert "fix: include jammy in distros that receive perfmon for esm-detect-virt AppArmor profile LP: #2156929"

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -318,9 +318,8 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
 
     capability sys_ptrace,
     # LP: #2143251
-    # LP: #2156929
-    # Include only for jammy+; avoid changing releases that don't report the bug.
-{% if ubuntu_codename not in ["xenial", "bionic", "focal"] %}
+    # Include only for noble+; avoid changing releases that don't report the bug.
+{% if ubuntu_codename not in ["xenial", "bionic", "focal", "jammy"] %}
     capability perfmon,
 {% endif %}
 

--- a/sru/release-38/ubuntu-pro-esm-cache-detect-virt-apparmor.md
+++ b/sru/release-38/ubuntu-pro-esm-cache-detect-virt-apparmor.md
@@ -61,7 +61,3 @@ sudo apt update
 # Confirm still no logs
 journalctl --no-pager | grep 'apparmor="DENIED"' | grep 'ubuntu_pro_esm_cache'
 ```
-
-## Amended to include jammy
-
-Amended to include jammy as of [LP #2156929](https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/2156929). This has the same reproduction steps and was confirmed by the CPC team to fix the issue on jammy.


### PR DESCRIPTION
Reverts canonical/ubuntu-pro-client#3549

This still needs a repro and confirmation of fix before it can be backported.