### PR TITLE
test: uncomment resolute and noble test scenarios

### DIFF
--- a/features/anbox.feature
+++ b/features/anbox.feature
@@ -128,10 +128,7 @@ Feature: Enable anbox on Ubuntu
     And I verify that no files exist matching `/var/lib/ubuntu-advantage/private/anbox-cloud-credentials`
 
     Examples: ubuntu release
-      | release | machine_type |
-      | jammy   | lxd-vm       |
-      | noble   | lxd-vm       |
-
-# TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
-# gains capability perfmon on resolute (needed by systemd-detect-virt at boot)
-# | resolute | lxd-vm       |
+      | release  | machine_type |
+      | jammy    | lxd-vm       |
+      | noble    | lxd-vm       |
+      | resolute | lxd-vm       |

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -131,9 +131,9 @@ Feature: APT Messages
 
     Examples: ubuntu release
       | release | machine_type  | ad_message                                                                                |
-      | xenial  | lxd-container | Learn more about Ubuntu Pro for <version>\.04 at https:\/\/ubuntu\.com\/<version>-04      |
-      | bionic  | lxd-container | Learn more about Ubuntu Pro for <version>\.04 at https:\/\/ubuntu\.com\/<version>-04      |
-      | focal   | lxd-container | Learn more about Ubuntu Pro at https:\/\/ubuntu\.com\/pro                                 |
+      | xenial  | lxd-container | Learn more about Ubuntu Pro for <version>\\.04 at https:\\/\\/ubuntu\\.com\\/<version>-04 |
+      | bionic  | lxd-container | Learn more about Ubuntu Pro for <version>\\.04 at https:\\/\\/ubuntu\\.com\\/<version>-04 |
+      | focal   | lxd-container | Learn more about Ubuntu Pro at https:\\/\\/ubuntu\\.com\\/pro                             |
 
   @uses.config.contract_token
   Scenario Outline: APT Hook advertises esm-apps on upgrade
@@ -732,10 +732,8 @@ Feature: APT Messages
       | resolute | lxd-container |
       | stonking | lxd-container |
       | stonking | lxd-vm        |
+      | resolute | lxd-vm        |
 
-  # TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
-  # gains capability perfmon on resolute (needed by systemd-detect-virt at boot)
-  # | resolute | lxd-vm        |
   Scenario Outline: Cloud and series-specific URLs
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I apt install `ansible`

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -36,14 +36,12 @@ Feature: Livepatch
       """
 
     Examples: ubuntu release
-      | release | machine_type | livepatch_status |
-      | xenial  | lxd-vm       | warning          |
-      | bionic  | lxd-vm       | enabled          |
-      | noble   | lxd-vm       | enabled          |
+      | release  | machine_type | livepatch_status |
+      | xenial   | lxd-vm       | warning          |
+      | bionic   | lxd-vm       | enabled          |
+      | noble    | lxd-vm       | enabled          |
+      | resolute | lxd-vm       | enabled          |
 
-  # TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
-  # gains capability perfmon on resolute (needed by systemd-detect-virt at boot)
-  # | resolute | lxd-vm       | enabled          |
   Scenario Outline: Unattached livepatch status shows warning when on unsupported kernel
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I change config key `livepatch_url` to use value `<livepatch_url>`

--- a/features/lxd.feature
+++ b/features/lxd.feature
@@ -146,12 +146,10 @@ Feature: LXD Pro features
       """
 
     Examples:
-      | release | machine_type | guest_release |
-      | jammy   | lxd-vm       | jammy         |
+      | release  | machine_type | guest_release |
+      | jammy    | lxd-vm       | jammy         |
+      | resolute | lxd-vm       | resolute      |
 
-  # TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
-  # gains capability perfmon on resolute (needed by systemd-detect-virt at boot)
-  # | resolute | lxd-vm | resolute |
   Scenario Outline: LXD guest auto-attach
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # Ensure default is "off" and setup lxd
@@ -233,9 +231,6 @@ Feature: LXD Pro features
       """
 
     Examples:
-      | release | machine_type | guest_release |
-      | jammy   | lxd-vm       | jammy         |
-
-# TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
-# gains capability perfmon on resolute (needed by systemd-detect-virt at boot)
-# | resolute | lxd-vm | resolute |
+      | release  | machine_type | guest_release |
+      | jammy    | lxd-vm       | jammy         |
+      | resolute | lxd-vm       | resolute      |

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -378,16 +378,14 @@ Feature: Proxy configuration
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | resolute | lxd-container |
 
-  # TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
-  # gains capability perfmon on resolute (needed by systemd-detect-virt at boot)
-  # | resolute | lxd-container |
   @slow
   Scenario Outline: Attach command when authenticated proxy is configured
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -1075,12 +1073,9 @@ Feature: Proxy configuration
       """
 
     Examples: ubuntu release
-      | release | machine_type |
-      | bionic  | lxd-vm       |
-      | focal   | lxd-vm       |
-      | jammy   | lxd-vm       |
-      | noble   | lxd-vm       |
-
-# TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
-# gains capability perfmon on resolute (needed by systemd-detect-virt at boot)
-# | resolute | lxd-vm       |
+      | release  | machine_type |
+      | bionic   | lxd-vm       |
+      | focal    | lxd-vm       |
+      | jammy    | lxd-vm       |
+      | noble    | lxd-vm       |
+      | resolute | lxd-vm       |

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -46,18 +46,16 @@ Feature: Upgrade between releases when uaclient is attached
       """
 
     Examples: ubuntu release
-      | release | machine_type  | next_release | prompt | devel_release   | service1  | service1_status | service2 | service2_status | before_cmd     |
-      | xenial  | lxd-container | bionic       | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-      | bionic  | lxd-container | focal        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-      | bionic  | lxd-container | focal        | lts    |                 | usg       | enabled         | usg      | enabled         | pro enable cis |
-      | focal   | lxd-container | jammy        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-      | jammy   | lxd-container | noble        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
-      | noble   | lxd-container | resolute     | normal | --devel-release | esm-infra | n/a             | esm-apps | n/a             | true           |
+      | release  | machine_type  | next_release | prompt | devel_release   | service1  | service1_status | service2 | service2_status | before_cmd     |
+      | xenial   | lxd-container | bionic       | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
+      | bionic   | lxd-container | focal        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
+      | bionic   | lxd-container | focal        | lts    |                 | usg       | enabled         | usg      | enabled         | pro enable cis |
+      | focal    | lxd-container | jammy        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
+      | jammy    | lxd-container | noble        | lts    |                 | esm-infra | enabled         | esm-apps | enabled         | true           |
+      | noble    | lxd-container | resolute     | normal | --devel-release | esm-infra | n/a             | esm-apps | n/a             | true           |
+      | questing | lxd-container | resolute     | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
+      | stonking | lxd-container | resolute     | normal |                 | esm-infra | n/a             | esm-apps | n/a             | true           |
 
-  # TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
-  # gains capability perfmon in the resolute archive (archive package installed post-upgrade)
-  # | questing | lxd-container | resolute     | normal |               | esm-infra | n/a             | esm-apps | n/a             | true           |
-  # | stonking | lxd-container | resolute     | normal |               | esm-infra | n/a             | esm-apps | n/a             | true           |
   @slow @upgrade
   Scenario Outline: Attached FIPS upgrade across LTS releases
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -64,9 +64,7 @@ Feature: Upgrade between releases when uaclient is unattached
       | bionic  | lxd-container | focal        | lts    |                 | enabled        |
       | focal   | lxd-container | jammy        | lts    |                 | enabled        |
       | jammy   | lxd-container | noble        | lts    |                 | enabled        |
-      # TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
-      # gains capability perfmon in the resolute archive (archive package installed post-upgrade)
-      # | noble    | lxd-container | resolute     | lts    |               | enabled        |
+      | noble   | lxd-container | resolute     | lts    |                 | enabled        |
       | noble   | lxd-container | resolute     | normal | --devel-release | n/a            |
 
 # | questing | lxd-container | resolute     | normal |               | n/a            |


### PR DESCRIPTION
## Why is this needed?
Some test cases on features tests were commented out as TODOs for when certain fixes are implemented. Now that these fixes are implemented, we're uncommenting these tests.

## Test Steps
Run the uncommented test cases.

Example:
```
UACLIENT_BEHAVE_CONTRACT_TOKEN=<token>  \
tox -e behave -- features/apt_messages.feature -D releases=resolute -D machine_types=lxd-vm

```